### PR TITLE
Add dart docs to clients index

### DIFF
--- a/docs/clients/index.rst
+++ b/docs/clients/index.rst
@@ -34,5 +34,6 @@ Client Libraries
     python/index
     go/index
     rust/index
+    dart/index
     http/index
 


### PR DESCRIPTION
Depends on https://github.com/edgedb/edgedb.com/pull/526