### PR TITLE
Fix explicit references to the enclosing type in access policies

### DIFF
--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -299,6 +299,13 @@ def compile_dml_policy(
 
         subctx.anchors[qlast.Subject().name] = result
         subctx.partial_path_prefix = result
+
+        # Make sure an explicit object reference also routes to the
+        # right set
+        subctx.path_scope = subctx.env.path_scope.root.attach_fence()
+        subctx.path_scope.attach_path(result.path_id, context=None)
+        setgen.update_view_map(result.path_id, result, ctx=subctx)
+
         return irast.PolicyExpr(
             expr=dispatch.compile(condition, ctx=subctx)
         )

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -303,8 +303,8 @@ class AccessPolicyCommand(
 
             item_vn = e.item.get_verbosename(schema, with_parent=True)
             # Recursion involving more than one schema object.
-            rec_vn = e.path[-1].get_verbosename(
-                schema, with_parent=True)
+            el = e.path[-1] if e.path else e.item
+            rec_vn = el.get_verbosename(schema, with_parent=True)
             # Sort for output determinism
             vn1, vn2 = sorted([rec_vn, item_vn])
             msg = (


### PR DESCRIPTION
Currently references to the type act like they are DETACHED in dml.

There is still a bug here (and in constraints and computeds as well)
if there is an explicit object reference and then subtypes.

Here, at least, that issue manifests as a somewhat bogus error.