### PR TITLE
Move invariant dicts from ctx -> env in edgeql compilation

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -267,6 +267,9 @@ class Environment:
     ]
     """Type cache for shape expressions."""
 
+    path_scope_map: Dict[irast.Set, ScopeInfo]
+    """A dictionary of scope info that are appropriate for a given view."""
+
     def __init__(
         self,
         *,
@@ -315,6 +318,7 @@ class Environment:
         self.type_rewrites = {}
         self.shape_type_cache = {}
         self.expr_view_cache = {}
+        self.path_scope_map = {}
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:
@@ -487,9 +491,6 @@ class ContextLevel(compiler.ContextLevel):
     path_scope: irast.ScopeTreeNode
     """Path scope tree, with per-lexical-scope levels."""
 
-    path_scope_map: Dict[irast.Set, ScopeInfo]
-    """A dictionary of scope info that are appropriate for a given view."""
-
     iterator_ctx: Optional[ContextLevel]
     """The context of the statement where all iterators should be placed."""
 
@@ -582,7 +583,6 @@ class ContextLevel(compiler.ContextLevel):
             self.inserting_paths = {}
             self.view_map = collections.ChainMap()
             self.path_scope = env.path_scope
-            self.path_scope_map = {}
             self.iterator_path_ids = frozenset()
             self.scope_id_ctr = compiler.SimpleCounter()
             self.view_scls = None
@@ -625,7 +625,6 @@ class ContextLevel(compiler.ContextLevel):
             if prevlevel.path_scope is None:
                 prevlevel.path_scope = self.env.path_scope
             self.path_scope = prevlevel.path_scope
-            self.path_scope_map = prevlevel.path_scope_map
             self.scope_id_ctr = prevlevel.scope_id_ctr
             self.view_scls = prevlevel.view_scls
             self.expr_exposed = prevlevel.expr_exposed

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -254,6 +254,19 @@ class Environment:
     that had rewrites in its components.
     """
 
+    expr_view_cache: Dict[Tuple[qlast.Base, s_name.Name], irast.Set]
+    """Type cache used by expression-level views."""
+
+    shape_type_cache: Dict[
+        Tuple[
+            s_objtypes.ObjectType,
+            s_types.ExprType,
+            Tuple[qlast.ShapeElement, ...],
+        ],
+        s_objtypes.ObjectType,
+    ]
+    """Type cache for shape expressions."""
+
     def __init__(
         self,
         *,
@@ -300,6 +313,8 @@ class Environment:
         self.script_params = {}
         self.source_map = {}
         self.type_rewrites = {}
+        self.shape_type_cache = {}
+        self.expr_view_cache = {}
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:
@@ -424,19 +439,6 @@ class ContextLevel(compiler.ContextLevel):
 
     aliased_views: ChainMap[s_name.Name, s_types.Type]
     """A dictionary of views aliased in a statement body."""
-
-    expr_view_cache: Dict[Tuple[qlast.Base, s_name.Name], irast.Set]
-    """Type cache used by expression-level views."""
-
-    shape_type_cache: Dict[
-        Tuple[
-            s_objtypes.ObjectType,
-            s_types.ExprType,
-            Tuple[qlast.ShapeElement, ...],
-        ],
-        s_objtypes.ObjectType,
-    ]
-    """Type cache for shape expressions."""
 
     class_view_overrides: Dict[uuid.UUID, s_types.Type]
     """Object mapping used by implicit view override in SELECT."""
@@ -569,8 +571,6 @@ class ContextLevel(compiler.ContextLevel):
             self.view_sets = {}
             self.suppress_rewrites = frozenset()
             self.aliased_views = collections.ChainMap()
-            self.expr_view_cache = {}
-            self.shape_type_cache = {}
             self.class_view_overrides = {}
 
             self.toplevel_stmt = None
@@ -613,8 +613,6 @@ class ContextLevel(compiler.ContextLevel):
             self.view_nodes = prevlevel.view_nodes
             self.view_sets = prevlevel.view_sets
             self.suppress_rewrites = prevlevel.suppress_rewrites
-            self.expr_view_cache = prevlevel.expr_view_cache
-            self.shape_type_cache = prevlevel.shape_type_cache
 
             self.iterator_path_ids = prevlevel.iterator_path_ids
             self.path_id_namespace = prevlevel.path_id_namespace

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -233,6 +233,9 @@ class Environment:
 
     Used to make sure the types are consistent."""
 
+    source_map: Dict[s_pointers.PointerLike, irast.ComputableInfo]
+    """A mapping of computable pointers to QL source AST and context."""
+
     def __init__(
         self,
         *,
@@ -276,6 +279,7 @@ class Environment:
         self.compiled_stmts = {}
         self.alias_result_view_name = alias_result_view_name
         self.script_params = {}
+        self.source_map = {}
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:
@@ -388,9 +392,6 @@ class ContextLevel(compiler.ContextLevel):
 
     func: Optional[s_func.Function]
     """Schema function object required when compiling functions bodies."""
-
-    source_map: Dict[s_pointers.PointerLike, irast.ComputableInfo]
-    """A mapping of computable pointers to QL source AST and context."""
 
     view_nodes: Dict[s_name.Name, s_types.Type]
     """A dictionary of newly derived Node classes representing views."""
@@ -562,7 +563,6 @@ class ContextLevel(compiler.ContextLevel):
             self.anchors = {}
             self.modaliases = {}
 
-            self.source_map = {}
             self.view_nodes = {}
             self.view_sets = {}
             self.type_rewrites = {}
@@ -610,7 +610,6 @@ class ContextLevel(compiler.ContextLevel):
             self.derived_target_module = prevlevel.derived_target_module
             self.aliases = prevlevel.aliases
 
-            self.source_map = prevlevel.source_map
             self.view_nodes = prevlevel.view_nodes
             self.view_sets = prevlevel.view_sets
             self.type_rewrites = prevlevel.type_rewrites

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -236,6 +236,14 @@ class Environment:
     source_map: Dict[s_pointers.PointerLike, irast.ComputableInfo]
     """A mapping of computable pointers to QL source AST and context."""
 
+    type_rewrites: Dict[
+        Tuple[s_types.Type, bool], irast.Set | None | Literal[True]]
+    """Access policy rewrites for schema-level types.
+
+    None indicates no rewrite, True indicates a compound type
+    that had rewrites in its components.
+    """
+
     def __init__(
         self,
         *,
@@ -280,6 +288,7 @@ class Environment:
         self.alias_result_view_name = alias_result_view_name
         self.script_params = {}
         self.source_map = {}
+        self.type_rewrites = {}
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:
@@ -398,14 +407,6 @@ class ContextLevel(compiler.ContextLevel):
 
     view_sets: Dict[s_types.Type, irast.Set]
     """A dictionary of IR expressions for views declared in the query."""
-
-    type_rewrites: Dict[
-        Tuple[s_types.Type, bool], irast.Set | None | Literal[True]]
-    """Access policy rewrites for schema-level types.
-
-    None indicates no rewrite, True indicates a compound type
-    that had rewrites in its components.
-    """
 
     suppress_rewrites: FrozenSet[s_types.Type]
     """Types to suppress using rewrites on"""
@@ -565,7 +566,6 @@ class ContextLevel(compiler.ContextLevel):
 
             self.view_nodes = {}
             self.view_sets = {}
-            self.type_rewrites = {}
             self.suppress_rewrites = frozenset()
             self.aliased_views = collections.ChainMap()
             self.must_use_views = {}
@@ -612,7 +612,6 @@ class ContextLevel(compiler.ContextLevel):
 
             self.view_nodes = prevlevel.view_nodes
             self.view_sets = prevlevel.view_sets
-            self.type_rewrites = prevlevel.type_rewrites
             self.suppress_rewrites = prevlevel.suppress_rewrites
             self.must_use_views = prevlevel.must_use_views
             self.expr_view_cache = prevlevel.expr_view_cache

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -270,9 +270,9 @@ def derive_view(
                 # computable expressions for pointers are carried over.
                 src_ptr = scls_pointers.get(ctx.env.schema, pn)
                 computable_data = (
-                    ctx.source_map.get(src_ptr) if src_ptr else None)
+                    ctx.env.source_map.get(src_ptr) if src_ptr else None)
                 if computable_data is not None:
-                    ctx.source_map[ptr] = computable_data
+                    ctx.env.source_map[ptr] = computable_data
 
                 if src_ptr in ctx.env.pointer_specified_info:
                     ctx.env.pointer_derivation_map[src_ptr].append(ptr)
@@ -348,9 +348,9 @@ def derive_ptr(
                 # mypy somehow loses the type argument in the
                 # "pointers" ObjectIndex.
                 assert isinstance(src_ptr, s_pointers.Pointer)
-                computable_data = ctx.source_map.get(src_ptr)
+                computable_data = ctx.env.source_map.get(src_ptr)
                 if computable_data is not None:
-                    ctx.source_map[ptr] = computable_data
+                    ctx.env.source_map[ptr] = computable_data
 
     if preserve_shape and ptr in ctx.env.view_shapes:
         preserve_view_shape(ptr, derived, ctx=ctx)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -256,7 +256,7 @@ def derive_view(
             and not (
                 stype.generic(ctx.env.schema)
                 and (view_ir := ctx.view_sets.get(stype))
-                and (scope_info := ctx.path_scope_map.get(view_ir))
+                and (scope_info := ctx.env.path_scope_map.get(view_ir))
                 and scope_info.binding_kind
             )
             and isinstance(derived, s_objtypes.ObjectType)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -119,7 +119,7 @@ def _get_type_variant(
 ) -> Optional[s_obj.Object]:
     type_variant = ctx.aliased_views.get(name)
     if type_variant is not None:
-        ctx.must_use_views[type_variant] = None
+        ctx.env.must_use_views[type_variant] = None
         return type_variant
     else:
         return None

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -336,7 +336,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
 
                 view_set = ctx.view_sets.get(stype)
                 if view_set is not None:
-                    view_scope_info = ctx.path_scope_map[view_set]
+                    view_scope_info = ctx.env.path_scope_map[view_set]
                     path_tip = new_set_from_set(
                         view_set,
                         merge_current_ns=(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -880,7 +880,7 @@ def _is_computable_ptr(
     ctx: context.ContextLevel,
 ) -> bool:
     try:
-        qlexpr = ctx.source_map[ptrcls].qlexpr
+        qlexpr = ctx.env.source_map[ptrcls].qlexpr
     except KeyError:
         pass
     else:
@@ -1280,7 +1280,7 @@ def computable_ptr_set(
     qlctx: Optional[context.ContextLevel]
 
     try:
-        comp_info = ctx.source_map[ptrcls]
+        comp_info = ctx.env.source_map[ptrcls]
         qlexpr = comp_info.qlexpr
         assert isinstance(comp_info.context, context.ContextLevel)
         qlctx = comp_info.context
@@ -1667,8 +1667,8 @@ def should_materialize(
     ):
         reasons.append(irast.MaterializeVisible(sets=vis))
 
-    if ptrcls and ptrcls in ctx.source_map:
-        reasons += ctx.source_map[ptrcls].should_materialize
+    if ptrcls and ptrcls in ctx.env.source_map:
+        reasons += ctx.env.source_map[ptrcls].should_materialize
 
     reasons += should_materialize_type(typ, ctx=ctx)
 
@@ -1683,8 +1683,8 @@ def should_materialize_type(
     if isinstance(
             typ, (s_objtypes.ObjectType, s_pointers.Pointer)):
         for pointer in typ.get_pointers(schema).objects(schema):
-            if pointer in ctx.source_map:
-                reasons += ctx.source_map[pointer].should_materialize
+            if pointer in ctx.env.source_map:
+                reasons += ctx.env.source_map[pointer].should_materialize
     elif isinstance(typ, s_types.Collection):
         for sub in typ.get_subtypes(schema):
             reasons += should_materialize_type(sub, ctx=ctx)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -93,7 +93,7 @@ def new_set(
 
     if (
         not ignore_rewrites
-        and rw_key not in ctx.type_rewrites
+        and rw_key not in ctx.env.type_rewrites
         and isinstance(stype, s_objtypes.ObjectType)
         and ctx.env.options.apply_query_rewrites
     ):
@@ -852,7 +852,7 @@ def needs_rewrite_existence_assertion(
         ptrcls.get_required(ctx.env.schema)
         and direction == PtrDir.Outbound
         and (target := ptrcls.get_target(ctx.env.schema))
-        and ctx.type_rewrites.get((target, False))
+        and ctx.env.type_rewrites.get((target, False))
         and ptrcls.get_shortname(ctx.env.schema).name != '__type__'
     )
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -197,7 +197,7 @@ def compile_ForQuery(
                 context=ctx.env.type_origins.get(iterator_type),
             )
 
-        view_scope_info = sctx.path_scope_map[iterator_view]
+        view_scope_info = sctx.env.path_scope_map[iterator_view]
 
         pathctx.register_set_in_scope(
             iterator_stmt,
@@ -273,7 +273,7 @@ def _make_group_binding(
     name = s_name.UnqualName(alias)
     ctx.aliased_views[name] = binding_type
     ctx.view_sets[binding_type] = binding_set
-    ctx.path_scope_map[binding_set] = context.ScopeInfo(
+    ctx.env.path_scope_map[binding_set] = context.ScopeInfo(
         path_scope=ctx.path_scope,
         binding_kind=irast.BindingKind.For,
         pinned_path_id_ns=ctx.path_id_namespace,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -257,7 +257,7 @@ def fini_expression(
     group.infer_group_aggregates(ir, ctx=ctx)
 
     assert isinstance(ir, irast.Set)
-    source_map = {k: v for k, v in ctx.source_map.items()
+    source_map = {k: v for k, v in ctx.env.source_map.items()
                   if isinstance(k, s_pointers.Pointer)}
     params = list(ctx.env.query_parameters.values())
     if params and params[0].name.isdecimal():
@@ -304,7 +304,7 @@ def _fixup_materialized_sets(
     # Make sure that all materialized sets have their views compiled
     flt = lambda n: isinstance(n, irast.Stmt)
     children: List[irast.Stmt] = ast_visitor.find_children(ir, flt)
-    for nobe in ctx.source_map.values():
+    for nobe in ctx.env.source_map.values():
         if nobe.irexpr:
             children += ast_visitor.find_children(nobe.irexpr, flt)
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -166,7 +166,7 @@ def fini_expression(
     ctx.path_scope.validate_unique_ids()
 
     # Infer cardinalities of type rewrites
-    for rw in ctx.type_rewrites.values():
+    for rw in ctx.env.type_rewrites.values():
         if isinstance(rw, irast.Set):
             inference.infer_cardinality(
                 rw, scope_tree=ctx.path_scope, ctx=inf_ctx)
@@ -290,7 +290,7 @@ def fini_expression(
         ),
         type_rewrites={
             (typ.id, not skip_subtypes): s
-            for (typ, skip_subtypes), s in ctx.type_rewrites.items()
+            for (typ, skip_subtypes), s in ctx.env.type_rewrites.items()
             if isinstance(s, irast.Set)},
         dml_exprs=ctx.env.dml_exprs,
         singletons=ctx.env.singletons,
@@ -483,7 +483,7 @@ def compile_anchor(
     if isinstance(anchor, s_types.Type):
         # Anchors should not receive type rewrites; we are already
         # evaluating in their context.
-        ctx.type_rewrites[anchor, False] = None
+        ctx.env.type_rewrites[anchor, False] = None
         step = setgen.class_set(anchor, ctx=ctx)
 
     elif (isinstance(anchor, s_pointers.Pointer) and
@@ -491,7 +491,7 @@ def compile_anchor(
         src = anchor.get_source(ctx.env.schema)
         if src is not None:
             assert isinstance(src, s_objtypes.ObjectType)
-            ctx.type_rewrites[src, False] = None
+            ctx.env.type_rewrites[src, False] = None
             path = setgen.extend_path(
                 setgen.class_set(src, ctx=ctx),
                 anchor,
@@ -502,7 +502,7 @@ def compile_anchor(
             ptrcls = schemactx.derive_dummy_ptr(anchor, ctx=ctx)
             src = ptrcls.get_source(ctx.env.schema)
             assert isinstance(src, s_types.Type)
-            ctx.type_rewrites[src, False] = None
+            ctx.env.type_rewrites[src, False] = None
             path = setgen.extend_path(
                 setgen.class_set(src, ctx=ctx),
                 ptrcls,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -600,7 +600,7 @@ def declare_view(
             subctx.path_id_namespace = path_id_namespace
 
         if not fully_detached:
-            cached_view_set = ctx.expr_view_cache.get((expr, alias))
+            cached_view_set = ctx.env.expr_view_cache.get((expr, alias))
             # Detach the view namespace and record the prefix
             # in the parent statement's fence node.
             view_path_id_ns = ctx.aliases.get('ns')
@@ -653,7 +653,7 @@ def declare_view(
 
         view_type = setgen.get_set_type(view_set, ctx=ctx)
         ctx.aliased_views[alias] = view_type
-        ctx.expr_view_cache[expr, alias] = view_set
+        ctx.env.expr_view_cache[expr, alias] = view_set
 
         if must_be_used and view_type not in ctx.env.must_use_views:
             ctx.env.must_use_views[view_type] = (alias, expr.context)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -92,7 +92,7 @@ def init_context(
     for orig, remapped in options.type_remaps.items():
         rset = compile_anchor('__', remapped, ctx=ctx)
         ctx.view_sets[orig] = rset
-        ctx.path_scope_map[rset] = context.ScopeInfo(
+        ctx.env.path_scope_map[rset] = context.ScopeInfo(
             path_scope=ctx.path_scope, binding_kind=None
         )
 
@@ -637,7 +637,7 @@ def declare_view(
         view_set = dispatch.compile(astutils.ensure_qlstmt(expr), ctx=subctx)
         assert isinstance(view_set, irast.Set)
 
-        ctx.path_scope_map[view_set] = context.ScopeInfo(
+        ctx.env.path_scope_map[view_set] = context.ScopeInfo(
             path_scope=subctx.path_scope,
             pinned_path_id_ns=pinned_pid_ns,
             binding_kind=binding_kind,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -243,7 +243,7 @@ def fini_expression(
                 hint='Consider using an explicit type cast.',
                 context=ctx.env.type_origins.get(anytype))
 
-    must_use_views = [val for val in ctx.must_use_views.values() if val]
+    must_use_views = [val for val in ctx.env.must_use_views.values() if val]
     if must_use_views:
         alias, srcctx = must_use_views[0]
         raise errors.QueryError(
@@ -655,8 +655,8 @@ def declare_view(
         ctx.aliased_views[alias] = view_type
         ctx.expr_view_cache[expr, alias] = view_set
 
-        if must_be_used and view_type not in ctx.must_use_views:
-            ctx.must_use_views[view_type] = (alias, expr.context)
+        if must_be_used and view_type not in ctx.env.must_use_views:
+            ctx.env.must_use_views[view_type] = (alias, expr.context)
 
     return view_set
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -86,9 +86,10 @@ def _ql_typeexpr_to_type(
             # Use an empty scope tree, to avoid polluting things pointlessly
             subctx.path_scope = irast.ScopeTreeNode()
             subctx.expr_exposed = context.Exposure.UNEXPOSED
-            subctx.type_rewrites = subctx.type_rewrites.copy()
+            orig_rewrites = ctx.env.type_rewrites.copy()
             ir_set = dispatch.compile(ql_t.expr, ctx=subctx)
             stype = setgen.get_set_type(ir_set, ctx=subctx)
+            ctx.env.type_rewrites = orig_rewrites
 
         return [stype]
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -76,7 +76,7 @@ def process_view(
 ) -> Tuple[s_objtypes.ObjectType, irast.Set]:
 
     cache_key = (stype, exprtype, tuple(elements))
-    view_scls = ctx.shape_type_cache.get(cache_key)
+    view_scls = ctx.env.shape_type_cache.get(cache_key)
     if view_scls is not None:
         return view_scls, ir_set
 
@@ -104,7 +104,7 @@ def process_view(
         ctx=ctx,
     )
 
-    ctx.shape_type_cache[cache_key] = view_scls
+    ctx.env.shape_type_cache[cache_key] = view_scls
 
     return view_scls, ir
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -324,7 +324,7 @@ def _process_view(
             source = view_scls
 
         if is_defining_shape:
-            cinfo = ctx.source_map.get(ptrcls)
+            cinfo = ctx.env.source_map.get(ptrcls)
             if cinfo is not None:
                 shape_op = cinfo.shape_op
             else:
@@ -586,7 +586,7 @@ def _normalize_view_ptr_expr(
                 ptrcls, view_scls, ctx=ctx)
 
         base_ptrcls = ptrcls.get_bases(ctx.env.schema).first(ctx.env.schema)
-        base_ptr_is_computable = base_ptrcls in ctx.source_map
+        base_ptr_is_computable = base_ptrcls in ctx.env.source_map
         ptr_name = sn.QualName(
             module='__',
             name=ptrcls.get_shortname(ctx.env.schema).name,
@@ -991,7 +991,7 @@ def _normalize_view_ptr_expr(
         )
 
     if qlexpr is not None:
-        ctx.source_map[ptrcls] = irast.ComputableInfo(
+        ctx.env.source_map[ptrcls] = irast.ComputableInfo(
             qlexpr=qlexpr,
             irexpr=irexpr,
             context=ctx,
@@ -1260,7 +1260,7 @@ def _inline_type_computable(
         ptr = setgen.resolve_ptr(stype, compname, track_ref=None, ctx=ctx)
         # The pointer might exist on the base type. That doesn't count,
         # and we need to re-inject it.
-        if ptr not in ctx.source_map:
+        if ptr not in ctx.env.source_map:
             ptr = None
     except errors.InvalidReferenceError:
         ptr = None


### PR DESCRIPTION
There are a lot of dicts that are never assigned to but get dutifully
copied between every context. Lift them to env.

(I think we are due for a general audit of ctx/env, of which this is
the start.)