### PR TITLE
Fix slicing with an empty set (2.x cherry-pick)

### DIFF
--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -5171,6 +5171,113 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
+    async def test_edgeql_select_slice_04(self):
+
+        await self.assert_query_result(
+            r"""
+            select [1,2,3,4,5][1:];
+            """,
+            [[2, 3, 4, 5]],
+        )
+
+        await self.assert_query_result(
+            r"""
+            select [1,2,3,4,5][:3];
+            """,
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            r"""
+            select [1,2,3][1:<int64>{}];
+            """,
+            [],
+        )
+
+        # try to trick the compiler and to pass NULL into edgedb._slice
+        await self.assert_query_result(
+            r"""
+            select [1,2,3][1:<optional int64>$0];
+            """,
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r"""
+            select [1,2,3][<optional int64>$0:2];
+            """,
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r"""
+            select [1,2,3][<optional int64>$0:<optional int64>$1];
+            """,
+            [],
+            variables=(None, None,),
+        )
+
+        self.assertEqual(
+            await self.con.query(
+                r"""
+                select to_json('[true, 3, 4, null]')[1:];
+                """
+            ),
+            edgedb.Set(('[3, 4, null]',))
+        )
+
+        self.assertEqual(
+            await self.con.query(
+                r"""
+                select to_json('[true, 3, 4, null]')[:2];
+                """
+            ),
+            edgedb.Set(('[true, 3]',))
+        )
+
+        await self.assert_query_result(
+            r"""
+            select (<optional json>$0)[2:];
+            """,
+            [],
+            variables=(None,),
+        )
+
+        self.assertEqual(
+            await self.con.query(
+                r"""
+                select to_json('"hello world"')[2:];
+                """
+            ),
+            edgedb.Set(('"llo world"',))
+        )
+
+        self.assertEqual(
+            await self.con.query(
+                r"""
+                select to_json('"hello world"')[:4];
+                """
+            ),
+            edgedb.Set(('"hell"',))
+        )
+
+        await self.assert_query_result(
+            r"""
+            select (<array<str>>[])[0:];
+            """,
+            [[]]
+        )
+
+        await self.assert_query_result(
+            r'''select to_json('[]')[0:];''',
+            # JSON:
+            [[]],
+            # Binary:
+            ['[]'],
+        )
+
     async def test_edgeql_select_tuple_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Fixes #4327

Check the namespaces - I see that your other SQL patch uses `edgedbstd`.

Also, to fix the types I had to drop the function and create it again. Do this patches run in sequence they are defined in?