### PR TITLE
Prevent lingering incomplete migration

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1647,13 +1647,15 @@ class Compiler:
             query = self._compile_ql_migration(
                 ctx, ql, in_script=in_script,
             )
-            if isinstance(
-                query,
-                (dbstate.MigrationControlQuery, dbstate.DDLQuery),
-            ):
-                return (query, enums.Capability.DDL)
+            if isinstance(query, dbstate.MigrationControlQuery):
+                capability = enums.Capability.DDL
+                if query.tx_action:
+                    capability |= enums.Capability.TRANSACTION
+                return query, capability
+            elif isinstance(query, dbstate.DDLQuery):
+                return query, enums.Capability.DDL
             else:  # DESCRIBE CURRENT MIGRATION
-                return (query, enums.Capability(0))
+                return query, enums.Capability(0)
 
         elif isinstance(ql, (qlast.DatabaseCommand, qlast.DDL)):
             return (

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1939,6 +1939,12 @@ class Compiler:
             rv.append(unit)
 
         if script_info:
+            if ctx.state.current_tx().is_implicit():
+                if ctx.state.current_tx().get_migration_state() is not None:
+                    raise errors.QueryError(
+                        "Cannot leave an incomplete migration in scripts"
+                    )
+
             params, in_type_args = self._extract_params(
                 list(script_info.params.values()),
                 argmap=None, script_info=None, schema=script_info.schema,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11083,3 +11083,14 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
         await self.con.execute("ABORT MIGRATION")
 
         self.assertEqual(await self.con.query_single("SELECT 1"), 1)
+
+    async def test_edgeql_script_partial_migration(self):
+        with self.assertRaisesRegex(edgedb.QueryError, "incomplete migration"):
+            await self.con.execute(r"""
+                START MIGRATION TO {
+                    module test {
+                        type Foo;
+                    }
+                };
+                POPULATE MIGRATION;
+            """)

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -3129,3 +3129,11 @@ class TestServerCapabilities(tb.QueryTestCase):
                 'CONFIGURE INSTANCE SET singleprop := "42"',
                 __allow_capabilities__=caps,
             )
+
+    async def test_server_capabilities_06(self):
+        caps = enums.Capability.ALL & ~enums.Capability.TRANSACTION
+        with self.assertRaises(edgedb.DisabledCapabilityError):
+            await self.con._fetchall(
+                'START MIGRATION TO {}',
+                __allow_capabilities__=caps,
+            )


### PR DESCRIPTION
* Standalone `start migration` requires TRANSACTION capability
* Disallow incomplete migration in scripts