### PR TITLE
For query_single, only check that the *last* query in a script is single

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -625,10 +625,6 @@ class Compiler:
             options=self._get_compile_options(ctx),
         )
 
-        if ir.cardinality.is_multi() and ctx.expected_cardinality_one:
-            raise errors.ResultCardinalityMismatchError(
-                f'the query has cardinality {ir.cardinality.name} '
-                f'which does not match the expected cardinality ONE')
         result_cardinality = enums.cardinality_from_ir_value(ir.cardinality)
 
         sql_text, argmap = pg_compiler.compile_ir_to_sql(
@@ -2011,6 +2007,14 @@ class Compiler:
             ):
                 raise errors.InternalServerError(
                     f'QueryUnit {unit!r} is cacheable but has config/aliases')
+
+            multi_card = unit.cardinality in (
+                enums.Cardinality.MANY, enums.Cardinality.AT_LEAST_ONE,
+            )
+            if multi_card and ctx.expected_cardinality_one:
+                raise errors.ResultCardinalityMismatchError(
+                    f'the query has cardinality {unit.cardinality.name} '
+                    f'which does not match the expected cardinality ONE')
 
             if not na_cardinality and (
                     len(unit.sql) > 1 or

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -3058,6 +3058,15 @@ class TestServerProtoDDL(tb.DDLTestCase):
         ''')
         self.assertEqual(result, ['"test1"', '"test2"'])
 
+    async def test_query_single_script(self):
+        # query single should work even if earlier parts of the script
+        # are multisets
+        result = await self.con.query_single('''
+            select {1, 2};
+            select 1;
+        ''')
+        self.assertEqual(result, 1)
+
 
 class TestServerProtoConcurrentDDL(tb.DDLTestCase):
 


### PR DESCRIPTION
Previously we errored if *any* were, which is needless.

Fixes #4311.