### PR TITLE
Skip redundant prompts in digitalocean guide

### DIFF
--- a/docs/guides/deployment/digitalocean.rst
+++ b/docs/guides/deployment/digitalocean.rst
@@ -88,7 +88,11 @@ instance link``.
 
 .. code-block:: bash
 
-   $ edgedb instance link --dsn <dsn> --trust-tls-cert my_instance
+   $ edgedb instance link \
+       --dsn <dsn> \
+       --trust-tls-cert \
+       --non-interactive \
+       my_instance
    Authenticating to edgedb://edgedb@1.2.3.4:5656/edgedb
    Trusting unknown server certificate:
    SHA1:1880da9527be464e2cad3bdb20dfc430a6af5727


### PR DESCRIPTION
Omitting the `--non-interactive` argument results in the CLI prompting for all connection options even if the DSN specifies all necessary options.