### PR TITLE
Fix cardinality in CommandDataDescription

### DIFF
--- a/edb/protocol/enums.py
+++ b/edb/protocol/enums.py
@@ -22,6 +22,8 @@ from typing import *
 
 import enum
 
+from edb.edgeql import qltypes as ir
+
 
 class Cardinality(enum.Enum):
     # Cardinality isn't applicable for the query:
@@ -41,3 +43,18 @@ class Cardinality(enum.Enum):
 
     # Cardinality is >= 1
     AT_LEAST_ONE = 0x4d
+
+    @classmethod
+    def from_ir_value(cls, card: ir.Cardinality) -> Cardinality:
+        if card == ir.Cardinality.AT_MOST_ONE:
+            return Cardinality.AT_MOST_ONE
+        elif card == ir.Cardinality.ONE:
+            return Cardinality.ONE
+        elif card == ir.Cardinality.MANY:
+            return Cardinality.MANY
+        elif card == ir.Cardinality.AT_LEAST_ONE:
+            return Cardinality.AT_LEAST_ONE
+        else:
+            raise ValueError(
+                f"Cardinality.from_ir_value() got an invalid input: {card}"
+            )

--- a/edb/protocol/enums.py
+++ b/edb/protocol/enums.py
@@ -46,13 +46,13 @@ class Cardinality(enum.Enum):
 
     @classmethod
     def from_ir_value(cls, card: ir.Cardinality) -> Cardinality:
-        if card == ir.Cardinality.AT_MOST_ONE:
+        if card is ir.Cardinality.AT_MOST_ONE:
             return Cardinality.AT_MOST_ONE
-        elif card == ir.Cardinality.ONE:
+        elif card is ir.Cardinality.ONE:
             return Cardinality.ONE
-        elif card == ir.Cardinality.MANY:
+        elif card is ir.Cardinality.MANY:
             return Cardinality.MANY
-        elif card == ir.Cardinality.AT_LEAST_ONE:
+        elif card is ir.Cardinality.AT_LEAST_ONE:
             return Cardinality.AT_LEAST_ONE
         else:
             raise ValueError(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -625,20 +625,11 @@ class Compiler:
             options=self._get_compile_options(ctx),
         )
 
-        if ir.cardinality.is_single():
-            if ir.cardinality.can_be_zero():
-                result_cardinality = enums.Cardinality.AT_MOST_ONE
-            else:
-                result_cardinality = enums.Cardinality.ONE
-        else:
-            if ir.cardinality.can_be_zero():
-                result_cardinality = enums.Cardinality.MANY
-            else:
-                result_cardinality = enums.Cardinality.AT_LEAST_ONE
-            if ctx.expected_cardinality_one:
-                raise errors.ResultCardinalityMismatchError(
-                    f'the query has cardinality {result_cardinality.name} '
-                    f'which does not match the expected cardinality ONE')
+        if ir.cardinality.is_multi() and ctx.expected_cardinality_one:
+            raise errors.ResultCardinalityMismatchError(
+                f'the query has cardinality {ir.cardinality.name} '
+                f'which does not match the expected cardinality ONE')
+        result_cardinality = enums.Cardinality.from_ir_value(ir.cardinality)
 
         sql_text, argmap = pg_compiler.compile_ir_to_sql(
             ir,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -626,9 +626,15 @@ class Compiler:
         )
 
         if ir.cardinality.is_single():
-            result_cardinality = enums.Cardinality.AT_MOST_ONE
+            if ir.cardinality.can_be_zero():
+                result_cardinality = enums.Cardinality.AT_MOST_ONE
+            else:
+                result_cardinality = enums.Cardinality.ONE
         else:
-            result_cardinality = enums.Cardinality.MANY
+            if ir.cardinality.can_be_zero():
+                result_cardinality = enums.Cardinality.MANY
+            else:
+                result_cardinality = enums.Cardinality.AT_LEAST_ONE
             if ctx.expected_cardinality_one:
                 raise errors.ResultCardinalityMismatchError(
                     f'the query has cardinality {result_cardinality.name} '


### PR DESCRIPTION
Previously the cardinality in CommandDataDescription can only be one of AT_MOST_ONE, MANY or NO_RESULT, now it could also be ONE or AT_LEAST_ONE.