### PR TITLE
When finding common parent for arrays, never use expr alias arrays

### DIFF
--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1301,10 +1301,10 @@ class Array(
             other.get_element_type(schema), schema)
 
     def find_common_implicitly_castable_type(
-        self: Array_T,
+        self,
         other: Type,
         schema: s_schema.Schema,
-    ) -> typing.Tuple[s_schema.Schema, Optional[Array_T]]:
+    ) -> typing.Tuple[s_schema.Schema, Optional[Array]]:
 
         if not isinstance(other, Array):
             return schema, None

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1319,7 +1319,7 @@ class Array(
         if subtype is None:
             return schema, None
 
-        return type(self).from_subtypes(schema, [subtype])
+        return Array.from_subtypes(schema, [subtype])
 
     def _resolve_polymorphic(
         self,

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -6875,6 +6875,14 @@ aa \
             [],
         )
 
+        await self.assert_query_result(
+            r"""
+                with test := ['']
+                select test if false else <array<str>>[];
+            """,
+            [[]],
+        )
+
     async def test_edgeql_expr_setop_01(self):
         await self.assert_query_result(
             r"""SELECT EXISTS <str>{};""",


### PR DESCRIPTION
Fixes #4080.