### PR TITLE
Fix casting `date_duration` to `str` and `json`.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_01_00_00
+EDGEDB_CATALOG_VERSION = 2022_07_05_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -1275,7 +1275,14 @@ CREATE CAST FROM cal::relative_duration TO std::str {
 
 CREATE CAST FROM cal::date_duration TO std::str {
     SET volatility := 'Immutable';
-    USING SQL CAST;
+    # We want the 0 date_duration canonically represented be in lowest
+    # date_duration units, i.e. in days.
+    USING SQL $$
+    SELECT CASE WHEN (val = '0'::interval)
+        THEN 'P0D'
+        ELSE val::text
+    END
+    $$;
 };
 
 
@@ -1306,6 +1313,14 @@ CREATE CAST FROM cal::relative_duration TO std::json {
 CREATE CAST FROM cal::date_duration TO std::json {
     SET volatility := 'Immutable';
     USING SQL FUNCTION 'to_jsonb';
+    # We want the 0 date_duration canonically represented be in lowest
+    # date_duration units, i.e. in days.
+    USING SQL $$
+    SELECT CASE WHEN (val = '0'::interval)
+        THEN to_jsonb('P0D'::text)
+        ELSE to_jsonb(val)
+    END
+    $$;
 };
 
 

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -240,6 +240,17 @@ class TestEdgeQLDT(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
+            r"SELECT <str><cal::date_duration>'0 days'",
+            ['P0D'],
+        )
+
+        await self.assert_query_result(
+            r"SELECT <json><cal::date_duration>'0 days'",
+            ['P0D'],
+            ['"P0D"'],
+        )
+
+        await self.assert_query_result(
             r"""
             WITH
                 dt := <datetime>'2000-01-01T00:00:00Z',


### PR DESCRIPTION
When casting `cal::date_duration` of "0 days" to `str` or `json`, the
canonical representation should use the smallest valid units - days.