### PR TITLE
Propagate database quarantine before dropping it

### DIFF
--- a/edb/common/retryloop.py
+++ b/edb/common/retryloop.py
@@ -1,0 +1,141 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import (
+    Callable,
+    Optional,
+    Tuple,
+    Type,
+)
+
+import asyncio
+import random
+import time
+import types
+
+
+def const_backoff(delay: float) -> Callable[[int], float]:
+    return lambda _: delay
+
+
+def exp_backoff(
+    *,
+    factor: float = 0.1,
+    jitter_scale: float = 0.001,
+) -> Callable[[int], float]:
+    def _f(i: int) -> float:
+        delay: int = 2 ** i
+        return delay * factor + random.randrange(100) * jitter_scale
+    return _f
+
+
+class RetryLoop:
+
+    def __init__(
+        self,
+        *,
+        backoff: Callable[[int], float] = const_backoff(0.5),
+        timeout: float,
+        ignore: Optional[Type[Exception] | Tuple[Type[Exception]]] = None,
+        wait_for: Optional[Type[Exception] | Tuple[Type[Exception]]] = None,
+    ) -> None:
+        self._iteration = 0
+        self._backoff = backoff
+        self._timeout = timeout
+        self._ignore = ignore
+        self._wait_for = wait_for
+        self._started_at = 0.0
+        self._stop_request = False
+
+    def __aiter__(self) -> RetryLoop:
+        return self
+
+    async def __anext__(self) -> RetryIteration:
+        if self._stop_request:
+            raise StopAsyncIteration
+
+        if self._started_at == 0:
+            # First run
+            self._started_at = time.monotonic()
+        else:
+            # Second or greater run -- delay before yielding
+            delay = self._backoff(self._iteration)
+            await asyncio.sleep(delay)
+
+        self._iteration += 1
+
+        return RetryIteration(self)
+
+
+class RetryIteration:
+
+    def __init__(self, loop: RetryLoop) -> None:
+        self._loop = loop
+
+    async def __aenter__(self) -> RetryIteration:
+        return self
+
+    async def __aexit__(
+        self,
+        et: Type[BaseException],
+        e: BaseException,
+        _tb: types.TracebackType,
+    ) -> bool:
+        elapsed = time.monotonic() - self._loop._started_at
+
+        if self._loop._ignore is not None:
+            # Mode 1: Try until we don't get errors matching `ignore`
+
+            if et is None:
+                self._loop._stop_request = True
+                return False
+
+            if not isinstance(e, self._loop._ignore):
+                # Propagate, it's not the error we expected.
+                return False
+
+            if elapsed > self._loop._timeout:
+                # Propagate -- we've run it enough times.
+                return False
+
+            # Ignore the exception until next run.
+            return True
+
+        else:
+            # Mode 2: Try until we fail with an error matching `wait_for`
+
+            assert self._loop._wait_for is not None
+
+            if et is not None:
+                if isinstance(e, self._loop._wait_for):
+                    # We're done, we've got what we waited for.
+                    self._loop._stop_request = True
+                    return True
+                else:
+                    # Propagate, it's not the error we expected.
+                    return False
+
+            if elapsed > self._loop._timeout:
+                raise TimeoutError(
+                    f'exception matching {self._loop._wait_for!r} '
+                    f'has not happen in {self._loop._timeout} seconds')
+
+            # Ignore the exception until next run.
+            return True

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1940,6 +1940,8 @@ cdef class PGConnection:
                     # at a different layer.
                     return True
 
+                logger.debug("received system event: %s", event)
+
                 event_payload = event_data.get('args')
                 if event == 'schema-changes':
                     dbname = event_payload['dbname']
@@ -1953,6 +1955,9 @@ cdef class PGConnection:
                     self.server._on_global_schema_change()
                 elif event == 'database-changes':
                     self.server._on_remote_database_changes()
+                elif event == 'ensure-database-not-used':
+                    dbname = event_payload['dbname']
+                    self.server._on_remote_database_quarantine(dbname)
                 else:
                     raise AssertionError(f'unexpected system event: {event!r}')
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -466,11 +466,9 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         logger.debug('received connection request by %s to database %s',
                      user, database)
 
-        if database == edbdef.EDGEDB_TEMPLATE_DB:
-            # Prevent connections to the template database.
+        if not self.server.is_database_connectable(database):
             raise errors.AccessError(
-                f'database {database!r} does not '
-                f'accept connections'
+                f'database {database!r} does not accept connections'
             )
 
         await self._start_connection(database)

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -188,7 +188,10 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
         logger.debug('received connection request by %s to database %s',
                      user, database)
 
-        if database in edbdef.EDGEDB_SPECIAL_DBS:
+        if (
+            database in edbdef.EDGEDB_SPECIAL_DBS
+            or not self.server.is_database_connectable(database)
+        ):
             # Prevent connections to internal system databases,
             # which only purpose is to serve as a template for new
             # databases.
@@ -1245,6 +1248,11 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
                         if state is not orig_state:
                             # see the same comments in _legacy_execute()
                             conn.last_state = state
+                finally:
+                    if query_unit.create_db_template:
+                        await self.server._allow_database_connections(
+                            query_unit.create_db_template,
+                        )
         finally:
             self.maybe_release_pgcon(conn)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ module = [
     "edb.common.compiler",
     "edb.common.ordered",
     "edb.common.parametric",
+    "edb.common.retryloop",
     "edb.common.struct",
     "edb.common.topological",
     "edb.common.uuidgen",

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2212,6 +2212,44 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                     await con2.query("select 1")
                     await con2.aclose()
 
+            async for tr in self.try_until_succeeds(
+                ignore=edgedb.ExecutionError,
+            ):
+                async with tr:
+                    await self.con.execute('''
+                        DROP DATABASE test_db_prop;
+                    ''')
+
+            # Now, recreate the DB and try the other way around
+            con2 = await sd.connect(
+                user=conargs.get('user'),
+                password=conargs.get('password'),
+                database=self.get_database_name(),
+            )
+
+            await con2.execute('''
+                CREATE DATABASE test_db_prop;
+            ''')
+
+            async for tr in self.try_until_succeeds(
+                ignore=edgedb.UnknownDatabaseError,
+                timeout=30,
+            ):
+                async with tr:
+                    con1 = await self.connect(database="test_db_prop")
+                    await con1.query("select 1")
+                    await con1.aclose()
+
+            async for tr in self.try_until_succeeds(
+                ignore=edgedb.ExecutionError,
+            ):
+                async with tr:
+                    await con2.execute('''
+                        DROP DATABASE test_db_prop;
+                    ''')
+
+            await con2.aclose()
+
 
 class TestServerProtoDDL(tb.DDLTestCase):
 


### PR DESCRIPTION
Even though there may not be active connections to a database being
dropped, adjacent servers may still be keeping warm Postgres connections in
the pool, so use signaling to trigger remote pruning.