### PR TITLE
Update setup-gcloud branch name

### DIFF
--- a/.github/workflows.src/tests-managed-pg.tpl.yml
+++ b/.github/workflows.src/tests-managed-pg.tpl.yml
@@ -11,7 +11,7 @@
 
 <% macro setup_gcp_creds() -%>
     - name: Configure GCP Credentials
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@main
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -773,7 +773,7 @@ jobs:
         run: terraform init
 
       - name: Configure GCP Credentials
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@main
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
@@ -942,7 +942,7 @@ jobs:
         run: terraform init
 
       - name: Configure GCP Credentials
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@main
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true


### PR DESCRIPTION
Obviously Google renamed it from `master` to `main`.