### PR TITLE
Eagerly introspect the extensions for each database

### DIFF
--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -149,7 +149,8 @@ cdef class Database:
         object user_schema,
         object db_config,
         object reflection_cache,
-        object backend_ids
+        object backend_ids,
+        object extensions,
     ):
         self.name = name
 
@@ -170,11 +171,11 @@ cdef class Database:
         self.backend_ids = backend_ids
         if user_schema is not None:
             self.extensions = {
-                ext.get_name(user_schema).name: ext
+                ext.get_name(user_schema).name
                 for ext in user_schema.get_objects(type=s_ext.Extension)
             }
         else:
-            self.extensions = {}
+            self.extensions = extensions
 
     @property
     def server(self):
@@ -198,7 +199,7 @@ cdef class Database:
         self.user_schema = new_schema
 
         self.extensions = {
-            ext.get_name(new_schema).name: ext
+            ext.get_name(new_schema).name
             for ext in new_schema.get_objects(type=s_ext.Extension)
         }
 
@@ -1121,6 +1122,7 @@ cdef class DatabaseIndex:
         db_config,
         reflection_cache,
         backend_ids,
+        extensions=None,
     ):
         cdef Database db
         db = self._dbs.get(dbname)
@@ -1135,6 +1137,7 @@ cdef class DatabaseIndex:
                 db_config=db_config,
                 reflection_cache=reflection_cache,
                 backend_ids=backend_ids,
+                extensions=extensions,
             )
             self._dbs[dbname] = db
 


### PR DESCRIPTION
This is necessary because otherwise we won't accept http/graphql
connections until a connection is made from the native protocol.