### PR TITLE
[2.x only] Invalidate prior 2.x schema storage functions

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -419,6 +419,13 @@ class Compiler:
         with cache.mutate() as cache_mm:
             for eql, args in meta_blocks:
                 eql_hash = hashlib.sha1(eql.encode()).hexdigest()
+                # Bugs prior to 2.3 caused us to generate SQL that
+                # performed extremely poorly as the database grew
+                # large. Invalidate those schema storage functions by
+                # adding a v2 to the name.
+                # (This is just for the 2.x branch, future versions will
+                # just have good queries compiled from the start.)
+                eql_hash += '_v2'
                 fname = ('edgedb', f'__rh_{eql_hash}')
 
                 if eql_hash in cache_mm:


### PR DESCRIPTION
Because of a bug fixed in #4401, the schema storage queries could contain an EXISTS in a WHERE clause for .id constraint enforcement that forced a table scan of every table in the database.

This caused pretty drastic performance problems. The fix has been cherry-picked into 2.x, but existing databases will have the slow versions already cached.

Invalidate the cache by adding `_v2` to the cache key.

This mechanism was chosen because it was much easier than writing a PL/pgSQL patch that would delete all of the `__rh_*` functions, and the extra cost of having a few orphaned functions sitting around is not a big deal.

I'm also going to go make our internal schema updates skip the id verification, and this will catch that change too