### PR TITLE
Put an empty list as elements for an empty shape instead of None

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -351,7 +351,7 @@ class WithDeclList(ListNonterm, element=WithDecl,
 
 class Shape(Nonterm):
     def reduce_LBRACE_RBRACE(self, *kids):
-        self.val = None
+        self.val = []
 
     def reduce_LBRACE_ShapeElementList_RBRACE(self, *kids):
         self.val = kids[1].val

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -372,6 +372,17 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(errors.InvalidReferenceError,
+                  "object type or alias 'std::str' does not exist")
+    def test_schema_bad_prop_07(self):
+        """
+            type Person {
+                required property name := str {
+                    # empty block
+                }
+            }
+        """
+
+    @tb.must_fail(errors.InvalidReferenceError,
                   "type 'test::int' does not exist",
                   position=73)
     def test_schema_bad_type_01(self):


### PR DESCRIPTION
This is what our types call for. Many use sites seemed to not mind
None (though I'm sure it is under tested), but tracer would choke
on it.

Fixes #4192.