### PR TITLE
Don't apply access policies when compiling indexes

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3110,7 +3110,7 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
             anchors={ql_ast.Subject().name: subject},
             path_prefix_anchor=path_prefix_anchor,
             singletons=singletons,
-            apply_query_rewrites=not context.stdmode,
+            apply_query_rewrites=False,
         )
 
         index_expr = index.get_expr(schema)

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -312,7 +312,7 @@ class IndexCommand(
                     anchors={qlast.Subject().name: subject},
                     path_prefix_anchor=qlast.Subject().name,
                     singletons=frozenset([subject]),
-                    apply_query_rewrites=not context.stdmode,
+                    apply_query_rewrites=False,
                     track_schema_ref_exprs=track_schema_ref_exprs,
                 ),
             )

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10984,11 +10984,12 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         """)
 
-    async def test_edgeql_migration_access_policy_constraint(self):
-        # Make sure policies don't interfere with constraints.
+    async def test_edgeql_migration_access_policy_02(self):
+        # Make sure policies don't interfere with constraints or indexes
         await self.migrate(r"""
+            required global foo -> bool { default := true };
             abstract type Base {
-                access policy locked allow all using (false);
+                access policy locked allow all using (global foo);
             }
 
             type Tgt extending Base;
@@ -10997,6 +10998,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 required link tgt -> Tgt {
                     constraint exclusive;
                 }
+                index on (.tgt)
             }
         """)
 


### PR DESCRIPTION
Similar problems to constraints, where this change was made in #4245.