### PR TITLE
Fix interaction between DETACHED and aliases/globals

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -132,7 +132,7 @@ class Environment:
     path_scope: irast.ScopeTreeNode
     """Overrall expression path scope tree."""
 
-    schema_view_cache: Dict[s_types.Type, s_types.Type]
+    schema_view_cache: Dict[s_types.Type, tuple[s_types.Type, irast.Set]]
     """Type cache used by schema-level views."""
 
     query_parameters: Dict[str, irast.Param]

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -1106,3 +1106,11 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             await self.con.execute("""
                 SELECT __AwardAlias2__winner
             """)
+
+    async def test_edgeql_aliases_detached_01(self):
+        await self.assert_query_result(
+            r"""
+                select count((detached FireCard, detached FireCard))
+            """,
+            [4]
+        )


### PR DESCRIPTION
Referring to an alias in a detached block can result in the `expr` not
being attached to the set, which leads to it simply referring to the
underlying set. The cause here is a skew between
ctx.env.schema_view_cache and ctx.view_sets.

Fix this by separating the (cached) original compilation of a view and
the (uncached) population of ctx fields.

Fixes #4258.