### PR TITLE
Fix global defaults with nontrivial computation

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1024,7 +1024,8 @@ def _register_item(
             elif (isinstance(cmd, qlast.SetField)
                   and not cmd.special_syntax
                   and not isinstance(cmd.value, qlast.BaseConstant)
-                  and not isinstance(op, qlast.CreateAlias)):
+                  and not isinstance(
+                      op, (qlast.CreateAlias, qlast.CreateGlobal))):
                 subcmds.append(cmd)
             else:
                 commands.append(cmd)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5860,7 +5860,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """, r"""
             required global foo -> int64 {
-                default := 0;
+                default := 0 + 1;
             }
         """])
 


### PR DESCRIPTION
The SET DEFAULT in a global must never be split off into a separate
command by `declarative`. Aliases had a similar special case; extend
it to cover globals.

Fixes #4173.