### PR TITLE
Remove a compiler hack around json -> array<json> cast

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_08_02_00_00
+EDGEDB_CATALOG_VERSION = 2022_08_05_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 


### PR DESCRIPTION
A hack was added in #4217. Fix it in the stdlib instead.