### PR TITLE
Disable access policy rewrite when compiling constraints

### DIFF
--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -171,7 +171,7 @@ class ConstraintMech:
         options = qlcompiler.CompilerOptions(
             anchors={qlast.Subject().name: subject},
             path_prefix_anchor=qlast.Subject().name,
-            apply_query_rewrites=not context.stdmode,
+            apply_query_rewrites=False,
             singletons=singletons,
             # Remap the constraint origin to the subject, so that if
             # we have B <: A, and the constraint references A.foo, it
@@ -244,7 +244,7 @@ class ConstraintMech:
             origin_options = qlcompiler.CompilerOptions(
                 anchors={qlast.Subject().name: origin_subject},
                 path_prefix_anchor=origin_path_prefix_anchor,
-                apply_query_rewrites=not context.stdmode,
+                apply_query_rewrites=False,
                 singletons=singletons,
             )
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10984,6 +10984,22 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         """)
 
+    async def test_edgeql_migration_access_policy_constraint(self):
+        # Make sure policies don't interfere with constraints.
+        await self.migrate(r"""
+            abstract type Base {
+                access policy locked allow all using (false);
+            }
+
+            type Tgt extending Base;
+
+            type Src {
+                required link tgt -> Tgt {
+                    constraint exclusive;
+                }
+            }
+        """)
+
     async def test_edgeql_migration_globals_01(self):
         schema = r"""
             global current_user_id -> uuid;

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11055,7 +11055,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         await self.migrate(schema)
         await self.migrate(schema)
 
-    @test.xfail('''
+    @test.xerror('''
         Infinite recursion via _propagate_if_expr_refs
     ''')
     async def test_edgeql_migration_policies_and_collections(self):


### PR DESCRIPTION
Access policies are applied _before_ the constraint is checked anyway
and performing rewrites confuses constraint IR analysis.  This was
partially fixed in #3892, but not all the way.

Fixes: #4245