### PR TITLE
Support more env vars in args.py, standardize docs

### DIFF
--- a/docs/guides/deployment/bare_metal.rst
+++ b/docs/guides/deployment/bare_metal.rst
@@ -86,7 +86,7 @@ To set environment variables when running EdgeDB with ``systemctl``,
 
    $ systemctl edit --full edgedb-server-2
 
-This opens a ``systemd`` unit file. Set the desireed environment variables
+This opens a ``systemd`` unit file. Set the desired environment variables
 under the ``[Service]`` section. View the supported environment variables at
 :ref:`Reference > Environment Variables <ref_reference_environment>`.
 

--- a/docs/guides/deployment/bare_metal.rst
+++ b/docs/guides/deployment/bare_metal.rst
@@ -75,12 +75,35 @@ default. You can start the server by enabling the unit.
    $ sudo systemctl enable --now edgedb-server-2
 
 This will start the server on port 5656, and the data directory will be
-``/var/lib/edgedb/1/data``. You can edit the unit to specify server arguments
-via the environment. The variables are largely the same as :ref:`those
-documented for Docker <ref_guides_deployment_docker_customization>`.
+``/var/lib/edgedb/1/data``.
+
+Set environment variables
+=========================
+
+To set environment variables when running EdgeDB with ``systemctl``,
+
+.. code-block:: bash
+
+   $ systemctl edit --full edgedb-server-2
+
+This opens a ``systemd`` unit file. Set the desireed environment variables
+under the ``[Service]`` section. View the supported environment variables at
+:ref:`Reference > Environment Variables <ref_reference_environment>`.
+
+.. code-block:: toml
+
+   [Service]
+   Environment="EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed"
+   Environment="EDGEDB_SERVER_ADMIN_UI=enabled"
+
+Save the file and exit, then restart the service.
+
+.. code-block:: bash
+
+   $ systemctl restart edgedb-server-2
 
 
-Set a Password
+Set a password
 ==============
 There is no default password. Set a password by connecting from localhost.
 
@@ -112,11 +135,11 @@ You may need to restart the server after changing the listen port or addresses.
    $ sudo systemctl restart edgedb-server-2
 
 
-Linking a Bare Metal Instance
-=============================
+Link the instance with the CLI
+==============================
 
 The following is an example of linking a bare metal instance that is running on
-``localhost``.
+``localhost``. This command assigns the
 
 .. code-block:: bash
 

--- a/docs/guides/deployment/bare_metal.rst
+++ b/docs/guides/deployment/bare_metal.rst
@@ -139,7 +139,8 @@ Link the instance with the CLI
 ==============================
 
 The following is an example of linking a bare metal instance that is running on
-``localhost``. This command assigns the
+``localhost``. This command assigns a name to the instance, to make it more
+convenient to refer to when running CLI commands.
 
 .. code-block:: bash
 
@@ -151,7 +152,7 @@ The following is an example of linking a bare metal instance that is running on
       --trust-tls-cert \
       bare_metal_instance
 
-This allows connecting to the instance with it's name.
+This allows connecting to the instance with its name.
 
 .. code-block:: bash
 

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -180,6 +180,34 @@ If ``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` is set, this variable will be ignored.
 The ``*_FILE`` and ``*_ENV`` variants are also supported.
 
 
+EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT
+.......................................
+
+.. warning::
+
+   Deprecated: use ``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``
+   instead.
+
+Set this option to ``1`` to tell the server to automatically generate a
+self-signed certificate with key file in the ``EDGEDB_SERVER_DATADIR`` (if
+present, see below), and echo the certificate content in the logs. If the
+certificate file exists, the server will use it instead of generating a new
+one.
+
+Self-signed certificates are usually used in development and testing, you
+should likely provide your own certificate and key file with the variables
+below.
+
+
+EDGEDB_SERVER_TLS_CERT/EDGEDB_SERVER_TLS_KEY
+............................................
+
+The TLS certificate and private key data, exclusive with
+``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``.
+
+The ``*_FILE`` and ``*_ENV`` variants are also supported.
+
+
 Custom scripts in ``/docker-entrypoint.d/``
 ...........................................
 

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -157,6 +157,28 @@ The following environment variables affect the bootstrap only and have no
 effect on subsequent container runs.
 
 
+EDGEDB_SERVER_BOOTSTRAP_COMMAND
+...............................
+
+Useful to fine-tune initial user and database creation, and other initial
+setup. If neither the ``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
+``EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE`` are explicitly specified, the container
+will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
+(which can be placed in a derived image).
+
+Maps directly to the ``edgedb-server`` flag ``--default-auth-method``. The
+``*_FILE`` and ``*_ENV`` variants are also supported.
+
+
+EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE
+...................................
+Deprecated in image version 2.8: use ``EDGEDB_SERVER_BOOTSTRAP_COMMAND_FILE``
+instead.
+
+Run the script when initializing the database. The script is run by default
+user within default database.
+
+
 EDGEDB_SERVER_PASSWORD
 ......................
 

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -160,7 +160,11 @@ effect on subsequent container runs.
 EDGEDB_SERVER_PASSWORD
 ......................
 
-Determines the password used for the default superuser account.
+The password for the default superuser account will be set to this value. If
+no value is provided a password will not be set, unless set via
+``EDGEDB_SERVER_BOOTSTRAP_COMMAND``. (If a value for
+``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` is provided, this variable will be
+ignored.)
 
 The ``*_FILE`` and ``*_ENV`` variants are also supported.
 
@@ -170,6 +174,8 @@ EDGEDB_SERVER_PASSWORD_HASH
 
 A variant of ``EDGEDB_SERVER_PASSWORD``, where the specified value is a hashed
 password verifier instead of plain text.
+
+If ``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` is set, this variable will be ignored.
 
 The ``*_FILE`` and ``*_ENV`` variants are also supported.
 

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -129,26 +129,20 @@ machine, you can use the CLI bundled with the server container:
 
 .. _ref_guides_deployment_docker_customization:
 
-Customization
+Configuration
 =============
 
-The behavior of the EdgeDB docker image can be customized via environment
-variables and initialization scripts.
+The Docker image supports the same set of enviroment variables as the EdgeDB
+server process, which are documented under :ref:`Reference > Environment
+Variables <ref_reference_environment>`.
 
-Some environment variables (noted below) support ``*_FILE`` and ``*_ENV``
-variants. The ``*_FILE`` variant expects its value to be a file name.  The
-file's contents will be read and used as the value. This is useful for
-referencing files that are mounted in the container. The ``*_ENV`` variant
-expects its value to be the name of another environment variable. The value of
-the other environment variable is then used as the final value. This is
-convenient in deployment scenarios where relevant values are auto populated
-into fixed environment variables.
-
+EdgeDB containers can be additionally configured using initialization scripts
+and some Docker-specific environment variables, documented below.
 
 .. _ref_guides_deployment_docker_initial_setup:
 
-Initial container setup
------------------------
+Initial configuration
+---------------------
 
 When an EdgeDB container starts on the specified data directory or remote
 Postgres cluster for the first time, initial instance setup is performed. This
@@ -175,112 +169,23 @@ password verifier instead of plain text.
 The ``*_FILE`` and ``*_ENV`` variants are also supported.
 
 
-EDGEDB_SERVER_USER
-..................
+Custom scripts in ``/docker-entrypoint.d/``
+...........................................
 
-Optionally specifies the name of the default superuser account. Defaults to
-``edgedb`` if not specified.
-
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_TLS_CERT_MODE
-...........................
-Specifies what to do when the TLS certificate and key are either not specified
-or are missing.  When set to ``require_file``, the TLS certificate and key must
-be specified in the ``EDGEDB_SERVER_TLS_CERT`` and ``EDGEDB_SERVER_TLS_KEY``
-variables and both must exist.  When set to ``generate_self_signed`` a new
-self-signed certificate and private key will be generated and placed in the
-path specified by ``EDGEDB_SERVER_TLS_CERT`` and ``EDGEDB_SERVER_TLS_KEY``, if
-those are set, otherwise the generated certificate and key are stored as
-``edbtlscert.pem`` and ``edbprivkey.pem`` in ``EDGEDB_SERVER_DATADIR``, or, if
-``EDGEDB_SERVER_DATADIR`` is not set then they will be placed in
-``/etc/ssl/edgedb``.
-
-The default is ``generate_self_signed`` when
-``EDGEDB_SERVER_SECURITY=insecure_dev_mode``. Otherwise the default is
-``require_file``.
-
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
+To perform additional initialization, a derived image may include one or more
+executable files in ``/docker-entrypoint.d/``, which will get executed by the
+container entrypoint *before* any other processing takes place.
 
 
-EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT
-.......................................
+Runtime configuration
+---------------------
 
-Deprecated: use ``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed`` instead.
+EDGEDB_DOCKER_LOG_LEVEL
+.......................
 
-Set this option to ``1`` to tell the server to automatically generate a
-self-signed certificate with key file in the ``EDGEDB_SERVER_DATADIR`` (if
-present, see below), and echo the certificate content in the logs. If the
-certificate file exists, the server will use it instead of generating a new
-one.
-
-Self-signed certificates are usually used in development and testing, you
-should likely provide your own certificate and key file with the variables
-below.
-
-
-EDGEDB_SERVER_TLS_CERT EDGEDB_SERVER_TLS_KEY
-............................................
-
-The TLS certificate and private key, exclusive with
-``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``.
-
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_DATABASE
-......................
-
-Optionally specifies the name of a default database that is created during
-bootstrap. Defaults to ``edgedb`` if not specified.
-
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_DEFAULT_AUTH_METHOD
-.................................
-
-Optionally specifies the authentication method used by the server instance.
-Supported values are ``SCRAM`` (the default) and ``Trust``.  When set to
-``Trust``, the database will allow complete unauthenticated access for all who
-have access to the database port.  In this case the ``EDGEDB_SERVER_PASSWORD``
-(or equivalent) setting is not required.
-
-Use at your own risk and only for development and testing.
-
-
-EDGEDB_SERVER_SECURITY
-......................
-
-When set to ``insecure_dev_mode``, sets ``EDGEDB_SERVER_DEFAULT_AUTH_METHOD``
-to ``Trust`` (see above), and ``EDGEDB_SERVER_TLS_CERT_MODE`` to
-``generate_self_signed`` (unless an explicit TLS certificate is specified).
-Finally, if this option is set, the server will accept plaintext HTTP
-connections.
-
-Use at your own risk and only for development and testing.
-
-
-EDGEDB_SERVER_BOOTSTRAP_COMMAND
-...............................
-
-Specifies one or more EdgeQL statements to run at bootstrap. If specified,
-overrides ``EDGEDB_SERVER_PASSWORD``, ``EDGEDB_SERVER_PASSWORD_HASH``,
-``EDGEDB_SERVER_USER`` and ``EDGEDB_SERVER_DATABASE``. Useful to fine-tune
-initial user and database creation, and other initial setup. If neither the
-``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
-``EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE`` are explicitly specified, the container
-will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
-(which can be placed in a derived image).
-
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE
-...................................
-Run the script when initializing the database. The script is run by default
-user within default database.
+Determines the log verbosity level in the entrypoint script. Valid levels are
+``trace``, ``debug``, ``info``, ``warning``, and ``error``.  The default is
+``info``.
 
 
 Custom scripts in ``/edgedb-bootstrap.d/`` and ``/edgedb-bootstrap-late.d``
@@ -293,101 +198,3 @@ _after_ the initialization specified by the environment variables above or the
 executed _before_ any schema migrations are applied, and parts in
 ``/edgedb-bootstrap-late.d`` are executed _after_ the schema migration have
 been applied.
-
-
-Runtime Options
----------------
-
-Unlike options listed in the :ref:`ref_guides_deployment_docker_initial_setup`
-section above, the configuration documented below applies to all container
-invocations.  It can be specified either as environment variables or
-command-line arguments.
-
-
-EDGEDB_SERVER_PORT
-..................
-
-Specifies the network port on which EdgeDB will listen inside the container.
-The default is ``5656``.  This usually doesn't need to be changed unless you
-run in ``host`` networking mode.
-
-Maps directly to the ``edgedb-server`` flag ``--port``. The ``*_FILE`` and
-``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_BIND_ADDRESS
-..........................
-
-Specifies the network interface on which EdgeDB will listen inside the
-container.  The default is ``0.0.0.0``, which means all interfaces.  This
-usually doesn't need to be changed unless you run in ``host`` networking mode.
-
-Maps directly to the ``edgedb-server`` flag ``--bind-address``. The ``*_FILE``
-and ``*_ENV`` variants are also supported.
-
-
-.. _ref_reference_docer_edgedb_server_datadir:
-
-EDGEDB_SERVER_DATADIR
-.....................
-
-Specifies a path within the container in which the database files are located.
-Defaults to ``/var/lib/edgedb/data``.  The container needs to be able to change
-the ownership of the mounted directory to ``edgedb``.  Cannot be specified at
-the same time with ``EDGEDB_SERVER_BACKEND_DSN``.
-
-Maps directly to the ``edgedb-server`` flag ``--data-dir``.
-
-
-.. _ref_reference_docker_edgedb_server_backend_dsn:
-
-EDGEDB_SERVER_BACKEND_DSN
-.........................
-
-Specifies a PostgreSQL connection string in the `URI format`_.  If set, the
-PostgreSQL cluster specified by the URI is used instead of the builtin
-PostgreSQL server.  Cannot be specified at the same time with
-``EDGEDB_SERVER_DATADIR``.
-
-Maps directly to the ``edgedb-server`` flag ``--backend-dsn``. The ``*_FILE``
-and ``*_ENV`` variants are also supported.
-
-.. _URI format:
-   https://www.postgresql.org/docs/13/libpq-connect.html#id-1.7.3.8.3.6
-
-
-EDGEDB_SERVER_RUNSTATE_DIR
-..........................
-
-Specifies a path within the container in which EdgeDB will place its Unix
-socket and other transient files.
-
-Maps directly to the ``edgedb-server`` flag ``--runstate-dir``.
-
-EDGEDB_SERVER_ADMIN_UI
-......................
-
-Set to ``enabled`` to enable the Web-based admininstrative UI for the instance.
-
-EDGEDB_SERVER_EXTRA_ARGS
-........................
-
-Extra arguments to be passed to EdgeDB server.
-
-Maps directly to the ``edgedb-server`` flag ``--extra-arg, ...``.
-
-
-Custom scripts in ``/docker-entrypoint.d/``
-...........................................
-
-To perform additional initialization, a derived image may include one or more
-executable files in ``/docker-entrypoint.d/``, which will get executed by the
-container entrypoint *before* any other processing takes place.
-
-
-EDGEDB_DOCKER_LOG_LEVEL
-.......................
-
-Determines the log verbosity level in the entrypoint script. Valid levels are
-``trace``, ``debug``, ``info``, ``warning``, and ``error``.  The default is
-``info``.

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -139,6 +139,11 @@ Variables <ref_reference_environment>`.
 EdgeDB containers can be additionally configured using initialization scripts
 and some Docker-specific environment variables, documented below.
 
+.. note::
+
+   Seme variables support ``_ENV`` and ``_FILE`` :ref:`variants
+   <ref_reference_envvar_variants>` to support more advanced configurations.
+
 .. _ref_guides_deployment_docker_initial_setup:
 
 Initial configuration

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -79,7 +79,7 @@ and ``*_ENV`` variants are also supported.
 
 
 EDGEDB_SERVER_TLS_CERT_FILE/EDGEDB_SERVER_TLS_KEY_FILE
-............................................
+......................................................
 
 The TLS certificate and private key files, exclusive with
 ``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``.

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -8,6 +8,9 @@ variables documented on this page are supported when using the
 ``edgedb-server`` tool and the official :ref:`Docker image
 <ref_guide_deployment_docker>`.
 
+
+.. _ref_reference_envvar_variants:
+
 Variants
 --------
 Some environment variables (noted below) support ``*_FILE`` and ``*_ENV``
@@ -24,15 +27,39 @@ variants.
 Supported variables
 -------------------
 
-.. Initialization
-.. --------------
+EDGEDB_SERVER_BOOTSTRAP_COMMAND
+...............................
 
-.. When an EdgeDB container starts on the specified data directory or remote
-.. Postgres cluster for the first time, initial instance setup is performed.
-.. This is called the *bootstrap phase*.
+Specifies one or more EdgeQL statements to run at bootstrap. If specified,
+overrides ``EDGEDB_SERVER_PASSWORD``, ``EDGEDB_SERVER_PASSWORD_HASH``,
+``EDGEDB_SERVER_USER`` and ``EDGEDB_SERVER_DATABASE``. Useful to fine-tune
+initial user and database creation, and other initial setup. If neither the
+``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
+``EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE`` are explicitly specified, the container
+will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
+(which can be placed in a derived image).
 
-.. The following environment variables affect the bootstrap only and have no
-.. effect on subsequent container runs.
+The ``*_FILE`` and ``*_ENV`` variants are also supported.
+
+
+EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE
+...................................
+
+Run the script when initializing the database. The script is run by default
+user within default database.
+
+
+EDGEDB_SERVER_DEFAULT_AUTH_METHOD
+.................................
+
+Optionally specifies the authentication method used by the server instance.
+Supported values are ``SCRAM`` (the default) and ``Trust``.  When set to
+``Trust``, the database will allow complete unauthenticated access for all who
+have access to the database port.  In this case the ``EDGEDB_SERVER_PASSWORD``
+(or equivalent) setting is not required.
+
+Use at your own risk and only for development and testing.
+
 
 EDGEDB_SERVER_TLS_CERT_MODE
 ...........................
@@ -54,7 +81,6 @@ The default is ``generate_self_signed`` when
 
 The ``*_FILE`` and ``*_ENV`` variants are also supported.
 
-
 EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT
 .......................................
 
@@ -74,26 +100,13 @@ should likely provide your own certificate and key file with the variables
 below.
 
 
-EDGEDB_SERVER_TLS_CERT EDGEDB_SERVER_TLS_KEY
+EDGEDB_SERVER_TLS_CERT/EDGEDB_SERVER_TLS_KEY
 ............................................
 
 The TLS certificate and private key, exclusive with
 ``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``.
 
 The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_DEFAULT_AUTH_METHOD
-.................................
-
-Optionally specifies the authentication method used by the server instance.
-Supported values are ``SCRAM`` (the default) and ``Trust``.  When set to
-``Trust``, the database will allow complete unauthenticated access for all who
-have access to the database port.  In this case the ``EDGEDB_SERVER_PASSWORD``
-(or equivalent) setting is not required.
-
-Use at your own risk and only for development and testing.
-
 
 EDGEDB_SERVER_SECURITY
 ......................
@@ -105,37 +118,6 @@ Finally, if this option is set, the server will accept plaintext HTTP
 connections.
 
 Use at your own risk and only for development and testing.
-
-
-EDGEDB_SERVER_BOOTSTRAP_COMMAND
-...............................
-
-Specifies one or more EdgeQL statements to run at bootstrap. If specified,
-overrides ``EDGEDB_SERVER_PASSWORD``, ``EDGEDB_SERVER_PASSWORD_HASH``,
-``EDGEDB_SERVER_USER`` and ``EDGEDB_SERVER_DATABASE``. Useful to fine-tune
-initial user and database creation, and other initial setup. If neither the
-``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
-``EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE`` are explicitly specified, the container
-will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
-(which can be placed in a derived image).
-
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE
-...................................
-Run the script when initializing the database. The script is run by default
-user within default database.
-
-
-.. Runtime Options
-.. ---------------
-
-.. The variables in this section affect the runtime behavior
-.. :ref:`ref_guides_deployment_docker_initial_setup`
-.. section above, the configuration documented below applies to all container
-.. invocations. It can be specified either as environment variables or
-.. command-line arguments.
 
 
 EDGEDB_SERVER_PORT
@@ -201,7 +183,7 @@ Maps directly to the ``edgedb-server`` flag ``--runstate-dir``.
 EDGEDB_SERVER_ADMIN_UI
 ......................
 
-Set to ``enabled`` to enable the Web-based admininstrative UI for the instance.
+Set to ``enabled`` to enable the web-based admininstrative UI for the instance.
 
 EDGEDB_SERVER_EXTRA_ARGS
 ........................

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -16,9 +16,8 @@ Variants
 Some environment variables (noted below) support ``*_FILE`` and ``*_ENV``
 variants.
 
-- The ``*_FILE`` variant expects its value to be a file name.  The
-  file's contents will be read and used as the value. This is useful for
-  referencing files that are mounted in the container.
+- The ``*_FILE`` variant expects its value to be a file name.  The file's
+  contents will be read and used as the value.
 - The ``*_ENV`` variant expects its value to be the name of another
   environment variable. The value of the other environment variable is then
   used as the final value. This is convenient in deployment scenarios where
@@ -102,9 +101,8 @@ Maps directly to the ``edgedb-server`` flag ``--security``.
 EDGEDB_SERVER_PORT
 ..................
 
-Specifies the network port on which EdgeDB will listen inside the container.
-The default is ``5656``.  This usually doesn't need to be changed unless you
-run in ``host`` networking mode.
+Specifies the network port on which EdgeDB will listen.  The default is
+``5656``.
 
 Maps directly to the ``edgedb-server`` flag ``--port``. The ``*_FILE`` and
 ``*_ENV`` variants are also supported.
@@ -113,9 +111,7 @@ Maps directly to the ``edgedb-server`` flag ``--port``. The ``*_FILE`` and
 EDGEDB_SERVER_BIND_ADDRESS
 ..........................
 
-Specifies the network interface on which EdgeDB will listen inside the
-container.  The default is ``0.0.0.0``, which means all interfaces.  This
-usually doesn't need to be changed unless you run in ``host`` networking mode.
+Specifies the network interface on which EdgeDB will listen.
 
 Maps directly to the ``edgedb-server`` flag ``--bind-address``. The ``*_FILE``
 and ``*_ENV`` variants are also supported.
@@ -127,10 +123,9 @@ and ``*_ENV`` variants are also supported.
 EDGEDB_SERVER_DATADIR
 .....................
 
-Specifies a path within the container in which the database files are located.
-Defaults to ``/var/lib/edgedb/data``.  The container needs to be able to change
-the ownership of the mounted directory to ``edgedb``.  Cannot be specified at
-the same time with ``EDGEDB_SERVER_BACKEND_DSN``.
+Specifies a path where the database files are located.  Defaults to
+``/var/lib/edgedb/data``.  Cannot be specified at the same time with
+``EDGEDB_SERVER_BACKEND_DSN``.
 
 Maps directly to the ``edgedb-server`` flag ``--data-dir``.
 
@@ -156,8 +151,8 @@ and ``*_ENV`` variants are also supported.
 EDGEDB_SERVER_RUNSTATE_DIR
 ..........................
 
-Specifies a path within the container in which EdgeDB will place its Unix
-socket and other transient files.
+Specifies a path where EdgeDB will place its Unix socket and other transient
+files.
 
 Maps directly to the ``edgedb-server`` flag ``--runstate-dir``.
 

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -30,11 +30,8 @@ Supported variables
 EDGEDB_SERVER_BOOTSTRAP_COMMAND
 ...............................
 
-Specifies one or more EdgeQL statements to run at bootstrap. If specified,
-overrides ``EDGEDB_SERVER_PASSWORD``, ``EDGEDB_SERVER_PASSWORD_HASH``,
-``EDGEDB_SERVER_USER`` and ``EDGEDB_SERVER_DATABASE``. Useful to fine-tune
-initial user and database creation, and other initial setup. If neither the
-``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
+Useful to fine-tune initial user and database creation, and other initial
+setup. If neither the ``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
 ``EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE`` are explicitly specified, the container
 will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
 (which can be placed in a derived image).
@@ -53,10 +50,12 @@ EDGEDB_SERVER_DEFAULT_AUTH_METHOD
 .................................
 
 Optionally specifies the authentication method used by the server instance.
-Supported values are ``SCRAM`` (the default) and ``Trust``.  When set to
-``Trust``, the database will allow complete unauthenticated access for all who
-have access to the database port.  In this case the ``EDGEDB_SERVER_PASSWORD``
-(or equivalent) setting is not required.
+Supported values are ``SCRAM`` (the default) and ``Trust``. When set to
+``Trust``, the database will allow complete unauthenticated access
+for all who have access to the database port.
+
+This is often useful when setting an admin password on an instance that lacks
+one.
 
 Use at your own risk and only for development and testing.
 
@@ -184,8 +183,3 @@ EDGEDB_SERVER_ADMIN_UI
 ......................
 
 Set to ``enabled`` to enable the web-based admininstrative UI for the instance.
-
-EDGEDB_SERVER_EXTRA_ARGS
-........................
-
-Extra arguments to be passed to EdgeDB server.

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -1,0 +1,209 @@
+.. _ref_reference_environment:
+
+Environment Variables
+=====================
+
+The behavior of EdgeDB can the configured with environment variables. The
+variables documented on this page are supported when using the
+``edgedb-server`` tool and the official :ref:`Docker image
+<ref_guide_deployment_docker>`.
+
+Variants
+--------
+Some environment variables (noted below) support ``*_FILE`` and ``*_ENV``
+variants.
+
+- The ``*_FILE`` variant expects its value to be a file name.  The
+  file's contents will be read and used as the value. This is useful for
+  referencing files that are mounted in the container.
+- The ``*_ENV`` variant expects its value to be the name of another
+  environment variable. The value of the other environment variable is then
+  used as the final value. This is convenient in deployment scenarios where
+  relevant values are auto populated into fixed environment variables.
+
+Supported variables
+-------------------
+
+.. Initialization
+.. --------------
+
+.. When an EdgeDB container starts on the specified data directory or remote
+.. Postgres cluster for the first time, initial instance setup is performed.
+.. This is called the *bootstrap phase*.
+
+.. The following environment variables affect the bootstrap only and have no
+.. effect on subsequent container runs.
+
+EDGEDB_SERVER_TLS_CERT_MODE
+...........................
+
+Specifies what to do when the TLS certificate and key are either not specified
+or are missing.  When set to ``require_file``, the TLS certificate and key must
+be specified in the ``EDGEDB_SERVER_TLS_CERT`` and ``EDGEDB_SERVER_TLS_KEY``
+variables and both must exist.  When set to ``generate_self_signed`` a new
+self-signed certificate and private key will be generated and placed in the
+path specified by ``EDGEDB_SERVER_TLS_CERT`` and ``EDGEDB_SERVER_TLS_KEY``, if
+those are set, otherwise the generated certificate and key are stored as
+``edbtlscert.pem`` and ``edbprivkey.pem`` in ``EDGEDB_SERVER_DATADIR``, or, if
+``EDGEDB_SERVER_DATADIR`` is not set then they will be placed in
+``/etc/ssl/edgedb``.
+
+The default is ``generate_self_signed`` when
+``EDGEDB_SERVER_SECURITY=insecure_dev_mode``. Otherwise the default is
+``require_file``.
+
+The ``*_FILE`` and ``*_ENV`` variants are also supported.
+
+
+EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT
+.......................................
+
+.. warning::
+
+   Deprecated: use ``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``
+   instead.
+
+Set this option to ``1`` to tell the server to automatically generate a
+self-signed certificate with key file in the ``EDGEDB_SERVER_DATADIR`` (if
+present, see below), and echo the certificate content in the logs. If the
+certificate file exists, the server will use it instead of generating a new
+one.
+
+Self-signed certificates are usually used in development and testing, you
+should likely provide your own certificate and key file with the variables
+below.
+
+
+EDGEDB_SERVER_TLS_CERT EDGEDB_SERVER_TLS_KEY
+............................................
+
+The TLS certificate and private key, exclusive with
+``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``.
+
+The ``*_FILE`` and ``*_ENV`` variants are also supported.
+
+
+EDGEDB_SERVER_DEFAULT_AUTH_METHOD
+.................................
+
+Optionally specifies the authentication method used by the server instance.
+Supported values are ``SCRAM`` (the default) and ``Trust``.  When set to
+``Trust``, the database will allow complete unauthenticated access for all who
+have access to the database port.  In this case the ``EDGEDB_SERVER_PASSWORD``
+(or equivalent) setting is not required.
+
+Use at your own risk and only for development and testing.
+
+
+EDGEDB_SERVER_SECURITY
+......................
+
+When set to ``insecure_dev_mode``, sets ``EDGEDB_SERVER_DEFAULT_AUTH_METHOD``
+to ``Trust`` (see above), and ``EDGEDB_SERVER_TLS_CERT_MODE`` to
+``generate_self_signed`` (unless an explicit TLS certificate is specified).
+Finally, if this option is set, the server will accept plaintext HTTP
+connections.
+
+Use at your own risk and only for development and testing.
+
+
+EDGEDB_SERVER_BOOTSTRAP_COMMAND
+...............................
+
+Specifies one or more EdgeQL statements to run at bootstrap. If specified,
+overrides ``EDGEDB_SERVER_PASSWORD``, ``EDGEDB_SERVER_PASSWORD_HASH``,
+``EDGEDB_SERVER_USER`` and ``EDGEDB_SERVER_DATABASE``. Useful to fine-tune
+initial user and database creation, and other initial setup. If neither the
+``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
+``EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE`` are explicitly specified, the container
+will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
+(which can be placed in a derived image).
+
+The ``*_FILE`` and ``*_ENV`` variants are also supported.
+
+
+EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE
+...................................
+Run the script when initializing the database. The script is run by default
+user within default database.
+
+
+.. Runtime Options
+.. ---------------
+
+.. The variables in this section affect the runtime behavior
+.. :ref:`ref_guides_deployment_docker_initial_setup`
+.. section above, the configuration documented below applies to all container
+.. invocations. It can be specified either as environment variables or
+.. command-line arguments.
+
+
+EDGEDB_SERVER_PORT
+..................
+
+Specifies the network port on which EdgeDB will listen inside the container.
+The default is ``5656``.  This usually doesn't need to be changed unless you
+run in ``host`` networking mode.
+
+Maps directly to the ``edgedb-server`` flag ``--port``. The ``*_FILE`` and
+``*_ENV`` variants are also supported.
+
+
+EDGEDB_SERVER_BIND_ADDRESS
+..........................
+
+Specifies the network interface on which EdgeDB will listen inside the
+container.  The default is ``0.0.0.0``, which means all interfaces.  This
+usually doesn't need to be changed unless you run in ``host`` networking mode.
+
+Maps directly to the ``edgedb-server`` flag ``--bind-address``. The ``*_FILE``
+and ``*_ENV`` variants are also supported.
+
+
+.. _ref_reference_docer_edgedb_server_datadir:
+
+EDGEDB_SERVER_DATADIR
+.....................
+
+Specifies a path within the container in which the database files are located.
+Defaults to ``/var/lib/edgedb/data``.  The container needs to be able to change
+the ownership of the mounted directory to ``edgedb``.  Cannot be specified at
+the same time with ``EDGEDB_SERVER_BACKEND_DSN``.
+
+Maps directly to the ``edgedb-server`` flag ``--data-dir``.
+
+
+.. _ref_reference_docker_edgedb_server_backend_dsn:
+
+EDGEDB_SERVER_BACKEND_DSN
+.........................
+
+Specifies a PostgreSQL connection string in the `URI format`_.  If set, the
+PostgreSQL cluster specified by the URI is used instead of the builtin
+PostgreSQL server.  Cannot be specified at the same time with
+``EDGEDB_SERVER_DATADIR``.
+
+Maps directly to the ``edgedb-server`` flag ``--backend-dsn``. The ``*_FILE``
+and ``*_ENV`` variants are also supported.
+
+.. _URI format:
+   https://www.postgresql.org/docs/13/libpq-connect.html#id-1.7.3.8.3.6
+
+
+EDGEDB_SERVER_RUNSTATE_DIR
+..........................
+
+Specifies a path within the container in which EdgeDB will place its Unix
+socket and other transient files.
+
+Maps directly to the ``edgedb-server`` flag ``--runstate-dir``.
+
+EDGEDB_SERVER_ADMIN_UI
+......................
+
+Set to ``enabled`` to enable the Web-based admininstrative UI for the instance.
+
+EDGEDB_SERVER_EXTRA_ARGS
+........................
+
+Extra arguments to be passed to EdgeDB server.

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -31,10 +31,7 @@ EDGEDB_SERVER_BOOTSTRAP_COMMAND
 ...............................
 
 Useful to fine-tune initial user and database creation, and other initial
-setup. If neither the ``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
-``EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE`` are explicitly specified, the container
-will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
-(which can be placed in a derived image).
+setup.
 
 Maps directly to the ``edgedb-server`` flag ``--default-auth-method``. The
 ``*_FILE`` and ``*_ENV`` variants are also supported.

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -3,7 +3,7 @@
 Environment Variables
 =====================
 
-The behavior of EdgeDB can the configured with environment variables. The
+The behavior of EdgeDB can be configured with environment variables. The
 variables documented on this page are supported when using the
 ``edgedb-server`` tool and the official :ref:`Docker image
 <ref_guide_deployment_docker>`.
@@ -36,14 +36,8 @@ setup. If neither the ``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` variable or the
 will look for the presence of ``/edgedb-bootstrap.edgeql`` in the container
 (which can be placed in a derived image).
 
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-
-EDGEDB_SERVER_BOOTSTRAP_SCRIPT_FILE
-...................................
-
-Run the script when initializing the database. The script is run by default
-user within default database.
+Maps directly to the ``edgedb-server`` flag ``--default-auth-method``. The
+``*_FILE`` and ``*_ENV`` variants are also supported.
 
 
 EDGEDB_SERVER_DEFAULT_AUTH_METHOD
@@ -58,6 +52,8 @@ This is often useful when setting an admin password on an instance that lacks
 one.
 
 Use at your own risk and only for development and testing.
+
+The ``*_FILE`` and ``*_ENV`` variants are also supported.
 
 
 EDGEDB_SERVER_TLS_CERT_MODE
@@ -78,34 +74,19 @@ The default is ``generate_self_signed`` when
 ``EDGEDB_SERVER_SECURITY=insecure_dev_mode``. Otherwise the default is
 ``require_file``.
 
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
-
-EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT
-.......................................
-
-.. warning::
-
-   Deprecated: use ``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``
-   instead.
-
-Set this option to ``1`` to tell the server to automatically generate a
-self-signed certificate with key file in the ``EDGEDB_SERVER_DATADIR`` (if
-present, see below), and echo the certificate content in the logs. If the
-certificate file exists, the server will use it instead of generating a new
-one.
-
-Self-signed certificates are usually used in development and testing, you
-should likely provide your own certificate and key file with the variables
-below.
+Maps directly to the ``edgedb-server`` flag ``--tls-cert-mode``. The ``*_FILE``
+and ``*_ENV`` variants are also supported.
 
 
-EDGEDB_SERVER_TLS_CERT/EDGEDB_SERVER_TLS_KEY
+EDGEDB_SERVER_TLS_CERT_FILE/EDGEDB_SERVER_TLS_KEY_FILE
 ............................................
 
-The TLS certificate and private key, exclusive with
+The TLS certificate and private key files, exclusive with
 ``EDGEDB_SERVER_TLS_CERT_MODE=generate_self_signed``.
 
-The ``*_FILE`` and ``*_ENV`` variants are also supported.
+Maps directly to the ``edgedb-server`` flags ``--tls-cert-file`` and
+``--tls-key-file``.
+
 
 EDGEDB_SERVER_SECURITY
 ......................
@@ -117,6 +98,8 @@ Finally, if this option is set, the server will accept plaintext HTTP
 connections.
 
 Use at your own risk and only for development and testing.
+
+Maps directly to the ``edgedb-server`` flag ``--security``.
 
 
 EDGEDB_SERVER_PORT
@@ -143,6 +126,7 @@ and ``*_ENV`` variants are also supported.
 
 .. _ref_reference_docer_edgedb_server_datadir:
 
+
 EDGEDB_SERVER_DATADIR
 .....................
 
@@ -155,6 +139,7 @@ Maps directly to the ``edgedb-server`` flag ``--data-dir``.
 
 
 .. _ref_reference_docker_edgedb_server_backend_dsn:
+
 
 EDGEDB_SERVER_BACKEND_DSN
 .........................
@@ -179,7 +164,10 @@ socket and other transient files.
 
 Maps directly to the ``edgedb-server`` flag ``--runstate-dir``.
 
+
 EDGEDB_SERVER_ADMIN_UI
 ......................
 
 Set to ``enabled`` to enable the web-based admininstrative UI for the instance.
+
+Maps directly to the ``edgedb-server`` flag ``--admin-ui``.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -15,6 +15,7 @@ Reference
     sdl/index
     ddl/index
     connection
+    environment
     projects
     dsn
     observability

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -474,7 +474,7 @@ def _validate_default_auth_method(
 
 
 class EnvvarResolver(click.Option):
-    def resolve_envvar_value(self, ctx: click.Context) -> Optional[str]:
+    def resolve_envvar_value(self, ctx: click.Context):
         if self.envvar is None:
             return None
 
@@ -491,18 +491,18 @@ class EnvvarResolver(click.Option):
 
         if var_val and file_var_val:
             raise click.BadParameter(
-                    f'{self.envvar} and ${file_var} are exclusive, '
-                    f'but both are set.')
+                f'{self.envvar} and ${file_var} are exclusive, '
+                f'but both are set.')
 
         if var_val and alt_var_val:
             raise click.BadParameter(
-                    f'{self.envvar} and ${alt_var} are exclusive, '
-                    f'but both are set.')
+                f'{self.envvar} and ${alt_var} are exclusive, '
+                f'but both are set.')
 
         if file_var_val and alt_var_val:
             raise click.BadParameter(
-                    f'{file_var} and ${alt_var} are exclusive, '
-                    f'but both are set.')
+                f'{file_var} and ${alt_var} are exclusive, '
+                f'but both are set.')
 
         if alt_var_val:
             var_val = os.environ.get(alt_var_val)

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -525,7 +525,7 @@ class EnvvarResolver(click.Option):
 _server_options = [
     click.option(
         '-D', '--data-dir', type=PathPath(),
-        envvar="EDGEDB_SERVER_DATADIR",
+        envvar="EDGEDB_SERVER_DATADIR", cls=EnvvarResolver,
         help='database cluster directory'),
     click.option(
         '--postgres-dsn', type=str, hidden=True,

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -473,6 +473,55 @@ def _validate_default_auth_method(
     return ServerAuthMethods(methods)
 
 
+class EnvvarResolver(click.Option):
+    def resolve_envvar_value(self, ctx: click.Context) -> Optional[str]:
+        if self.envvar is None:
+            return None
+
+        if not isinstance(self.envvar, str):
+            raise click.BadParameter(
+                "expected a single envvar value but got multiple")
+
+        file_var = f'{self.envvar}_FILE'
+        alt_var = f'{self.envvar}_ENV'
+
+        var_val = os.environ.get(self.envvar)
+        alt_var_val = os.environ.get(alt_var)
+        file_var_val = os.environ.get(file_var)
+
+        if var_val and file_var_val:
+            raise click.BadParameter(
+                    f'{self.envvar} and ${file_var} are exclusive, '
+                    f'but both are set.')
+
+        if var_val and alt_var_val:
+            raise click.BadParameter(
+                    f'{self.envvar} and ${alt_var} are exclusive, '
+                    f'but both are set.')
+
+        if file_var_val and alt_var_val:
+            raise click.BadParameter(
+                    f'{file_var} and ${alt_var} are exclusive, '
+                    f'but both are set.')
+
+        if alt_var_val:
+            var_val = os.environ.get(alt_var_val)
+
+        if var_val:
+            return var_val
+
+        if file_var_val:
+            try:
+                with open(file_var_val, 'rt') as f:
+                    return f.read()
+            except Exception as e:
+                raise click.BadParameter(
+                    f'could not read the file specified by '
+                    f'{file_var} ({file_var_val!r})') from e
+
+        return None
+
+
 _server_options = [
     click.option(
         '-D', '--data-dir', type=PathPath(),
@@ -483,7 +532,7 @@ _server_options = [
         help='[DEPRECATED] DSN of a remote Postgres cluster, if using one'),
     click.option(
         '--backend-dsn', type=str,
-        envvar="EDGEDB_SERVER_BACKEND_DSN",
+        envvar="EDGEDB_SERVER_BACKEND_DSN", cls=EnvvarResolver,
         help='DSN of a remote backend cluster, if using one. '
              'Also supports HA clusters, for example: stolon+consul+http://'
              'localhost:8500/test_cluster'),
@@ -533,25 +582,22 @@ _server_options = [
         help='[DEPRECATED] bootstrap the database cluster and exit'),
     click.option(
         '--bootstrap-only', is_flag=True,
-        envvar="EDGEDB_SERVER_BOOTSTRAP_ONLY",
+        envvar="EDGEDB_SERVER_BOOTSTRAP_ONLY", cls=EnvvarResolver,
         help='bootstrap the database cluster and exit'),
     click.option(
-        '--default-database', type=str,
-        envvar="EDGEDB_SERVER_DATABASE",
-        hidden=True,
+        '--default-database', type=str, hidden=True,
         help='[DEPRECATED] the name of the default database to create'),
     click.option(
         '--default-database-user', type=str, hidden=True,
         help='[DEPRECATED] the name of the default database owner'),
     click.option(
         '--bootstrap-command', metavar="QUERIES",
-        envvar="EDGEDB_SERVER_BOOTSTRAP_COMMAND",
+        envvar="EDGEDB_SERVER_BOOTSTRAP_COMMAND", cls=EnvvarResolver,
         help='run the commands when initializing the database. '
              'Queries are executed by default user within default '
              'database. May be used with or without `--bootstrap-only`.'),
     click.option(
         '--bootstrap-command-file', type=PathPath(), metavar="PATH",
-        envvar="EDGEDB_SERVER_BOOTSTRAP_COMMAND_FILE",
         help='run the script when initializing the database. '
              'Script run by default user within default database. '
              'May be used with or without `--bootstrap-only`.'),
@@ -567,15 +613,13 @@ _server_options = [
         help='enable or disable the test mode',
         default=False),
     click.option(
-        '-I', '--bind-address', type=str,
-        envvar="EDGEDB_SERVER_BIND_ADDRESS",
-        multiple=True,
+        '-I', '--bind-address', type=str, multiple=True,
+        envvar="EDGEDB_SERVER_BIND_ADDRESS", cls=EnvvarResolver,
         help='IP addresses to listen on, specify multiple times for more than '
              'one address to listen on'),
     click.option(
-        '-P', '--port', type=PortType(),
-        envvar="EDGEDB_SERVER_PORT",
-        default=None,
+        '-P', '--port', type=PortType(), default=None,
+        envvar="EDGEDB_SERVER_PORT", cls=EnvvarResolver,
         help='port to listen on'),
     click.option(
         '-b', '--background', is_flag=True, help='daemonize'),
@@ -587,9 +631,8 @@ _server_options = [
     click.option(
         '--daemon-group', type=int),
     click.option(
-        '--runstate-dir', type=PathPath(),
+        '--runstate-dir', type=PathPath(), default=None,
         envvar="EDGEDB_SERVER_RUNSTATE_DIR",
-        default=None,
         help=f'directory where UNIX sockets and other temporary '
              f'runtime files will be placed ({_get_runstate_dir_default()} '
              f'by default)'),
@@ -670,7 +713,7 @@ _server_options = [
              'be automatically created in the specified path.'),
     click.option(
         '--tls-cert-mode',
-        envvar="EDGEDB_SERVER_TLS_CERT_MODE",
+        envvar="EDGEDB_SERVER_TLS_CERT_MODE", cls=EnvvarResolver,
         type=click.Choice(
             ['default'] + list(ServerTlsCertMode.__members__.values()),
             case_sensitive=True,
@@ -691,9 +734,7 @@ _server_options = [
              'and "generate_self_signed" when the --security option is set to '
              '"insecure_dev_mode"'),
     click.option(
-        '--generate-self-signed-cert',
-        type=bool,
-        default=False, is_flag=True,
+        '--generate-self-signed-cert', type=bool, default=False, is_flag=True,
         help='DEPRECATED.\n\n'
              'Use --tls-cert-mode=generate_self_signed instead.'),
     click.option(
@@ -769,7 +810,7 @@ _server_options = [
              '--security option is set to "insecure_dev_mode"'),
     click.option(
         "--default-auth-method",
-        envvar="EDGEDB_SERVER_DEFAULT_AUTH_METHOD",
+        envvar="EDGEDB_SERVER_DEFAULT_AUTH_METHOD", cls=EnvvarResolver,
         callback=_validate_default_auth_method,
         type=str,
         help=(

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -476,12 +476,14 @@ def _validate_default_auth_method(
 _server_options = [
     click.option(
         '-D', '--data-dir', type=PathPath(),
+        envvar="EDGEDB_SERVER_DATADIR",
         help='database cluster directory'),
     click.option(
         '--postgres-dsn', type=str, hidden=True,
         help='[DEPRECATED] DSN of a remote Postgres cluster, if using one'),
     click.option(
         '--backend-dsn', type=str,
+        envvar="EDGEDB_SERVER_BACKEND_DSN",
         help='DSN of a remote backend cluster, if using one. '
              'Also supports HA clusters, for example: stolon+consul+http://'
              'localhost:8500/test_cluster'),
@@ -534,7 +536,9 @@ _server_options = [
         envvar="EDGEDB_SERVER_BOOTSTRAP_ONLY",
         help='bootstrap the database cluster and exit'),
     click.option(
-        '--default-database', type=str, hidden=True,
+        '--default-database', type=str,
+        envvar="EDGEDB_SERVER_DATABASE",
+        hidden=True,
         help='[DEPRECATED] the name of the default database to create'),
     click.option(
         '--default-database-user', type=str, hidden=True,
@@ -563,11 +567,15 @@ _server_options = [
         help='enable or disable the test mode',
         default=False),
     click.option(
-        '-I', '--bind-address', type=str, multiple=True,
+        '-I', '--bind-address', type=str,
+        envvar="EDGEDB_SERVER_BIND_ADDRESS",
+        multiple=True,
         help='IP addresses to listen on, specify multiple times for more than '
              'one address to listen on'),
     click.option(
-        '-P', '--port', type=PortType(), default=None,
+        '-P', '--port', type=PortType(),
+        envvar="EDGEDB_SERVER_PORT",
+        default=None,
         help='port to listen on'),
     click.option(
         '-b', '--background', is_flag=True, help='daemonize'),
@@ -579,7 +587,9 @@ _server_options = [
     click.option(
         '--daemon-group', type=int),
     click.option(
-        '--runstate-dir', type=PathPath(), default=None,
+        '--runstate-dir', type=PathPath(),
+        envvar="EDGEDB_SERVER_RUNSTATE_DIR",
+        default=None,
         help=f'directory where UNIX sockets and other temporary '
              f'runtime files will be placed ({_get_runstate_dir_default()} '
              f'by default)'),
@@ -681,7 +691,9 @@ _server_options = [
              'and "generate_self_signed" when the --security option is set to '
              '"insecure_dev_mode"'),
     click.option(
-        '--generate-self-signed-cert', type=bool, default=False, is_flag=True,
+        '--generate-self-signed-cert',
+        type=bool,
+        default=False, is_flag=True,
         help='DEPRECATED.\n\n'
              'Use --tls-cert-mode=generate_self_signed instead.'),
     click.option(


### PR DESCRIPTION
Before merging:

- [ ] Implement support for `EDGEDB_SERVER_TLS_CERT{_ENV}`/`EDGEDB_SERVER_TLS_KEY{_ENV}` in `edgedb-server`. Currently only the `_FILE` variant is supported.
