### PR TITLE
Fix globals with empty str/bytes values

### DIFF
--- a/edb/common/binwrapper.py
+++ b/edb/common/binwrapper.py
@@ -111,3 +111,10 @@ class BinWrapper:
     def read_len32_prefixed_bytes(self) -> bytes:
         size = self.read_ui32()
         return self.read_bytes(size)
+
+    def read_nullable_len32_prefixed_bytes(self) -> bytes | None:
+        size = self.read_i32()
+        if size == -1:
+            return None
+        else:
+            return self.read_bytes(size)

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -523,9 +523,11 @@ def _compile_config_value(
                     name=('record_send',),
                     args=[pgast.RowExpr(args=[val])],
                 ),
-                # The first twelve bytes are header, the rest is the
-                # encoding of the actual element
-                pgast.NumericConstant(val="13"),
+                # The first 8 bytes are header, then 4 bytes are the length
+                # of our element, then the encoding of our actual element.
+                # We include the length so we can distinguish NULL (len=-1)
+                # from empty strings and the like (len=0).
+                pgast.NumericConstant(val="9"),
             ],
         )
         cast_name = s_casts.get_cast_fullname_from_names(

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -121,7 +121,10 @@ class Operation(NamedTuple):
             return None
         else:
             assert isinstance(self.value, str)
-            return base64.b64decode(self.value)
+            b = base64.b64decode(self.value)
+            # Input comes prefixed with length; if the length is -1,
+            # the value has explicitly been set to {}.
+            return b[4:] if b[:4] != b'\xff\xff\xff\xff' else None
 
     def apply(self, spec: spec.Spec, storage: SettingsMap) -> SettingsMap:
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -662,7 +662,7 @@ cdef class DatabaseConnectionView:
         )
 
     cdef inline recode_global(self, serializer, k, v):
-        if v[:4] == b'\x00\x00\x00\x01':
+        if v and v[:4] == b'\x00\x00\x00\x01':
             array_type_id = serializer.get_global_array_type_id(k)
             if array_type_id:
                 va = bytearray(v)

--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -209,14 +209,14 @@ cdef _inject_globals(
         entry = state_globals.get(name)
         if entry:
             val = entry.value
-        if val:
+        if val is not None:
             out_buf.write_int32(len(val))
             out_buf.write_bytes(val)
         else:
             out_buf.write_int32(-1)
         if has_present_arg:
             out_buf.write_int32(1)
-            present = b'\x01' if val is not None else b'\x00'
+            present = b'\x01' if entry is not None else b'\x00'
             out_buf.write_bytes(present)
 
 

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -354,3 +354,20 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             r'''select global cur_user''',
             ['test!!!']
         )
+
+    async def test_edgeql_globals_11(self):
+        await self.con.execute('''
+            set global cur_user := "";
+        ''')
+        await self.assert_query_result(
+            r'''select global cur_user''',
+            ['']
+        )
+
+        await self.con.execute('''
+            set global cur_user := {};
+        ''')
+        await self.assert_query_result(
+            r'''select global cur_user''',
+            []
+        )


### PR DESCRIPTION
Currently we implement SET GLOBAL by calling record_send and slicing
off the header and field length, and only storing the encoding
bytes. An empty encoding bytestring is treated as {}. This is
incorrect, because that is the valid encoding of the empty string and
the empty bytes, which are distinguished from NULL by the *length*
field, which is -1 for NULL.

Handle all of this properly by extracting and decoding the length
field and by storing {} values as `None` in the global state, not as
`b''`.