### PR TITLE
raise `InvalidReferenceError` when setting value for invalid link property in statement inside other modifying statement

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -746,8 +746,13 @@ def _normalize_view_ptr_expr(
                 base_ptrcls = ptrcls.get_bases(
                     ctx.env.schema).first(ctx.env.schema)
             except errors.InvalidReferenceError:
-                # This is a NEW computable pointer, it's fine.
-                pass
+                # Check if we aren't inside of modifying statement
+                # for link property, otherwise this is a NEW
+                # computable pointer, it's fine.
+                if (view_rptr is not None
+                        and view_rptr.exprtype.is_mutation()
+                        and is_linkprop):
+                    raise
 
         qlexpr = astutils.ensure_qlstmt(compexpr)
 

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1318,3 +1318,23 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                     };
                 '''
             )
+
+    async def test_edgeql_props_modification_01(self):
+        await self.con.execute(r'''
+            CREATE TYPE Tgt;
+            CREATE TYPE Src {
+                CREATE LINK l -> Tgt {
+                    CREATE PROPERTY x -> str;
+                };
+            };
+        ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidReferenceError,
+                r"link 'l' of object type 'default::Src' has no property 'y'",
+                _hint="did you mean 'x'?"):
+            await self.con.query(
+                r'''
+                    insert Src { l := assert_single(Tgt { @y := "..." }) };
+                '''
+            )


### PR DESCRIPTION
Closes #3612

cc @msullivan
