### PR TITLE
Revert "Skip doing id exclusivity checks in schema mutation code (#4412)"

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -666,10 +666,7 @@ def compile_inheritance_conflict_checks(
     *, ctx: context.ContextLevel,
 ) -> Optional[List[irast.OnConflictClause]]:
 
-    has_id_write = (
-        _has_explicit_id_write(stmt)
-        and not ctx.env.options.unsafe_user_specified_id
-    )
+    has_id_write = _has_explicit_id_write(stmt)
 
     if not ctx.env.dml_stmts and not has_id_write:
         return None

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -49,11 +49,6 @@ class GlobalCompilerOptions:
     #: Whether to allow specifying 'id' explicitly in INSERT
     allow_user_specified_id: bool = False
 
-    #: Whether to skip actually doing the exclusivity check when
-    #: using a user-specified id. This is only used when compiling
-    #: our internal schema modification code, as an optimization.
-    unsafe_user_specified_id: bool = False
-
     #: Enables constant folding optimization (enabled by default).
     constant_folding: bool = True
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -601,7 +601,6 @@ class Compiler:
                 ctx, 'apply_access_policies'),
             allow_user_specified_id=self.get_config_val(
                 ctx, 'allow_user_specified_id') or ctx.schema_reflection_mode,
-            unsafe_user_specified_id=ctx.schema_reflection_mode,
             testmode=self.get_config_val(ctx, '__internal_testmode'),
             devmode=self._is_dev_instance(),
         )


### PR DESCRIPTION
This reverts commit 73f15a1ac4f71b5935ee2afc3cc35fe110c0fa55.

It introduced a potential id collision bug with collections. There are
workarounds for this that we can deploy in the future, but for now
just revert it.