### PR TITLE
Allow customizing assertion messages in `assert_exists` and friends

### DIFF
--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -341,7 +341,10 @@ Set
 ----------
 
 
-.. eql:function:: std::assert_distinct(s: set of anytype) -> set of anytype
+.. eql:function:: std::assert_distinct( \
+                    s: set of anytype, \
+                    named only message: optional str = <str>{} \
+                  ) -> set of anytype
 
     :index: multiplicity uniqueness
 
@@ -352,6 +355,8 @@ Set
     as a runtime distinctness assertion in queries and computed
     expressions that should always return proper sets, but where static
     multiplicity inference is not capable enough or outright impossible.
+    An optional *message* named argument can be used to customize the error
+    message.
 
     .. code-block:: edgeql-repl
 
@@ -370,11 +375,21 @@ Set
         ERROR: ConstraintViolationError: assert_distinct violation: expression
                returned a set with duplicate elements.
 
+        db> select assert_distinct(
+        ...   (select User filter .groups.name = "Users")
+        ...   union
+        ...   (select User filter .groups.name = "Guests"),
+        ...   message := "duplicate users!"
+        ... )
+        ERROR: ConstraintViolationError: duplicate users!
 
 ----------
 
 
-.. eql:function:: std::assert_single(s: set of anytype) -> anytype
+.. eql:function:: std::assert_single( \
+                    s: set of anytype, \
+                    named only message: optional str = <str>{} \
+                  ) -> set of anytype
 
     :index: cardinality singleton
 
@@ -385,7 +400,8 @@ Set
     as a runtime cardinality assertion in queries and computed
     expressions that should always return sets with at most a single
     element, but where static cardinality inference is not capable
-    enough or outright impossible.
+    enough or outright impossible.  An optional *message* named argument
+    can be used to customize the error message.
 
     .. code-block:: edgeql-repl
 
@@ -396,11 +412,16 @@ Set
         ERROR: CardinalityViolationError: assert_single violation: more than
                one element returned by an expression
 
+        db> select assert_single((select User), message := "too many users!")
+        ERROR: CardinalityViolationError: too many users!
 
 ----------
 
 
-.. eql:function:: std::assert_exists(s: set of anytype) -> set of anytype
+.. eql:function:: std::assert_exists( \
+                    s: set of anytype, \
+                    named only message: optional str = <str>{} \
+                  ) -> set of anytype
 
     :index: cardinality existence empty
 
@@ -411,7 +432,8 @@ Set
     as a runtime existence assertion in queries and computed
     expressions that should always return sets with at least a single
     element, but where static cardinality inference is not capable
-    enough or outright impossible.
+    enough or outright impossible.  An optional *message* named argument
+    can be used to customize the error message.
 
     .. code-block:: edgeql-repl
 
@@ -422,6 +444,11 @@ Set
         ERROR: CardinalityViolationError: assert_exists violation: expression
                returned an empty set.
 
+        db> select assert_exists(
+        ...   (select User filter .name = "Nonexistent"),
+        ...   message := "no users!"
+        ... )
+        ERROR: CardinalityViolationError: no users!
 
 ----------
 

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_06_23_00_00
+EDGEDB_CATALOG_VERSION = 2022_07_01_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -678,10 +678,12 @@ def __infer_func_call(
         # of declaration.
         arg_cards = []
 
-        for arg in ir.args:
+        for arg, typemod in zip(ir.args, ir.params_typemods):
             arg.cardinality = infer_cardinality(
                 arg.expr, scope_tree=scope_tree, ctx=ctx)
-            arg_cards.append(arg.cardinality)
+
+            if typemod is not qltypes.TypeModifier.OptionalType:
+                arg_cards.append(arg.cardinality)
 
         arg_card = zip(*(_card_to_bounds(card) for card in arg_cards))
         arg_lower, arg_upper = arg_card

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -331,7 +331,7 @@ def __infer_func_call(
     elif str(ir.func_shortname) == 'std::assert_distinct':
         return ONE
     elif str(ir.func_shortname) == 'std::assert_exists':
-        return args_mult[0]
+        return args_mult[1]
     elif str(ir.func_shortname) == 'std::enumerate':
         # The output of enumerate is always of multiplicity ONE because
         # it's a set of tuples with first elements being guaranteed to be

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -304,7 +304,7 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
             isinstance(cur_set.expr, irast.FunctionCall)
             and str(cur_set.expr.func_shortname) == 'std::assert_exists'
         ):
-            cur_set = cur_set.expr.args[0].expr
+            cur_set = cur_set.expr.args[1].expr
         elif cur_set.rptr is not None:
             cur_set = cur_set.rptr.source
         else:

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -23,7 +23,10 @@
 # -----------------------------------------------------------------
 
 CREATE FUNCTION
-std::assert_single(input: SET OF anytype) -> OPTIONAL anytype
+std::assert_single(
+    input: SET OF anytype,
+    NAMED ONLY message: OPTIONAL str = <str>{},
+) -> OPTIONAL anytype
 {
     CREATE ANNOTATION std::description :=
         "Check that the input set contains at most one element, raise
@@ -38,7 +41,10 @@ std::assert_single(input: SET OF anytype) -> OPTIONAL anytype
 # -----------------------------------------------------------------
 
 CREATE FUNCTION
-std::assert_exists(input: SET OF anytype) -> SET OF anytype
+std::assert_exists(
+    input: SET OF anytype,
+    NAMED ONLY message: OPTIONAL str = <str>{},
+) -> SET OF anytype
 {
     CREATE ANNOTATION std::description :=
         "Check that the input set contains at least one element, raise
@@ -53,7 +59,10 @@ std::assert_exists(input: SET OF anytype) -> SET OF anytype
 # ------------------------------------------------------
 
 CREATE FUNCTION
-std::assert_distinct(input: SET OF anytype) -> SET OF anytype
+std::assert_distinct(
+    input: SET OF anytype,
+    NAMED ONLY message: OPTIONAL str = <str>{},
+) -> SET OF anytype
 {
     CREATE ANNOTATION std::description :=
         "Check that the input set is a proper set, i.e. all elements

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2140,7 +2140,7 @@ def process_set_as_singleton_assertion(
     expr = ir_set.expr
     assert isinstance(expr, irast.FunctionCall)
 
-    ir_arg = expr.args[0]
+    ir_arg = expr.args[1]
     ir_arg_set = ir_arg.expr
 
     if ir_arg.cardinality.is_single():
@@ -2154,6 +2154,8 @@ def process_set_as_singleton_assertion(
     with ctx.subrel() as newctx:
         arg_ref = dispatch.compile(ir_arg_set, ctx=newctx)
         arg_val = output.output_as_value(arg_ref, env=newctx.env)
+
+        msg = dispatch.compile(expr.args[0].expr, ctx=newctx)
 
         # Generate a singleton set assertion as the following SQL:
         #
@@ -2185,9 +2187,14 @@ def process_set_as_singleton_assertion(
                 pgast.StringConstant(val='cardinality_violation'),
                 pgast.NamedFuncArg(
                     name='msg',
-                    val=pgast.StringConstant(
-                        val='assert_single violation: more than one element '
-                            'returned by an expression',
+                    val=pgast.CoalesceExpr(
+                        args=[
+                            msg,
+                            pgast.StringConstant(
+                                val='assert_single violation: more than one '
+                                    'element returned by an expression',
+                            ),
+                        ],
                     ),
                 ),
                 pgast.NamedFuncArg(
@@ -2236,7 +2243,7 @@ def process_set_as_existence_assertion(
     expr = ir_set.expr
     assert isinstance(expr, irast.FunctionCall)
 
-    ir_arg = expr.args[0]
+    ir_arg = expr.args[1]
     ir_arg_set = ir_arg.expr
 
     if not ir_arg.cardinality.can_be_zero():
@@ -2255,6 +2262,9 @@ def process_set_as_existence_assertion(
         pathctx.put_path_id_map(newctx.rel, ir_set.path_id, ir_arg_set.path_id)
         arg_ref = dispatch.compile(ir_arg_set, ctx=newctx)
         arg_val = output.output_as_value(arg_ref, env=newctx.env)
+
+        msg = dispatch.compile(expr.args[0].expr, ctx=newctx)
+
         set_expr = pgast.FuncCall(
             name=('edgedb', 'raise_on_null'),
             args=[
@@ -2262,9 +2272,14 @@ def process_set_as_existence_assertion(
                 pgast.StringConstant(val='cardinality_violation'),
                 pgast.NamedFuncArg(
                     name='msg',
-                    val=pgast.StringConstant(
-                        val='assert_exists violation: expression returned '
-                            'an empty set',
+                    val=pgast.CoalesceExpr(
+                        args=[
+                            msg,
+                            pgast.StringConstant(
+                                val='assert_exists violation: expression '
+                                    'returned an empty set',
+                            ),
+                        ]
                     ),
                 ),
                 pgast.NamedFuncArg(
@@ -2314,7 +2329,7 @@ def process_set_as_multiplicity_assertion(
     expr = ir_set.expr
     assert isinstance(expr, irast.FunctionCall)
 
-    ir_arg = expr.args[0]
+    ir_arg = expr.args[1]
     ir_arg_set = ir_arg.expr
 
     if not ir_arg.multiplicity.is_many():
@@ -2369,6 +2384,8 @@ def process_set_as_multiplicity_assertion(
                 )
             )
 
+        msg = dispatch.compile(expr.args[0].expr, ctx=newctx)
+
         do_raise = pgast.FuncCall(
             name=('edgedb', 'raise'),
             args=[
@@ -2382,9 +2399,14 @@ def process_set_as_multiplicity_assertion(
                 pgast.StringConstant(val='cardinality_violation'),
                 pgast.NamedFuncArg(
                     name='msg',
-                    val=pgast.StringConstant(
-                        val='assert_distinct violation: expression returned '
-                            'a set with duplicate elements',
+                    val=pgast.CoalesceExpr(
+                        args=[
+                            msg,
+                            pgast.StringConstant(
+                                val='assert_distinct violation: expression '
+                                    'returned a set with duplicate elements',
+                            ),
+                        ],
                     ),
                 ),
                 pgast.NamedFuncArg(

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -7582,6 +7582,17 @@ aa \
                 };
             """)
 
+        async with self.assertRaisesRegexTx(
+            edgedb.CardinalityViolationError,
+            "custom message",
+        ):
+            await self.con.query("""
+                SELECT assert_single(
+                    (SELECT User FILTER .name ILIKE "Hunter B%"),
+                    message := "custom message",
+                );
+            """)
+
     async def test_edgeql_assert_single_no_op(self):
         await self.con.query("""
             SELECT assert_single(1)
@@ -7703,6 +7714,17 @@ aa \
             await self.con.query("""
                 SELECT assert_exists(
                     (SELECT User FILTER .name = "nonexistent")
+                ).name;
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.CardinalityViolationError,
+            "custom message",
+        ):
+            await self.con.query("""
+                SELECT assert_exists(
+                    (SELECT User FILTER .name = "nonexistent"),
+                    message := "custom message",
                 ).name;
             """)
 
@@ -7840,6 +7862,14 @@ aa \
         ):
             await self.con.query("""
                 SELECT assert_distinct({(), ()});
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "custom message",
+        ):
+            await self.con.query("""
+                SELECT assert_distinct({(), ()}, message := "custom message");
             """)
 
     async def test_edgeql_assert_distinct_no_op(self):


### PR DESCRIPTION
The `assert_exists`, `assert_distinct` and `assert_single` now accept an
optional `message` named-only argument that allows changing the default
error text to something more specific.