### PR TITLE
Run _propagate_if_expr_refs in link deletion

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3587,6 +3587,10 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
                 )
 
         schema = schema.delete(self.scls)
+
+        if not context.canonical:
+            schema = self._finalize_affected_refs(schema, context)
+
         return schema
 
     def _has_outside_references(

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -693,6 +693,23 @@ class DeleteLink(
     # NB: target type cleanup (e.g. target compound type) is done by
     #     the DeleteProperty handler for the @target property.
 
+    def _delete_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._delete_begin(schema, context)
+        if not context.canonical:
+            # We need to do a propagate here, too, since there could
+            # be backrefs to this link that technically reference
+            # us but will be fine if it is deleted.
+            schema = self._propagate_if_expr_refs(
+                schema,
+                context,
+                action=self.get_friendly_description(schema=schema),
+            )
+        return schema
+
     def _get_ast(
         self,
         schema: s_schema.Schema,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11105,6 +11105,33 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         """)
 
+    async def test_edgeql_migration_link_to_sub_with_ref_01(self):
+        # Test moving a link to a subtype while a ref exists to it
+        await self.migrate(r"""
+            type Athlete {
+                multi link schedules := Athlete.<owner[IS AthleteSchedule];
+            }
+
+            abstract type Schedule  {
+                required property name -> str;
+                required link owner -> Athlete;
+            }
+            type AthleteSchedule extending Schedule;
+        """)
+
+        await self.migrate(r"""
+            type Athlete {
+                multi link schedules := Athlete.<owner[IS AthleteSchedule];
+            }
+
+            abstract type Schedule  {
+                required property name -> str;
+            }
+            type AthleteSchedule extending Schedule {
+                required link owner -> Athlete;
+            }
+        """)
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4409,11 +4409,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
-    @test.xerror('''
-        edb.errors.SchemaError: cannot drop link 'user' of object type
-        'default::Action' because other objects in the schema depend
-        on it
-    ''')
     def test_schema_migrations_equivalence_47(self):
         # change a link used in a computable
         self._assert_migration_equivalence([r"""


### PR DESCRIPTION
Back references can refer to any objects that has a link with a
certain name, and it is often fine to delete some of them.  Run
_propagate_if_expr_refs in link deletion so that we understand this
properly.

Fixes at least part of #4345.