### PR TITLE
Skip populating pointer sets when creating opaque pointer unions

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2850,7 +2850,7 @@ def get_or_create_union_pointer(
         transient=transient,
     )
 
-    if isinstance(result, s_sources.Source):
+    if isinstance(result, s_sources.Source) and not opaque:
         # cast below, because in this case the list of Pointer
         # is also a list of Source (links.Link)
         schema = s_sources.populate_pointer_set_for_source_union(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3085,6 +3085,29 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_get_migration_53(self):
+        schema = r'''
+            scalar type ClipType extending enum<Test1, Test2>;
+            scalar type RecordingType extending enum<Test3, Test4>;
+
+            type LiveClass {
+              link _clips := .<_class[is Clip];
+              link _recordings := .<_class[is Recording];
+            }
+
+            type Clip {
+              required property _type -> ClipType;
+              link _class -> LiveClass;
+            }
+
+            type Recording {
+              required property _type -> RecordingType;
+              link _class -> LiveClass;
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different


### PR DESCRIPTION
This matches what we do for opaque object unions, and is also clearly
correct: the point of an opaque union is that you can construct one
from anything and you can't do anything with it.

Fixes #4354.