### PR TITLE
Expose instance name as `sys::get_instance_name()`

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_06_02_00
+EDGEDB_CATALOG_VERSION = 2022_07_07_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -95,7 +95,9 @@ sys::__version_internal() -> tuple<major: std::int64,
         (SELECT coalesce(array_agg(el), ARRAY[]::text[])
          FROM jsonb_array_elements_text(v -> 'local') AS el)
     FROM
-        edgedb._sys_version() as v
+        (SELECT
+            pg_catalog.current_setting('edgedb.server_version')::jsonb AS v
+        ) AS q
     $$;
 };
 
@@ -136,6 +138,16 @@ sys::get_version_as_str() -> std::str
             ++ (('+' ++ std::array_join(v.local, '.')) IF len(v.local) > 0
                 ELSE '')
     );
+};
+
+
+CREATE FUNCTION sys::get_instance_name() -> std::str{
+    CREATE ANNOTATION std::description :=
+        'Return the server instance name.';
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT pg_catalog.current_setting('edgedb.instance_name');
+    $$;
 };
 
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3782,29 +3782,6 @@ class ApplySessionConfigFunction(dbops.Function):
         )
 
 
-class SysVersionFunction(dbops.Function):
-
-    text = f'''
-        BEGIN
-        RETURN (
-            SELECT value
-            FROM _edgecon_state
-            WHERE name = 'server_version' AND type = 'R'
-        );
-        END;
-    '''
-
-    def __init__(self) -> None:
-        super().__init__(
-            name=('edgedb', '_sys_version'),
-            args=[],
-            returns=('jsonb',),
-            language='plpgsql',
-            volatility='stable',
-            text=self.text,
-        )
-
-
 class SysGetTransactionIsolation(dbops.Function):
     "Get transaction isolation value as text compatible with EdgeDB's enum."
     text = r'''
@@ -4064,7 +4041,6 @@ async def bootstrap(
         dbops.CreateFunction(PostgresConfigValueToJsonFunction()),
         dbops.CreateFunction(SysConfigFullFunction()),
         dbops.CreateFunction(SysConfigFunction()),
-        dbops.CreateFunction(SysVersionFunction()),
         dbops.CreateFunction(ResetSessionConfigFunction()),
         dbops.CreateFunction(ApplySessionConfigFunction(config_spec)),
         dbops.CreateFunction(SysGetTransactionIsolation()),

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -199,7 +199,7 @@ class ServerConfig(NamedTuple):
     binary_endpoint_security: ServerEndpointSecurityMode
     http_endpoint_security: ServerEndpointSecurityMode
 
-    instance_name: Optional[str]
+    instance_name: str
 
     backend_capability_sets: BackendCapabilitySets
 
@@ -1203,6 +1203,12 @@ def parse_args(**kwargs: Any):
             kwargs['admin_ui'] = 'disabled'
 
     kwargs['admin_ui'] = kwargs['admin_ui'] == 'enabled'
+
+    if not kwargs['instance_name']:
+        if devmode.is_in_dev_mode():
+            kwargs['instance_name'] = '_localdev'
+        else:
+            kwargs['instance_name'] = '_unknown'
 
     return ServerConfig(
         startup_script=startup_script,

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -219,6 +219,7 @@ class BaseCluster:
             'timezone': 'UTC',
             'intervalstyle': 'iso_8601',
             'jit': 'off',
+            'default_transaction_isolation': 'serializable',
         }
 
         conn_dict['server_settings'] = {**cluster_settings, **edgedb_settings}

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -151,7 +151,7 @@ class Server(ha_base.ClusterProtocol):
         default_auth_method: srvargs.ServerAuthMethods = (
             srvargs.DEFAULT_AUTH_METHODS),
         admin_ui: bool = False,
-        instance_name: Optional[str] = None,
+        instance_name: str,
     ):
         self.__loop = asyncio.get_running_loop()
         self._config_settings = config.get_settings()
@@ -292,6 +292,9 @@ class Server(ha_base.ClusterProtocol):
 
     def get_tenant_id(self):
         return self._tenant_id
+
+    def get_instance_name(self):
+        return self._instance_name
 
     def in_dev_mode(self):
         return self._devmode


### PR DESCRIPTION
The new `sys::get_instance_name()` function returns the instance name
configured for the server, or `_localdev` for development instances, or
`_unknown` otherwise.

While at it, replace the use of temporary table for server metadata with
custom Postgres GUC variables.