### PR TITLE
Fix migration that removes policy using clause

### DIFF
--- a/docs/reference/ddl/access_policies.rst
+++ b/docs/reference/ddl/access_policies.rst
@@ -143,6 +143,7 @@ Alter access policy
         [ reset when ; ]
         { allow | deny } <action> [, <action> ... ; ]
         [ using (<expr>) ; ]
+        [ reset expression ; ]
         [ create annotation <annotation-name> := <value> ; ]
         [ alter annotation <annotation-name> := <value> ; ]
         [ drop annotation <annotation-name>; ]
@@ -171,8 +172,11 @@ subcommands that are allowed in the ``create access policy`` block:
 
 :eql:synopsis:`reset when`
     Clear the :eql:synopsis:`when (<condition>)` so that the policy applies to
-    all objects of a given type. This is exactly equivalent to ``when
-    (true)``.
+    all objects of a given type. This is equivalent to ``when (true)``.
+
+:eql:synopsis:`reset expression`
+    Clear the :eql:synopsis:`using (<condition>)` so that the policy always
+    passes. This is equivalent to ``using (true)``.
 
 :eql:synopsis:`alter annotation <annotation-name>;`
     Alter access policy annotation :eql:synopsis:`<annotation-name>`.

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1812,7 +1812,7 @@ class AccessUsingStmt(Nonterm):
             special_syntax=True,
         )
 
-    def reduce_RESET_USING(self, *kids):
+    def reduce_RESET_EXPRESSION(self, *kids):
         self.val = qlast.SetField(
             name='expr',
             value=None,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11073,6 +11073,19 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
             """
         )
 
+    async def test_edgeql_migration_access_policy_01(self):
+        await self.migrate(r"""
+            type Test2 {
+                access policy asdf allow all using (true);
+            }
+        """)
+
+        await self.migrate(r"""
+            type Test2 {
+                access policy asdf allow all;
+            }
+        """)
+
     async def test_edgeql_migration_recovery(self):
         await self.con.execute(r"""
             START MIGRATION TO {


### PR DESCRIPTION
I had made the (100% undocumented and untested) syntax for resetting a
policy USING clause be `RESET USING`. This was inconsistent with how
to reset every other single field that is set with `USING`, which is
`RESET EXPRESSION`, as well as the generic code in codegen that
generates it.  Switch it to `RESET EXPRESSION` and document it.

There was a schema test for removing a USING clause from a policy, but
that flow only ever operates on ASTs, and so the mismatch between the
codegen and the parser was undetecgted.

Fixes #4175.