### PR TITLE
Treat `ABORT MIGRATION` as `ROLLBACK` when in error state

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1957,7 +1957,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         _dbview = self.get_dbview()
 
-        query_unit_group = await _dbview.compile(query_req)
+        compiled = await _dbview.parse(query_req)
+        query_unit_group = compiled.query_unit_group
         assert len(query_unit_group) == 1
         query_unit = query_unit_group[0]
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11065,3 +11065,21 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
                 }
             """
         )
+
+    async def test_edgeql_migration_recovery(self):
+        await self.con.execute(r"""
+            START MIGRATION TO {
+                module test {
+                    type Foo;
+                }
+            };
+        """)
+
+        with self.assertRaises(edgedb.EdgeQLSyntaxError):
+            await self.con.execute(r"""
+                ALTER TYPE Foo;
+            """)
+
+        await self.con.execute("ABORT MIGRATION")
+
+        self.assertEqual(await self.con.query_single("SELECT 1"), 1)

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1255,7 +1255,7 @@ class TestServerProto(tb.QueryTestCase):
             await con.query('SELECT 1 / 0')
 
         await con.query('ROLLBACK')
-        self.assertEqual(self.con._get_last_status(), 'ROLLBACK')
+        self.assertEqual(self.con._get_last_status(), 'ROLLBACK TRANSACTION')
 
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
@@ -1376,6 +1376,12 @@ class TestServerProto(tb.QueryTestCase):
             with self.assertRaisesRegex(
                     edgedb.TransactionError, "current transaction is aborted"):
                 await self.con.execute('SELECT 1;')
+
+            # Test that syntax errors are not papered over by
+            # a TransactionError.
+            with self.assertRaisesRegex(
+                    edgedb.EdgeQLSyntaxError, "Unexpected 'ROLLBA'"):
+                await self.con.execute('ROLLBA;')
 
         finally:
             await self.con.query('ROLLBACK')


### PR DESCRIPTION
If the corresponding `START MIGRATION TO` started a transaction (as
opposed to a savepoint), then `ABORT MIGRATION` should be allowed to
recover the session like `ROLLBACK`, because that's exactly what it
does.

Also, clean up the relevant code so that it tests for rollback
attributes on the returned query unit instead of going through a
dedicated utility compilation step.  Avoid masking syntax errors and
ISEs with a `TransactionError`.

Fixes: #4056