### PR TITLE
Prohibit access policy expressions with multi cardinality

### DIFF
--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -164,6 +164,14 @@ class AccessPolicyCommand(
                     context=srcctx
                 )
 
+            if expression.irast.cardinality.is_multi():
+                srcctx = self.get_attribute_source_context(field)
+                raise errors.SchemaDefinitionError(
+                    f'possibly more than one element returned by {vname} '
+                    f'expression for the {pol_name} ',
+                    context=srcctx
+                )
+
             target = schema.get(sn.QualName('std', 'bool'), type=s_types.Type)
             expr_type = expression.irast.stype
             if not expr_type.issubclass(schema, target):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5711,13 +5711,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-        # This is fine though
-        await self.con.execute("""
-            create type X {
-                create access policy test
-                    allow all using ({true, false});
-            };
-        """)
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            r"possibly more than one element returned",
+        ):
+            await self.con.execute("""
+                create type X {
+                    create access policy test
+                        allow all using ({true, false});
+                };
+            """)
 
     async def test_edgeql_ddl_policies_03(self):
         async with self.assertRaisesRegexTx(

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -75,7 +75,10 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
                     create constraint exclusive;
                 };
                 create access policy cur_only allow all
-                using (not exists global cur_user or global cur_user ?= .name);
+                using (
+                    not exists global cur_user
+                    or (global cur_user in .name) ?? false
+                );
             };
         '''
     ]


### PR DESCRIPTION
I think it's semantically unclear what a multi cardinality value ought
to mean in a `deny` rule. There are two ways to think about what deny
rules should mean:
 1. Any object for which a deny rule returns `true` should be removed
    from the candidate set of objects
 2. We evaluate the following condition as a filter on each object
   `(allow_1 OR ... OR allow_n) AND NOT deny_1 ... AND NOT deny_m`

These definitions coincide if each rule has cardinality ONE, but they
differ if a rule can have cardinality AT_LEAST_ONE: if a rule returns
`{true, false}`, then definition 1 would exclude the object while
definition 2 would include it.

Currently the implementation follows definition 2, because it operates
based on boolean arithmetic; I think that if we had to choose that
definition 1 would be less surprising behavior, but that the best
option is to disallow multi cardinality, which lets our two ways of
thinking about the rules coincide.

We can always add it back in later if we want.