### PR TITLE
Fix slicing arrays of tuples

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -678,14 +678,16 @@ def compile_Introspect(
 
 @dispatch.compile.register(qlast.Indirection)
 def compile_Indirection(
-        expr: qlast.Indirection, *, ctx: context.ContextLevel) -> irast.Set:
+    expr: qlast.Indirection, *, ctx: context.ContextLevel
+) -> irast.Set:
     node: Union[irast.Set, irast.Expr] = dispatch.compile(expr.arg, ctx=ctx)
     for indirection_el in expr.indirection:
         if isinstance(indirection_el, qlast.Index):
             idx = dispatch.compile(indirection_el.index, ctx=ctx)
             idx.context = indirection_el.index.context
-            node = irast.IndexIndirection(expr=node, index=idx,
-                                          context=expr.context)
+            node = irast.IndexIndirection(
+                expr=node, index=idx, context=expr.context
+            )
 
         elif isinstance(indirection_el, qlast.Slice):
             start: Optional[irast.Base]
@@ -701,11 +703,14 @@ def compile_Indirection(
             else:
                 stop = None
 
+            node_set = setgen.ensure_set(node, ctx=ctx)
             node = irast.SliceIndirection(
-                expr=node, start=start, stop=stop)
+                expr=node_set, start=start, stop=stop
+            )
         else:
-            raise ValueError('unexpected indirection node: '
-                             '{!r}'.format(indirection_el))
+            raise ValueError(
+                'unexpected indirection node: ' '{!r}'.format(indirection_el)
+            )
 
     return setgen.ensure_set(node, ctx=ctx)
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1327,7 +1327,7 @@ def __infer_slice(
 ) -> qltypes.Cardinality:
     # slice indirection cardinality depends on the cardinality of
     # the base expression and the slice index expressions
-    args = [ir.expr]
+    args: List[irast.Base] = [ir.expr]
     if ir.start is not None:
         args.append(ir.start)
     if ir.stop is not None:

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -309,7 +309,7 @@ def __infer_slice(
 ) -> InferredVolatility:
     # slice indirection volatility depends on the volatility of
     # the base expression and the slice index expressions
-    args = [ir.expr]
+    args: List[irast.Base] = [ir.expr]
     if ir.start is not None:
         args.append(ir.start)
     if ir.stop is not None:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -853,7 +853,7 @@ class IndexIndirection(ImmutableExpr):
 
 class SliceIndirection(ImmutableExpr):
 
-    expr: Base
+    expr: Set
     start: typing.Optional[Base]
     stop: typing.Optional[Base]
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -5216,7 +5216,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             select [1,2,3][<optional int64>$0:<optional int64>$1];
             """,
             [],
-            variables=(None, None,),
+            variables=(
+                None,
+                None,
+            ),
         )
 
         self.assertEqual(
@@ -5225,7 +5228,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 select to_json('[true, 3, 4, null]')[1:];
                 """
             ),
-            edgedb.Set(('[3, 4, null]',))
+            edgedb.Set(('[3, 4, null]',)),
         )
 
         self.assertEqual(
@@ -5234,7 +5237,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 select to_json('[true, 3, 4, null]')[:2];
                 """
             ),
-            edgedb.Set(('[true, 3]',))
+            edgedb.Set(('[true, 3]',)),
         )
 
         await self.assert_query_result(
@@ -5251,7 +5254,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 select to_json('"hello world"')[2:];
                 """
             ),
-            edgedb.Set(('"llo world"',))
+            edgedb.Set(('"llo world"',)),
         )
 
         self.assertEqual(
@@ -5260,14 +5263,14 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 select to_json('"hello world"')[:4];
                 """
             ),
-            edgedb.Set(('"hell"',))
+            edgedb.Set(('"hell"',)),
         )
 
         await self.assert_query_result(
             r"""
             select (<array<str>>[])[0:];
             """,
-            [[]]
+            [[]],
         )
 
         await self.assert_query_result(
@@ -5276,6 +5279,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [[]],
             # Binary:
             ['[]'],
+        )
+
+        await self.assert_query_result(
+            r'''select [(1,'foo'), (2,'bar'), (3,'baz')][1:];''',
+            [[(2, 'bar'), (3, 'baz')]],
+        )
+
+        await self.assert_query_result(
+            r'''select [(1,'foo'), (2,'bar'), (3,'baz')][:2];''',
+            [[(1, 'foo'), (2, 'bar')]],
+        )
+
+        await self.assert_query_result(
+            r'''select [(1,'foo'), (2,'bar'), (3,'baz')][1:2];''',
+            [[(2, 'bar')]],
         )
 
     async def test_edgeql_select_tuple_01(self):


### PR DESCRIPTION
- change `irast.SliceIndirection#expr` from `irast.Base` to `irast.Set`
- inline `edgedb._slice` call for arrays of tuples

We could actually inline for all arrays, now that the code is written. There would be more code generated, but could reduce number of functions in stdlib by 1.