### PR TITLE
Fix major bootstrap perf regression caused by making casts strict

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_06_01_00
+EDGEDB_CATALOG_VERSION = 2022_07_06_02_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -2539,6 +2539,9 @@ CREATE CAST FROM std::float32 TO std::decimal {
                        AND val != '-Infinity'
             THEN
                 val::numeric
+            WHEN val IS NULL
+            THEN
+                NULL::numeric
             ELSE
                 edgedb.raise(
                     NULL::numeric,
@@ -2584,6 +2587,9 @@ CREATE CAST FROM std::float64 TO std::decimal {
                        AND val != '-Infinity'
             THEN
                 val::numeric
+            WHEN val IS NULL
+            THEN
+                NULL::numeric
             ELSE
                 edgedb.raise(
                     NULL::numeric,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1743,11 +1743,18 @@ class CastCommand(MetaCommand):
 
         returns = types.pg_type_from_object(schema, cast.get_to_type(schema))
 
+        # N.B: Semantically, strict *ought* to be true, since we want
+        # all of our casts to have strict behavior. Unfortunately,
+        # actually marking them as strict causes a huge performance
+        # regression when bootstrapping (and probably anything else that
+        # is heavy on json casts), so instead we just need to make sure
+        # to write cast code that is naturally strict (this is enforced
+        # by test_edgeql_casts_all_null).
         return dbops.Function(
             name=name,
             args=args,
             returns=returns,
-            strict=True,
+            strict=False,
             text=cast.get_code(schema),
         )
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -451,6 +451,7 @@ class StrToConfigMemoryFunction(dbops.Function):
                 ('val', ('text',)),
             ],
             returns=('edgedb', 'memory_t'),
+            strict=True,
             volatility='immutable',
             language='sql',
             text=self.text,
@@ -2692,6 +2693,7 @@ class StrToBool(dbops.Function):
             name=('edgedb', 'str_to_bool'),
             args=[('val', ('text',))],
             returns=('bool',),
+            strict=True,
             # Stable because it's raising exceptions.
             volatility='stable',
             text=self.text)

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -791,6 +791,8 @@ class ConnectedTestCaseMixin:
                 res, exp_result_json, self.fail, message=msg)
         except Exception:
             self.add_fail_notes(serialization='json')
+            if msg:
+                self.add_fail_notes(msg=msg)
             raise
 
         if json_only:
@@ -822,6 +824,8 @@ class ConnectedTestCaseMixin:
                 serialization='binary',
                 __typenames__=typenames,
                 __typeids__=typeids)
+            if msg:
+                self.add_fail_notes(msg=msg)
             raise
 
 


### PR DESCRIPTION
f64b9fe579a7a106ed331e1094115801ed5cdc8e made casts strict, since some
new tests for casting empty ranges discovered that float->decimal
casts misbehaved if NULL got past as an input.

This caused a huge bootstrap perf regression, though, probably because
it slowed down casts from json that are used very heavily in the
schema modification code.

So instead we make the cast functions not strict and must instead make
sure that all cast functions behave correctly on NULL input.

To make sure that we don't have any future issues along these lines,
add a test that enumerates all casts and attempts to do a cast of a
value that comes directly from an empty property (which should
actually be represented as a NULL). This found a couple more
cases that were mishandled.