### PR TITLE
Fix permitted JSON null in nested array cast

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -164,10 +164,10 @@ def compile_cast(
             ctx.env.schema, json_array_typ = s_types.Array.from_subtypes(
                 ctx.env.schema, [json_t])
             json_array_ir = compile_cast(
-                ir_expr, json_array_typ, srcctx=srcctx, ctx=ctx)
-            return compile_cast(
-                json_array_ir, new_stype, cardinality_mod=cardinality_mod,
+                ir_expr, json_array_typ, cardinality_mod=cardinality_mod,
                 srcctx=srcctx, ctx=ctx)
+            return compile_cast(
+                json_array_ir, new_stype, srcctx=srcctx, ctx=ctx)
         elif (orig_stype.issubclass(ctx.env.schema, json_t)
               and isinstance(new_stype, s_types.Tuple)):
             return _cast_json_to_tuple(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2215,6 +2215,12 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
+                r'invalid null value in cast'):
+            await self.con.query_single(
+                r"select <tuple<array<str>>>to_json('[null]')")
+
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
                 r'cannot extract elements from a scalar'):
             await self.con.query_single(
                 r"SELECT <array<int64>><json>'asdf'")


### PR DESCRIPTION
`select <tuple<array<str>>>to_json('[null]')` and similar would return `{}`
because we were trying to put the NULL check on the `array<json>` ->
`array<str>` part of the cast. But that doesn't generate a TypeCast
ir op and loses the NULL v. no rows distinction.

Instead put the NULL check on the `json` -> `array<json>` step.