### PR TITLE
Fix a number of related access policy semantics issues

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -406,6 +406,9 @@ class ContextLevel(compiler.ContextLevel):
     that had rewrites in its components.
     """
 
+    suppress_rewrites: FrozenSet[s_types.Type]
+    """Types to suppress using rewrites on"""
+
     aliased_views: ChainMap[s_name.Name, s_types.Type]
     """A dictionary of views aliased in a statement body."""
 
@@ -563,6 +566,7 @@ class ContextLevel(compiler.ContextLevel):
             self.view_nodes = {}
             self.view_sets = {}
             self.type_rewrites = {}
+            self.suppress_rewrites = frozenset()
             self.aliased_views = collections.ChainMap()
             self.must_use_views = {}
             self.expr_view_cache = {}
@@ -610,6 +614,7 @@ class ContextLevel(compiler.ContextLevel):
             self.view_nodes = prevlevel.view_nodes
             self.view_sets = prevlevel.view_sets
             self.type_rewrites = prevlevel.type_rewrites
+            self.suppress_rewrites = prevlevel.suppress_rewrites
             self.must_use_views = prevlevel.must_use_views
             self.expr_view_cache = prevlevel.expr_view_cache
             self.shape_type_cache = prevlevel.shape_type_cache

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -124,3 +124,5 @@ class CompilerOptions(GlobalCompilerOptions):
     #: expressions to their subtypes when necessary.
     type_remaps: Dict[s_types.Type, s_types.Type] = (
         dc_field(default_factory=dict))
+
+    detached: bool = False

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -103,9 +103,7 @@ def compile_pol(
         expr = qlast.BinOp(op='AND', left=condition.qlast, right=expr)
 
     # Find all descendants of the original subject of the rule
-    ancs = (pol,) + pol.get_ancestors(schema).objects(schema)
-    subject = ancs[-1].get_subject(schema)
-    assert isinstance(subject, s_objtypes.ObjectType)
+    subject = pol.get_original_subject(schema)
     descs = {subject} | {
         desc for desc in subject.descendants(schema)
         if desc.is_material_object_type(schema)

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -78,6 +78,48 @@ def has_own_policies(
     )
 
 
+def compile_pol(
+    stype: s_objtypes.ObjectType,
+    pol: s_policies.AccessPolicy, *,
+    ctx: context.ContextLevel,
+) -> irast.Set:
+    """Compile the condition from an individual policy.
+
+    A policy is evaluated in a context where it is allowed to access
+    the *original subject type of the policy* and *all of its
+    descendants*.
+
+    Because it is based on the original source of the policy,
+    we need to compile each policy separately.
+    """
+    schema = ctx.env.schema
+
+    expr_field = pol.get_expr(schema)
+    if expr_field:
+        expr = expr_field.qlast
+    else:
+        expr = qlast.BooleanConstant(value='true')
+    if condition := pol.get_condition(schema):
+        expr = qlast.BinOp(op='AND', left=condition.qlast, right=expr)
+
+    # Find all descendants of the original subject of the rule
+    ancs = (pol,) + pol.get_ancestors(schema).objects(schema)
+    subject = ancs[-1].get_subject(schema)
+    assert isinstance(subject, s_objtypes.ObjectType)
+    descs = {subject} | {
+        desc for desc in subject.descendants(schema)
+        if desc.is_material_object_type(schema)
+    }
+
+    # Compile it with all of the
+    with ctx.detached() as dctx:
+        dctx.partial_path_prefix = ctx.partial_path_prefix
+        dctx.expr_exposed = context.Exposure.UNEXPOSED
+        dctx.suppress_rewrites = frozenset(descs)
+
+        return dispatch.compile(expr, ctx=dctx)
+
+
 def get_rewrite_filter(
     stype: s_objtypes.ObjectType, *,
     mode: qltypes.AccessKind,
@@ -86,20 +128,17 @@ def get_rewrite_filter(
     schema = ctx.env.schema
     pols = get_access_policies(stype, ctx=ctx)
 
+    ctx.anchors = ctx.anchors.copy()
+
     allow, deny = [], []
     for pol in pols:
         if mode not in pol.get_access_kinds(schema):
             continue
 
-        is_allow = pol.get_action(schema) == qltypes.AccessPolicyAction.Allow
-        expr_field = pol.get_expr(schema)
-        if expr_field:
-            expr = expr_field.qlast
-        else:
-            expr = qlast.BooleanConstant(value='true')
-        if condition := pol.get_condition(schema):
-            expr = qlast.BinOp(op='AND', left=condition.qlast, right=expr)
+        ir_set = compile_pol(stype, pol, ctx=ctx)
+        expr = ctx.create_anchor(ir_set)
 
+        is_allow = pol.get_action(schema) == qltypes.AccessPolicyAction.Allow
         if is_allow:
             allow.append(expr)
         else:
@@ -286,9 +325,10 @@ def compile_dml_policy(
     if not ctx.type_rewrites.get((stype, False)):
         return None
 
-    condition = get_rewrite_filter(stype, mode=mode, ctx=ctx)
-    if not condition:
+    pols = get_access_policies(stype, ctx=ctx)
+    if not pols:
         return None
+
     with ctx.detached() as subctx:
         # TODO: can we make sure to always avoid generating needless
         # select filters
@@ -300,11 +340,8 @@ def compile_dml_policy(
         subctx.anchors[qlast.Subject().name] = result
         subctx.partial_path_prefix = result
 
-        # Make sure an explicit object reference also routes to the
-        # right set
-        subctx.path_scope = subctx.env.path_scope.root.attach_fence()
-        subctx.path_scope.attach_path(result.path_id, context=None)
-        setgen.update_view_map(result.path_id, result, ctx=subctx)
+        condition = get_rewrite_filter(stype, mode=mode, ctx=subctx)
+        assert condition
 
         return irast.PolicyExpr(
             expr=dispatch.compile(condition, ctx=subctx)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -88,6 +88,9 @@ def new_set(
     ignore_rewrites: bool = kwargs.get('ignore_rewrites', False)
     rw_key = (stype, skip_subtypes)
 
+    if stype in ctx.suppress_rewrites:
+        ignore_rewrites = kwargs['ignore_rewrites'] = True
+
     if (
         not ignore_rewrites
         and rw_key not in ctx.type_rewrites

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -109,6 +109,9 @@ def init_context(
         ctx.partial_path_prefix.anchor = options.path_prefix_anchor
         ctx.partial_path_prefix.show_as_anchor = options.path_prefix_anchor
 
+    if options.detached:
+        ctx.path_id_namespace = frozenset({ctx.aliases.get('ns')})
+
     ctx.derived_target_module = options.derived_target_module
     ctx.toplevel_result_view_name = options.result_view_name
     ctx.implicit_id_in_shapes = options.implicit_id_in_shapes

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -206,6 +206,7 @@ class AccessPolicyCommand(
                     apply_query_rewrites=not context.stdmode,
                     track_schema_ref_exprs=track_schema_ref_exprs,
                     in_ddl_context_name=in_ddl_context_name,
+                    detached=True,
                 ),
             )
         else:
@@ -334,8 +335,9 @@ def get_type_policy_deps(
                     typs.add(tgt)
 
     typs.discard(stype)
-
     typs.update({x for typ in typs for x in typ.descendants(schema)})
+    # ... discard again, to avoid self cycles
+    typs.discard(stype)
 
     return typs
 

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -112,6 +112,15 @@ class AccessPolicy(
             objs.extend(expr.refs.objects(schema))
         return objs
 
+    def get_subject(self, schema: s_schema.Schema) -> s_objtypes.ObjectType:
+        subj: s_objtypes.ObjectType = self.get_field_value(schema, 'subject')
+        return subj
+
+    def get_original_subject(
+            self, schema: s_schema.Schema) -> s_objtypes.ObjectType:
+        ancs = (self,) + self.get_ancestors(schema).objects(schema)
+        return ancs[-1].get_subject(schema)
+
 
 class AccessPolicyCommandContext(
     sd.ObjectCommandContext[AccessPolicy],
@@ -264,9 +273,7 @@ class AccessPolicyCommand(
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> None:
-        from . import objtypes as s_objtypes
         subject = self.scls.get_subject(schema)
-        assert isinstance(subject, s_objtypes.ObjectType)
 
         for obj in self.scls.get_expr_refs(schema):
             if isinstance(obj, s_props.Property):
@@ -325,19 +332,26 @@ def get_type_policy_deps(
     for pol in stype.get_access_policies(schema).objects(schema):
         objs = pol.get_expr_refs(schema)
 
+        ntyps = set()
         for obj in objs:
             if isinstance(obj, s_objtypes.ObjectType):
-                typs.add(obj)
-                typs.update(stype.get_union_of(schema).objects(schema))
-                typs.update(stype.get_intersection_of(schema).objects(schema))
+                ntyps.add(obj)
+                ntyps.update(stype.get_union_of(schema).objects(schema))
+                ntyps.update(stype.get_intersection_of(schema).objects(schema))
             elif isinstance(obj, s_links.Link):
                 if tgt := obj.get_target(schema):
-                    typs.add(tgt)
+                    ntyps.add(tgt)
 
-    typs.discard(stype)
+        # The original subject of a rule and its children don't have
+        # their policies applied while evaluating a policy, so we
+        # don't depend on them.
+        orig_subj = pol.get_original_subject(schema)
+        ntyps.discard(orig_subj)
+        ntyps.difference_update(orig_subj.descendants(schema))
+
+        typs.update(ntyps)
+
     typs.update({x for typ in typs for x in typ.descendants(schema)})
-    # ... discard again, to avoid self cycles
-    typs.discard(stype)
 
     return typs
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5720,29 +5720,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         """)
 
     async def test_edgeql_ddl_policies_03(self):
-        async with self.assertRaisesRegexTx(
-            edgedb.SchemaDefinitionError,
-            r"dependency cycle between access policies of object type "
-            r"'default::Bar' and object type 'default::Foo'"
-        ):
-            await self.con.execute("""
-                CREATE TYPE Bar {
-                    CREATE REQUIRED PROPERTY b -> bool;
-                };
-                CREATE TYPE Foo {
-                    CREATE LINK bar -> Bar;
-                    CREATE REQUIRED PROPERTY b -> bool;
-                    CREATE ACCESS POLICY redact
-                        ALLOW ALL USING ((.bar.b ?? false));
-                };
-                ALTER TYPE Bar {
-                    CREATE LINK foo -> Foo;
-                    CREATE ACCESS POLICY redact
-                        ALLOW ALL USING ((.foo.b ?? false));
-                };
-            """)
-
-    async def test_edgeql_ddl_policies_04(self):
         # Ideally we will make this actually work instead of rejecting it!
         await self.con.execute("""
             CREATE TYPE Tgt;


### PR DESCRIPTION
1. Fix semantics of which policies apply *inside* of access policies

While evaluating a rule, the subject type *of the rule* and
*all of its descendants* may be accessed without restriction.
I think this is the only coherent thing.

Implementing this requires being substantially more intentional in the
compiler about when we want to use a type rewrite: previously we would
essentially always use a type rewrite, except when in the process of
compiling the type rewrite CTE itself, and that decision was made on
the pgsql side. There existed an `ignore_rewrites` mechanism, but it
was so-far only used to compile a conflict CTE for BaseObject when
doing an INSERT with explicit id.

We expand the use of `ignore_rewrites` to tag all references to a type
and its descendants while compiling an access policy defined on the
type. Since it needs to be based at the *source* of the type, we need
to compile each rule individually in order to compile them with the
proper exclusions.

2. DML policies also are evaluated without restriction on those types

Currently SELECT policies will be applied during the evaluation of DML
polices.  Change this for consistency, to avoid bizarre scenarios such
as being unable to update a SELECT-visible object of a type that only
has a single `allow all` rule, because it evaluates as true when
interpreted as a `select` rule but false when interpreted as an
`update read` rule.

3. Evaluate access policy rules in a detached context

Non-detached schema exprs cause a lot of trouble when they interact
with inheritance (see #4142). We discovered that issue too late to
deal with it properly for 2.0, since it will require a compatibility
break and a recovery strategy, but let's get it right for new features.