### PR TITLE
Fix failing cargo-test

### DIFF
--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -53,7 +53,9 @@ jobs:
       uses: syphar/restore-virtualenv@v1.2
       id: venv-cache
       with:
-        requirement_files: setup.py
+        requirement_files: |
+          setup.py
+          pyproject.toml
         custom_cache_key_element: v2
 
     - name: Stop if we cannot retrieve the cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -336,7 +336,9 @@ jobs:
       uses: syphar/restore-virtualenv@v1.2
       id: venv-cache
       with:
-        requirement_files: setup.py
+        requirement_files: |
+          setup.py
+          pyproject.toml
         custom_cache_key_element: v2
 
     - name: Stop if we cannot retrieve the cache


### PR DESCRIPTION
The virtualenv key is changed after we migrate to pyproject.toml