### PR TITLE
Fix issue when type injecting some nested DML cases

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1063,8 +1063,10 @@ def init_stmt(
         elif (
             (dv := ctx.defining_view) is not None
             and dv.get_expr_type(ctx.env.schema) is s_types.ExprType.Select
-            and not irutils.is_trivial_free_object(
-                not_none(ctx.partial_path_prefix))
+            and not (
+                ctx.partial_path_prefix
+                and irutils.is_trivial_free_object(ctx.partial_path_prefix)
+            )
         ):
             # This is some shape in a regular query. Although
             # DML is not allowed in the computable, but it may

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5534,3 +5534,24 @@ class TestInsert(tb.QueryTestCase):
                      )
                 };
             ''')
+
+    async def test_edgeql_insert_rebind_with_typenames_01(self):
+        await self.assert_query_result(
+            '''
+            with
+              update1 := (insert InsertTest {l2:=1}),
+            select (select update1);
+            ''',
+            [{'id': str}],
+            always_typenames=True,
+        )
+
+        await self.assert_query_result(
+            '''
+            with
+              update1 := (insert InsertTest {l2:=1}),
+            select {update1};
+            ''',
+            [{'id': str}],
+            always_typenames=True,
+        )


### PR DESCRIPTION
In order to avoid some strange scope tree issues when allowing DML in
free shapes, #4002 made unsound changes to the logic for pushing
shapes down into the query, leading to pushing them onto DML result
fields in a way that didn't work.

Undo those changes and add a more targeted hack to fix the free shape
DML issue.

Fixes #4155.