### PR TITLE
Protect protocol tests from concurrent execution on the same db

### DIFF
--- a/edb/testbase/protocol/test.py
+++ b/edb/testbase/protocol/test.py
@@ -26,6 +26,9 @@ from edb.protocol import protocol  # type: ignore
 
 class ProtocolTestCase(server.DatabaseTestCase):
 
+    PARALLELISM_GRANULARITY = 'database'
+    BASE_TEST_CLASS = True
+
     def setUp(self):
         self.con = self.loop.run_until_complete(
             protocol.new_connection(


### PR DESCRIPTION
Protocol tests use DDL, and so concurrent test runners must not share
the same database.