### PR TITLE
Add simple Rust page

### DIFF
--- a/docs/clients/index.rst
+++ b/docs/clients/index.rst
@@ -1,6 +1,5 @@
 .. eql:section-intro-page:: clients
 
-
 .. _ref_clients_index:
 
 ================
@@ -12,6 +11,7 @@ Client Libraries
 * `Python <python/index>`_
 * `TypeScript/Javascript <js/index>`_
 * `Go <go/index>`_
+* `Rust <rust/index>`_
 
 
 **Community-Maintained Clients**
@@ -33,5 +33,6 @@ Client Libraries
     js/index
     python/index
     go/index
+    rust/index
     http/index
 

--- a/docs/clients/rust/index.rst
+++ b/docs/clients/rust/index.rst
@@ -1,0 +1,21 @@
+====
+Rust
+====
+
+:edb-alt-title: EdgeDB Rust Client
+
+EdgeDB maintains an client library for Rust. View the `full documentation <https://docs.rs/edgedb-tokio/latest/edgedb_tokio/>`_.
+
+.. code-block:: rust
+
+  #[tokio::main]
+  async fn main() -> anyhow::Result<()> {
+      let conn = edgedb_tokio::create_client().await?;
+      let val = conn.query_required_single::<i64, _>(
+          "SELECT 7*8",
+          &(),
+      ).await?;
+      println!("7*8 is: {}", val);
+      Ok(())
+  }
+

--- a/docs/clients/rust/index.rst
+++ b/docs/clients/rust/index.rst
@@ -4,7 +4,8 @@ Rust
 
 :edb-alt-title: EdgeDB Rust Client
 
-EdgeDB maintains an client library for Rust. View the `full documentation <https://docs.rs/edgedb-tokio/latest/edgedb_tokio/>`_.
+EdgeDB maintains an client library for Rust. View the `full documentation
+<https://docs.rs/edgedb-tokio/latest/edgedb_tokio/>`_.
 
 .. code-block:: rust
 
@@ -18,4 +19,3 @@ EdgeDB maintains an client library for Rust. View the `full documentation <https
       println!("7*8 is: {}", val);
       Ok(())
   }
-

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -353,6 +353,7 @@ class TestDocSnippets(unittest.TestCase):
                     'go',
                     'yaml',
                     'jsx',
+                    'rust',
                     'tsx',
                     'elixir'
                 }:


### PR DESCRIPTION
Interim solution, we can go a proper conversion step when we have the resources. In the meantime I think it's important that we have a link in the sidebar. 

Should probably hold off on merging until `v0.3` lands, cc @tailhook 