### PR TITLE
Properly quote numeric names when in codegen

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -64,13 +64,13 @@ def any_ident_to_str(ident: str) -> str:
         return ident_to_str(ident)
 
 
-def ident_to_str(ident: str) -> str:
-    return edgeql_quote.quote_ident(ident)
+def ident_to_str(ident: str, allow_num: bool=False) -> str:
+    return edgeql_quote.quote_ident(ident, allow_num=allow_num)
 
 
 def param_to_str(ident: str) -> str:
     return '$' + edgeql_quote.quote_ident(
-        ident, allow_reserved=True)
+        ident, allow_reserved=True, allow_num=True)
 
 
 def module_to_str(module: str) -> str:
@@ -553,7 +553,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         elif node.direction and node.direction != '>':
             self.write(node.direction)
 
-        self.visit(node.ptr)
+        self.write(ident_to_str(node.ptr.name, allow_num=True))
 
     def visit_TypeIntersection(self, node: qlast.TypeIntersection) -> None:
         self._write_keywords('[IS ')

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -26,6 +26,10 @@ from .parser.grammar import keywords
 
 _re_ident = re.compile(r'''(?x)
     [^\W\d]\w*  # alphanumeric identifier
+''')
+
+_re_ident_or_num = re.compile(r'''(?x)
+    [^\W\d]\w*  # alphanumeric identifier
     |
     ([1-9]\d* | 0)  # purely integer identifier
 ''')
@@ -59,13 +63,14 @@ def dollar_quote_literal(text: str) -> str:
     return quote + text + quote
 
 
-def needs_quoting(string: str, allow_reserved: bool) -> bool:
+def needs_quoting(string: str, allow_reserved: bool, allow_num: bool) -> bool:
     if not string or string.startswith('@') or '::' in string:
         # some strings are illegal as identifiers and as such don't
         # require quoting
         return False
 
-    isalnum = _re_ident.fullmatch(string)
+    r = _re_ident_or_num if allow_num else _re_ident
+    isalnum = r.fullmatch(string)
 
     string = string.lower()
 
@@ -85,8 +90,10 @@ def _quote_ident(string: str) -> str:
 
 
 def quote_ident(string: str, *,
-                force: bool = False, allow_reserved: bool = False) -> str:
-    if force or needs_quoting(string, allow_reserved):
+                force: bool = False,
+                allow_reserved: bool = False,
+                allow_num: bool = False) -> str:
+    if force or needs_quoting(string, allow_reserved, allow_num):
         return _quote_ident(string)
     else:
         return string

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -5223,6 +5223,13 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_type_23(self):
+        """
+        CREATE TYPE `123` {
+            CREATE PROPERTY `456` -> str;
+        };
+        """
+
     def test_edgeql_syntax_set_command_01(self):
         """
         SET MODULE default;


### PR DESCRIPTION
Fixes #4344, in which dump wouldn't work in a schema with such a name.
Anybody who actually has such a schema is still in for a world of
pain, since the migration log won't dump properly. Fortunately, this
bug also *prevented* using the migration system to create types with
number names, so probably nobody is in this situation.