### PR TITLE
Annotate all type names when INJECT_OUTPUT_TYPE_NAMES is set

### DIFF
--- a/docs/reference/protocol/typedesc.rst
+++ b/docs/reference/protocol/typedesc.rst
@@ -336,10 +336,11 @@ Ranges are encoded on the wire as :ref:`ranges <ref_protocol_fmt_range>`.
 Scalar Type Name Annotation
 ===========================
 
-Part of the type descriptor when the :ref:`ref_protocol_msg_execute`
-client message has the ``INLINE_TYPENAMES`` header set.  Every non-builtin
-base scalar type and all enum types would have their full schema name
-provided via this annotation.
+Part of the type descriptor when the :ref:`ref_protocol_msg_parse` or
+:ref:`ref_protocol_msg_execute` client message has the
+``INJECT_OUTPUT_TYPE_NAMES`` CompilationFlag set.  Every scalar type, all enum
+types and object types would have their full schema name provided via this
+annotation.
 
 .. code-block:: c
 

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -397,7 +397,7 @@ class TypeSerializer:
                 buf.append(_uint16_packer(self.uuid_to_pos[el_type]))
 
             if self.inline_typenames:
-                self._add_annotation(mt, type_id.bytes)
+                self._add_typename_annotation(mt, type_id.bytes)
             self._register_type_id(type_id)
             return type_id
 
@@ -436,7 +436,7 @@ class TypeSerializer:
                 buf.append(_uint16_packer(self.uuid_to_pos[bt_id]))
 
             if self.inline_typenames:
-                self._add_annotation(mt)
+                self._add_typename_annotation(mt)
             self._register_type_id(type_id)
             return type_id
 
@@ -502,7 +502,7 @@ class TypeSerializer:
         else:
             return self._describe_type(t, {}, {}, protocol_version)
 
-    def _add_annotation(self, t: s_types.Type, type_id=None):
+    def _add_typename_annotation(self, t: s_types.Type, type_id=None):
         self.anno_buffer.append(CTYPE_ANNO_TYPENAME)
 
         self.anno_buffer.append(type_id or t.id.bytes)

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -396,6 +396,8 @@ class TypeSerializer:
                 buf.append(el_name_bytes)
                 buf.append(_uint16_packer(self.uuid_to_pos[el_type]))
 
+            if self.inline_typenames:
+                self._add_annotation(mt, type_id.bytes)
             self._register_type_id(type_id)
             return type_id
 
@@ -420,9 +422,6 @@ class TypeSerializer:
                     buf.append(_uint32_packer(len(enum_val_bytes)))
                     buf.append(enum_val_bytes)
 
-                if self.inline_typenames:
-                    self._add_annotation(mt)
-
             elif mt == base_type:
                 buf.append(CTYPE_BASE_SCALAR)
                 buf.append(type_id.bytes)
@@ -436,9 +435,8 @@ class TypeSerializer:
                 buf.append(type_id.bytes)
                 buf.append(_uint16_packer(self.uuid_to_pos[bt_id]))
 
-                if self.inline_typenames:
-                    self._add_annotation(mt)
-
+            if self.inline_typenames:
+                self._add_annotation(mt)
             self._register_type_id(type_id)
             return type_id
 
@@ -504,10 +502,10 @@ class TypeSerializer:
         else:
             return self._describe_type(t, {}, {}, protocol_version)
 
-    def _add_annotation(self, t: s_types.Type):
+    def _add_annotation(self, t: s_types.Type, type_id=None):
         self.anno_buffer.append(CTYPE_ANNO_TYPENAME)
 
-        self.anno_buffer.append(t.id.bytes)
+        self.anno_buffer.append(type_id or t.id.bytes)
 
         tn = t.get_displayname(self.schema)
 

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -66,7 +66,8 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
                         'kind': 'data',
                         'data': [
                             'AAAAAAAAAAAAAAAAAAABBQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQU=',
+                            'AgAAAAAAAAAAAAAAAAAAAQX/AAAAAAAAAAAAAAAAAA'
+                            'ABBQAAAApzdGQ6OmludDY0',
                             'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
                             'U0VMRUNU'
                         ]
@@ -75,7 +76,8 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
                         'kind': 'data',
                         'data': [
                             'AAAAAAAAAAAAAAAAAAABAQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQE=',
+                            'AgAAAAAAAAAAAAAAAAAAAQH/AAAAAAAAAAAAAAAAAA'
+                            'ABAQAAAAhzdGQ6OnN0cg==',
                             'RAAAAA4AAQAAAARBQUFB',
                             'U0VMRUNU'
                         ]
@@ -100,7 +102,8 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
                         'kind': 'data',
                         'data': [
                             'AAAAAAAAAAAAAAAAAAABBQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQU=',
+                            'AgAAAAAAAAAAAAAAAAAAAQX/AAAAAAAAAAAAAAAAAA'
+                            'ABBQAAAApzdGQ6OmludDY0',
                             'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
                             'U0VMRUNU'
                         ]
@@ -181,7 +184,8 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
                         'kind': 'data',
                         'data': [
                             'AAAAAAAAAAAAAAAAAAABBQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQU=',
+                            'AgAAAAAAAAAAAAAAAAAAAQX/AAAAAAAAAAAAAAAAAA'
+                            'ABBQAAAApzdGQ6OmludDY0',
                             'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
                             'U0VMRUNU'
                         ]


### PR DESCRIPTION
This includes type desc annotation for type names of objects and basic scalar types.