### PR TITLE
Fix access policies on DELETE of a UNION type

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -385,12 +385,12 @@ def derive_view_name(
 
 
 def get_union_type(
-    types: Iterable[s_types.Type],
+    types: Iterable[s_types.TypeT],
     *,
     opaque: bool = False,
     preserve_derived: bool = False,
     ctx: context.ContextLevel,
-) -> s_types.Type:
+) -> s_types.TypeT:
 
     ctx.env.schema, union, created = s_utils.ensure_union_type(
         ctx.env.schema, types,
@@ -407,14 +407,14 @@ def get_union_type(
     ):
         ctx.env.add_schema_ref(union, expr=None)
 
-    return union
+    return cast(s_types.TypeT, union)
 
 
 def get_intersection_type(
-    types: Iterable[s_types.Type],
+    types: Iterable[s_types.TypeT],
     *,
     ctx: context.ContextLevel,
-) -> s_types.Type:
+) -> s_types.TypeT:
 
     ctx.env.schema, intersection, created = s_utils.ensure_intersection_type(
         ctx.env.schema, types, transient=True)
@@ -430,7 +430,7 @@ def get_intersection_type(
     ):
         ctx.env.add_schema_ref(intersection, expr=None)
 
-    return intersection
+    return cast(s_types.TypeT, intersection)
 
 
 def get_material_type(
@@ -444,10 +444,10 @@ def get_material_type(
 
 
 def concretify(
-    t: s_types.Type,
+    t: s_types.TypeT,
     *,
     ctx: context.ContextLevel,
-) -> s_types.Type:
+) -> s_types.TypeT:
     """Produce a version of t with all views removed.
 
     This procedes recursively through unions and intersections,

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -765,3 +765,20 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
         await self.con.execute('''
             insert A;
         ''')
+
+    async def test_edgeql_policies_delete_union_01(self):
+        await self.con.execute('''
+            create type T {
+                create access policy insert_select
+                    allow insert, select;
+            };
+            create type S;
+            insert T;
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                delete {T, S};
+            ''',
+            []
+        )


### PR DESCRIPTION
The problem was that we looked only at descendents and not union
elements.

Similarly fix access policies for UPDATE of UNION, probably, except
that is still broken too much.