### PR TITLE
Adapt setup.py/pyproject.toml to setuptools 54

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -33,10 +33,14 @@
 
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
+      shell: bash
       run: |
-        pip install wheel
-        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
-        pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
+        set -e
+        python -m pip install -U pip setuptools wheel build
+        bdeps_script="import build; print('\n'.join(build.ProjectBuilder('.').build_system_requires))"
+        readarray -t build_deps < <(python -c "${bdeps_script}")
+        python -m pip download --dest=$VIRTUAL_ENV/deps "${build_deps[@]}" .[test]
+        python -m pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts
 
@@ -255,9 +259,9 @@
         if [[ "$CACHE_HIT" == "true" ]]; then
           rsync -av $VIRTUAL_ENV/edgedb_server.egg-info/ ./edgedb_server.egg-info/
         else
-          # --no-use-pep517 because we have explicitly installed all deps
+          # --no-build-isolation because we have explicitly installed all deps
           # and don't want them to be reinstalled in an "isolated env".
-          pip install --no-use-pep517 --no-deps -e .[test,docs]
+          pip install --no-build-isolation --no-deps -e .[test,docs]
           rsync -av ./edgedb_server.egg-info/ $VIRTUAL_ENV/edgedb_server.egg-info/
         fi
 

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Install Python deps
         run: |
-          pip install requests
+          python -m pip install requests
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -40,10 +40,14 @@ jobs:
 
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
+      shell: bash
       run: |
-        pip install wheel
-        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
-        pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
+        set -e
+        python -m pip install -U pip setuptools wheel build
+        bdeps_script="import build; print('\n'.join(build.ProjectBuilder('.').build_system_requires))"
+        readarray -t build_deps < <(python -c "${bdeps_script}")
+        python -m pip download --dest=$VIRTUAL_ENV/deps "${build_deps[@]}" .[test]
+        python -m pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts
 
@@ -278,9 +282,9 @@ jobs:
         if [[ "$CACHE_HIT" == "true" ]]; then
           rsync -av $VIRTUAL_ENV/edgedb_server.egg-info/ ./edgedb_server.egg-info/
         else
-          # --no-use-pep517 because we have explicitly installed all deps
+          # --no-build-isolation because we have explicitly installed all deps
           # and don't want them to be reinstalled in an "isolated env".
-          pip install --no-use-pep517 --no-deps -e .[test,docs]
+          pip install --no-build-isolation --no-deps -e .[test,docs]
           rsync -av ./edgedb_server.egg-info/ $VIRTUAL_ENV/edgedb_server.egg-info/
         fi
 

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -40,10 +40,14 @@ jobs:
 
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
+      shell: bash
       run: |
-        pip install wheel
-        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
-        pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
+        set -e
+        python -m pip install -U pip setuptools wheel build
+        bdeps_script="import build; print('\n'.join(build.ProjectBuilder('.').build_system_requires))"
+        readarray -t build_deps < <(python -c "${bdeps_script}")
+        python -m pip download --dest=$VIRTUAL_ENV/deps "${build_deps[@]}" .[test]
+        python -m pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts
 
@@ -276,9 +280,9 @@ jobs:
         if [[ "$CACHE_HIT" == "true" ]]; then
           rsync -av $VIRTUAL_ENV/edgedb_server.egg-info/ ./edgedb_server.egg-info/
         else
-          # --no-use-pep517 because we have explicitly installed all deps
+          # --no-build-isolation because we have explicitly installed all deps
           # and don't want them to be reinstalled in an "isolated env".
-          pip install --no-use-pep517 --no-deps -e .[test,docs]
+          pip install --no-build-isolation --no-deps -e .[test,docs]
           rsync -av ./edgedb_server.egg-info/ $VIRTUAL_ENV/edgedb_server.egg-info/
         fi
 

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -40,10 +40,14 @@ jobs:
 
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
+      shell: bash
       run: |
-        pip install wheel
-        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
-        pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
+        set -e
+        python -m pip install -U pip setuptools wheel build
+        bdeps_script="import build; print('\n'.join(build.ProjectBuilder('.').build_system_requires))"
+        readarray -t build_deps < <(python -c "${bdeps_script}")
+        python -m pip download --dest=$VIRTUAL_ENV/deps "${build_deps[@]}" .[test]
+        python -m pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts
 
@@ -276,9 +280,9 @@ jobs:
         if [[ "$CACHE_HIT" == "true" ]]; then
           rsync -av $VIRTUAL_ENV/edgedb_server.egg-info/ ./edgedb_server.egg-info/
         else
-          # --no-use-pep517 because we have explicitly installed all deps
+          # --no-build-isolation because we have explicitly installed all deps
           # and don't want them to be reinstalled in an "isolated env".
-          pip install --no-use-pep517 --no-deps -e .[test,docs]
+          pip install --no-build-isolation --no-deps -e .[test,docs]
           rsync -av ./edgedb_server.egg-info/ $VIRTUAL_ENV/edgedb_server.egg-info/
         fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,14 @@ jobs:
 
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
+      shell: bash
       run: |
-        pip install wheel
-        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
-        pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
+        set -e
+        python -m pip install -U pip setuptools wheel build
+        bdeps_script="import build; print('\n'.join(build.ProjectBuilder('.').build_system_requires))"
+        readarray -t build_deps < <(python -c "${bdeps_script}")
+        python -m pip download --dest=$VIRTUAL_ENV/deps "${build_deps[@]}" .[test]
+        python -m pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts
 
@@ -288,9 +292,9 @@ jobs:
         if [[ "$CACHE_HIT" == "true" ]]; then
           rsync -av $VIRTUAL_ENV/edgedb_server.egg-info/ ./edgedb_server.egg-info/
         else
-          # --no-use-pep517 because we have explicitly installed all deps
+          # --no-build-isolation because we have explicitly installed all deps
           # and don't want them to be reinstalled in an "isolated env".
-          pip install --no-use-pep517 --no-deps -e .[test,docs]
+          pip install --no-build-isolation --no-deps -e .[test,docs]
           rsync -av ./edgedb_server.egg-info/ $VIRTUAL_ENV/edgedb_server.egg-info/
         fi
 
@@ -654,7 +658,7 @@ jobs:
 
       - name: Install Python deps
         run: |
-          pip install requests
+          python -m pip install requests
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_REQS_SCRIPT='print("\x00".join(__import__("build").ProjectBuilder(".").bui
 
 build-reqs:
 	python -m pip install --no-build-isolation build
-	python -c $(BUILD_REQS_SCRIPT) | xargs --null python -m pip install --no-build-isolation
+	python -c $(BUILD_REQS_SCRIPT) | xargs -0 python -m pip install --no-build-isolation
 
 
 cython: build-reqs

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,48 @@
-.PHONY: build docs cython postgres postgres-ext pygments
+.PHONY: build docs cython postgres postgres-ext pygments build-reqs
 .DEFAULT_GOAL := build
 
 SPHINXOPTS:="-W -n"
 
+BUILD_REQS_SCRIPT='print("\x00".join(__import__("build").ProjectBuilder(".").build_system_requires))'
 
-cython:
+build-reqs:
+	python -m pip install --no-build-isolation build
+	python -c $(BUILD_REQS_SCRIPT) | xargs --null python -m pip install --no-build-isolation
+
+
+cython: build-reqs
 	find edb -name '*.pyx' | xargs touch
 	BUILD_EXT_MODE=py-only python setup.py build_ext --inplace
 
-rust:
+
+rust: build-reqs
 	BUILD_EXT_MODE=rust-only python setup.py build_ext --inplace
 
-docs:
+
+docs: build-reqs
 	find docs -name '*.rst' | xargs touch
 	$(MAKE) -C docs html SPHINXOPTS=$(SPHINXOPTS) BUILDDIR="../build"
 
 
-postgres:
+postgres: build-reqs
 	python setup.py build_postgres
 
-ui:
+
+ui: build-reqs
 	python setup.py build_ui
 
-pygments:
+
+pygments: build-reqs
 	out=$$(edb gen-meta-grammars edgeql) && \
 		echo "$$out" > edb/tools/pygments/edgeql/meta.py
 
 
-casts:
+casts: build-reqs
 	out=$$(edb gen-cast-table) && \
 		echo "$$out" > docs/reference/edgeql/casts.csv
 
 
-build:
+build: build-reqs
 	find edb -name '*.pyx' | xargs touch
 	pip install -Ue .[docs,test]
 

--- a/build_backend.py
+++ b/build_backend.py
@@ -1,0 +1,23 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is a straight proxy to setuptools.build_meta backend that exists
+# solely because someone thought that in-tree build dependencies should
+# require this.
+
+from setuptools.build_meta import *  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,93 @@
+[project]
+name = "edgedb-server"
+description = "EdgeDB Server"
+requires-python = '>=3.10.0'
+dynamic = ["entry-points", "version"]
+dependencies = [
+    'edgedb==0.24.0',
+
+    'httptools>=0.3.0',
+    'immutables>=0.18',
+    'parsing~=2.0',
+    'uvloop~=0.16.0',
+
+    'click~=7.1',
+    'cryptography~=35.0',
+    'graphql-core~=3.1.5',
+    'jwcrypto~=1.3.1',
+    'psutil~=5.8',
+    'setproctitle~=1.2',
+    'wcwidth~=0.2',
+]
+
+[project.optional-dependencies]
+test = [
+    'black~=21.7b0',
+    'coverage~=5.5',
+    'flake8~=3.9.2',
+    'flake8-bugbear~=21.4.3',
+    'pycodestyle~=2.7.0',
+    'pyflakes~=2.3.1',
+
+    # Needed for test_docs_sphinx_ext
+    'requests-xml~=0.2.3',
+
+    # For rebuilding GHA workflows
+    'Jinja2~=2.11',
+    'MarkupSafe~=1.1',
+    'PyYAML~=5.4',
+
+    'mypy==0.941',
+    # mypy stub packages; when updating, you can use mypy --install-types
+    # to install stub packages and then pip freeze to read out the specifier
+    'types-click~=7.1',
+    'types-docutils~=0.17.0,<0.17.6',  # incomplete nodes.document.__init__
+    'types-Jinja2~=2.11',
+    'types-MarkupSafe~=1.1',
+    'types-pkg-resources~=0.1.3',
+    'types-typed-ast~=1.4.2',
+    'types-requests~=2.25.6',
+
+    'prometheus_client~=0.11.0',
+
+    'docutils~=0.17.0',
+    'lxml~=4.8.0',
+    'Pygments~=2.10.0',
+    'Sphinx~=4.2.0',
+    'sphinxcontrib-asyncio~=0.3.0',
+    'sphinx_code_tabs~=0.5.3',
+]
+
+docs = [
+    'docutils~=0.17.0',
+    'lxml~=4.8.0',
+    'Pygments~=2.10.0',
+    'Sphinx~=4.2.0',
+    'sphinxcontrib-asyncio~=0.3.0',
+    'sphinx_code_tabs~=0.5.3',
+]
+
+[build-system]
+requires = [
+    "Cython (>=0.29.32, <0.30.0)",
+    "packaging >= 21.0",
+    "setuptools >= 54",
+    "setuptools-rust ~= 0.12.1",
+    "wheel",
+
+    "parsing ~= 2.0",
+    'edgedb == 0.24.0',
+]
+# Custom backend needed to set up build-time sys.path because
+# setup.py needs to import `edb.buildmeta`.
+build-backend = "build_backend"
+backend-path = ["."]
+
+[tool.setuptools]
+packages = {find = { include = ["edb", "edb.*"] }}
+zip-safe = false
+
+
 # ========================
 #          BLACK
 # ========================


### PR DESCRIPTION
The "editable mode" has been changed in >=setuptools-54 to no longer
call `setup.py develop` on which we've been relying so far.  And
although the `SETUPTOOLS_ENABLE_FEATURE=legacy-editable` escape hatch
exists, it probably wouldn't for long, so it's a good idea to switch
everything to be compatible with the brave new world of PEP 517/660.