### PR TITLE
Still start when only admin server is functional

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1466,7 +1466,9 @@ class Server(ha_base.ClusterProtocol):
                 if fut.result() is not None
             })
 
-        if not servers:
+        # Fail if none of the servers can be started, except when the admin
+        # server on a UNIX domain socket will be started.
+        if not servers and not (admin and port):
             raise StartupError("could not create any listen sockets")
 
         addrs = []

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1468,7 +1468,7 @@ class Server(ha_base.ClusterProtocol):
 
         # Fail if none of the servers can be started, except when the admin
         # server on a UNIX domain socket will be started.
-        if not servers and not (admin and port):
+        if not servers and (not admin or port == 0):
             raise StartupError("could not create any listen sockets")
 
         addrs = []


### PR DESCRIPTION
This prevents bricking the server with invalid listen_addresses or
listen_port followed by a restart.