### PR TITLE
Add dump tests for new 2.0 types/features

### DIFF
--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -702,7 +702,11 @@ class TypeSerializer:
             return ArrayDesc(
                 tid=tid, dim_len=dim_len, subtype=codecs_list[pos])
 
-        elif (t >= 0x80 and t <= 0xff):
+        elif t == CTYPE_RANGE:
+            pos = desc.read_ui16()
+            return RangeDesc(tid=tid, inner=codecs_list[pos])
+
+        elif (t[0] >= 0x80 and t[0] <= 0xff):
             # Ignore all type annotations.
             desc.read_len32_prefixed_bytes()
             return None
@@ -1035,6 +1039,11 @@ class EnumDesc(TypeDesc):
 class ArrayDesc(SetDesc):
     dim_len: int
     impl: typing.ClassVar[type] = list
+
+
+@dataclasses.dataclass(frozen=True)
+class RangeDesc(TypeDesc):
+    inner: TypeDesc
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/schemas/dump04_default.esdl
+++ b/tests/schemas/dump04_default.esdl
@@ -23,3 +23,31 @@ type Test1 {
         default := <array<tuple<name: str, severity: int16>>>[]
     };
 };
+
+type Test2 {
+    property range_of_int -> range<int64>;
+    property range_of_date -> range<datetime>;
+    property date_duration -> cal::date_duration;
+
+    access policy test allow all using (true);
+};
+
+
+type TargetA {
+    required property name -> str {
+        constraint exclusive;
+    }
+}
+
+type SourceA {
+    required property name -> str {
+        constraint exclusive;
+    }
+
+    link link1 -> TargetA {
+        on source delete delete target;
+    };
+    link link2 -> TargetA {
+        on source delete delete target if orphan;
+    };
+};

--- a/tests/schemas/dump04_default.esdl
+++ b/tests/schemas/dump04_default.esdl
@@ -32,6 +32,11 @@ type Test2 {
     access policy test allow all using (true);
 };
 
+global foo -> str;
+required global bar -> int64 {
+    default := -1;
+};
+global baz := (select TargetA filter .name = global foo);
 
 type TargetA {
     required property name -> str {

--- a/tests/schemas/dump04_setup.edgeql
+++ b/tests/schemas/dump04_setup.edgeql
@@ -1,1 +1,20 @@
 INSERT Test1;  # https://github.com/edgedb/edgedb/issues/2606
+
+INSERT Test2 {
+    range_of_int := range(-1, 10),
+    range_of_date := range(
+        <datetime>'2010-12-27T23:59:59-07:00',
+        <datetime>'2012-12-27T23:59:59-07:00',
+    ),
+    date_duration := <cal::date_duration>'1month 3days',
+};
+
+INSERT TargetA {name := 't0'};
+INSERT TargetA {name := 't1'};
+INSERT TargetA {name := 't2'};
+
+INSERT SourceA {name := 's0', link1 := (SELECT TargetA FILTER .name = 't0')};
+INSERT SourceA {name := 's1', link1 := (SELECT TargetA FILTER .name = 't1')};
+INSERT SourceA {name := 's2', link1 := (SELECT TargetA FILTER .name = 't1')};
+INSERT SourceA {name := 's3', link2 := (SELECT TargetA FILTER .name = 't2')};
+INSERT SourceA {name := 's4', link2 := (SELECT TargetA FILTER .name = 't2')};

--- a/tests/test_dump04.py
+++ b/tests/test_dump04.py
@@ -35,7 +35,7 @@ class DumpTestCaseMixin:
             await tx.rollback()
 
     async def _ensure_schema_data_integrity(self):
-        # Make sure access policies came in
+        # Validate access policies
         await self.assert_query_result(
             r'''
             SELECT schema::ObjectType {access_policies: {name}}
@@ -43,6 +43,36 @@ class DumpTestCaseMixin:
             ''',
             [
                 {'access_policies': [{'name': 'test'}]},
+            ],
+        )
+
+        # Validate globals
+        await self.assert_query_result(
+            r'''
+            SELECT schema::Global {
+                name, tgt := .target.name, required, default
+            }
+            ORDER BY .name
+            ''',
+            [
+                {
+                    'name': 'default::bar',
+                    'tgt': 'std::int64',
+                    'required': True,
+                    'default': '-1',
+                },
+                {
+                    'name': 'default::baz',
+                    'tgt': 'default::baz',
+                    'required': False,
+                    'default': None,
+                },
+                {
+                    'name': 'default::foo',
+                    'tgt': 'std::str',
+                    'required': False,
+                    'default': None,
+                },
             ],
         )
 

--- a/tests/test_dump04.py
+++ b/tests/test_dump04.py
@@ -19,6 +19,8 @@
 
 import os.path
 
+import edgedb
+
 from edb.testbase import server as tb
 
 
@@ -33,7 +35,54 @@ class DumpTestCaseMixin:
             await tx.rollback()
 
     async def _ensure_schema_data_integrity(self):
-        pass
+        # Make sure access policies came in
+        await self.assert_query_result(
+            r'''
+            SELECT schema::ObjectType {access_policies: {name}}
+            FILTER .name = 'default::Test2';
+            ''',
+            [
+                {'access_policies': [{'name': 'test'}]},
+            ],
+        )
+
+        # Test that on source delete all work correctly still
+        await self.con.execute(r'DELETE SourceA FILTER .name = "s0"')
+
+        await self.assert_query_result(
+            r'''
+            SELECT TargetA {name}
+            FILTER .name = 't0';
+            ''',
+            [],
+        )
+
+        # Should trigger a cascade that then causes a link policy error
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                r'prohibited by link target policy'):
+            async with self.con.transaction():
+                await self.con.execute(r'DELETE SourceA FILTER .name = "s1"')
+
+        # Shouldn't delete anything
+        await self.con.execute(r'DELETE SourceA FILTER .name = "s3"')
+        await self.assert_query_result(
+            r'''
+            SELECT TargetA {name}
+            FILTER .name = 't2';
+            ''',
+            [{'name': 't2'}],
+        )
+
+        # But deleting the last reamining one should
+        await self.con.execute(r'DELETE SourceA FILTER .name = "s4"')
+        await self.assert_query_result(
+            r'''
+            SELECT TargetA {name}
+            FILTER .name = 't2';
+            ''',
+            [],
+        )
 
 
 class TestDump04(tb.StableDumpTestCase, DumpTestCaseMixin):
@@ -50,3 +99,12 @@ class TestDump04(tb.StableDumpTestCase, DumpTestCaseMixin):
     async def test_dump04_dump_restore(self):
         await self.check_dump_restore(
             DumpTestCaseMixin.ensure_schema_data_integrity)
+
+
+class TestDump04Compat(
+    tb.DumpCompatTestCase,
+    DumpTestCaseMixin,
+    dump_subdir='dump04',
+    check_method=DumpTestCaseMixin.ensure_schema_data_integrity,
+):
+    pass


### PR DESCRIPTION
Set up the test so that it will do compatability dump tests as soon as
we add 2.0 dump snapshots.

Also, fix a sertypes bug it found.