### PR TITLE
Fix TestDatabase flakes by giving it suite granularity

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,6 +25,7 @@ from edb.testbase import server as tb
 
 class TestDatabase(tb.ConnectedTestCase):
     TRANSACTION_ISOLATION = False
+    PARALLELISM_GRANULARITY = 'suite'
 
     async def test_database_create_01(self):
         if not self.has_create_database:


### PR DESCRIPTION
I've been getting flakes with TestDatabase because some of the tests
create/delete the same databases. Give it suite granularity to avoid
this.