### PR TITLE
docs: use exclusive in favor of unique

### DIFF
--- a/docs/datamodel/primer.rst
+++ b/docs/datamodel/primer.rst
@@ -38,7 +38,7 @@ Constraints
 
   type Movie {
     required property title -> str {
-      constraint unique;
+      constraint exclusive;
       constraint min_len_value(8);
       constraint regexp(r'^[A-Za-z0-9 ]+$');
     }


### PR DESCRIPTION
The EdgeDB schema have no `unique` value for `constraint` key.

Schema API: [constraints datamodel](https://www.edgedb.com/docs/datamodel/constraints#ref-datamodel-constraints)