### PR TITLE
Fix params in script queries when there are no extracted constants

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -752,7 +752,8 @@ class Compiler:
         else:
             first_extra = None
 
-        user_params = first_extra if first_extra is not None else len(params)
+        total_params = len(script_info.params) if script_info else len(params)
+        user_params = first_extra if first_extra is not None else total_params
 
         if script_info is not None:
             outer_mapping = {n: i for i, n in enumerate(script_info.params)}

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -830,6 +830,29 @@ class TestServerProto(tb.QueryTestCase):
             ),
             edgedb.Set(('!?',)))
 
+    async def test_server_proto_args_11(self):
+        async with self._run_and_rollback():
+            self.assertEqual(
+                await self.con.query(
+                    '''
+                        insert Tmp { tmp := <str>$0 };
+                        select Tmp.tmp ++ <str>$1;
+                    ''',
+                    "?", "!"),
+                edgedb.Set(["?!"]),
+            )
+
+        async with self._run_and_rollback():
+            self.assertEqual(
+                await self.con.query(
+                    '''
+                        insert Tmp { tmp := <str>$foo };
+                        select Tmp.tmp ++ <str>$bar;
+                    ''',
+                    foo="?", bar="!"),
+                edgedb.Set(["?!"]),
+            )
+
     async def test_server_proto_wait_cancel_01(self):
         # Test that client protocol handles waits interrupted
         # by closing.


### PR DESCRIPTION
Fixes #4113