### PR TITLE
Better messages for required links hidden by policies

### DIFF
--- a/edb/common/ordered.py
+++ b/edb/common/ordered.py
@@ -66,7 +66,7 @@ class OrderedSet(MutableSet[K]):
         return iter(self.map)
 
     def __reversed__(self) -> Iterator[K]:
-        return reversed(list(self.map))
+        return reversed(self.map.keys())
 
     def __repr__(self) -> str:
         if not self:

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -225,6 +225,7 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             };
             CREATE TYPE Ptr {
                 CREATE REQUIRED LINK tgt -> Tgt;
+                CREATE PROPERTY tb := .tgt.b;
             };
         ''')
         await self.con.query('''
@@ -236,28 +237,37 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.CardinalityViolationError,
-                r"returned an empty set"):
+                r"is hidden by access policy"):
             await self.con.query('''
                 select Ptr { tgt }
             ''')
 
         async with self.assertRaisesRegexTx(
                 edgedb.CardinalityViolationError,
-                r"returned an empty set"):
+                r"is hidden by access policy"):
             await self.con.query('''
                 select Ptr { z := .tgt.b }
             ''')
 
         async with self.assertRaisesRegexTx(
                 edgedb.CardinalityViolationError,
-                r"returned an empty set"):
+                r"required link 'tgt' of object type 'default::Ptr' is "
+                r"hidden by access policy \(while evaluating computed "
+                r"property 'tb' of object type 'default::Ptr'\)"):
+            await self.con.query('''
+                select Ptr { tb }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
             await self.con.query('''
                 select Ptr.tgt
             ''')
 
         async with self.assertRaisesRegexTx(
                 edgedb.CardinalityViolationError,
-                r"returned an empty set"):
+                r"is hidden by access policy"):
             await self.con.query('''
                 select Ptr.tgt.b
             ''')
@@ -305,7 +315,7 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.CardinalityViolationError,
-                r"returned an empty set"):
+                r"is hidden by access policy"):
             await self.con.query('''
                 select Ptr { tgt }
             ''')


### PR DESCRIPTION
Use the error message field of assert_exists to put a good message
in. Additionally, track pending computeds being compiled and use those
to produce more detailed messages.
I only list the closest enclosing computed, though we could go further.