### PR TITLE
Fix an ISE when a computed link is directly a property reference

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1189,7 +1189,10 @@ class PointerCommandOrFragment(
                 # link props). Random paths coming from other sources
                 # get treated same as any other arbitrary expression
                 # in a computable.
-                if aliased_ptr.get_source(new_schema) == source:
+                if (
+                    aliased_ptr.get_source(new_schema) == source
+                    and isinstance(aliased_ptr, self.get_schema_metaclass())
+                ):
                     base = aliased_ptr
                     schema = new_schema
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -313,6 +313,19 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
         """
 
+    @tb.must_fail(
+        errors.InvalidLinkTargetError,
+        "invalid link target type, expected object type, "
+        "got scalar type 'std::str'",
+    )
+    def test_schema_bad_link_04(self):
+        """
+            type Object {
+                property foo -> str;
+                link bar := .foo;
+            };
+        """
+
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
                   "or a scalar collection, got object type 'test::Object'",


### PR DESCRIPTION
Give a correct error instead.