### PR TITLE
Add computed_backlink as a real property on Pointer

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_07_26_00_00
+EDGEDB_CATALOG_VERSION = 2022_08_02_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -611,7 +611,7 @@ def _infer_set_inner(
                     card = cartesian_cardinality([source_card, rptr_spec_card])
 
         else:
-            if rptrref.union_components and not rptrref.is_computed_backlink:
+            if rptrref.union_components:
                 # We use cartesian cardinality instead of union cardinality
                 # because the union of pointers in this context is disjoint
                 # in a sense that for any specific source only a given union

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -313,8 +313,7 @@ def derive_ptr(
 
     if derive_backlink:
         attrs = attrs.copy() if attrs else {}
-        attrs['union_of'] = [ptr]
-        attrs['intersection_of'] = [ptr]
+        attrs['computed_backlink'] = ptr
 
     ctx.env.schema, derived = ptr.derive_ref(
         ctx.env.schema,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -223,6 +223,7 @@ class BasePointerRef(ImmutableBase):
     # Inbound cardinality of the pointer.
     in_cardinality: qltypes.Cardinality = qltypes.Cardinality.MANY
     defined_here: bool = False
+    computed_backlink: typing.Optional[BasePointerRef] = None
 
     def dir_target(self, direction: s_pointers.PointerDirection) -> TypeRef:
         if direction is s_pointers.PointerDirection.Outbound:
@@ -261,10 +262,6 @@ class BasePointerRef(ImmutableBase):
     @property
     def real_base_ptr(self) -> BasePointerRef:
         return self.base_ptr or self
-
-    @property
-    def is_computed_backlink(self) -> bool:
-        return bool(self.intersection_components and self.union_components)
 
     def __repr__(self) -> str:
         return f'<ir.{type(self).__name__} \'{self.name}\' at 0x{id(self):x}>'

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -523,6 +523,12 @@ def ptrref_from_ptrcls(  # NoQA: F811
         ircls = irast.PointerRef
         kwargs['id'] = ptrcls.id
         kwargs['defined_here'] = ptrcls.get_defined_here(schema)
+        if backlink := ptrcls.get_computed_backlink(schema):
+            assert isinstance(backlink, s_pointers.Pointer)
+            kwargs['computed_backlink'] = ptrref_from_ptrcls(
+                ptrcls=backlink, schema=schema,
+                cache=cache, typeref_cache=typeref_cache,
+            )
 
     else:
         raise AssertionError(f'unexpected pointer class: {ptrcls}')

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -616,7 +616,7 @@ def _new_mapped_pointer_rvar(
     # Set up references according to the link direction.
     if (
         ir_ptr.direction == s_pointers.PointerDirection.Inbound
-        or ptrref.is_computed_backlink
+        or ptrref.computed_backlink
     ):
         near_ref = target_ref
         far_ref = source_ref
@@ -1752,6 +1752,8 @@ def range_for_ptrref(
         # needs to appear in *all* of the tables, so we just pick any
         # one of them.
         refs = {next(iter((ptrref.intersection_components)))}
+    elif ptrref.computed_backlink:
+        refs = {ptrref.computed_backlink}
     else:
         refs = {ptrref}
         assert isinstance(ptrref, irast.PointerRef), \

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -288,7 +288,7 @@ def _merge_types(
     # This is a hack: when deriving computed backlink pointers, we
     # (ab)use inheritance to populate them with the appropriate
     # linkprops. We fix it up to remove the bogus parents later.
-    if ptr.is_computed_backlink(schema):
+    if ptr.get_computed_backlink(schema):
         return schema, t2
 
     elif (isinstance(t1, s_abc.ScalarType) !=
@@ -496,6 +496,11 @@ class Pointer(referencing.ReferencedInheritingObject,
         type_is_generic_self=True,
     )
 
+    computed_backlink = so.SchemaField(
+        so.Object,
+        default=None,
+    )
+
     def is_tuple_indirection(self) -> bool:
         return False
 
@@ -504,14 +509,6 @@ class Pointer(referencing.ReferencedInheritingObject,
 
     def is_generated(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_from_alias(schema))
-
-    def is_computed_backlink(self, schema: s_schema.Schema) -> bool:
-        # HACK: To avoid needing a schema change for a change we want to
-        # cherry-pick, we indicate that a pointer is a computed backlink
-        # by making it both a union and an intersection.
-        return bool(
-            self.get_union_of(schema) and self.get_intersection_of(schema)
-        )
 
     @classmethod
     def get_displayname_static(cls, name: sn.Name) -> str:


### PR DESCRIPTION
Previously we had a hack where pointers that were both a union and an
intersection were known to be computed backlinks.

This was done so that the change could be cherry picked into a 1.x
release, with the idea of fixing it before 2.0. Oops.