### PR TITLE
Don't create constraints on derived views when adding a pointer to a type

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11086,6 +11086,61 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
             }
         """)
 
+    async def test_edgeql_migration_globals_01(self):
+        schema = r"""
+            global current_user_id -> uuid;
+            global current_user := (
+              select Member filter .id = global current_user_id
+            );
+
+            type Foo {
+              link owner := .<avatar[is Member];
+            };
+            type Member {
+              link avatar -> Foo {
+                constraint exclusive;
+              }
+            }
+        """
+        # Make sure it doesn't get into a wedged state
+        await self.migrate(schema)
+        await self.migrate(schema)
+
+    async def test_edgeql_migration_globals_02(self):
+        await self.migrate(r"""
+            global current_user_id -> uuid;
+            global current_user := (
+              select Member filter .id = global current_user_id
+            );
+
+            type Foo;
+            type Base {
+              link avatar -> Foo {
+                constraint exclusive;
+              }
+            }
+            type Member;
+        """)
+
+        schema = r"""
+            global current_user_id -> uuid;
+            global current_user := (
+              select Member filter .id = global current_user_id
+            );
+
+            type Foo;
+            type Base {
+              link avatar -> Foo {
+                constraint exclusive;
+              }
+            }
+            type Member extending Base;
+        """
+
+        # Make sure it doesn't get into a wedged state
+        await self.migrate(schema)
+        await self.migrate(schema)
+
     async def test_edgeql_migration_recovery(self):
         await self.con.execute(r"""
             START MIGRATION TO {


### PR DESCRIPTION
If we have a derived schema view of a type (a global or an alias) and
try to add a pointer with a constraint on it to the base type, we will
also add the constraint to the derived, not real, view type. This is
a bad problem, because we do *not* include constraints and the like
when directly creating these views.

Make sure that we avoid doing this.

Also fix another bug I ran into when trying to test if this works in
the rebase case.

Fixes #4186.