### PR TITLE
Gate explicit id setting behind a configuration flag

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_20_00_00
+EDGEDB_CATALOG_VERSION = 2022_07_22_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -40,14 +40,14 @@ class GlobalCompilerOptions:
     #: Whether to allow the expression to be of a generic type.
     allow_generic_type_output: bool = False
 
-    #: Allow writing to protected pointers in INSERT.
-    allow_writing_protected_pointers: bool = False
-
     #: Whether to apply various query rewrites, including access policy.
     apply_query_rewrites: bool = True
 
     #: Whether to apply user-specified access policies
     apply_user_access_policies: bool = True
+
+    #: Whether to allow specifying 'id' explicitly in INSERT
+    allow_user_specified_id: bool = False
 
     #: Enables constant folding optimization (enabled by default).
     constant_folding: bool = True

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1106,7 +1106,10 @@ def _normalize_view_ptr_expr(
         else:
             msg = f'cannot assign to {ptrcls_sn.name}'
         if id_access and not ctx.env.options.allow_user_specified_id:
-            hint = 'consider enabling the "allow_user_specified_id" configuration parameter to allow setting custom object ids'
+            hint = (
+                'consider enabling the "allow_user_specified_id" '
+                'configuration parameter to allow setting custom object ids'
+            )
         else:
             hint = None
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1078,6 +1078,14 @@ def _normalize_view_ptr_expr(
         ctx.env.schema = ptrcls.set_field_value(
             ctx.env.schema, 'cardinality', qltypes.SchemaCardinality.Unknown)
 
+    # Prohibit update of readonly
+    if exprtype.is_update() and ptrcls.get_readonly(ctx.env.schema):
+        raise errors.QueryError(
+            f'cannot update {ptrcls.get_verbosename(ctx.env.schema)}: '
+            f'it is declared as read-only',
+            context=compexpr and compexpr.context,
+        )
+
     # Prohibit invalid operations on id and __type__
     ptrcls_sn = ptrcls.get_shortname(ctx.env.schema)
     id_access = (
@@ -1103,13 +1111,6 @@ def _normalize_view_ptr_expr(
             hint = None
 
         raise errors.QueryError(msg, context=shape_el.context, hint=hint)
-
-    if exprtype.is_update() and ptrcls.get_readonly(ctx.env.schema):
-        raise errors.QueryError(
-            f'cannot update {ptrcls.get_verbosename(ctx.env.schema)}: '
-            f'it is declared as read-only',
-            context=compexpr and compexpr.context,
-        )
 
     return ptrcls, irexpr
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1106,7 +1106,7 @@ def _normalize_view_ptr_expr(
         else:
             msg = f'cannot assign to {ptrcls_sn.name}'
         if id_access and not ctx.env.options.allow_user_specified_id:
-            hint = 'config setting allow_user_specified_id must be enabled'
+            hint = 'consider enabling the "allow_user_specified_id" configuration parameter to allow setting custom object ids'
         else:
             hint = None
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -120,6 +120,11 @@ CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject {
         CREATE ANNOTATION cfg::affects_compilation := 'true';
     };
 
+    CREATE PROPERTY allow_user_specified_id -> std::bool {
+        SET default := false;
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+    };
+
     # Exposed backend settings follow.
     # When exposing a new setting, remember to modify
     # the _read_sys_config function to select the value

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -696,14 +696,9 @@ class Pointer(referencing.ReferencedInheritingObject,
     def is_link_property(self, schema: s_schema.Schema) -> bool:
         raise NotImplementedError
 
-    def is_protected_pointer(
-        self, exprtype: s_types.ExprType, schema: s_schema.Schema
-    ) -> bool:
+    def is_protected_pointer(self, schema: s_schema.Schema) -> bool:
         sn = self.get_shortname(schema).name
-        return (
-            sn == '__type__'
-            or (sn == 'id' and not exprtype.is_mutation())
-        )
+        return sn == '__type__'
 
     def is_dumpable(self, schema: s_schema.Schema) -> bool:
         return (

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -591,7 +591,6 @@ class Compiler:
             constant_folding=not disable_constant_folding,
             json_parameters=ctx.json_parameters,
             implicit_limit=ctx.implicit_limit,
-            allow_writing_protected_pointers=ctx.schema_reflection_mode,
             bootstrap_mode=ctx.bootstrap_mode,
             apply_query_rewrites=(
                 not ctx.bootstrap_mode
@@ -599,6 +598,8 @@ class Compiler:
             ),
             apply_user_access_policies=self.get_config_val(
                 ctx, 'apply_access_policies'),
+            allow_user_specified_id=self.get_config_val(
+                ctx, 'allow_user_specified_id') or ctx.schema_reflection_mode,
             testmode=self.get_config_val(ctx, '__internal_testmode'),
             devmode=self._is_dev_instance(),
         )

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5217,7 +5217,22 @@ class TestInsert(tb.QueryTestCase):
 
         )
 
+    async def test_edgeql_insert_explicit_id_00(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                "cannot assign to id"):
+            await self.con.execute('''
+                INSERT Person {
+                    id := <uuid>'ffffffff-ffff-ffff-ffff-ffffffffffff',
+                    name := "test",
+                 }
+            ''')
+
     async def test_edgeql_insert_explicit_id_01(self):
+        await self.con.execute('''
+            configure session set allow_user_specified_id := true
+        ''')
+
         await self.con.execute('''
             INSERT Person {
                 id := <uuid>'ffffffff-ffff-ffff-ffff-ffffffffffff',
@@ -5235,6 +5250,10 @@ class TestInsert(tb.QueryTestCase):
         )
 
     async def test_edgeql_insert_explicit_id_02(self):
+        await self.con.execute('''
+            configure session set allow_user_specified_id := true
+        ''')
+
         await self.con.execute('''
             INSERT Person {
                 id := <uuid>'ffffffff-ffff-ffff-ffff-ffffffffffff',
@@ -5254,6 +5273,10 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_explicit_id_03(self):
         await self.con.execute('''
+            configure session set allow_user_specified_id := true
+        ''')
+
+        await self.con.execute('''
             INSERT Person {
                 id := <uuid>'ffffffff-ffff-ffff-ffff-ffffffffffff',
                 name := "test",
@@ -5271,6 +5294,10 @@ class TestInsert(tb.QueryTestCase):
             ''')
 
     async def test_edgeql_insert_explicit_id_04(self):
+        await self.con.execute('''
+            configure session set allow_user_specified_id := true
+        ''')
+
         await self.con.execute('''
             create required global break -> bool { set default := false; };
             create type X {


### PR DESCRIPTION
This deals with some potential security issues in some use cases
if it is always enabled.