### PR TITLE
Allow connecting to `__edgedbsys__` in read-only mode

### DIFF
--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -117,3 +117,14 @@ class AlterDatabase(DatabaseCommand, sd.AlterObject[Database]):
 
 class DropDatabase(DatabaseCommand, sd.DeleteExternalObject[Database]):
     astnode = qlast.DropDatabase
+
+    def _validate_legal_command(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> None:
+        super()._validate_legal_command(schema, context)
+        if self.classname.name in s_def.EDGEDB_SPECIAL_DBS:
+            raise errors.ExecutionError(
+                f"database {self.classname.name!r} cannot be dropped"
+            )

--- a/edb/schema/defines.py
+++ b/edb/schema/defines.py
@@ -29,3 +29,9 @@ MAX_NAME_LENGTH = 63 - MAX_TENANT_ID_LENGTH - 1 - 1
 
 # Maximum number of arguments supported by SQL functions.
 MAX_FUNC_ARG_COUNT = 100
+
+EDGEDB_SUPERUSER = 'edgedb'
+EDGEDB_TEMPLATE_DB = '__edgedbtpl__'
+EDGEDB_SYSTEM_DB = '__edgedbsys__'
+
+EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3643,6 +3643,7 @@ class DeleteExternalObject(
         schema: s_schema.Schema,
         context: CommandContext,
     ) -> s_schema.Schema:
+        self._validate_legal_command(schema, context)
         return schema
 
     def _delete_innards(

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -217,3 +217,14 @@ class AlterRole(RoleCommand, inheriting.AlterInheritingObject[Role]):
 
 class DeleteRole(RoleCommand, inheriting.DeleteInheritingObject[Role]):
     astnode = qlast.DropRole
+
+    def _validate_legal_command(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> None:
+        super()._validate_legal_command(schema, context)
+        if self.classname.name == s_def.EDGEDB_SUPERUSER:
+            raise errors.ExecutionError(
+                f"role {self.classname.name!r} cannot be dropped"
+            )

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1094,7 +1094,10 @@ async def _compile_sys_queries(
     _, sql = compile_bootstrap_script(
         compiler,
         schema,
-        'SELECT (SELECT sys::Database FILTER NOT .builtin).name',
+        f"""SELECT (
+            SELECT sys::Database
+            FILTER .name != "{edbdef.EDGEDB_TEMPLATE_DB}"
+        ).name""",
         expected_cardinality_one=False,
     )
 

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -148,6 +148,8 @@ cdef class DatabaseConnectionView:
         bint _in_tx_with_set
         bint _tx_error
 
+        uint64_t _capability_mask
+
         object _last_comp_state
         int _last_comp_state_id
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -20,19 +20,20 @@
 from __future__ import annotations
 
 from edb import buildmeta
+from edb.schema import defines as s_def
 
 
 EDGEDB_PORT = 5656
 EDGEDB_REMOTE_COMPILER_PORT = 5660
 EDGEDB_SUPERGROUP = 'edgedb_supergroup'
-EDGEDB_SUPERUSER = 'edgedb'
-EDGEDB_TEMPLATE_DB = '__edgedbtpl__'
+EDGEDB_SUPERUSER = s_def.EDGEDB_SUPERUSER
+EDGEDB_TEMPLATE_DB = s_def.EDGEDB_TEMPLATE_DB
 EDGEDB_SUPERUSER_DB = 'edgedb'
-EDGEDB_SYSTEM_DB = '__edgedbsys__'
+EDGEDB_SYSTEM_DB = s_def.EDGEDB_SYSTEM_DB
 EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
-EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
+EDGEDB_SPECIAL_DBS = s_def.EDGEDB_SPECIAL_DBS
 
 EDGEDB_CATALOG_VERSION = buildmeta.EDGEDB_CATALOG_VERSION
 MIN_POSTGRES_VERSION = (13, 0)

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -466,10 +466,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         logger.debug('received connection request by %s to database %s',
                      user, database)
 
-        if database in edbdef.EDGEDB_SPECIAL_DBS:
-            # Prevent connections to internal system databases,
-            # which only purpose is to serve as a template for new
-            # databases.
+        if database == edbdef.EDGEDB_TEMPLATE_DB:
+            # Prevent connections to the template database.
             raise errors.AccessError(
                 f'database {database!r} does not '
                 f'accept connections'

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1832,6 +1832,9 @@ class Server(ha_base.ClusterProtocol):
 
         dbs = {}
         for db in self._dbindex.iter_dbs():
+            if db.name in defines.EDGEDB_SPECIAL_DBS:
+                continue
+
             dbs[db.name] = dict(
                 name=db.name,
                 dbver=db.dbver,

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1648,7 +1648,7 @@ class _EdgeDBServer:
         self.proc: asyncio.Process = await asyncio.create_subprocess_exec(
             *cmd,
             env=env,
-            stdout=subprocess.PIPE,
+            stdout=subprocess.PIPE if not self.debug else None,
             stderr=subprocess.STDOUT,
             pass_fds=(status_w.fileno(),),
         )
@@ -1734,7 +1734,7 @@ def start_edgedb_server(
     compiler_pool_size: int=2,
     compiler_pool_mode: Optional[edgedb_args.CompilerPoolMode] = None,
     adjacent_to: Optional[tconn.Connection]=None,
-    debug: bool=False,
+    debug: bool=debug.flags.server,
     backend_dsn: Optional[str] = None,
     runstate_dir: Optional[str] = None,
     data_dir: Optional[str] = None,


### PR DESCRIPTION
The `__edgedbsys__` database now allows read-only connections.  Since
`__edgedbsys__` cannot be dropped it represents an always-available
connection destination for cases where the target database name is
uncertain.

We also explicitly prohibit deletion of system databases and the
superuser role here.