### PR TITLE
Also use default key files when --jose-key-mode=require_file

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1098,43 +1098,62 @@ def parse_args(**kwargs: Any):
             " is not a regular file"
         )
 
-    if kwargs['jose_key_mode'] is JOSEKeyMode.Generate:
-        if not kwargs['jws_key_file']:
-            if kwargs['data_dir']:
-                jws_key_file = kwargs['data_dir'] / JWS_KEY_FILE_NAME
-            else:
-                jws_key_file = pathlib.Path('<runstate>') / JWS_KEY_FILE_NAME
-            kwargs['jws_key_file'] = jws_key_file
-        if not kwargs['jwe_key_file']:
-            if kwargs['data_dir']:
-                jwe_key_file = kwargs['data_dir'] / JWE_KEY_FILE_NAME
-            else:
-                jwe_key_file = pathlib.Path('<runstate>') / JWE_KEY_FILE_NAME
-            kwargs['jwe_key_file'] = jwe_key_file
-    else:
-        if kwargs['jws_key_file']:
-            if not kwargs['jws_key_file'].exists():
-                abort(
-                    f"JWS key file \"{kwargs['jws_key_file']}\" does not exist"
-                )
+    generate_jose = kwargs['jose_key_mode'] is JOSEKeyMode.Generate
 
-            if not kwargs['jws_key_file'].is_file():
-                abort(
-                    f"JWT key file \"{kwargs['jws_key_file']}\""
-                    " is not a regular file"
-                )
+    if not kwargs['jws_key_file']:
+        if kwargs['data_dir']:
+            jws_key_file = kwargs['data_dir'] / JWS_KEY_FILE_NAME
+        elif generate_jose:
+            jws_key_file = pathlib.Path('<runstate>') / JWS_KEY_FILE_NAME
+        else:
+            abort(
+                "no JWS key specified and JOSE keys auto-generation"
+                " has not been requested; see help for --jose-key-mode",
+                exit_code=11,
+            )
+        kwargs['jws_key_file'] = jws_key_file
 
-        if kwargs['jwe_key_file']:
-            if not kwargs['jwe_key_file'].exists():
-                abort(
-                    f"JWE key file \"{kwargs['jwe_key_file']}\" does not exist"
-                )
+    if not kwargs['jwe_key_file']:
+        if kwargs['data_dir']:
+            jwe_key_file = kwargs['data_dir'] / JWE_KEY_FILE_NAME
+        elif generate_jose:
+            jwe_key_file = pathlib.Path('<runstate>') / JWE_KEY_FILE_NAME
+        else:
+            abort(
+                "no JWE key specified and JOSE keys auto-generation"
+                " has not been requested; see help for --jose-key-mode",
+                exit_code=11,
+            )
+        kwargs['jwe_key_file'] = jwe_key_file
 
-            if not kwargs['jwe_key_file'].is_file():
-                abort(
-                    f"JWE key file \"{kwargs['jwe_key_file']}\""
-                    " is not a regular file"
-                )
+    if not kwargs['bootstrap_only'] and not generate_jose:
+        if not kwargs['jws_key_file'].exists():
+            abort(
+                f"JWS key file \"{kwargs['jws_key_file']}\" does not exist"
+            )
+
+        if not kwargs['jwe_key_file'].exists():
+            abort(
+                f"JWE key file \"{kwargs['jwe_key_file']}\" does not exist"
+            )
+
+    if (
+        kwargs['jws_key_file'].exists() and
+        not kwargs['jws_key_file'].is_file()
+    ):
+        abort(
+            f"JWT key file \"{kwargs['jws_key_file']}\""
+            " is not a regular file"
+        )
+
+    if (
+        kwargs['jwe_key_file'].exists() and
+        not kwargs['jwe_key_file'].is_file()
+    ):
+        abort(
+            f"JWE key file \"{kwargs['jwe_key_file']}\""
+            " is not a regular file"
+        )
 
     if kwargs['log_level']:
         kwargs['log_level'] = kwargs['log_level'].lower()[0]

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1069,13 +1069,7 @@ def parse_args(**kwargs: Any):
         kwargs['tls_cert_file'] = tls_cert_file
         kwargs['tls_key_file'] = tls_key_file
 
-    will_init_server = (
-        not kwargs['bootstrap_only']
-        or kwargs['bootstrap_script']
-        or kwargs['bootstrap_command']
-    )
-
-    if will_init_server and not self_signing:
+    if not kwargs['bootstrap_only'] and not self_signing:
         if not kwargs['tls_cert_file'].exists():
             abort(
                 f"TLS certificate file \"{kwargs['tls_cert_file']}\""
@@ -1130,7 +1124,7 @@ def parse_args(**kwargs: Any):
             )
         kwargs['jwe_key_file'] = jwe_key_file
 
-    if will_init_server and not generate_jose:
+    if not kwargs['bootstrap_only'] and not generate_jose:
         if not kwargs['jws_key_file'].exists():
             abort(
                 f"JWS key file \"{kwargs['jws_key_file']}\" does not exist"

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -70,6 +70,7 @@ class BaseCluster:
         self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
 
         self._edgedb_cmd.append('--tls-cert-mode=generate_self_signed')
+        self._edgedb_cmd.append('--jose-key-mode=generate')
 
         if log_level:
             self._edgedb_cmd.extend(['--log-level', log_level])

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -231,6 +231,11 @@ async def _run_server(
                 _generate_jose_keys(args.jwe_key_file)
                 jwe_keys_newly_generated = True
 
+        if args.bootstrap_only:
+            if args.startup_script and new_instance:
+                await sc.wait_for(ss.run_startup_script_and_exit())
+            return
+
         ss.init_tls(
             args.tls_cert_file, args.tls_key_file, tls_cert_newly_generated)
 
@@ -240,11 +245,6 @@ async def _run_server(
             jws_keys_newly_generated,
             jwe_keys_newly_generated,
         )
-
-        if args.bootstrap_only:
-            if args.startup_script and new_instance:
-                await sc.wait_for(ss.run_startup_script_and_exit())
-            return
 
         try:
             await sc.wait_for(ss.start())

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1523,40 +1523,38 @@ class Server(ha_base.ClusterProtocol):
 
     def init_jwcrypto(
         self,
-        jws_key_file: pathlib.Path | None,
-        jwe_key_file: pathlib.Path | None,
+        jws_key_file: pathlib.Path,
+        jwe_key_file: pathlib.Path,
         jws_keys_newly_generated: bool,
         jwe_keys_newly_generated: bool,
     ) -> None:
-        if jws_key_file is not None:
-            try:
-                with open(jws_key_file, 'rb') as kf:
-                    self._jws_key = jwk.JWK.from_pem(kf.read())
-            except Exception as e:
-                raise StartupError(f"cannot load JWS key: {e}") from e
+        try:
+            with open(jws_key_file, 'rb') as kf:
+                self._jws_key = jwk.JWK.from_pem(kf.read())
+        except Exception as e:
+            raise StartupError(f"cannot load JWS key: {e}") from e
 
-            if (
-                not self._jws_key.has_public
-                or self._jws_key['kty'] not in {"RSA", "EC"}
-            ):
-                raise StartupError(
-                    f"the provided JWS key file does not "
-                    f"contain a valid RSA or EC public key")
+        if (
+            not self._jws_key.has_public
+            or self._jws_key['kty'] not in {"RSA", "EC"}
+        ):
+            raise StartupError(
+                f"the provided JWS key file does not "
+                f"contain a valid RSA or EC public key")
 
-        if jwe_key_file is not None:
-            try:
-                with open(jwe_key_file, 'rb') as kf:
-                    self._jwe_key = jwk.JWK.from_pem(kf.read())
-            except Exception as e:
-                raise StartupError(f"cannot load JWE key: {e}") from e
+        try:
+            with open(jwe_key_file, 'rb') as kf:
+                self._jwe_key = jwk.JWK.from_pem(kf.read())
+        except Exception as e:
+            raise StartupError(f"cannot load JWE key: {e}") from e
 
-            if (
-                not self._jwe_key.has_private
-                or self._jwe_key['kty'] not in {"RSA", "EC"}
-            ):
-                raise StartupError(
-                    f"the provided JWE key file does not "
-                    f"contain a valid RSA or EC private key")
+        if (
+            not self._jwe_key.has_private
+            or self._jwe_key['kty'] not in {"RSA", "EC"}
+        ):
+            raise StartupError(
+                f"the provided JWE key file does not "
+                f"contain a valid RSA or EC private key")
         self._jws_keys_newly_generated = jws_keys_newly_generated
         self._jwe_keys_newly_generated = jwe_keys_newly_generated
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1541,6 +1541,7 @@ class _EdgeDBServer:
             '--emit-server-status', f'fd://{status_w.fileno()}',
             '--compiler-pool-size', str(self.compiler_pool_size),
             '--tls-cert-mode', str(self.tls_cert_mode),
+            '--jose-key-mode', 'generate',
         ]
 
         if self.compiler_pool_mode is not None:


### PR DESCRIPTION
After generating the keys, the CLI is starting instances with the default ` --jose-key-mode=require_file` without specifying the actual file paths. We should use the default path if none is provided.