### PR TITLE
Fix potentially missed constraints on DML

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -117,6 +117,10 @@ class DMLDummyTable(dbops.Table):
             ),
         )
 
+    SETUP_QUERY = '''
+        INSERT INTO edgedb._dml_dummy VALUES (0, false)
+    '''
+
 
 class ExpressionType(dbops.CompositeType):
     def __init__(self) -> None:
@@ -4017,6 +4021,7 @@ async def bootstrap(
         dbops.CreateView(NormalizedPgSettingsView()),
         dbops.CreateTable(DBConfigTable()),
         dbops.CreateTable(DMLDummyTable()),
+        dbops.Query(DMLDummyTable.SETUP_QUERY),
         dbops.CreateFunction(IntervalToMillisecondsFunction()),
         dbops.CreateFunction(SafeIntervalCastFunction()),
         dbops.CreateFunction(QuoteIdentFunction()),

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1658,6 +1658,11 @@ async def _bootstrap(ctx: BootstrapContext) -> None:
 
         schema = s_schema.FlatSchema()
         schema = await _init_defaults(schema, compiler, tpl_ctx.conn)
+
+        await conn.sql_execute(
+            b"ANALYZE",
+        )
+
     finally:
         if in_dev_mode:
             await ctx.conn.sql_execute(


### PR DESCRIPTION
We use updates to a _dml_dummy table to force scans of constraint
checking CTEs. Unfortunately, if postgres analyzes the tables and
realizes that _dml_dummy is empty, this can cause all of these checks
to be optimized away.

Populate _dml_dummy, and run an analyze during template db creation to
catch this sort of issue.