### PR TITLE
add support for conditional top-level DDL statements

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -720,11 +720,11 @@ class CreateObject(ObjectDDL):
 
 
 class AlterObject(ObjectDDL):
-    pass
+    alter_if_exists: bool = False
 
 
 class DropObject(ObjectDDL):
-    pass
+    drop_if_exists: bool = False
 
 
 class CreateExtendingObject(CreateObject, BasesMixin):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -962,6 +962,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if after_name:
             after_name()
 
+        if node.alter_if_exists and not self.sdlmode:
+            self._write_keywords(' IF EXISTS')
+
         commands = node.commands
         if ignored_cmds:
             commands = [cmd for cmd in commands
@@ -993,6 +996,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                            ident_to_str(node.name.name))
         if after_name:
             after_name()
+
+        if node.drop_if_exists and not self.sdlmode:
+            self._write_keywords(' IF EXISTS')
+
         if node.commands:
             self.write(' {')
             self._block_ws(1)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1083,13 +1083,15 @@ class CreateScalarTypeStmt(Nonterm):
     def reduce_CreateAbstractScalarTypeStmt(self, *kids):
         r"""%reduce \
             CREATE ABSTRACT SCALAR TYPE NodeName \
-            OptExtending OptCreateScalarTypeCommandsBlock \
+            OptExtending OptIfNotExists \
+            OptCreateScalarTypeCommandsBlock \
         """
         self.val = qlast.CreateScalarType(
             name=kids[4].val,
             abstract=True,
             bases=kids[5].val,
-            commands=kids[6].val
+            create_if_not_exists=kids[6].val,
+            commands=kids[7].val,
         )
 
     def reduce_CreateFinalScalarTypeStmt(self, *kids):
@@ -1111,12 +1113,14 @@ class CreateScalarTypeStmt(Nonterm):
     def reduce_CreateScalarTypeStmt(self, *kids):
         r"""%reduce \
             CREATE SCALAR TYPE NodeName \
-            OptExtending OptCreateScalarTypeCommandsBlock \
+            OptExtending OptIfNotExists \
+            OptCreateScalarTypeCommandsBlock \
         """
         self.val = qlast.CreateScalarType(
             name=kids[3].val,
             bases=kids[4].val,
-            commands=kids[5].val
+            create_if_not_exists=kids[5].val,
+            commands=kids[6].val,
         )
 
 
@@ -1143,19 +1147,21 @@ commands_block(
 class AlterScalarTypeStmt(Nonterm):
     def reduce_AlterScalarTypeStmt(self, *kids):
         r"""%reduce \
-            ALTER SCALAR TYPE NodeName \
+            ALTER SCALAR TYPE NodeName OptIfExists \
             AlterScalarTypeCommandsBlock \
         """
         self.val = qlast.AlterScalarType(
             name=kids[3].val,
-            commands=kids[4].val
+            alter_if_exists=kids[4].val,
+            commands=kids[5].val,
         )
 
 
 class DropScalarTypeStmt(Nonterm):
-    def reduce_DROP_SCALAR_TYPE_NodeName(self, *kids):
+    def reduce_DROP_SCALAR_TYPE_NodeName_OptIfExists(self, *kids):
         self.val = qlast.DropScalarType(
-            name=kids[3].val
+            name=kids[3].val,
+            drop_if_exists=kids[4].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -909,41 +909,49 @@ class DropRoleStmt(Nonterm):
 class CreateConstraintStmt(Nonterm):
     def reduce_CreateConstraint(self, *kids):
         r"""%reduce CREATE ABSTRACT CONSTRAINT NodeName OptOnExpr \
-                    OptExtendingSimple OptCreateCommandsBlock"""
+                    OptExtendingSimple OptIfNotExists \
+                    OptCreateCommandsBlock
+        """
         self.val = qlast.CreateConstraint(
             name=kids[3].val,
             subjectexpr=kids[4].val,
             bases=kids[5].val,
-            commands=kids[6].val,
+            create_if_not_exists=kids[6].val,
+            commands=kids[7].val,
         )
 
     def reduce_CreateConstraint_CreateFunctionArgs(self, *kids):
         r"""%reduce CREATE ABSTRACT CONSTRAINT NodeName CreateFunctionArgs \
-                    OptOnExpr OptExtendingSimple OptCreateCommandsBlock"""
+                    OptOnExpr OptExtendingSimple OptIfNotExists \
+                    OptCreateCommandsBlock
+        """
         self.val = qlast.CreateConstraint(
             name=kids[3].val,
             params=kids[4].val,
             subjectexpr=kids[5].val,
             bases=kids[6].val,
-            commands=kids[7].val,
+            create_if_not_exists=kids[7].val,
+            commands=kids[8].val,
         )
 
 
 class AlterConstraintStmt(Nonterm):
-    def reduce_CreateConstraint(self, *kids):
-        r"""%reduce ALTER ABSTRACT CONSTRAINT NodeName \
+    def reduce_AlterConstraint(self, *kids):
+        r"""%reduce ALTER ABSTRACT CONSTRAINT NodeName OptIfExists \
                     AlterCommandsBlock"""
         self.val = qlast.AlterConstraint(
             name=kids[3].val,
-            commands=kids[4].val,
+            alter_if_exists=kids[4].val,
+            commands=kids[5].val,
         )
 
 
 class DropConstraintStmt(Nonterm):
-    def reduce_CreateConstraint(self, *kids):
-        r"""%reduce DROP ABSTRACT CONSTRAINT NodeName"""
+    def reduce_DropConstraint(self, *kids):
+        r"""%reduce DROP ABSTRACT CONSTRAINT NodeName OptIfExists"""
         self.val = qlast.DropConstraint(
-            name=kids[3].val
+            name=kids[3].val,
+            drop_if_exists=kids[4].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2723,7 +2723,7 @@ class CreateGlobalStmt(Nonterm):
     def reduce_CreateRegularGlobal(self, *kids):
         """%reduce
             CREATE OptPtrQuals GLOBAL NodeName
-            ARROW FullTypeExpr
+            ARROW FullTypeExpr OptIfNotExists
             OptCreateGlobalCommandsBlock
         """
         self.val = qlast.CreateGlobal(
@@ -2731,26 +2731,28 @@ class CreateGlobalStmt(Nonterm):
             is_required=kids[1].val.required,
             cardinality=kids[1].val.cardinality,
             target=kids[5].val,
-            commands=kids[6].val,
+            create_if_not_exists=kids[6].val,
+            commands=kids[7].val,
         )
 
     def reduce_CreateComputableGlobal(self, *kids):
         """%reduce
-            CREATE OptPtrQuals GLOBAL NodeName ASSIGN Expr
+            CREATE OptPtrQuals GLOBAL NodeName OptIfNotExists ASSIGN Expr
         """
         self.val = qlast.CreateGlobal(
             name=kids[3].val,
             is_required=kids[1].val.required,
             cardinality=kids[1].val.cardinality,
-            target=kids[5].val,
+            create_if_not_exists=kids[4].val,
+            target=kids[6].val,
         )
 
     def reduce_CreateComputableGlobalWithUsing(self, *kids):
         """%reduce
-            CREATE OptPtrQuals GLOBAL NodeName
+            CREATE OptPtrQuals GLOBAL NodeName OptIfNotExists
             OptCreateConcretePropertyCommandsBlock
         """
-        cmds = kids[4].val
+        cmds = kids[5].val
         target = None
 
         for cmd in cmds:
@@ -2770,6 +2772,7 @@ class CreateGlobalStmt(Nonterm):
             name=kids[3].val,
             is_required=kids[1].val.required,
             cardinality=kids[1].val.cardinality,
+            create_if_not_exists=kids[4].val,
             target=target,
             commands=cmds,
         )
@@ -2814,20 +2817,22 @@ commands_block(
 class AlterGlobalStmt(Nonterm):
     def reduce_AlterGlobal(self, *kids):
         r"""%reduce \
-            ALTER GLOBAL NodeName \
+            ALTER GLOBAL NodeName OptIfExists \
             AlterGlobalCommandsBlock \
         """
         self.val = qlast.AlterGlobal(
             name=kids[2].val,
-            commands=kids[3].val
+            alter_if_exists=kids[3].val,
+            commands=kids[4].val,
         )
 
 
 class DropGlobalStmt(Nonterm):
     def reduce_DropGlobal(self, *kids):
-        r"""%reduce DROP GLOBAL NodeName"""
+        r"""%reduce DROP GLOBAL NodeName OptIfExists"""
         self.val = qlast.DropGlobal(
-            name=kids[2].val
+            name=kids[2].val,
+            drop_if_exists=kids[3].val,
         )
 
 #

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -769,12 +769,13 @@ class CreateExtensionStmt(Nonterm):
 
     def reduce_CreateExtensionStmt(self, *kids):
         r"""%reduce CREATE EXTENSION ShortNodeName OptExtensionVersion
-                    OptCreateExtensionCommandsBlock
+                    OptIfNotExists OptCreateExtensionCommandsBlock
         """
         self.val = qlast.CreateExtension(
             name=kids[2].val,
             version=kids[3].val,
-            commands=kids[4].val,
+            create_if_not_exists=kids[4].val,
+            commands=kids[5].val,
         )
 
 
@@ -784,10 +785,13 @@ class CreateExtensionStmt(Nonterm):
 class DropExtensionStmt(Nonterm):
 
     def reduce_DropExtensionPackageStmt(self, *kids):
-        r"""%reduce DROP EXTENSION ShortNodeName OptExtensionVersion"""
+        r"""%reduce DROP EXTENSION ShortNodeName
+                    OptExtensionVersion OptIfExists
+        """
         self.val = qlast.DropExtension(
             name=kids[2].val,
             version=kids[3].val,
+            drop_if_exists=kids[4].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2174,7 +2174,7 @@ commands_block(
 class CreateFunctionStmt(Nonterm, commondl.ProcessFunctionBlockMixin):
     def reduce_CreateFunction(self, *kids):
         r"""%reduce CREATE FUNCTION NodeName CreateFunctionArgs \
-                ARROW OptTypeQualifier FunctionType \
+                ARROW OptTypeQualifier FunctionType OptIfNotExists \
                 CreateFunctionCommandsBlock
         """
         self.val = qlast.CreateFunction(
@@ -2182,16 +2182,19 @@ class CreateFunctionStmt(Nonterm, commondl.ProcessFunctionBlockMixin):
             params=kids[3].val,
             returning=kids[6].val,
             returning_typemod=kids[5].val,
-            **self._process_function_body(kids[7])
+            create_if_not_exists=kids[7].val,
+            **self._process_function_body(kids[8]),
         )
 
 
 class DropFunctionStmt(Nonterm):
     def reduce_DropFunction(self, *kids):
-        r"""%reduce DROP FUNCTION NodeName CreateFunctionArgs"""
+        r"""%reduce DROP FUNCTION NodeName CreateFunctionArgs OptIfExists"""
         self.val = qlast.DropFunction(
             name=kids[2].val,
-            params=kids[3].val)
+            params=kids[3].val,
+            drop_if_exists=kids[4].val,
+        )
 
 
 #
@@ -2214,13 +2217,14 @@ commands_block(
 class AlterFunctionStmt(Nonterm, commondl.ProcessFunctionBlockMixin):
     def reduce_AlterFunctionStmt(self, *kids):
         """%reduce
-           ALTER FUNCTION NodeName CreateFunctionArgs
+           ALTER FUNCTION NodeName CreateFunctionArgs OptIfExists
            AlterFunctionCommandsBlock
         """
         self.val = qlast.AlterFunction(
             name=kids[2].val,
             params=kids[3].val,
-            **self._process_function_body(kids[4], optional_using=True)
+            alter_if_exists=kids[4].val,
+            **self._process_function_body(kids[5], optional_using=True)
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1177,19 +1177,21 @@ commands_block(
 class CreateAnnotationStmt(Nonterm):
     def reduce_CreateAnnotation(self, *kids):
         r"""%reduce CREATE ABSTRACT ANNOTATION NodeName \
-                    OptCreateAnnotationCommandsBlock"""
+                    OptIfNotExists OptCreateAnnotationCommandsBlock"""
         self.val = qlast.CreateAnnotation(
             name=kids[3].val,
-            commands=kids[4].val,
+            create_if_not_exists=kids[4].val,
+            commands=kids[5].val,
             inheritable=False,
         )
 
     def reduce_CreateInheritableAnnotation(self, *kids):
         r"""%reduce CREATE ABSTRACT INHERITABLE ANNOTATION
-                    NodeName OptCreateCommandsBlock"""
+                    NodeName OptIfNotExists OptCreateCommandsBlock"""
         self.val = qlast.CreateAnnotation(
             name=kids[4].val,
-            commands=kids[5].val,
+            create_if_not_exists=kids[5].val,
+            commands=kids[6].val,
             inheritable=True,
         )
 
@@ -1210,10 +1212,11 @@ commands_block(
 class AlterAnnotationStmt(Nonterm):
     def reduce_AlterAnnotation(self, *kids):
         r"""%reduce ALTER ABSTRACT ANNOTATION NodeName \
-                    AlterAnnotationCommandsBlock"""
+                    OptIfExists AlterAnnotationCommandsBlock"""
         self.val = qlast.AlterAnnotation(
             name=kids[3].val,
-            commands=kids[4].val
+            alter_if_exists=kids[4].val,
+            commands=kids[5].val
         )
 
 
@@ -1222,9 +1225,10 @@ class AlterAnnotationStmt(Nonterm):
 #
 class DropAnnotationStmt(Nonterm):
     def reduce_DropAnnotation(self, *kids):
-        r"""%reduce DROP ABSTRACT ANNOTATION NodeName"""
+        r"""%reduce DROP ABSTRACT ANNOTATION NodeName OptIfExists"""
         self.val = qlast.DropAnnotation(
             name=kids[3].val,
+            drop_if_exists=kids[4].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -227,6 +227,14 @@ class UnqualifiedPointerName(Nonterm):
         self.val = kids[0].val
 
 
+class OptIfExists(Nonterm):
+    def reduce_IF_EXISTS(self, *kids):
+        self.val = True
+
+    def reduce_empty(self, *kids):
+        self.val = False
+
+
 class OptIfNotExists(Nonterm):
     def reduce_IF_NOT_EXISTS(self, *kids):
         self.val = True

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1934,25 +1934,29 @@ class CreateObjectTypeStmt(Nonterm):
     def reduce_CreateAbstractObjectTypeStmt(self, *kids):
         r"""%reduce \
             CREATE ABSTRACT TYPE NodeName \
-            OptExtendingSimple OptCreateObjectTypeCommandsBlock \
+            OptExtendingSimple OptIfNotExists \
+            OptCreateObjectTypeCommandsBlock \
         """
         self.val = qlast.CreateObjectType(
             name=kids[3].val,
             bases=kids[4].val,
             abstract=True,
-            commands=kids[5].val,
+            create_if_not_exists=kids[5].val,
+            commands=kids[6].val,
         )
 
     def reduce_CreateRegularObjectTypeStmt(self, *kids):
         r"""%reduce \
             CREATE TYPE NodeName \
-            OptExtendingSimple OptCreateObjectTypeCommandsBlock \
+            OptExtendingSimple OptIfNotExists \
+            OptCreateObjectTypeCommandsBlock \
         """
         self.val = qlast.CreateObjectType(
             name=kids[2].val,
             bases=kids[3].val,
             abstract=False,
-            commands=kids[4].val,
+            create_if_not_exists=kids[4].val,
+            commands=kids[5].val,
         )
 
 
@@ -1991,12 +1995,13 @@ commands_block(
 class AlterObjectTypeStmt(Nonterm):
     def reduce_AlterObjectTypeStmt(self, *kids):
         r"""%reduce \
-            ALTER TYPE NodeName \
+            ALTER TYPE NodeName OptIfExists \
             AlterObjectTypeCommandsBlock \
         """
         self.val = qlast.AlterObjectType(
             name=kids[2].val,
-            commands=kids[3].val
+            alter_if_exists=kids[3].val,
+            commands=kids[4].val,
         )
 
 
@@ -2017,11 +2022,12 @@ class DropObjectTypeStmt(Nonterm):
     def reduce_DropObjectType(self, *kids):
         r"""%reduce \
             DROP TYPE \
-            NodeName OptDropObjectTypeCommandsBlock \
+            NodeName OptIfExists OptDropObjectTypeCommandsBlock \
         """
         self.val = qlast.DropObjectType(
             name=kids[2].val,
-            commands=kids[3].val
+            drop_if_exists=kids[3].val,
+            commands=kids[4].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2048,14 +2048,15 @@ commands_block(
 class CreateAliasStmt(Nonterm):
     def reduce_CreateAliasShortStmt(self, *kids):
         r"""%reduce
-            CREATE ALIAS NodeName ASSIGN Expr
+            CREATE ALIAS NodeName OptIfNotExists ASSIGN Expr
         """
         self.val = qlast.CreateAlias(
             name=kids[2].val,
+            create_if_not_exists=kids[3].val,
             commands=[
                 qlast.SetField(
                     name='expr',
-                    value=kids[4].val,
+                    value=kids[5].val,
                     special_syntax=True,
                 )
             ]
@@ -2063,12 +2064,13 @@ class CreateAliasStmt(Nonterm):
 
     def reduce_CreateAliasRegularStmt(self, *kids):
         r"""%reduce
-            CREATE ALIAS NodeName
+            CREATE ALIAS NodeName OptIfNotExists
             CreateAliasCommandsBlock
         """
         self.val = qlast.CreateAlias(
             name=kids[2].val,
-            commands=kids[3].val,
+            create_if_not_exists=kids[3].val,
+            commands=kids[4].val,
         )
 
 
@@ -2092,12 +2094,13 @@ commands_block(
 class AlterAliasStmt(Nonterm):
     def reduce_AlterAliasStmt(self, *kids):
         r"""%reduce
-            ALTER ALIAS NodeName
+            ALTER ALIAS NodeName OptIfExists
             AlterAliasCommandsBlock
         """
         self.val = qlast.AlterAlias(
             name=kids[2].val,
-            commands=kids[3].val
+            alter_if_exists=kids[3].val,
+            commands=kids[4].val,
         )
 
 
@@ -2108,10 +2111,11 @@ class AlterAliasStmt(Nonterm):
 class DropAliasStmt(Nonterm):
     def reduce_DropAlias(self, *kids):
         r"""%reduce
-            DROP ALIAS NodeName
+            DROP ALIAS NodeName OptIfExists
         """
         self.val = qlast.DropAlias(
             name=kids[2].val,
+            drop_if_exists=kids[3].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1583,13 +1583,14 @@ commands_block(
 class CreateLinkStmt(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
-            CREATE ABSTRACT LINK NodeName OptExtendingSimple \
+            CREATE ABSTRACT LINK NodeName OptExtendingSimple OptIfNotExists \
             OptCreateLinkCommandsBlock \
         """
         self.val = qlast.CreateLink(
             name=kids[3].val,
             bases=kids[4].val,
-            commands=kids[5].val,
+            create_if_not_exists=kids[5].val,
+            commands=kids[6].val,
             abstract=True,
         )
 
@@ -1623,12 +1624,13 @@ commands_block(
 class AlterLinkStmt(Nonterm):
     def reduce_AlterLink(self, *kids):
         r"""%reduce \
-            ALTER ABSTRACT LINK NodeName \
+            ALTER ABSTRACT LINK NodeName OptIfExists \
             AlterLinkCommandsBlock \
         """
         self.val = qlast.AlterLink(
             name=kids[3].val,
-            commands=kids[4].val
+            alter_if_exists=kids[4].val,
+            commands=kids[5].val,
         )
 
 
@@ -1648,12 +1650,13 @@ commands_block(
 class DropLinkStmt(Nonterm):
     def reduce_DropLink(self, *kids):
         r"""%reduce \
-            DROP ABSTRACT LINK NodeName \
+            DROP ABSTRACT LINK NodeName OptIfExists \
             OptDropLinkCommandsBlock \
         """
         self.val = qlast.DropLink(
             name=kids[3].val,
-            commands=kids[4].val
+            drop_if_exists=kids[4].val,
+            commands=kids[5].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2136,11 +2136,12 @@ class CreateModuleStmt(Nonterm):
 # ALTER MODULE
 #
 class AlterModuleStmt(Nonterm):
-    def reduce_ALTER_MODULE_ModuleName_AlterCommandsBlock(
+    def reduce_ALTER_MODULE_ModuleName_OptIfExists_AlterCommandsBlock(
             self, *kids):
         self.val = qlast.AlterModule(
             name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val)),
-            commands=kids[3].val
+            alter_if_exists=kids[3].val,
+            commands=kids[4].val,
         )
 
 
@@ -2148,9 +2149,10 @@ class AlterModuleStmt(Nonterm):
 # DROP MODULE
 #
 class DropModuleStmt(Nonterm):
-    def reduce_DROP_MODULE_ModuleName(self, *kids):
+    def reduce_DROP_MODULE_ModuleName_OptIfExists(self, *kids):
         self.val = qlast.DropModule(
-            name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val))
+            name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val)),
+            drop_if_exists=kids[3].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -881,10 +881,14 @@ commands_block(
 
 
 class AlterRoleStmt(Nonterm):
-    def reduce_ALTER_ROLE_ShortNodeName_AlterRoleCommandsBlock(self, *kids):
+    def reduce_AlterRoleStmt(self, *kids):
+        r"""%reduce ALTER ROLE ShortNodeName OptIfExists
+                    AlterRoleCommandsBlock
+        """
         self.val = qlast.AlterRole(
             name=kids[2].val,
-            commands=kids[3].val,
+            alter_if_exists=kids[3].val,
+            commands=kids[4].val,
         )
 
 
@@ -892,9 +896,10 @@ class AlterRoleStmt(Nonterm):
 # DROP ROLE
 #
 class DropRoleStmt(Nonterm):
-    def reduce_DROP_ROLE_ShortNodeName(self, *kids):
+    def reduce_DROP_ROLE_ShortNodeName_OptIfExists(self, *kids):
         self.val = qlast.DropRole(
             name=kids[2].val,
+            drop_if_exists=kids[3].val,
         )
 
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -665,15 +665,22 @@ class ConstraintCommand(
             modaliases.update(
                 cls._modaliases_from_ast(schema, astnode, context))
             # Get the original constraint.
-            constr = schema.get(
-                utils.ast_ref_to_name(objref),
-                default=None,
-                module_aliases=modaliases,
-                type=Constraint,
-            )
 
-            if astnode.alter_if_exists and constr is None:
-                return localnames
+            if astnode.alter_if_exists:
+                constr = schema.get(
+                    utils.ast_ref_to_name(objref),
+                    default=None,
+                    module_aliases=modaliases,
+                    type=Constraint,
+                )
+                if constr is None:
+                    return localnames
+            else:
+                constr = schema.get(
+                    utils.ast_ref_to_name(objref),
+                    module_aliases=modaliases,
+                    type=Constraint,
+                )
 
             localnames |= {param.get_parameter_name(schema) for param in
                            constr.get_params(schema).objects(schema)}

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -667,9 +667,13 @@ class ConstraintCommand(
             # Get the original constraint.
             constr = schema.get(
                 utils.ast_ref_to_name(objref),
+                default=None,
                 module_aliases=modaliases,
                 type=Constraint,
             )
+
+            if astnode.alter_if_exists and constr is None:
+                return localnames
 
             localnames |= {param.get_parameter_name(schema) for param in
                            constr.get_params(schema).objects(schema)}

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3443,8 +3443,7 @@ class AlterObject(AlterObjectOrFragment[so.Object_T], Generic[so.Object_T]):
         schema: s_schema.Schema,
         context: CommandContext,
     ) -> s_schema.Schema:
-
-        if not context.canonical and self.if_exists:
+        if self.if_exists:
             scls = self.get_object(schema, context, default=None)
             if scls is None:
                 context.current().op.discard(self)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3405,7 +3405,8 @@ class AlterObject(AlterObjectOrFragment[so.Object_T], Generic[so.Object_T]):
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         assert isinstance(cmd, AlterObject)
 
-        # idk how, but somehow there could be an instance of CreateConcreteLink here
+        # idk how, but somehow there could be an instance
+        # of CreateConcreteLink here
         if isinstance(astnode, qlast.AlterObject):
             cmd.if_exists = astnode.alter_if_exists
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3403,10 +3403,11 @@ class AlterObject(AlterObjectOrFragment[so.Object_T], Generic[so.Object_T]):
         context: CommandContext,
     ) -> Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
-        assert isinstance(astnode, qlast.AlterObject)
         assert isinstance(cmd, AlterObject)
 
-        cmd.if_exists = astnode.alter_if_exists
+        # idk how, but somehow there could be an instance of CreateConcreteLink here
+        if isinstance(astnode, qlast.AlterObject):
+            cmd.if_exists = astnode.alter_if_exists
 
         if getattr(astnode, 'abstract', False):
             cmd.set_attribute_value('abstract', True)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3403,7 +3403,10 @@ class AlterObject(AlterObjectOrFragment[so.Object_T], Generic[so.Object_T]):
         context: CommandContext,
     ) -> Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        assert isinstance(astnode, qlast.AlterObject)
         assert isinstance(cmd, AlterObject)
+
+        cmd.if_exists = astnode.alter_if_exists
 
         if getattr(astnode, 'abstract', False):
             cmd.set_attribute_value('abstract', True)
@@ -3598,6 +3601,21 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
         ]
 
         return bool(refs)
+
+    @classmethod
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: CommandContext,
+    ) -> Command:
+        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        assert isinstance(astnode, qlast.DropObject)
+        assert isinstance(cmd, DeleteObject)
+
+        cmd.if_exists = astnode.drop_if_exists
+
+        return cmd
 
     def apply(
         self,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4627,6 +4627,64 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 $$;
             """)
 
+    async def test_edgeql_ddl_function_36(self):
+        await self.con.execute(r"""
+            CREATE FUNCTION f1(a: std::int64) -> std::int64
+            IF NOT EXISTS
+            USING EdgeQL $$
+                SELECT a
+            $$;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT f1(2)
+            """,
+            [2],
+        )
+
+        await self.con.execute(r"""
+            CREATE FUNCTION f1(a: std::int64) -> std::int64
+            IF NOT EXISTS
+            USING EdgeQL $$
+                SELECT a*a
+            $$;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT f1(2)
+            """,
+            [2],
+        )
+
+        await self.con.execute(r"""
+            ALTER FUNCTION f1(a: std::int64)
+            IF EXISTS
+            RENAME TO new_f1
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT new_f1(1)
+            """,
+            [1],
+        )
+
+        await self.con.execute(r"""
+            ALTER FUNCTION non_existent(a: std::int64)
+            IF EXISTS
+            RENAME TO non_existent2
+        """)
+
+        await self.con.execute(r"""
+            DROP FUNCTION new_f1(a: std::int64) IF EXISTS
+        """)
+
+        await self.con.execute(r"""
+            DROP FUNCTION non_existent(a: std::int64) IF EXISTS
+        """)
+
     async def test_edgeql_ddl_function_rename_01(self):
         await self.con.execute("""
             CREATE FUNCTION foo(s: str) -> str {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6591,6 +6591,57 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 alter global foo set type str using ('lol');
             """)
 
+    async def test_edgeql_ddl_global_09(self):
+        await self.con.execute('''
+            CREATE GLOBAL foo -> str IF NOT EXISTS;
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT GLOBAL foo;''',
+            []
+        )
+
+        await self.con.execute('''
+            CREATE GLOBAL foo IF NOT EXISTS := 'foo';
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT GLOBAL foo''',
+            []
+        )
+
+        await self.con.execute('''
+            CREATE GLOBAL bar IF NOT EXISTS := 'bar';
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT GLOBAL bar;''',
+            ['bar']
+        )
+
+        await self.con.execute('''
+            ALTER GLOBAL foo IF EXISTS SET TYPE int64 RESET TO DEFAULT;
+            SET GLOBAL foo := 42;
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT GLOBAL foo''',
+            [42]
+        )
+
+        await self.con.execute('''
+            ALTER GLOBAL non_existent IF EXISTS
+            SET TYPE int64 RESET TO DEFAULT;
+        ''')
+
+        await self.con.execute('''
+            DROP GLOBAL non_existent IF EXISTS;
+        ''')
+
+        await self.con.execute('''
+            DROP GLOBAL bar IF EXISTS;
+        ''')
+
     async def test_edgeql_ddl_property_computable_01(self):
         await self.con.execute('''\
             CREATE TYPE CompProp;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9677,6 +9677,36 @@ type default::Foo {
                 };
             """)
 
+    async def test_edgeql_ddl_constraint_21(self):
+        await self.con.execute(r"""
+            CREATE ABSTRACT CONSTRAINT NewConstraint IF NOT EXISTS {
+                USING ((__subject__ < 10));
+            };
+            CREATE TYPE Foo {
+                CREATE PROPERTY x -> int64 {
+                    CREATE CONSTRAINT NewConstraint;
+                };
+            };
+        """)
+
+        await self.con.execute(r"""
+            ALTER ABSTRACT CONSTRAINT NewConstraint IF EXISTS
+            RENAME TO NewConstraint2;
+        """)
+
+        await self.con.execute(r"""
+            ALTER ABSTRACT CONSTRAINT NonExistent IF EXISTS RENAME TO NonExistent2;
+        """)
+
+        await self.con.execute(r"""
+            DROP TYPE Foo;
+            DROP ABSTRACT CONSTRAINT NewConstraint2 IF EXISTS;
+        """)
+
+        await self.con.execute(r"""
+            DROP ABSTRACT CONSTRAINT NonExistent IF EXISTS;
+        """)
+
     async def test_edgeql_ddl_constraint_check_01a(self):
         await self.con.execute(r"""
             create type Foo {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5099,6 +5099,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             CREATE TYPE spam::Test;
         ''')
 
+    async def test_edgeql_ddl_module_03(self):
+        await self.con.execute('''\
+            CREATE MODULE spam IF NOT EXISTS;
+        ''')
+
+        await self.con.execute('''\
+            DROP MODULE spam IF EXISTS;
+        ''')
+
+        await self.con.execute('''\
+            DROP MODULE spam IF EXISTS;
+        ''')
+
+        with self.assertRaisesRegex(
+                edgedb.UnknownModuleError,
+                r"module 'spam' is not in this schema"):
+            await self.con.execute('''\
+                CREATE TYPE spam::Foo;
+            ''')
+
     async def test_edgeql_ddl_operator_01(self):
         await self.con.execute('''
             CREATE INFIX OPERATOR `+++`

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5500,6 +5500,46 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             ''')
 
+    async def test_edgeql_ddl_scalar_14(self):
+        await self.con.execute('''
+            CREATE ABSTRACT SCALAR TYPE a EXTENDING std::int64 IF NOT EXISTS;
+        ''')
+
+        await self.con.execute('''
+            CREATE ABSTRACT SCALAR TYPE a EXTENDING std::int64 IF NOT EXISTS;
+        ''')
+
+        await self.con.execute('''
+            CREATE SCALAR TYPE b EXTENDING std::int64 IF NOT EXISTS;
+        ''')
+
+        await self.con.execute('''
+            CREATE SCALAR TYPE b EXTENDING std::int64 IF NOT EXISTS;
+        ''')
+
+        await self.con.execute('''
+            ALTER SCALAR TYPE b IF EXISTS
+            CREATE CONSTRAINT std::one_of(1, 2);
+        ''')
+
+        await self.con.execute('''
+            ALTER SCALAR TYPE non_existent IF EXISTS
+            CREATE CONSTRAINT std::one_of(1, 2);
+        ''')
+
+        await self.con.execute('''
+            DROP SCALAR TYPE a IF EXISTS;
+        ''')
+
+        await self.con.execute('''
+            DROP SCALAR TYPE a IF EXISTS;
+        ''')
+
+        await self.con.execute('''
+            DROP SCALAR TYPE non_existent IF EXISTS;
+        ''')
+
+
     async def test_edgeql_ddl_cast_01(self):
         await self.con.execute('''
             CREATE SCALAR TYPE type_a EXTENDING std::str;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8032,6 +8032,89 @@ type default::Foo {
                 CREATE EXTENSION MyExtension VERSION '3.0';
             """)
 
+    async def test_edgeql_ddl_extension_02(self):
+        await self.con.execute(r"""
+            CREATE EXTENSION PACKAGE MyExtension VERSION '1.0';
+        """)
+
+        await self.con.execute(r"""
+            CREATE EXTENSION MyExtension IF NOT EXISTS;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT schema::Extension {
+                    name,
+                    package: {
+                        ver := (.version.major, .version.minor)
+                    }
+                }
+                FILTER .name = 'MyExtension'
+            """,
+            [{
+                'name': 'MyExtension',
+                'package': {
+                    'ver': [1, 0],
+                }
+            }]
+        )
+
+        await self.con.execute(r"""
+            CREATE EXTENSION MyExtension IF NOT EXISTS;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT schema::Extension {
+                    name,
+                    package: {
+                        ver := (.version.major, .version.minor)
+                    }
+                }
+                FILTER .name = 'MyExtension'
+            """,
+            [{
+                'name': 'MyExtension',
+                'package': {
+                    'ver': [1, 0],
+                }
+            }]
+        )
+
+        await self.con.execute(r"""
+            DROP EXTENSION MyExtension IF EXISTS;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT schema::Extension {
+                    name,
+                    package: {
+                        ver := (.version.major, .version.minor)
+                    }
+                }
+                FILTER .name = 'MyExtension'
+            """,
+            [],
+        )
+
+        await self.con.execute(r"""
+            DROP EXTENSION MyExtension IF EXISTS;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT schema::Extension {
+                    name,
+                    package: {
+                        ver := (.version.major, .version.minor)
+                    }
+                }
+                FILTER .name = 'MyExtension'
+            """,
+            [],
+        )
+
     async def test_edgeql_ddl_role_01(self):
         if not self.has_create_role:
             self.skipTest("create role is not supported by the backend")

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5539,7 +5539,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             DROP SCALAR TYPE non_existent IF EXISTS;
         ''')
 
-
     async def test_edgeql_ddl_cast_01(self):
         await self.con.execute('''
             CREATE SCALAR TYPE type_a EXTENDING std::str;
@@ -7415,7 +7414,6 @@ type default::Foo {
         await self.con.execute("""
             CREATE ABSTRACT ANNOTATION ann IF NOT EXISTS;
         """)
-
 
         await self.con.execute("""
             ALTER ABSTRACT ANNOTATION ann IF EXISTS {
@@ -9814,7 +9812,8 @@ type default::Foo {
         """)
 
         await self.con.execute(r"""
-            ALTER ABSTRACT CONSTRAINT NonExistent IF EXISTS RENAME TO NonExistent2;
+            ALTER ABSTRACT CONSTRAINT NonExistent IF EXISTS
+            RENAME TO NonExistent2;
         """)
 
         await self.con.execute(r"""


### PR DESCRIPTION
This adds support for conditional statements for most top-level DDL statements.

I skipped a few statements that look like internals or ones that IMO don't need this:
1. `CREATE/DROP DATABASE` - PostgreSQL doesn't allow you to create databases conditionally + for such "external" objects EdgeDB has its custom logic. But I can try to add this if you want to.
2. `CREATE/DROP EXTENSION PACKAGE` - it seems that these are statements for internal use. But if needed, I can add support for that there too.
3. `CREATE PSEUDO TYPE` - it doesn't seem that the user should be able to do that anyway.
4. `CREATE/ALTER/DROP OPERATOR` - also looks like internal statements.
5. `CREATE/ALTER/DROP CAST` - the same as above.
6. `CREATE/ALTER/DROP MIGRATION` - it seems to me that the user should not be able to manipulate migrations in conditional way.

Also, if you want, I can break this PR up into several separate PRs, though most of additions here are tests and grammar changes.

Closes #1385