### PR TITLE
Make sure that INSERT path ids in ELSE clauses differ from enclosing

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -42,6 +42,7 @@ from . import astutils
 from . import context
 from . import dispatch
 from . import inference
+from . import pathctx
 from . import setgen
 from . import typegen
 
@@ -534,6 +535,9 @@ def compile_insert_unless_conflict_on(
         # The ELSE needs to be able to reference the subject in an
         # UPDATE, even though that would normally be prohibited.
         ctx.path_scope.factoring_allowlist.add(stmt.subject.path_id)
+
+        pathctx.ban_inserting_path(
+            stmt.subject.path_id, location='else', ctx=ctx)
 
         # Compile else
         else_ir = dispatch.compile(

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -469,8 +469,8 @@ class ContextLevel(compiler.ContextLevel):
     pending_stmt_full_path_id_namespace: FrozenSet[str]
     """A set of path id namespaces to use in path ids in the next statement."""
 
-    banned_paths: Set[irast.PathId]
-    """A set of path ids that are considered invalid in this context."""
+    inserting_paths: Dict[irast.PathId, Literal['body'] | Literal['else']]
+    """A set of path ids that are currently being inserted."""
 
     view_map: ChainMap[
         irast.PathId,
@@ -588,7 +588,7 @@ class ContextLevel(compiler.ContextLevel):
             self.path_id_namespace = frozenset()
             self.pending_stmt_own_path_id_namespace = frozenset()
             self.pending_stmt_full_path_id_namespace = frozenset()
-            self.banned_paths = set()
+            self.inserting_paths = {}
             self.view_map = collections.ChainMap()
             self.path_scope = env.path_scope
             self.path_scope_map = {}
@@ -633,7 +633,7 @@ class ContextLevel(compiler.ContextLevel):
                 prevlevel.pending_stmt_own_path_id_namespace
             self.pending_stmt_full_path_id_namespace = \
                 prevlevel.pending_stmt_full_path_id_namespace
-            self.banned_paths = prevlevel.banned_paths
+            self.inserting_paths = prevlevel.inserting_paths
             self.view_map = prevlevel.view_map
             if prevlevel.path_scope is None:
                 prevlevel.path_scope = self.env.path_scope
@@ -667,7 +667,7 @@ class ContextLevel(compiler.ContextLevel):
 
                 self.pending_stmt_own_path_id_namespace = frozenset()
                 self.pending_stmt_full_path_id_namespace = frozenset()
-                self.banned_paths = prevlevel.banned_paths.copy()
+                self.inserting_paths = prevlevel.inserting_paths.copy()
 
                 self.view_rptr = None
                 self.view_scls = None
@@ -690,7 +690,7 @@ class ContextLevel(compiler.ContextLevel):
                 self.path_id_namespace = frozenset({self.aliases.get('ns')})
                 self.pending_stmt_own_path_id_namespace = frozenset()
                 self.pending_stmt_full_path_id_namespace = frozenset()
-                self.banned_paths = set()
+                self.inserting_paths = {}
 
                 self.iterator_path_ids = frozenset()
 

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -151,16 +151,22 @@ def extend_path_id(
     return path_id.extend(ptrref=ptrref, direction=direction, ns=ns)
 
 
-def ban_path(
+def ban_inserting_path(
         path_id: irast.PathId, *,
+        location: Literal['body'] | Literal['else'],
         ctx: context.ContextLevel) -> None:
 
-    ctx.banned_paths.add(path_id)
+    ctx.inserting_paths = ctx.inserting_paths.copy()
+    ctx.inserting_paths[path_id] = location
 
 
-def path_is_banned(
+def path_is_inserting(
         path_id: irast.PathId, *,
         ctx: context.ContextLevel) -> bool:
 
     node = ctx.path_scope.find_visible(path_id)
-    return bool(node and node.path_id in ctx.banned_paths)
+    return bool(
+        node
+        and node.path_id
+        and ctx.inserting_paths.get(node.path_id) == 'body'
+    )

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -518,7 +518,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         if is_computable:
             computables.append(path_tip)
 
-        if pathctx.path_is_banned(path_tip.path_id, ctx=ctx):
+        if pathctx.path_is_inserting(path_tip.path_id, ctx=ctx):
             dname = stype.get_displayname(ctx.env.schema)
             raise errors.QueryError(
                 f'invalid reference to {dname}: '


### PR DESCRIPTION
That is, if we have
```
  INSERT Person {name := "Madz"}
  UNLESS CONFLICT ON (.name)
  ELSE (INSERT Person {name := "Maddy"})
```

make sure that the inner `Person` has a distinct pathid (by
namespacing it) from the outer `Person`. They don't correlate despite
the outer one being visible to the inner.

This doesn't fix any current bugs, but that's mostly a matter of
luck. It fixes an issue in an experimental PR I'm working on.