### PR TITLE
Avoid generating TLS and JWK key material for every test cluster instance

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -212,7 +212,7 @@ async def _run_server(
             assert args.tls_cert_file is not None
             if not args.tls_cert_file.exists():
                 assert args.tls_key_file is not None
-                _generate_cert(
+                generate_tls_cert(
                     args.tls_cert_file,
                     args.tls_key_file,
                     ss.get_listen_hosts(),
@@ -225,10 +225,10 @@ async def _run_server(
             assert args.jws_key_file is not None
             assert args.jwe_key_file is not None
             if not args.jws_key_file.exists():
-                _generate_jose_keys(args.jws_key_file)
+                generate_jwk(args.jws_key_file)
                 jws_keys_newly_generated = True
             if not args.jwe_key_file.exists():
-                _generate_jose_keys(args.jwe_key_file)
+                generate_jwk(args.jwe_key_file)
                 jwe_keys_newly_generated = True
 
         if args.bootstrap_only:
@@ -267,7 +267,7 @@ async def _run_server(
             await sc.wait_for(ss.stop())
 
 
-def _generate_cert(
+def generate_tls_cert(
     tls_cert_file: pathlib.Path,
     tls_key_file: pathlib.Path,
     listen_hosts: Iterable[str]
@@ -329,7 +329,7 @@ def _generate_cert(
     tls_key_file.chmod(0o600)
 
 
-def _generate_jose_keys(keys_file: pathlib.Path) -> None:
+def generate_jwk(keys_file: pathlib.Path) -> None:
     logger.info(f'generating JOSE key pair in "{keys_file}"')
 
     key = jwk.JWK(generate='EC')

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -34,10 +34,10 @@ import sys
 import tempfile
 import uuid
 
-import uvloop
-
 import click
+from jwcrypto import jwk
 import setproctitle
+import uvloop
 
 from . import logsetup
 logsetup.early_setup()
@@ -332,20 +332,10 @@ def _generate_cert(
 def _generate_jose_keys(keys_file: pathlib.Path) -> None:
     logger.info(f'generating JOSE key pair in "{keys_file}"')
 
-    from cryptography.hazmat import backends
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import ec
-
-    backend = backends.default_backend()
-    private_key = ec.generate_private_key(ec.SECP256R1(), backend=backend)
+    key = jwk.JWK(generate='EC')
     with keys_file.open("wb") as f:
-        f.write(
-            private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
-        )
+        f.write(key.export_to_pem(private_key=True, password=None))
+
     keys_file.chmod(0o600)
 
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -49,6 +49,7 @@ from edb.edgeql import quote as qlquote
 from edb.server import args as edgedb_args
 from edb.server import cluster as edgedb_cluster
 from edb.server import defines as edgedb_defines
+from edb.server import main as edgedb_main
 
 from edb.common import assert_data_shape
 from edb.common import devmode
@@ -89,6 +90,9 @@ def get_test_cases(tests):
 
 
 bag = assert_data_shape.bag
+
+generate_jwk = edgedb_main.generate_jwk
+generate_tls_cert = edgedb_main.generate_tls_cert
 
 
 class TestCaseMeta(type(unittest.TestCase)):
@@ -187,6 +191,10 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
     def tearDownClass(cls):
         cls.loop.close()
         asyncio.set_event_loop(None)
+
+    @classmethod
+    def uses_server(cls) -> bool:
+        return True
 
     def add_fail_notes(self, **kwargs):
         if not hasattr(self, 'fail_notes'):
@@ -1296,6 +1304,15 @@ def get_test_cases_setup(
         result.append((case, dbname, setup_script))
 
     return result
+
+
+def test_cases_use_server(cases: Iterable[unittest.TestCase]) -> bool:
+    for case in cases:
+        if not hasattr(case, 'uses_server'):
+            continue
+
+        if case.uses_server():
+            return True
 
 
 async def setup_test_cases(cases, conn, num_jobs, verbose=False):

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -162,6 +162,7 @@ class TestServerOps(tb.TestCase):
             '--emit-server-status', status_file,
             '--emit-server-status', status_file_2,
             '--tls-cert-mode=generate_self_signed',
+            '--jose-key-mode=generate',
         ]
 
         proc: Optional[asyncio.Process] = None


### PR DESCRIPTION
CI runners are frequently entropy-starved, so repeated key generation
requests might slow things down in a major way and/or cause timeouts.