### PR TITLE
Fix diamond pattern delegated constraints

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_22_00_00
+EDGEDB_CATALOG_VERSION = 2022_07_25_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2142,9 +2142,7 @@ class AlterConstraint(
             ):
                 op = self.enforce_constraint(
                     constraint, schema, context, self.source_context)
-                self.schedule_post_inhview_update_command(
-                    schema, context, op,
-                    s_objtypes.ObjectTypeCommandContext,)
+                self.pgops.add(op)
 
             self.pgops.add(self.fixup_base_constraint_triggers(
                 constraint, orig_schema, schema, context, self.source_context,

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -164,11 +164,7 @@ class ConstraintMech:
             cls, subject, constraint, schema, context, source_context):
         assert constraint.get_subject(schema) is not None
 
-        constraint_origin = constraint.get_constraint_origin(schema)
-        if constraint_origin != constraint:
-            origin_subject = constraint_origin.get_subject(schema)
-        else:
-            origin_subject = subject
+        constraint_origins = constraint.get_constraint_origins(schema)
 
         singletons = frozenset({subject})
 
@@ -224,7 +220,14 @@ class ConstraintMech:
             'except_data': except_data,
         }
 
-        if constraint_origin != constraint:
+        different_origins = [
+            origin for origin in constraint_origins
+            if origin != constraint
+        ]
+
+        per_origin_parts = []
+        for constraint_origin in different_origins:
+            origin_subject = constraint_origin.get_subject(schema)
             origin_path_prefix_anchor = (
                 qlast.Subject().name
                 if isinstance(origin_subject, s_types.Type) else None
@@ -270,35 +273,72 @@ class ConstraintMech:
                 origin_except_data = cls._edgeql_tree_to_exprdata(except_sql)
 
             origin_exclusive_expr_refs = cls._get_exclusive_refs(origin_ir)
-            pg_constr_data['origin_subject_db_name'] = origin_subject_db_name
-            pg_constr_data['origin_except_data'] = origin_except_data
-        else:
-            origin_exclusive_expr_refs = None
-            pg_constr_data['origin_subject_db_name'] = subject_db_name
-            pg_constr_data['origin_except_data'] = except_data
+            per_origin_parts.append((
+                origin_subject,
+                origin_exclusive_expr_refs,
+                origin_subject_db_name,
+                origin_except_data,
+            ))
+
+        if not per_origin_parts:
+            origin_subject = subject
+            origin_subject_db_name = subject_db_name
+            origin_except_data = except_data
+            per_origin_parts.append((
+                origin_subject,
+                None,
+                origin_subject_db_name,
+                origin_except_data,
+            ))
 
         if exclusive_expr_refs:
+            exprdatas = []
             for ref in exclusive_expr_refs:
                 exprdata = cls._edgeql_ref_to_pg_constr(
-                    subject, origin_subject, ref, schema)
-                pg_constr_data['expressions'].append(exprdata)
+                    subject, None, ref, schema)
+                exprdata.update(
+                    origin_subject_db_name=subject_db_name,
+                    origin_except_data=except_data,
+                )
+                exprdatas.append(exprdata)
+
+            pg_constr_data['expressions'].extend(exprdatas)
+
+        else:
+            assert len(constraint_origins) == 1
+            exprdata = cls._edgeql_ref_to_pg_constr(
+                subject, origin_subject, ir, schema)
+            exprdata.update(
+                origin_subject_db_name=origin_subject_db_name,
+                origin_except_data=origin_except_data,
+            )
+            pg_constr_data['expressions'].append(exprdata)
+
+        for (
+            origin_subject,
+            origin_exclusive_expr_refs,
+            origin_subject_db_name,
+            origin_except_data
+        ) in per_origin_parts:
+            if not exclusive_expr_refs:
+                continue
 
             if origin_exclusive_expr_refs:
                 for ref in origin_exclusive_expr_refs:
                     exprdata = cls._edgeql_ref_to_pg_constr(
                         subject, origin_subject, ref, schema)
+                    exprdata.update(
+                        origin_subject_db_name=origin_subject_db_name,
+                        origin_except_data=origin_except_data,
+                    )
                     pg_constr_data['origin_expressions'].append(exprdata)
             else:
-                pg_constr_data['origin_expressions'] = (
-                    pg_constr_data['expressions'])
+                pg_constr_data['origin_expressions'].extend(exprdatas)
 
+        if exclusive_expr_refs:
             pg_constr_data['scope'] = 'relation'
             pg_constr_data['type'] = 'unique'
         else:
-            exprdata = cls._edgeql_ref_to_pg_constr(
-                subject, origin_subject, ir, schema)
-            pg_constr_data['expressions'].append(exprdata)
-
             pg_constr_data['scope'] = 'row'
             pg_constr_data['type'] = 'check'
 
@@ -374,18 +414,15 @@ class SchemaTableConstraint:
         pg_c = constr._pg_constr_data
 
         table_name = pg_c['subject_db_name']
-        origin_table_name = pg_c['origin_subject_db_name']
         expressions = pg_c['expressions']
         origin_expressions = pg_c['origin_expressions']
 
         constr = deltadbops.SchemaConstraintTableConstraint(
             table_name,
-            origin_table_name=origin_table_name,
             constraint=constr._constraint,
             exprdata=expressions,
             origin_exprdata=origin_expressions,
             except_data=pg_c['except_data'],
-            origin_except_data=pg_c['origin_except_data'],
             scope=pg_c['scope'],
             type=pg_c['type'],
             schema=constr._schema,
@@ -439,13 +476,15 @@ class SchemaTableConstraint:
         raw_constr_name = tabconstr.constraint_name(quote=False)
 
         for expr, origin_expr in zip(
-                tabconstr._exprdata, tabconstr._origin_exprdata):
+            itertools.cycle(tabconstr._exprdata),
+            tabconstr._origin_exprdata
+        ):
             exprdata = expr['exprdata']
             origin_exprdata = origin_expr['exprdata']
             old_expr = origin_exprdata['old']
             new_expr = exprdata['new']
 
-            schemaname, tablename = tabconstr.get_origin_table_name()
+            schemaname, tablename = origin_expr['origin_subject_db_name']
             real_tablename = tabconstr.get_subject_name(quote=False)
 
             errmsg = 'duplicate key value violates unique ' \
@@ -462,10 +501,13 @@ class SchemaTableConstraint:
             else:
                 key = "id"
 
-            if tabconstr._except_data:
+            except_data = tabconstr._except_data
+            origin_except_data = origin_expr['origin_except_data']
+
+            if except_data:
                 except_part = f'''
-                    AND ({tabconstr._origin_except_data['old']} is not true)
-                    AND ({tabconstr._except_data['new']} is not true)
+                    AND ({origin_except_data['old']} is not true)
+                    AND ({except_data['new']} is not true)
                 '''
             else:
                 except_part = ''

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9786,6 +9786,90 @@ type default::Foo {
                 };
             """)
 
+    async def test_edgeql_ddl_constraint_check_09(self):
+        # Test a diamond pattern with a delegated constraint
+
+        await self.con.execute(r"""
+            CREATE ABSTRACT TYPE R {
+                CREATE REQUIRED PROPERTY name -> std::str {
+                    CREATE DELEGATED CONSTRAINT std::exclusive;
+                };
+            };
+            CREATE TYPE S EXTENDING R;
+            CREATE TYPE T EXTENDING R;
+            CREATE TYPE V EXTENDING S, T;
+
+            INSERT S { name := "S" };
+            INSERT T { name := "T" };
+            INSERT V { name := "V" };
+        """)
+
+        for t1, t2 in ["SV", "TV", "VT", "VS"]:
+            with self.annotate(tables=(t1, t2)):
+                async with self.assertRaisesRegexTx(
+                        edgedb.ConstraintViolationError,
+                        r'violates exclusivity constraint'):
+                    await self.con.execute(f"""
+                        insert {t1} {{ name := "{t2}" }}
+                    """)
+
+                async with self.assertRaisesRegexTx(
+                        edgedb.ConstraintViolationError,
+                        r'violates exclusivity constraint'):
+                    await self.con.execute(f"""
+                        select {{
+                            (insert {t1} {{ name := "!" }}),
+                            (insert {t2} {{ name := "!" }}),
+                        }}
+                    """)
+
+        await self.con.execute(r"""
+            ALTER TYPE default::R {
+                DROP PROPERTY name;
+            };
+        """)
+
+    async def test_edgeql_ddl_constraint_check_10(self):
+        # Test a half-delegated twice inherited constraint pattern
+
+        await self.con.execute(r"""
+            CREATE ABSTRACT TYPE R {
+                CREATE REQUIRED PROPERTY name -> std::str {
+                    CREATE DELEGATED CONSTRAINT std::exclusive;
+                };
+            };
+            CREATE TYPE S EXTENDING R;
+            CREATE TYPE T {
+                CREATE REQUIRED PROPERTY name -> std::str {
+                    CREATE CONSTRAINT std::exclusive;
+                };
+            };
+            CREATE TYPE V EXTENDING S, T;
+
+            INSERT S { name := "S" };
+            INSERT T { name := "T" };
+            INSERT V { name := "V" };
+        """)
+
+        for t1, t2 in ["SV", "TV", "VT", "VS"]:
+            with self.annotate(tables=(t1, t2)):
+                async with self.assertRaisesRegexTx(
+                        edgedb.ConstraintViolationError,
+                        r'violates exclusivity constraint'):
+                    await self.con.execute(f"""
+                        insert {t1} {{ name := "{t2}" }}
+                    """)
+
+                async with self.assertRaisesRegexTx(
+                        edgedb.ConstraintViolationError,
+                        r'violates exclusivity constraint'):
+                    await self.con.execute(f"""
+                        select {{
+                            (insert {t1} {{ name := "!" }}),
+                            (insert {t2} {{ name := "!" }}),
+                        }}
+                    """)
+
     async def test_edgeql_ddl_constraint_alter_01(self):
         await self.con.execute(r"""
             CREATE TYPE ConTest01 {


### PR DESCRIPTION
If we have an inheritence tree like V <: S, T <: R, with R
declaring a delegated constraint, we need to check both S and T
in the constraint trigger for V.

This requires a decent amount of rearranging the guts of trigger
generation.

Also fix dropping a property with such a constraint, which was the
originally filed issue here.

Fixes #4105.