### PR TITLE
Strip out all views from DML subjects when computing what tables to use

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -443,6 +443,27 @@ def get_material_type(
     return mtype
 
 
+def concretify(
+    t: s_types.Type,
+    *,
+    ctx: context.ContextLevel,
+) -> s_types.Type:
+    """Produce a version of t with all views removed.
+
+    This procedes recursively through unions and intersections,
+    which can result in major simplifications with intersection types
+    in particular.
+    """
+    t = get_material_type(t, ctx=ctx)
+    if els := t.get_union_of(ctx.env.schema):
+        ts = [concretify(e, ctx=ctx) for e in els.objects(ctx.env.schema)]
+        return get_union_type(ts , ctx=ctx)
+    if els := t.get_intersection_of(ctx.env.schema):
+        ts = [concretify(e, ctx=ctx) for e in els.objects(ctx.env.schema)]
+        return get_intersection_type(ts , ctx=ctx)
+    return t
+
+
 class TypeIntersectionResult(NamedTuple):
 
     stype: s_types.Type

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -610,6 +610,14 @@ def compile_UpdateQuery(
             bodyctx.implicit_tname_in_shapes = False
             bodyctx.implicit_limit = 0
 
+            stmt._material_type = typeutils.type_to_typeref(
+                ctx.env.schema,
+                schemactx.concretify(subj_type, ctx=ctx),
+                include_descendants=True,
+                include_ancestors=True,
+                cache=ctx.env.type_ref_cache,
+            )
+
             stmt.subject = compile_query_subject(
                 subject,
                 shape=expr.shape,
@@ -727,6 +735,14 @@ def compile_DeleteQuery(
             bodyctx.implicit_id_in_shapes = False
             bodyctx.implicit_tid_in_shapes = False
             bodyctx.implicit_tname_in_shapes = False
+            stmt._material_type = typeutils.type_to_typeref(
+                ctx.env.schema,
+                schemactx.concretify(subj_type, ctx=ctx),
+                include_descendants=True,
+                include_ancestors=True,
+                cache=ctx.env.type_ref_cache,
+            )
+
             stmt.subject = compile_query_subject(
                 subject,
                 shape=None,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -598,6 +598,14 @@ def compile_UpdateQuery(
                 f'free objects cannot be updated',
                 context=expr.subject.context)
 
+        stmt._material_type = typeutils.type_to_typeref(
+            ctx.env.schema,
+            schemactx.concretify(subj_type, ctx=ctx),
+            include_descendants=True,
+            include_ancestors=True,
+            cache=ctx.env.type_ref_cache,
+        )
+
         ictx.partial_path_prefix = subject
 
         clauses.compile_where_clause(
@@ -609,14 +617,6 @@ def compile_UpdateQuery(
             bodyctx.implicit_tid_in_shapes = False
             bodyctx.implicit_tname_in_shapes = False
             bodyctx.implicit_limit = 0
-
-            stmt._material_type = typeutils.type_to_typeref(
-                ctx.env.schema,
-                schemactx.concretify(subj_type, ctx=ctx),
-                include_descendants=True,
-                include_ancestors=True,
-                cache=ctx.env.type_ref_cache,
-            )
 
             stmt.subject = compile_query_subject(
                 subject,
@@ -731,17 +731,18 @@ def compile_DeleteQuery(
                 f'free objects cannot be deleted',
                 context=expr.subject.context)
 
+        stmt._material_type = typeutils.type_to_typeref(
+            ctx.env.schema,
+            schemactx.concretify(subj_type, ctx=ctx),
+            include_descendants=True,
+            include_ancestors=True,
+            cache=ctx.env.type_ref_cache,
+        )
+
         with ictx.new() as bodyctx:
             bodyctx.implicit_id_in_shapes = False
             bodyctx.implicit_tid_in_shapes = False
             bodyctx.implicit_tname_in_shapes = False
-            stmt._material_type = typeutils.type_to_typeref(
-                ctx.env.schema,
-                schemactx.concretify(subj_type, ctx=ctx),
-                include_descendants=True,
-                include_ancestors=True,
-                cache=ctx.env.type_ref_cache,
-            )
 
             stmt.subject = compile_query_subject(
                 subject,

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -105,9 +105,7 @@ def init_dml_stmt(
         range_cte = None
         range_rvar = None
 
-    top_typeref = ir_stmt.subject.typeref
-    if top_typeref.material_type:
-        top_typeref = top_typeref.material_type
+    top_typeref = ir_stmt.material_type
 
     typerefs = [top_typeref]
 
@@ -1259,6 +1257,9 @@ def process_update_body(
         subctx.enclosing_cte_iterator = iterator
 
         for shape_el, shape_op in ir_stmt.subject.shape:
+            if shape_op == qlast.ShapeOp.MATERIALIZE:
+                continue
+
             assert shape_el.rptr is not None
             ptrref = shape_el.rptr.ptrref
             actual_ptrref = irtyputils.find_actual_ptrref(typeref, ptrref)
@@ -1522,7 +1523,7 @@ def check_update_type(
     """
 
     base_ptrref = irtyputils.find_actual_ptrref(
-        ir_stmt.subject.typeref, shape_ptrref)
+        ir_stmt.material_type, shape_ptrref)
     # We skip the check if either the base type matches exactly
     # or the shape type matches exactly. FIXME: *Really* we want to do
     # a subtype check, here, though, since this could do a needless


### PR DESCRIPTION
This avoids bugs where the dml pgsql compilation can't understand how
to deal with intersections between a view and something else.

This can come up in situations with type injection, as well as when
doing DML on an alias.

Fixes #4333.