### PR TITLE
Make access policy errors raise before exclusive constraints

### DIFF
--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -200,6 +200,9 @@ class AccessKind(s_enum.StrEnum):
     Delete = 'Delete'
     Insert = 'Insert'
 
+    def is_data_check(self) -> bool:
+        return self is AccessKind.UpdateWrite or self is AccessKind.Insert
+
 
 class DescribeLanguage(s_enum.StrEnum):
     DDL = 'DDL'

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -271,6 +271,28 @@ class IntersectionRangeVar(PathRangeVar):
     component_rvars: typing.List[PathRangeVar]
 
 
+class DynamicRangeVarFunc(typing.Protocol):
+    """A 'dynamic' range var that provides a callback hook.
+
+    Used to sneak more complex search logic in.
+    I am 100% going to regret this.
+    """
+
+    # Lookup function for a DynamicRangeVar. If it returns a
+    # PathRangeVar, keep looking in that rvar. If it returns
+    # another expression, that's the output.
+    def __call__(
+        self, rel: Query, path_id: irast.PathId, *,
+        flavor: str, aspect: str, env: typing.Any
+    ) -> typing.Optional[BaseExpr | PathRangeVar]:
+        pass
+
+
+class DynamicRangeVar(PathRangeVar):
+
+    dynamic_get_path: DynamicRangeVarFunc
+
+
 class TypeName(ImmutableBase):
     """Type in definitions and casts."""
 
@@ -394,8 +416,8 @@ class ResTarget(ImmutableBaseExpr):
 class UpdateTarget(ImmutableBaseExpr):
     """Query update target."""
 
-    # column name (optional)
-    name: str
+    # column names
+    name: str | typing.List[str]
     # value expression to assign
     val: BaseExpr
 

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -444,7 +444,12 @@ class SQLSourceGenerator(codegen.SourceGenerator):
             self.write(' AS ' + common.quote_ident(node.name))
 
     def visit_UpdateTarget(self, node):
-        self.write(common.quote_ident(node.name))
+        if isinstance(node.name, list):
+            self.write('(')
+            self.write(', '.join(common.quote_ident(n) for n in node.name))
+            self.write(')')
+        else:
+            self.write(common.quote_ident(node.name))
         self.write(' = ')
         self.visit(node.val)
 

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -244,6 +244,18 @@ def get_path_var(
     ):
         return astutils.compile_typeref(src_path_id.target.real_material_type)
 
+    if isinstance(rel_rvar, pgast.DynamicRangeVar):
+        var = rel_rvar.dynamic_get_path(
+            rel, path_id, flavor=flavor, aspect=aspect, env=env)
+        if isinstance(var, pgast.PathRangeVar):
+            rel_rvar = var
+        elif var:
+            put_path_var(
+                rel, path_id, var, aspect=aspect, flavor=flavor, env=env)
+            return var
+        else:
+            rel_rvar = None
+
     if rel_rvar is None:
         raise LookupError(
             f'there is no range var for '

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -2051,3 +2051,14 @@ def get_ptr_rel_overlays(
 ]:
     typeref = ptrref.out_source.real_material_type
     return ctx.ptr_rel_overlays[dml_source][typeref.id, ptrref.shortname.name]
+
+
+def clone_ptr_rel_overlays(
+    *,
+    ctx: context.CompilerContextLevel,
+) -> None:
+    ctx.ptr_rel_overlays = ctx.ptr_rel_overlays.copy()
+    for k, v in ctx.ptr_rel_overlays.items():
+        ctx.ptr_rel_overlays[k] = v.copy()
+        for k2, v2 in v.items():
+            v[k2] = list(v2)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1870,6 +1870,10 @@ class AlterPointer(
         if (
             self.get_attribute_value('expr') is not None
             or bool(self.get_subcommands(type=constraints.ConstraintCommand))
+            or (
+                self.get_attribute_value('default') is not None
+                and self.scls.is_link_property(schema)
+            )
         ):
             # If the expression gets changed, we need to propagate
             # this change to other expressions referring to this one,
@@ -1877,6 +1881,10 @@ class AlterPointer(
             #
             # Also, if constraints are modified, that can affect
             # cardinality of other expressions using backlinks.
+            #
+            # Also when setting a default on a link property, since
+            # access policies need to be prevented from accessing them.
+            # (Ugh.)
             schema = self._propagate_if_expr_refs(
                 schema,
                 context,


### PR DESCRIPTION
We do this by splitting out the computation of the insert/update
tuples into their own SELECT CTE, and using that to compute the access
policies.