### PR TITLE
Fix creating an enum and a variadic function that references at the same time

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_09_29_00_00
+EDGEDB_CATALOG_VERSION = 2022_09_29_00_01
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -858,12 +858,8 @@ class CallableObject(
         canonical_order = canonical_param_sort(schema, params)
         for param in canonical_order:
             pt = param.get_type_shell(schema)
-            if isinstance(pt, s_types.CollectionTypeShell):
-                quals.append(pt.get_schema_class_displayname())
-                pt_id = str(pt.get_id(schema))
-            else:
-                pt_id = str(pt.name)
 
+            pt_id = str(pt.get_name(schema))
             quals.append(pt_id)
             pk = param.get_kind(schema)
             if pk is ft.ParameterKind.NamedOnlyParam:

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -6678,6 +6678,14 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             ['^^SOME_NAME^^'],
         )
 
+    async def test_edgeql_migration_enum_and_var_function_01(self):
+        # Create an enum and a variadic function that references it
+        # in the same migration. Issue #4213.
+        await self.migrate(r"""
+            scalar type E extending enum<a, b, c>;
+            function f(variadic e: E) -> bool using (true);
+        """)
+
     async def test_edgeql_migration_eq_linkprops_01(self):
         await self.migrate(r"""
             type Child;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12289,6 +12289,17 @@ type default::Foo {
             type_refs=2,
         )
 
+    async def test_edgeql_ddl_rename_ref_function_05(self):
+        await self._simple_rename_ref_tests(
+            """
+            CREATE FUNCTION foo(x: array<Note>) -> str {
+                USING ('x')
+            }
+            """,
+            """DROP FUNCTION foo(x: array<default::Note>);""",
+            prop_refs=0,
+        )
+
     async def test_edgeql_ddl_rename_ref_default_01(self):
         await self._simple_rename_ref_tests(
             """


### PR DESCRIPTION
The issue here is that function name mangling currently uses the *id*
of collection types. Collection type ids are deterministic and depend
on the ids of their components, but we need to generate the name
before the enum is created.

Just use the name.

This can't be cherry-picked to 2.0 because it changes the names of
lots of objects.

Fixes #4213.