### PR TITLE
Move ir import from protocol/enums to server/compiler/enums

### DIFF
--- a/edb/protocol/enums.py
+++ b/edb/protocol/enums.py
@@ -22,8 +22,6 @@ from typing import *
 
 import enum
 
-from edb.edgeql import qltypes as ir
-
 
 class Cardinality(enum.Enum):
     # Cardinality isn't applicable for the query:
@@ -43,18 +41,3 @@ class Cardinality(enum.Enum):
 
     # Cardinality is >= 1
     AT_LEAST_ONE = 0x4d
-
-    @classmethod
-    def from_ir_value(cls, card: ir.Cardinality) -> Cardinality:
-        if card is ir.Cardinality.AT_MOST_ONE:
-            return Cardinality.AT_MOST_ONE
-        elif card is ir.Cardinality.ONE:
-            return Cardinality.ONE
-        elif card is ir.Cardinality.MANY:
-            return Cardinality.MANY
-        elif card is ir.Cardinality.AT_LEAST_ONE:
-            return Cardinality.AT_LEAST_ONE
-        else:
-            raise ValueError(
-                f"Cardinality.from_ir_value() got an invalid input: {card}"
-            )

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -629,7 +629,7 @@ class Compiler:
             raise errors.ResultCardinalityMismatchError(
                 f'the query has cardinality {ir.cardinality.name} '
                 f'which does not match the expected cardinality ONE')
-        result_cardinality = enums.Cardinality.from_ir_value(ir.cardinality)
+        result_cardinality = enums.cardinality_from_ir_value(ir.cardinality)
 
         sql_text, argmap = pg_compiler.compile_ir_to_sql(
             ir,

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -24,7 +24,7 @@ import enum
 
 from edb.common import enum as strenum
 from edb.edgeql import qltypes as ir
-from edb.protocol.enums import * # NoQA
+from edb.protocol.enums import Cardinality
 
 
 if TYPE_CHECKING:

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -23,6 +23,7 @@ from typing import *
 import enum
 
 from edb.common import enum as strenum
+from edb.edgeql import qltypes as ir
 from edb.protocol.enums import * # NoQA
 
 
@@ -76,3 +77,18 @@ class OutputFormat(strenum.StrEnum):
 class InputFormat(strenum.StrEnum):
     BINARY = 'BINARY'
     JSON = 'JSON'
+
+
+def cardinality_from_ir_value(card: ir.Cardinality) -> Cardinality:
+    if card is ir.Cardinality.AT_MOST_ONE:
+        return Cardinality.AT_MOST_ONE
+    elif card is ir.Cardinality.ONE:
+        return Cardinality.ONE
+    elif card is ir.Cardinality.MANY:
+        return Cardinality.MANY
+    elif card is ir.Cardinality.AT_LEAST_ONE:
+        return Cardinality.AT_LEAST_ONE
+    else:
+        raise ValueError(
+            f"Cardinality.from_ir_value() got an invalid input: {card}"
+        )

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -107,7 +107,7 @@ def cardinality_from_ptr(ptr, schema) -> enums.Cardinality:
     required = ptr.get_required(schema)
     schema_card = ptr.get_cardinality(schema)
     ir_card = qltypes.Cardinality.from_schema_value(required, schema_card)
-    return enums.Cardinality.from_ir_value(ir_card)
+    return enums.cardinality_from_ir_value(ir_card)
 
 
 class TypeSerializer:


### PR DESCRIPTION
`edb.protocol` is used in `edb.tools.docs.eql`, while the docs build environment doesn't have the Rust extensions or `parsing` lib to import `edb.edgeql` properly. So we move the import of `edb.edgeql.qltypes` into `edb.server.compiler` in order to unbreak the docs build.