### PR TITLE
Put backpressure on dump/restore pipes

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -2163,7 +2163,9 @@ cdef class EdgeConnection(frontend.FrontendConnection):
                     restore_block = restore_blocks[block_id]
                     type_id_map = self._build_type_id_map_for_restore_mending(
                         restore_block)
+                    self._transport.pause_reading()
                     await pgcon.restore(restore_block, block_data, type_id_map)
+                    self._transport.resume_reading()
 
                 elif mtype == b'.':
                     self.buffer.finish_message()
@@ -2183,6 +2185,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             await self._execute_utility_stmt('COMMIT', pgcon)
 
         finally:
+            self._transport.resume_reading()
             self._in_dump_restore = False
             server.release_pgcon(dbname, pgcon)
 


### PR DESCRIPTION
Without this the server may easily run out of memory if Postgres link
speed is much different from client link speed.