### PR TITLE
Avoid doing semi-joins after a sequence of single links

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1317,7 +1317,12 @@ def process_set_as_subquery(
 
             if is_objtype_path and not source_is_visible:
                 # Non-scalar computable semi-join.
-                semi_join = _source_path_needs_semi_join(ir_source, ctx=ctx)
+
+                # TODO: The basic path case has a more sophisticated
+                # understanding of when to do semi-joins. Using that
+                # naively here doesn't work, but perhaps it could be
+                # adapted?
+                semi_join = True
 
                 # We need to compile the source and include it in,
                 # since we need to do the semi-join deduplication here

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -964,18 +964,21 @@ def process_set_as_path_type_intersection(
         ir_set, stmt, aspects=['value', 'source'], ctx=ctx)
 
 
-def _source_path_is_visible(
+def _source_path_needs_semi_join(
         ir_source: irast.Set,
         ctx: context.CompilerContextLevel) -> bool:
-    """Check if the path is 'visible enough' to avoid a semi-join.
+    """Check if the path might need a semi-join
 
-    This means that it has a visible prefix followed by single pointers.
+    It does not need one if it has a visible prefix followed by single
+    pointers. Otherwise it might.
+
     This is an optimization that allows us to avoid doing a semi-join
     when there is a chain of single links referenced (probably in a filter
     or a computable).
+
     """
     if ctx.scope_tree.is_visible(ir_source.path_id):
-        return True
+        return False
 
     while (
         ir_source.rptr
@@ -985,9 +988,9 @@ def _source_path_is_visible(
         ir_source = ir_source.rptr.source
 
         if ctx.scope_tree.is_visible(ir_source.path_id):
-            return True
+            return False
 
-    return False
+    return True
 
 
 def process_set_as_path(
@@ -1009,8 +1012,6 @@ def process_set_as_path(
 
     root_source_is_visible = ctx.scope_tree.is_visible(backtrack_src.path_id)
     source_is_visible = ctx.scope_tree.is_visible(ir_source.path_id)
-
-    source_is_single = _source_path_is_visible(ir_source, ctx=ctx)
 
     rvars = []
 
@@ -1036,10 +1037,10 @@ def process_set_as_path(
         ctx.disable_semi_join |= new_paths
 
     semi_join = (
-        not source_is_single and
         not root_source_is_visible and
         ir_set.path_id not in ctx.disable_semi_join and
         not (is_linkprop or is_primitive_ref) and
+        _source_path_needs_semi_join(ir_source, ctx=ctx) and
         # This is an optimization for when we are inside of a semi-join on
         # a computable: process_set_as_subquery will have included an
         # rvar for the computable source, and we want to join on it
@@ -1316,7 +1317,7 @@ def process_set_as_subquery(
 
             if is_objtype_path and not source_is_visible:
                 # Non-scalar computable semi-join.
-                semi_join = True
+                semi_join = _source_path_needs_semi_join(ir_source, ctx=ctx)
 
                 # We need to compile the source and include it in,
                 # since we need to do the semi-join deduplication here

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -229,3 +229,15 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             " IN ", sql,
             "unexpected semi-join",
         )
+
+    def test_codegen_chained_single_no_semijoin(self):
+        sql = self._compile('''
+            select Issue {
+               z := .owner.todo
+            }
+       ''')
+
+        self.assertNotIn(
+            " IN ", sql,
+            "unexpected semi-join",
+        )


### PR DESCRIPTION
If we have a query like
```
select Post filter .owner.person.id = <uuid>$uid
```
where `owner` is `single`, there is no need to do a semi-join on
`.person`. This can have major performance impacts.

Fixes #4160.