### PR TITLE
Run the primary CI test suite on pushes to stable branches

### DIFF
--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -7,6 +7,7 @@ on:
       - master
       - ci
       - "releases/*"
+      - "stable/*"
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - master
       - ci
       - "releases/*"
+      - "stable/*"
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
This needs to be cherry picked to stable/2.x branch to make it take
effect.
Should we do the various other suites too?