### PR TITLE
Don't include union types in link triggers

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5807,7 +5807,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 if target_is_affected and current_target is not None:
                     affected_targets.add(current_target)
             else:
-                if source.is_view(eff_schema):
+                if not source.is_material_object_type(eff_schema):
                     continue
 
                 current_source = schema.get_by_id(source.id, None)
@@ -5913,7 +5913,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                     continue
 
                 source = link.get_source(schema)
-                if source.is_view(schema):
+                if not source.is_material_object_type(schema):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
                     link, schema=schema)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -14022,6 +14022,28 @@ type default::Foo {
                 ALTER TYPE Foo ALTER LINK link SET REQUIRED;
             """)
 
+    async def test_edgeql_ddl_link_union_delete_01(self):
+        await self.con.execute(r"""
+            CREATE TYPE default::M;
+            CREATE ABSTRACT TYPE default::Base {
+                CREATE LINK l -> default::M;
+            };
+            CREATE TYPE default::A EXTENDING default::Base;
+            CREATE TYPE default::B EXTENDING default::Base;
+            CREATE TYPE default::L {
+                CREATE LINK l -> (default::B | default::A);
+            };
+            CREATE TYPE ForceRedo {
+                CREATE LINK l -> default::M;
+            };
+        """)
+        await self.con.execute(r"""
+            insert M;
+        """)
+        await self.con.execute(r"""
+            delete M;
+        """)
+
     async def test_edgeql_ddl_alter_union_01(self):
         await self.con.execute(r"""
             CREATE TYPE Foo;


### PR DESCRIPTION
If the schema contains a union type that has a link to some type M
(because it appears in every union element), we have been putting that
union type in the link triggers. This is bad because it isn't real.

Fixes #4320.

If you encounter this issue, after upgrading to a version with this
patch, it can be fixed by doing a dump/restore or by adding a new link
to `M` to the schema (and then deleting it, I guess).

It might be worth calling that out in the changelog.