### PR TITLE
Eliminate use of __edb_token column

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -936,4 +936,3 @@ class IteratorCTE(ImmutableBase):
     path_id: irast.PathId
     cte: CommonTableExpr
     parent: typing.Optional[IteratorCTE]
-    is_dml_pseudo_iterator: bool = False


### PR DESCRIPTION
Move the SELECT that generates the INSERT tuples into its own CTE,
then add a new result CTE at the end that joins the INSERT and the
tuple generating SELECT CTE together. This makes any external iterator
visible without needing to insert it into a table.

(Depends on https://github.com/edgedb/edgedb/pull/4070)