### PR TITLE
Support UNLESS CONFLICT ON for pointers with DML in them

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -120,7 +120,13 @@ def _compile_conflict_select(
         ptrs_in_shape.add(name)
         if name in needed_ptrs and name not in ptr_anchors:
             assert elem.expr
-            if inference.infer_volatility(elem.expr, ctx.env).is_volatile():
+            # We don't properly support hoisting volatile properties out of
+            # UNLESS CONFLICT, so disallow it. We *do* support handling DML
+            # there, since that gets hoisted into CTEs via its own mechanism.
+            # See issue #1699.
+            if inference.infer_volatility(
+                elem.expr, ctx.env, exclude_dml=True
+            ).is_volatile():
                 if for_inheritance:
                     error = (
                         'INSERT does not support volatile properties with '

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -450,7 +450,7 @@ def compile_insert_unless_conflict_on(
 ) -> irast.OnConflictClause:
 
     with ctx.new() as constraint_ctx:
-        constraint_ctx.partial_path_prefix = stmt.subject
+        constraint_ctx.partial_path_prefix = setgen.class_set(typ, ctx=ctx)
 
         # We compile the name here so we can analyze it, but we don't do
         # anything else with it.

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -364,10 +364,9 @@ def infer_volatility(
     ir: irast.Base,
     env: context.Environment,
     *,
-    for_materialization: bool=False,
+    exclude_dml: bool=False,
 ) -> qltypes.Volatility:
-    result = _normalize_volatility(_infer_volatility(ir, env))[
-        for_materialization]
+    result = _normalize_volatility(_infer_volatility(ir, env))[exclude_dml]
 
     if result not in {VOLATILE, STABLE, IMMUTABLE}:
         raise errors.QueryError(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1651,8 +1651,7 @@ def should_materialize(
     skipped_bindings: AbstractSet[irast.PathId]=frozenset(),
     ctx: context.ContextLevel,
 ) -> Sequence[irast.MaterializeReason]:
-    volatility = inference.infer_volatility(
-        ir, ctx.env, for_materialization=True)
+    volatility = inference.infer_volatility(ir, ctx.env, exclude_dml=True)
     reasons: List[irast.MaterializeReason] = []
 
     if volatility.is_volatile():

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -967,7 +967,7 @@ def _normalize_view_ptr_expr(
         x.is_binding == irast.BindingKind.With
         and x.expr
         and inference.infer_volatility(
-            x.expr, ctx.env, for_materialization=True).is_volatile()
+            x.expr, ctx.env, exclude_dml=True).is_volatile()
 
         for reason in materialized
         if isinstance(reason, irast.MaterializeVisible)

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3252,11 +3252,12 @@ class TestInsert(tb.QueryTestCase):
                 }
             };
         ''')
+
         q = '''
             INSERT Y {
               l := (INSERT X { n := <str>$n } UNLESS CONFLICT ON (.n) ELSE (X))
             }
-            UNLESS CONFLICT ON (Y.l);
+            UNLESS CONFLICT ON (.l);
         '''
         await self.assert_query_result(
             q, [{}], variables={'n': "1"},

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3239,6 +3239,41 @@ class TestInsert(tb.QueryTestCase):
             );
         ''')
 
+    async def test_edgeql_insert_unless_conflict_25(self):
+        await self.con.execute('''
+            create type X {
+                create required property n -> str {
+                    create constraint exclusive;
+                }
+            };
+            create type Y {
+                create required link l -> X {
+                    create constraint exclusive;
+                }
+            };
+        ''')
+        q = '''
+            INSERT Y {
+              l := (INSERT X { n := <str>$n } UNLESS CONFLICT ON (.n) ELSE (X))
+            }
+            UNLESS CONFLICT ON (Y.l);
+        '''
+        await self.assert_query_result(
+            q, [{}], variables={'n': "1"},
+        )
+        await self.assert_query_result(
+            q, [], variables={'n': "1"},
+        )
+        await self.con.execute('''
+            insert X { n := "2" }
+        ''')
+        await self.assert_query_result(
+            q, [{}], variables={'n': "2"},
+        )
+        await self.assert_query_result(
+            q, [], variables={'n': "2"},
+        )
+
     async def test_edgeql_insert_dependent_01(self):
         query = r'''
             SELECT (


### PR DESCRIPTION
Disallowing volatile pointers is #1699, and we disallow it because
we currently lack the machinery necessary to properly hoist the values
into CTEs. We *do* hoist DML into CTEs, though, and so the only thing
preventing that case from working is that we disallow it.