### PR TITLE
Fix computed global scoping behavior

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -471,7 +471,10 @@ def compile_GlobalExpr(
     if glob.is_computable(ctx.env.schema):
         obj_ref = s_utils.name_to_ast_ref(
             glob.get_target(ctx.env.schema).get_name(ctx.env.schema))
-        return dispatch.compile(qlast.Path(steps=[obj_ref]), ctx=ctx)
+        # Wrap the reference in a subquery so that it does not get
+        # factored out or go directly into the scope tree.
+        qry = qlast.SelectQuery(result=qlast.Path(steps=[obj_ref]))
+        return dispatch.compile(qry, ctx=ctx)
 
     objctx = ctx.env.options.schema_object_context
     if objctx in (s_constr.Constraint, s_indexes.Index):

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -372,6 +372,21 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             []
         )
 
+    async def test_edgeql_globals_12(self):
+        await self.con.execute('''
+            create global Ug := User
+        ''')
+
+        await self.assert_query_result(
+            r'''select count((global Ug).deck)''',
+            [9]
+        )
+
+        await self.assert_query_result(
+            r'''select count(((global Ug).id, (global Ug).name))''',
+            [16]
+        )
+
     async def test_edgeql_globals_state_cardinality(self):
         await self.con.execute('''
             set global cur_user := {};


### PR DESCRIPTION
Computed globals should not participate in path factoring, since
`(global Foo).x` looks much more like `(select Foo).x` or
`(detached Foo).x` than `Foo.x`.

Additionally, fix links off of computed globals not being deduplicated.

Fixes #4388.