### PR TITLE
Fix a tracer issue with reverse links and IS

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -742,9 +742,6 @@ def trace_Path(
                             ctx.refs.add(qualify_name(
                                 tip_name, prev_step.ptr.name))
 
-                        # This is a backwards link, so we need the source.
-                        tip = ptr.get_source(ctx.schema)
-
         else:
             tr = trace(step, ctx=ctx)
             if tr is not None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1982,6 +1982,27 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """
 
+    def test_schema_computed_04(self):
+        """
+            type User {
+                required property name -> str;
+
+                multi link likedPosts := .<author[is PostLike].post;
+            }
+
+            type Post {
+                required property content -> str;
+            }
+
+            abstract type ALike {
+                required link author -> User;
+            }
+
+            type PostLike extending ALike {
+                required link post -> Post;
+            }
+        """
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.


### PR DESCRIPTION
The tracer handling for reverse links discarded the tip computed by
the type expr and grabbed the source of the pointer found instead.