### PR TITLE
Fix stringification of zero-equivalent date durations

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_06_01_00
+EDGEDB_CATALOG_VERSION = 2022_07_06_02_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -1278,7 +1278,7 @@ CREATE CAST FROM cal::date_duration TO std::str {
     # We want the 0 date_duration canonically represented be in lowest
     # date_duration units, i.e. in days.
     USING SQL $$
-    SELECT CASE WHEN (val = '0'::interval)
+    SELECT CASE WHEN (val::text = 'PT0S')
         THEN 'P0D'
         ELSE val::text
     END
@@ -1316,7 +1316,7 @@ CREATE CAST FROM cal::date_duration TO std::json {
     # We want the 0 date_duration canonically represented be in lowest
     # date_duration units, i.e. in days.
     USING SQL $$
-    SELECT CASE WHEN (val = '0'::interval)
+    SELECT CASE WHEN (val::text = 'PT0S')
         THEN to_jsonb('P0D'::text)
         ELSE to_jsonb(val)
     END

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -251,6 +251,12 @@ class TestEdgeQLDT(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
+            r"SELECT <json><cal::date_duration>'5 months -150 days'",
+            ['P5M-150D'],
+            ['"P5M-150D"'],
+        )
+
+        await self.assert_query_result(
             r"""
             WITH
                 dt := <datetime>'2000-01-01T00:00:00Z',


### PR DESCRIPTION
A `date_duration` that is equal to zero will not necessarily contain all
zero fields, such as a `5 months -150 days` duration.