### PR TITLE
Always arm auto-shutdown timer when it's greater than zero

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -624,9 +624,10 @@ _server_options = [
         help='shutdown the server after the last ' +
              'connection is closed'),
     click.option(
-        '--auto-shutdown-after', type=float, default=-1.0,
-        help='shutdown the server after the last connection has been closed '
-             'for N seconds. N < 0 is treated as infinite.'),
+        '--auto-shutdown-after', type=float, default=-1.0, metavar='N',
+        help='shutdown the server if no client connections were made in the '
+             'last N seconds, if N = 0, shut down after the last client has '
+             'disconnected, N < 0 (default) means no auto shutdown'),
     click.option(
         '--tls-cert-file',
         type=PathPath(),


### PR DESCRIPTION
Currently, the `--auto-shutdown-after` is always armed after last client
disconnection, which means that the server will continue to run
indefinitely if no client connections have happened.  Change the
behavior of `--auto-shutdown-after` to always arm the timer if the
timeout is greater than zero.  Zero timeout keeps the original behavior
of shutting down after last client disconnection.