### PR TITLE
Remove the `/ui/instance-info` endpoint

### DIFF
--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -446,15 +446,8 @@ cdef class HttpProtocol:
 
             extname = path_parts[2] if path_parts_len > 2 else None
 
-            if (
-                # Binary proto tunnelled through HTTP
-                (extname is None and request.method == b'POST')
-                # Legacy admin UI "extension" path for same
-                or (
-                    extname == 'admin_binary_http'
-                    and self.server.is_admin_ui_enabled()
-                )
-            ):
+            # Binary proto tunnelled through HTTP
+            if extname is None and request.method == b'POST':
                 if (
                     debug.flags.http_inject_cors
                     and request.method == b'OPTIONS'

--- a/edb/server/protocol/ui_ext.pyx
+++ b/edb/server/protocol/ui_ext.pyx
@@ -57,23 +57,6 @@ async def handle_request(
     server,
 ):
     try:
-        if path_parts == ['instance-info']:
-            # endpoint for data that either cannot be fetched by an edgeql query
-            # or is needed to make a connection to send queries
-            response.status = http.HTTPStatus.OK
-            response.content_type = b'application/json'
-            response.body = json.dumps({
-                'instance_name': server._instance_name if
-                    server._instance_name is not None else
-                    ('_localdev' if server.in_dev_mode() else None),
-                'databases': [
-                    {'name': db.name}
-                    for db in server._dbindex.iter_dbs()
-                ],
-                'roles': list(server._roles.keys()),
-            }).encode()
-            return
-
         if path_parts == []:
             path_parts = ['index.html']
 


### PR DESCRIPTION
It is insecure and the necessary data can be queried by connecting to
`__edgedbsys__` with correct authentication and running introspection
queries.

Depends on #4039 and #4041 