### PR TITLE
Remap explicit type reference to child in constraint compilation

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -84,7 +84,7 @@ class ViewRPtr:
 @dataclasses.dataclass
 class ScopeInfo:
     path_scope: irast.ScopeTreeNode
-    binding_kind: irast.BindingKind
+    binding_kind: Optional[irast.BindingKind]
     pinned_path_id_ns: Optional[FrozenSet[str]] = None
 
 

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -118,3 +118,9 @@ class CompilerOptions(GlobalCompilerOptions):
     #: as singletons in the context of this compilation.
     singletons: Collection[Union[s_types.Type, s_pointers.Pointer]] = (
         frozenset())
+
+    #: Type references that should be remaped to another type.  This
+    #: is for dealing with remapping explicit type names in schema
+    #: expressions to their subtypes when necessary.
+    type_remaps: Dict[s_types.Type, s_types.Type] = (
+        dc_field(default_factory=dict))

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -89,6 +89,13 @@ def init_context(
             ctx.env.path_scope.attach_path(path_id, context=None)
             ctx.env.singletons.append(path_id)
 
+    for orig, remapped in options.type_remaps.items():
+        rset = compile_anchor('__', remapped, ctx=ctx)
+        ctx.view_sets[orig] = rset
+        ctx.path_scope_map[rset] = context.ScopeInfo(
+            path_scope=ctx.path_scope, binding_kind=None
+        )
+
     ctx.modaliases.update(options.modaliases)
 
     if options.anchors:

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -173,6 +173,13 @@ class ConstraintMech:
             path_prefix_anchor=qlast.Subject().name,
             apply_query_rewrites=not context.stdmode,
             singletons=singletons,
+            # Remap the constraint origin to the subject, so that if
+            # we have B <: A, and the constraint references A.foo, it
+            # gets rewritten in the subtype to B.foo. It's OK to only
+            # look at one constraint origin, because if there were
+            # multiple different origins, they couldn't get away with
+            # referring to the type explicitly.
+            type_remaps={constraint_origins[0].get_subject(schema): subject},
         )
 
         ir = qlcompiler.compile_ast_to_ir(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9553,6 +9553,25 @@ type default::Foo {
                 };
             """)
 
+    async def test_edgeql_ddl_constraint_21(self):
+        # We plan on rejecting this, but for now do the thing closest
+        # to right.
+        await self.con.execute(r"""
+            create type A {
+                create property x -> str;
+                create constraint exclusive on (A.x);
+            };
+            create type B extending A;
+            insert A { x := "!" };
+        """)
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r'violates exclusivity constraint'):
+            await self.con.execute("""
+                insert B { x := "!" }
+            """)
+
     async def test_edgeql_ddl_constraint_check_01a(self):
         await self.con.execute(r"""
             create type Foo {


### PR DESCRIPTION
Fixes the most critical part of #4142.