### PR TITLE
fix link anchor in docs

### DIFF
--- a/docs/datamodel/computeds.rst
+++ b/docs/datamodel/computeds.rst
@@ -116,7 +116,7 @@ to traverse a link in the *reverse* direction.
 The ``User.blog_posts`` expression above uses the *backlink operator* ``.<`` in
 conjunction with a *type filter* ``[is BlogPost]`` to fetch all the
 ``BlogPosts`` associated with a given ``User``. For details on this syntax, see
-the EdgeQL docs for :ref:`Backlinks <ref_eql_paths>`.
+the EdgeQL docs for :ref:`Backlinks <ref_eql_paths_backlinks>`.
 
 
 .. list-table::


### PR DESCRIPTION
old ref: https://www.edgedb.com/docs/edgeql/paths#ref-eql-paths (goes to start of the page)
new ref: https://www.edgedb.com/docs/edgeql/paths#ref-eql-paths-backlinks (goes to the appropriate section)