### PR TITLE
Propagate database creation and deletion events to adjacent servers

### DIFF
--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -30,6 +30,7 @@ cpdef enum SideEffects:
     InstanceConfigChanges = 1 << 2
     RoleChanges = 1 << 3
     GlobalSchemaChanges = 1 << 4
+    DatabaseChanges = 1 << 5
 
 
 @cython.final

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -819,6 +819,10 @@ cdef class DatabaseConnectionView:
             if query_unit.database_config:
                 self.update_database_config()
                 side_effects |= SideEffects.DatabaseConfigChanges
+            if query_unit.create_db:
+                side_effects |= SideEffects.DatabaseChanges
+            if query_unit.drop_db:
+                side_effects |= SideEffects.DatabaseChanges
             if query_unit.global_schema is not None:
                 side_effects |= SideEffects.GlobalSchemaChanges
                 self._db._index.update_global_schema(

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1951,6 +1951,8 @@ cdef class PGConnection:
                     self.server._on_remote_system_config_change()
                 elif event == 'global-schema-changes':
                     self.server._on_global_schema_change()
+                elif event == 'database-changes':
+                    self.server._on_remote_database_changes()
                 else:
                     raise AssertionError(f'unexpected system event: {event!r}')
 

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -365,6 +365,14 @@ def signal_side_effects(dbv, side_effects):
             interruptable=False,
         )
 
+    if side_effects & dbview.SideEffects.DatabaseChanges:
+        server.create_task(
+            server._signal_sysevent(
+                'database-changes',
+            ),
+            interruptable=False,
+        )
+
     if side_effects & dbview.SideEffects.InstanceConfigChanges:
         server.create_task(
             server._signal_sysevent(

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2178,6 +2178,40 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                             DROP ROLE ddlprop01;
                         ''')
 
+    @unittest.skipUnless(devmode.is_in_dev_mode(),
+                         'the test requires devmode')
+    async def test_server_adjacent_database_propagation(self):
+        if not self.has_create_database:
+            self.skipTest('create database is not supported by the backend')
+
+        conargs = self.get_connect_args()
+
+        server_args = {}
+        if self.backend_dsn:
+            server_args['backend_dsn'] = self.backend_dsn
+        else:
+            server_args['adjacent_to'] = self.con
+        async with tb.start_edgedb_server(**server_args) as sd:
+
+            await self.con.execute('''
+                CREATE DATABASE test_db_prop;
+            ''')
+
+            # Make sure the adjacent server picks up on the new db
+            async for tr in self.try_until_succeeds(
+                ignore=edgedb.UnknownDatabaseError,
+                timeout=30,
+            ):
+                async with tr:
+                    con2 = await sd.connect(
+                        user=conargs.get('user'),
+                        password=conargs.get('password'),
+                        database="test_db_prop",
+                    )
+
+                    await con2.query("select 1")
+                    await con2.aclose()
+
 
 class TestServerProtoDDL(tb.DDLTestCase):
 


### PR DESCRIPTION
Make sure `CREATE DATABASE` and `DROP DATABASE` gets noticed properly by
adjacent servers.

This doesn't fully solve the `DROP DATABASE` case, as adjacent servers
might be maintaining inactive connections in their pools, this
preventing the database from getting dropped.  This is solvable, but is
somewhat messy, so I left this for a future patch.