### PR TITLE
Fix slicing of tuple arrays with null inputs

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -730,12 +730,14 @@ class NamedFuncArg(ImmutableBaseExpr):
     val: BaseExpr
 
 
-class Index(ImmutableBase):
+# N.B: Index and Slice aren't *really* Exprs but we mark them as such
+# so that nullability inference gets done on them.
+class Index(ImmutableBaseExpr):
     """Array subscript."""
     idx: BaseExpr
 
 
-class Slice(ImmutableBase):
+class Slice(ImmutableBaseExpr):
     """Array slice bounds."""
     # Lower bound, if any
     lidx: typing.Optional[BaseExpr]

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -5296,6 +5296,14 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [[(2, 'bar')]],
         )
 
+        await self.assert_query_result(
+            r'''
+                select [(1,'foo'), (2,'bar'), (3,'baz')][<optional int32>$0:];
+            ''',
+            [],
+            variables=(None,),
+        )
+
     async def test_edgeql_select_tuple_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
The issue here was kind of silly: NULL was being produced, as is
proper, but because the Index and Slice nodes in pgast weren't derived
from BaseExpr (since they weren't *really* exprs), _infer_nullability
didn't consider it when figuring out the nullability of the output
slice, which then didn't get checked for NULL and was output to the
client.