### PR TITLE
Fix properties of type array<uuid> in migrations

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_15_00_00
+EDGEDB_CATALOG_VERSION = 2022_07_20_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/schema/reflection/reader.py
+++ b/edb/schema/reflection/reader.py
@@ -100,6 +100,9 @@ def parse_into(
         name = s_name.name_from_string(entry['name__internal'])
         layout = schema_class_layout[mcls]
 
+        if base_schema.has_object(objid) and str(name) != '__schema_version__':
+            continue
+
         if isinstance(obj, s_obj.QualifiedObject):
             name_to_id[name] = objid
         else:

--- a/edb/schema/reflection/reader.py
+++ b/edb/schema/reflection/reader.py
@@ -36,6 +36,7 @@ from edb.schema import name as s_name
 from edb.schema import objects as s_obj
 from edb.schema import operators as s_oper
 from edb.schema import schema as s_schema
+from edb.schema import version as s_ver
 
 from . import structure as sr_struct
 
@@ -100,7 +101,10 @@ def parse_into(
         name = s_name.name_from_string(entry['name__internal'])
         layout = schema_class_layout[mcls]
 
-        if base_schema.has_object(objid) and str(name) != '__schema_version__':
+        if (
+            base_schema.has_object(objid)
+            and not isinstance(obj, s_ver.BaseSchemaVersion)
+        ):
             continue
 
         if isinstance(obj, s_obj.QualifiedObject):

--- a/edb/schema/version.py
+++ b/edb/schema/version.py
@@ -25,9 +25,13 @@ from . import delta as sd
 from . import objects as so
 
 
-class SchemaVersion(so.InternalObject):
+class BaseSchemaVersion(so.Object):
 
     version = so.SchemaField(uuid.UUID)
+
+
+class SchemaVersion(BaseSchemaVersion, so.InternalObject):
+    pass
 
 
 class SchemaVersionCommandContext(sd.ObjectCommandContext[SchemaVersion]):
@@ -55,9 +59,10 @@ class AlterSchemaVersion(
     pass
 
 
-class GlobalSchemaVersion(so.InternalObject, so.GlobalObject):
-
-    version = so.SchemaField(uuid.UUID)
+class GlobalSchemaVersion(
+    BaseSchemaVersion, so.InternalObject, so.GlobalObject
+):
+    pass
 
 
 class GlobalSchemaVersionCommandContext(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10858,6 +10858,13 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         ''')
 
+    async def test_edgeql_migration_uuid_array_01(self):
+        await self.migrate(r'''
+            type Foo {
+                property x -> array<uuid>;
+            }
+        ''')
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
The issue is that the type array<uuid> was in an inconsistent
state. The shadow reflection schema uses array<uuid>, so it is always
in the reflected schema, but since it is created by the reflection
schema code and does not appear in the stdlib, it didn't appear in the
stdschema.

Fix this by adding any collection types that appear in the reflschema
into the stdschema.

Also to avoid related inconsistencies, skip loading objects that
appear in the stdschema when processing the json from the reflection
query. The query filters out qualified objects from the std schema but
not "global" ones, so collections and some other things were being
duplicated between _base_schema and _top_schema.

Fixes #4107.