### PR TITLE
Make range() properly strict in its non-optional arguments

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -676,6 +676,12 @@ def _cast_json_to_range(
                     type=ql_range_el_t,
                 ),
             ],
+            # inc_lower and inc_upper are required to be present for
+            # non-empty casts from json, and this is checked in
+            # __range_validate_json. We still need to provide default
+            # arguments when fetching them, though, since if those
+            # arguments to range are {} it will cause {"empty": true}
+            # to evaluate to {}.
             kwargs={
                 "inc_lower": qlast.TypeCast(
                     expr=qlast.FunctionCall(
@@ -684,6 +690,12 @@ def _cast_json_to_range(
                             source_path,
                             qlast.StringConstant(value='inc_lower'),
                         ],
+                        kwargs={
+                            'default': qlast.FunctionCall(
+                                func=('__std__', 'to_json'),
+                                args=[qlast.StringConstant(value="true")],
+                            ),
+                        },
                     ),
                     type=ql_bool_t
                 ),
@@ -694,6 +706,12 @@ def _cast_json_to_range(
                             source_path,
                             qlast.StringConstant(value='inc_upper'),
                         ],
+                        kwargs={
+                            'default': qlast.FunctionCall(
+                                func=('__std__', 'to_json'),
+                                args=[qlast.StringConstant(value="false")],
+                            ),
+                        },
                     ),
                     type=ql_bool_t
                 ),
@@ -704,6 +722,12 @@ def _cast_json_to_range(
                             source_path,
                             qlast.StringConstant(value='empty'),
                         ],
+                        kwargs={
+                            'default': qlast.FunctionCall(
+                                func=('__std__', 'to_json'),
+                                args=[qlast.StringConstant(value="false")],
+                            ),
+                        },
                     ),
                     type=ql_bool_t
                 ),

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2719,14 +2719,33 @@ def process_set_as_std_range(
         type_name=pgast.TypeName(name=pg_type),
     )
 
+    # If any of the non-optional arguments are nullable, add an explicit
+    # null check for them.
+    null_checks = [
+        pgast.NullTest(arg=e) for e in [empty, inc_upper, inc_lower]
+        if e.nullable
+    ]
+    if null_checks:
+        null_case = [
+            pgast.CaseWhen(
+                expr=astutils.extend_binop(None, *null_checks, op='OR'),
+                result=pgast.NullConstant(),
+            )
+        ]
+    else:
+        null_case = []
+
     set_expr = pgast.CaseExpr(
-        args=[pgast.CaseWhen(
-            expr=pgast.FuncCall(
-                name=('edgedb', 'range_validate'),
-                args=[lower, upper, inc_lower, inc_upper, empty],
+        args=[
+            *null_case,
+            pgast.CaseWhen(
+                expr=pgast.FuncCall(
+                    name=('edgedb', 'range_validate'),
+                    args=[lower, upper, inc_lower, inc_upper, empty],
+                ),
+                result=empty_range,
             ),
-            result=empty_range,
-        )],
+        ],
         defresult=non_empty_range,
     )
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -6499,6 +6499,15 @@ aa \
                 }');
             """)
 
+        await self.assert_query_result(
+            r'''
+                select range_is_empty(<range<int64>>to_json('{
+                    "empty": true
+                }'))
+            ''',
+            [True],
+        )
+
     async def test_edgeql_expr_range_35(self):
         # Test casting shapes containing ranges to JSON.
 
@@ -6570,6 +6579,41 @@ aa \
                 select range(<cal::local_date>'2022-07-09',
                              <cal::local_date>'2022-07-08');
             """)
+
+    async def test_edgeql_expr_range_37(self):
+        # Test nullable arguments to range
+        await self.assert_query_result(
+            r'''
+                select range(<int64>{}, empty:=<optional bool>$0);
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select range(<int64>{}, inc_lower:=<optional bool>$0);
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select range(<int64>{}, inc_upper:=<optional bool>$0);
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select range(
+                    <int64>{}, inc_upper:=<optional bool>$0, empty := true);
+            ''',
+            [],
+            variables=(None,),
+        )
 
     async def test_edgeql_expr_cannot_assign_dunder_type_01(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
range() is currently not strict in its non-optional arguments:
 * NULL empty is treated as false
 * NULL inc_lower and inc_upper produce errors

Fix this by adding NULL checks when necessary.
Update casting from JSON, which relied upon this behavior.