### PR TITLE
reference ``make docs`` in contributing docs

### DIFF
--- a/docs/guides/contributing.rst
+++ b/docs/guides/contributing.rst
@@ -72,16 +72,6 @@ Python "venv" with all dependencies and commands installed into it.
    Python virtual environment.
 
    It will also install libraries used during development.
-   
-#. Build documentation
-
-   .. code-block:: bash
-      
-      $ make docs
-      
-   The ``edgedb`` repository will come with a ``Makefile`` containing build
-   requirements necessary for carrying out Sphinx builds. Once ran, a new
-   directory `docs/build` will be generated with the HTML converted result.
 
 #. Run tests:
 
@@ -120,6 +110,20 @@ To pattern-match a test by its name:
 
 See ``$ edb test --help`` for more options.
 
+
+Writing Documentation
+=====================
+
+The ``edgedb`` repository contains all of its documentation in the ``docs/``
+directory. EdgeDB uses reStructuredText instead of Mkdocs, with Sphinx to
+build and generate from source.
+
+Use the ``$ make docs`` command to build and generate HTML files from the
+documentation. The repository contains a ``Makefile`` for all of Sphinx's
+necessary build options.
+
+Upon success, HTML generated documentation will be a new directory path
+as ``docs/build``.
 
 Dev Server
 ==========

--- a/docs/guides/contributing.rst
+++ b/docs/guides/contributing.rst
@@ -72,6 +72,16 @@ Python "venv" with all dependencies and commands installed into it.
    Python virtual environment.
 
    It will also install libraries used during development.
+   
+#. Build documentation
+
+   .. code-block:: bash
+      
+      $ make docs
+      
+   The ``edgedb`` repository will come with a ``Makefile`` containing build
+   requirements necessary for carrying out Sphinx builds. Once ran, a new
+   directory `docs/build` will be generated with the HTML converted result.
 
 #. Run tests:
 

--- a/docs/guides/contributing.rst
+++ b/docs/guides/contributing.rst
@@ -115,7 +115,7 @@ Writing Documentation
 =====================
 
 The ``edgedb`` repository contains all of its documentation in the ``docs/``
-directory. EdgeDB uses reStructuredText (``.rst``) instead of Markdown.
+directory. EdgeDB uses `reStructuredText with Sphinx <rst_>`_.
 
 Use the ``$ make docs`` command to build and generate HTML files from the
 documentation. The repository contains a ``Makefile`` for all of Sphinx's
@@ -139,6 +139,6 @@ Test Databases
 Use the ``$ edb inittestdb`` command to create and populate databases
 that are used by unit tests.
 
-
+.. _rst: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _edgedbpy: https://github.com/edgedb/edgedb-python
 .. _edgedb: https://github.com/edgedb/edgedb

--- a/docs/guides/contributing.rst
+++ b/docs/guides/contributing.rst
@@ -115,8 +115,7 @@ Writing Documentation
 =====================
 
 The ``edgedb`` repository contains all of its documentation in the ``docs/``
-directory. EdgeDB uses reStructuredText instead of Mkdocs, with Sphinx to
-build and generate from source.
+directory. EdgeDB uses reStructuredText (``.rst``) instead of Markdown.
 
 Use the ``$ make docs`` command to build and generate HTML files from the
 documentation. The repository contains a ``Makefile`` for all of Sphinx's


### PR DESCRIPTION
This references the `make docs` command for `Makefile` containing the necessary arguments and build steps for constructing HTML content from `docs/` with Sphinx.