### PR TITLE
Fix a number of error messages involving collection types in schemas

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -799,11 +799,12 @@ class ConstraintCommand(
         assert isinstance(final_expr.irast, ir_ast.Statement)
 
         expr_type = final_expr.irast.stype
-        if not expr_type.issubclass(schema, bool_t):
+        expr_schema = final_expr.irast.schema
+        if not expr_type.issubclass(expr_schema, bool_t):
             raise errors.InvalidConstraintDefinitionError(
                 f'{name} constraint expression expected '
                 f'to return a bool value, got '
-                f'{expr_type.get_verbosename(schema)}',
+                f'{expr_type.get_verbosename(expr_schema)}',
                 context=sourcectx
             )
 

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -231,6 +231,7 @@ class GlobalCommand(
 
             assert isinstance(default_expr.irast, irast.Statement)
 
+            default_schema = default_expr.irast.schema
             default_type = default_expr.irast.stype
 
             source_context = self.get_attribute_source_context('default')
@@ -241,10 +242,10 @@ class GlobalCommand(
                     context=source_context,
                 )
 
-            if not default_type.assignment_castable_to(target, schema):
+            if not default_type.assignment_castable_to(target, default_schema):
                 raise errors.SchemaDefinitionError(
                     f'default expression is of invalid type: '
-                    f'{default_type.get_displayname(schema)}, '
+                    f'{default_type.get_displayname(default_schema)}, '
                     f'expected {target.get_displayname(schema)}',
                     context=source_context,
                 )

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1595,21 +1595,23 @@ class PointerCommand(
 
             assert isinstance(default_expr.irast, irast.Statement)
 
+            default_schema = default_expr.irast.schema
             default_type = default_expr.irast.stype
             assert default_type is not None
             ptr_target = scls.get_target(schema)
             assert ptr_target is not None
 
             source_context = self.get_attribute_source_context('default')
-            if default_type.is_view(default_expr.irast.schema):
+            if default_type.is_view(default_schema):
                 raise errors.SchemaDefinitionError(
                     f'default expression may not include a shape',
                     context=source_context,
                 )
-            if not default_type.assignment_castable_to(ptr_target, schema):
+            if not default_type.assignment_castable_to(
+                    ptr_target, default_schema):
                 raise errors.SchemaDefinitionError(
                     f'default expression is of invalid type: '
-                    f'{default_type.get_displayname(schema)}, '
+                    f'{default_type.get_displayname(default_schema)}, '
                     f'expected {ptr_target.get_displayname(schema)}',
                     context=source_context,
                 )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1935,6 +1935,30 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             ''')
 
+    async def test_edgeql_ddl_default_10(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                'default expression is of invalid type: array<std::int32>, '
+                'expected array<std::int16>'):
+            await self.con.execute(r"""
+                CREATE TYPE X {
+                    CREATE PROPERTY y -> array<int16> {
+                        SET default := <array<int32>>[]
+                    };
+                };
+            """)
+
+    async def test_edgeql_ddl_default_11(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                'default expression is of invalid type: array<std::int32>, '
+                'expected array<std::int16>'):
+            await self.con.execute(r"""
+                CREATE GLOBAL y -> array<int16> {
+                    SET default := <array<int32>>[]
+                };
+            """)
+
     async def test_edgeql_ddl_default_circular(self):
         await self.con.execute(r"""
             CREATE TYPE TestDefaultCircular {
@@ -9561,6 +9585,18 @@ type default::Foo {
                 r'violates exclusivity constraint'):
             await self.con.execute("""
                 insert B { x := "!" }
+            """)
+
+    async def test_edgeql_ddl_constraint_22(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidConstraintDefinitionError,
+                r'expected to return a bool value, got collection'):
+            await self.con.execute("""
+                create type X {
+                    create property y -> str {
+                        create constraint expression on (<array<int32>>[]);
+                    }
+                };
             """)
 
     async def test_edgeql_ddl_constraint_check_01a(self):


### PR DESCRIPTION
When we try to do typechecking or type error formatting of a default
or similar in the schema, if the inferred type is a never-before-seen
collection type, we choke. Make sure to operate using the inferred
schema.

Fixes #4191.