### PR TITLE
Fix abort migration in transactions

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1381,7 +1381,7 @@ class Compiler:
             if mstate.initial_savepoint:
                 current_tx.abort_migration(mstate.initial_savepoint)
                 sql = (b'SELECT LIMIT 0',)
-                tx_action = None
+                tx_action = dbstate.TxAction.ROLLBACK_TO_SAVEPOINT
             else:
                 tx_cmd = qlast.RollbackTransaction()
                 tx_query = self._compile_ql_transaction(ctx, tx_cmd)
@@ -1899,6 +1899,9 @@ class Compiler:
                     unit.tx_commit = True
                 elif comp.tx_action == dbstate.TxAction.ROLLBACK:
                     unit.tx_rollback = True
+                elif comp.tx_action == dbstate.TxAction.ROLLBACK_TO_SAVEPOINT:
+                    unit.tx_savepoint_rollback = True
+                    unit.sp_name = dbstate.ABORT_MIGRATION_SAVEPOINT
 
             elif isinstance(comp, dbstate.SessionStateQuery):
                 unit.sql = comp.sql

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1381,7 +1381,10 @@ class Compiler:
             if mstate.initial_savepoint:
                 current_tx.abort_migration(mstate.initial_savepoint)
                 sql = (b'SELECT LIMIT 0',)
-                tx_action = dbstate.TxAction.ROLLBACK_TO_SAVEPOINT
+                if in_script:
+                    tx_action = None
+                else:
+                    tx_action = dbstate.TxAction.ROLLBACK_TO_SAVEPOINT
             else:
                 tx_cmd = qlast.RollbackTransaction()
                 tx_query = self._compile_ql_transaction(ctx, tx_cmd)

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1381,10 +1381,7 @@ class Compiler:
             if mstate.initial_savepoint:
                 current_tx.abort_migration(mstate.initial_savepoint)
                 sql = (b'SELECT LIMIT 0',)
-                if in_script:
-                    tx_action = None
-                else:
-                    tx_action = dbstate.TxAction.ROLLBACK_TO_SAVEPOINT
+                tx_action = None
             else:
                 tx_cmd = qlast.RollbackTransaction()
                 tx_query = self._compile_ql_transaction(ctx, tx_cmd)
@@ -1902,9 +1899,8 @@ class Compiler:
                     unit.tx_commit = True
                 elif comp.tx_action == dbstate.TxAction.ROLLBACK:
                     unit.tx_rollback = True
-                elif comp.tx_action == dbstate.TxAction.ROLLBACK_TO_SAVEPOINT:
-                    unit.tx_savepoint_rollback = True
-                    unit.sp_name = dbstate.ABORT_MIGRATION_SAVEPOINT
+                elif comp.action == dbstate.MigrationAction.ABORT:
+                    unit.tx_abort_migration = True
 
             elif isinstance(comp, dbstate.SessionStateQuery):
                 unit.sql = comp.sql

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -43,6 +43,9 @@ from . import enums
 from . import sertypes
 
 
+ABORT_MIGRATION_SAVEPOINT = '__edb_migration_sp__'
+
+
 class TxAction(enum.IntEnum):
 
     START = 1

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -43,9 +43,6 @@ from . import enums
 from . import sertypes
 
 
-ABORT_MIGRATION_SAVEPOINT = '__edb_migration_sp__'
-
-
 class TxAction(enum.IntEnum):
 
     START = 1
@@ -234,6 +231,10 @@ class QueryUnit:
     # 'ROLLBACK TO SAVEPOINT' is always compiled to a separate QueryUnit.
     tx_savepoint_rollback: bool = False
     tx_savepoint_declare: bool = False
+
+    # True if this unit is `ABORT MIGRATION` command within a transaction,
+    # that means abort_migration and tx_rollback cannot be both True
+    tx_abort_migration: bool = False
 
     # For SAVEPOINT commands, the name and sp_id
     sp_name: Optional[str] = None

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -158,6 +158,7 @@ cdef class DatabaseConnectionView:
     cdef _invalidate_local_cache(self)
     cdef _reset_tx_state(self)
 
+    cdef clear_tx_error(self)
     cdef rollback_tx_to_savepoint(self, name)
     cdef declare_savepoint(self, name, spid)
     cdef recover_aliases_and_config(self, modaliases, config, globals)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -326,6 +326,8 @@ cdef class DatabaseConnectionView:
 
     cdef rollback_tx_to_savepoint(self, name):
         self._tx_error = False
+        if name == dbstate.ABORT_MIGRATION_SAVEPOINT:
+            return
         # See also CompilerConnectionState.rollback_to_savepoint().
         while self._in_tx_savepoints:
             if self._in_tx_savepoints[-1][0] == name:

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1027,6 +1027,7 @@ cdef class DatabaseConnectionView:
                     self._protocol_version,
                     query_req.inline_objectids,
                     query_req.input_format is compiler.InputFormat.JSON,
+                    self.in_tx_error(),
                 )
             else:
                 result = await compiler_pool.compile(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11081,11 +11081,15 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
                 }
             };
         """)
+        await self.con.execute('POPULATE MIGRATION')
 
         with self.assertRaises(edgedb.EdgeQLSyntaxError):
             await self.con.execute(r"""
                 ALTER TYPE Foo;
             """)
+
+        with self.assertRaises(edgedb.TransactionError):
+            await self.con.execute("COMMIT MIGRATION")
 
         await self.con.execute("ABORT MIGRATION")
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1992,6 +1992,19 @@ class TestServerProto(tb.QueryTestCase):
             finally:
                 await con2.aclose()
 
+    async def test_server_proto_tx_22(self):
+        await self.con.query('START TRANSACTION')
+        try:
+            with self.assertRaises(edgedb.DivisionByZeroError):
+                await self.con.execute('SELECT 1/0')
+            # The commit
+            with self.assertRaises(edgedb.TransactionError):
+                await self.con.query('COMMIT')
+        finally:
+            await self.con.query('ROLLBACK')
+
+        self.assertEqual(await self.con.query_single('SELECT 42'), 42)
+
 
 class TestServerProtoMigration(tb.QueryTestCase):
 


### PR DESCRIPTION
Refs #4065, `abort transaction` should also work in implicit/explicit transactions.

This PR also fixes a regression introduced in #4065 that commit in failed transaction makes the connection unrecoverable, seel also #4105.