### PR TITLE
Check for computables when generating update types

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1298,7 +1298,7 @@ class GQLCoreSchema:
                 # only objects that have at least one non-readonly
                 # link/property are eligible
                 pointers = t.get_pointers(self.edb_schema)
-                if any(not (p.get_readonly(self.edb_schema) or 
+                if any(not (p.get_readonly(self.edb_schema) or
                        p.is_pure_computable(self.edb_schema))
                        for _, p in pointers.items(self.edb_schema)):
                     gqlupdatetype = GraphQLInputObjectType(

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1298,7 +1298,8 @@ class GQLCoreSchema:
                 # only objects that have at least one non-readonly
                 # link/property are eligible
                 pointers = t.get_pointers(self.edb_schema)
-                if any(not p.get_readonly(self.edb_schema)
+                if any(not (p.get_readonly(self.edb_schema) or 
+                       p.is_pure_computable(self.edb_schema))
                        for _, p in pointers.items(self.edb_schema)):
                     gqlupdatetype = GraphQLInputObjectType(
                         name=self.get_input_name('Update', gql_name),

--- a/tests/schemas/graphql_schema.esdl
+++ b/tests/schemas/graphql_schema.esdl
@@ -23,6 +23,19 @@ abstract type NamedObject {
     required property name -> str;
 }
 
+abstract type Commentable {
+    multi link comments := .<subject[is Comment];
+}
+
+type Blog extending Commentable {
+    required property content -> str;
+}
+
+type Comment {
+    required property content -> str;
+    required link subject -> Commentable;
+}
+
 type UserGroup extending NamedObject {
     multi link settings -> Setting {
         constraint exclusive;

--- a/tests/schemas/graphql_schema.esdl
+++ b/tests/schemas/graphql_schema.esdl
@@ -23,6 +23,7 @@ abstract type NamedObject {
     required property name -> str;
 }
 
+# Abstract type with only a computed value to reproduce #4231
 abstract type Commentable {
     multi link comments := .<subject[is Comment];
 }


### PR DESCRIPTION
This PR adds a check for computed fields before generating update types.

This should fix https://github.com/edgedb/edgedb/issues/4230 as empty update types can't be generated anymore. 
Unfortunately I'm not able to test it properly as I have issues getting the local development server working... 