### PR TITLE
Clarify error message when UI is not enabled

### DIFF
--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -65,7 +65,8 @@ cdef class HttpProtocol:
 
         HttpRequest current_request
 
-    cdef _not_found(self, HttpRequest request, HttpResponse response)
+    cdef _not_found(self, HttpRequest request, HttpResponse response,
+                    str message = ?)
     cdef _bad_request(self, HttpRequest request, HttpResponse response,
                       str message)
     cdef _return_binary_error(self, binary.EdgeConnection proto)


### PR DESCRIPTION
Instead of bland "Unknown path", show an informative error message
instead.