### PR TITLE
Remove (mostly) the WHEN clause from access policies

### DIFF
--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -182,44 +182,6 @@ the others.
 - ``all``: A shorthand policy that can be used to allow or deny full read/
   write permissions. Exactly equivalent to ``select, insert, update, delete``.
 
-The ``when`` clause
-^^^^^^^^^^^^^^^^^^^
-
-For readability, access policies can include a ``when`` clause.
-
-.. code-block:: sdl
-
-  type BlogPost {
-    required property title -> str;
-    link author -> User;
-    access policy own_posts
-      when ( .title[0] = "A" )
-      allow all
-      using ( .author.id ?= global current_user )
-  }
-
-Conceptually, you can think of the ``when`` clause as defining the *set of
-objects* to which the policy applies while the ``using`` clause represents the
-*access check* (likely referencing a global). Logically, the ``when`` and
-``using`` expressions are combined with ``and`` together to determine the
-scope of the policy.
-
-In practice, any policy can be expressed with just ``when``, just ``using``,
-or split across the two; this syntax is intended to enhance readability and
-maintainability. We can re-write the policy above without the ``when`` clause.
-
-.. code-block:: sdl-diff
-
-    type BlogPost {
-      required property title -> str;
-      link author -> User;
-      access policy own_posts
-  -     when ( .title[0] = "A" )
-        allow all
-  -     using( .author.id ?= global current_user)
-  +     using( .author.id ?= global current_user and .title[0] = "A" )
-    }
-
 Resolution order
 ^^^^^^^^^^^^^^^^
 
@@ -305,4 +267,3 @@ the author.
   * - **See also**
   * - :ref:`SDL > Access policies <ref_eql_sdl_access_policies>`
   * - :ref:`DDL > Access policies <ref_eql_ddl_access_policies>`
-

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_20_00_00
+EDGEDB_CATALOG_VERSION = 2022_07_22_00_01
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1181,6 +1181,7 @@ class AccessPolicyCommand(ObjectDDL):
 
 
 class CreateAccessPolicy(CreateObject, AccessPolicyCommand):
+    # condition is the deprecated and largely removed 'when'
     condition: typing.Optional[Expr]
     action: qltypes.AccessPolicyAction
     access_kinds: typing.List[qltypes.AccessKind]

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1192,14 +1192,6 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                     self.write(' (')
                     self.visit(node.value)
                     self.write(')')
-            elif node.name == 'condition':
-                if node.value is None:
-                    self._write_keywords('RESET', 'WHEN')
-                else:
-                    self._write_keywords('WHEN')
-                    self.write(' (')
-                    self.visit(node.value)
-                    self.write(')')
             elif node.name == 'target':
                 if node.value is None:
                     self._write_keywords('RESET', 'TYPE')

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -97,8 +97,6 @@ def get_rewrite_filter(
             expr = expr_field.qlast
         else:
             expr = qlast.BooleanConstant(value='true')
-        if condition := pol.get_condition(schema):
-            expr = qlast.BinOp(op='AND', left=condition.qlast, right=expr)
 
         if is_allow:
             allow.append(expr)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1820,23 +1820,6 @@ class AccessUsingStmt(Nonterm):
         )
 
 
-class AccessWhenStmt(Nonterm):
-
-    def reduce_WHEN_ParenExpr(self, *kids):
-        self.val = qlast.SetField(
-            name='condition',
-            value=kids[1].val,
-            special_syntax=True,
-        )
-
-    def reduce_RESET_WHEN(self, *kids):
-        self.val = qlast.SetField(
-            name='condition',
-            value=None,
-            special_syntax=True,
-        )
-
-
 commands_block(
     'AlterAccessPolicy',
     CreateAnnotationValueStmt,
@@ -1845,7 +1828,6 @@ commands_block(
     RenameStmt,
     AccessPermStmt,
     AccessUsingStmt,
-    AccessWhenStmt,
     opt=False
 )
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -946,17 +946,16 @@ class AccessPolicyDeclarationBlock(Nonterm):
     def reduce_CreateAccessPolicy(self, *kids):
         """%reduce
             ACCESS POLICY ShortNodeName
-            OptWhenBlock AccessPolicyAction AccessKindList
+            AccessPolicyAction AccessKindList
             OptUsingBlock
             CreateAccessPolicySDLCommandsBlock
         """
         self.val = qlast.CreateAccessPolicy(
             name=kids[2].val,
-            condition=kids[3].val,
-            action=kids[4].val,
-            access_kinds=[y for x in kids[5].val for y in x],
-            expr=kids[6].val,
-            commands=kids[7].val,
+            action=kids[3].val,
+            access_kinds=[y for x in kids[4].val for y in x],
+            expr=kids[5].val,
+            commands=kids[6].val,
         )
 
 
@@ -964,15 +963,14 @@ class AccessPolicyDeclarationShort(Nonterm):
     def reduce_CreateAccessPolicy(self, *kids):
         """%reduce
             ACCESS POLICY ShortNodeName
-            OptWhenBlock AccessPolicyAction AccessKindList
+            AccessPolicyAction AccessKindList
             OptUsingBlock
         """
         self.val = qlast.CreateAccessPolicy(
             name=kids[2].val,
-            condition=kids[3].val,
-            action=kids[4].val,
-            access_kinds=[y for x in kids[5].val for y in x],
-            expr=kids[6].val,
+            action=kids[3].val,
+            access_kinds=[y for x in kids[4].val for y in x],
+            expr=kids[5].val,
         )
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -397,7 +397,6 @@ ALTER TYPE schema::ObjectType {
 ALTER TYPE schema::AccessPolicy {
   CREATE REQUIRED LINK subject -> schema::ObjectType;
   CREATE MULTI PROPERTY access_kinds -> schema::AccessKind;
-  CREATE PROPERTY condition -> std::str;
   CREATE REQUIRED PROPERTY action -> schema::AccessPolicyAction;
   CREATE PROPERTY expr -> std::str;
 };

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -50,19 +50,20 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
 
             alter type Owned {
                 create access policy disable_filter
-                  when (not global filter_owned)
-                  allow select;
+                  allow select using (not global filter_owned);
 
                 create access policy cur_owner
-                  when (global cur_owner_active)
-                  allow all using (.owner.name ?= global cur_user);
+                  allow all using (
+                      (global cur_owner_active)
+                      and .owner.name ?= global cur_user
+                  );
             };
 
             alter type Issue {
                 create access policy cur_watchers
-                  when (global watchers_active)
                   allow select using (
-                      (global cur_user IN __subject__.watchers.name) ?? false
+                      global watchers_active and
+                      ((global cur_user IN __subject__.watchers.name) ?? false)
                   )
             };
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -5555,7 +5555,6 @@ aa';
         """
         create type Foo {
             alter access policy test {
-                when (false);
                 allow all;
                 using (true);
             };
@@ -5566,7 +5565,6 @@ aa';
         """
         create type Foo {
             alter access policy test {
-                reset when;
                 allow all;
                 using (true);
             };

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -1742,7 +1742,6 @@ annotation test::foo;
         module test {
             type Foo {
                 access policy test
-                when (true)
                 deny all
                 using (true) {
                    annotation title := 'foo';
@@ -1757,7 +1756,6 @@ annotation test::foo;
         module test {
             type Foo {
                 access policy test
-                when (true)
                 deny all
                 using (true);
                 property x -> str;


### PR DESCRIPTION
I decided to go halfway with the compatibility break with old DDL: we
accept a WHEN in CREATE, and merge it with the expr, but we *don't*
accept modifications of WHEN in ALTER, which would require
persistently keeping track of whether a WHEN was present and handling
it in a bunch of places.

This should cover most existing DDL, I suspect.

Maybe it's only worth trying to deal with the compatability at all if
we do it fully, though.