### PR TITLE
add Elixir client to list of clients compatible with EdgeDB 2.0

### DIFF
--- a/docs/changelog/2_x.rst
+++ b/docs/changelog/2_x.rst
@@ -59,9 +59,8 @@ upgrade.
     - ``edgedb-tokio@0.3.0``
   * - `.NET <https://github.com/quinchs/EdgeDB.Net>`_ (community-maintained)
     - ``EdgeDB.Net.Driver@0.3.0``
-
-There is also a community-maintained `Elixir
-<https://github.com/nsidnev/edgedb-elixir>`_ client with partial 2.0 support.
+  * - `Elixir <https://github.com/nsidnev/edgedb-elixir>`_ (community-maintained)
+    - ``edgedb@0.4.0``
 
 New features
 ============

--- a/docs/changelog/2_x.rst
+++ b/docs/changelog/2_x.rst
@@ -59,7 +59,8 @@ upgrade.
     - ``edgedb-tokio@0.3.0``
   * - `.NET <https://github.com/quinchs/EdgeDB.Net>`_ (community-maintained)
     - ``EdgeDB.Net.Driver@0.3.0``
-  * - `Elixir <https://github.com/nsidnev/edgedb-elixir>`_ (community-maintained)
+  * - `Elixir <https://github.com/nsidnev/edgedb-elixir>`_
+      (community-maintained)
     - ``edgedb@0.4.0``
 
 New features


### PR DESCRIPTION
I released `0.4.0` today. This version is also fully compatible with EdgeDB 1.0.

Link to `hex`: https://hex.pm/packages/edgedb