### PR TITLE
Reword and add uniformity to Standard Library documentation

### DIFF
--- a/docs/stdlib/abstract.rst
+++ b/docs/stdlib/abstract.rst
@@ -4,8 +4,8 @@
 Abstract Types
 ==============
 
-Abstract types are used to describe a polymorphic, otherwise known as
-generic function to be applicable over a broad range of types.
+Abstract types are used to describe polymorphic functions, otherwise known as
+"generic functions," which can be called on a broad range of value types.
 
 
 ----------
@@ -17,9 +17,9 @@ generic function to be applicable over a broad range of types.
 
     Represents a generic type.
 
-    This type is used as a placeholder in cases where there isn't a specific
-    set of type requirements, or are not necessary, such as defining
-    polymorphic parameters in functions and operators.
+    This type is used as a placeholder in cases where there aren't specific
+    type requirements such as when defining polymorphic parameters in functions
+    and operators.
 
 
 ----------
@@ -103,7 +103,7 @@ These types serve as the base types for all :ref:`ranges <ref_std_range>`.
 
 .. eql:type:: std::anypoint
 
-    :index: any anypoint anyrange point
+    :index: any anypoint anyrange
 
     Represents an abstract base type for all valid ranges.
 
@@ -119,7 +119,7 @@ These types serve as the base types for all :ref:`ranges <ref_std_range>`.
 
 .. eql:type:: std::anydiscrete
 
-    :index: any anydiscrete anyrange discrete
+    :index: any anydiscrete anyrange
 
     Represents an abstract base type for all valid *discrete* ranges.
 

--- a/docs/stdlib/abstract.rst
+++ b/docs/stdlib/abstract.rst
@@ -15,7 +15,7 @@ Abstract types are used to describe polymorphic functions, otherwise known as
 
     :index: any anytype
 
-    Represents a generic type.
+    A generic type.
 
     This type is used as a placeholder in cases where there aren't specific
     type requirements such as when defining polymorphic parameters in functions
@@ -29,7 +29,7 @@ Abstract types are used to describe polymorphic functions, otherwise known as
 
     :index: any anytype scalar
 
-    Represents an abstract base scalar type.
+    An abstract base scalar type.
 
     All scalar types are derived from this type.
 
@@ -41,7 +41,7 @@ Abstract types are used to describe polymorphic functions, otherwise known as
 
     :index: any anytype enum
 
-    Represents an abstract base enumerator type.
+    An abstract base enumerator type.
 
     All :eql:type:`enum` types are derived from this type.
 
@@ -53,7 +53,7 @@ Abstract types are used to describe polymorphic functions, otherwise known as
 
     :index: any anytype anytuple
 
-    Represents a generic tuple.
+    A generic tuple.
 
     Similar to :eql:type:`anytype`, this type is used to denote a generic
     tuple without detailing its constituents. This is useful when defining
@@ -70,7 +70,7 @@ Abstract numeric types are used when wanting to extend off of
 
     :index: any anytype int
 
-    Represents an abstract base scalar type for
+    An abstract base scalar type for
     :eql:type:`int16`, :eql:type:`int32` and :eql:type:`int64` types.
 
 
@@ -81,7 +81,7 @@ Abstract numeric types are used when wanting to extend off of
 
     :index: any anytype float
 
-    Represents an abstract base scalar type for
+    An abstract base scalar type for
     :eql:type:`float32` and :eql:type:`float64` types.
 
 
@@ -92,7 +92,7 @@ Abstract numeric types are used when wanting to extend off of
 
     :index: any anytype
 
-    Represents an abstract base scalar type for
+    An abstract base scalar type for
     :eql:type:`anyint`, :eql:type:`anyfloat` and :eql:type:`decimal` types.
 
 
@@ -105,7 +105,7 @@ These types serve as the base types for all :ref:`ranges <ref_std_range>`.
 
     :index: any anypoint anyrange
 
-    Represents an abstract base type for all valid ranges.
+    An abstract base type for all valid ranges.
 
     This is also an abstract base scalar type for
     :eql:type:`int32`, :eql:type:`int64`,
@@ -121,7 +121,7 @@ These types serve as the base types for all :ref:`ranges <ref_std_range>`.
 
     :index: any anydiscrete anyrange
 
-    Represents an abstract base type for all valid *discrete* ranges.
+    An abstract base type for all valid *discrete* ranges.
 
     This is also an abstract base scalar type for :eql:type:`int32`,
     :eql:type:`int64` and :eql:type:`cal::local_date` types.
@@ -134,7 +134,7 @@ These types serve as the base types for all :ref:`ranges <ref_std_range>`.
 
     :index: any anycontiguous anyrange
 
-    Represents an abstract base type for all valid *contiguous* ranges.
+    An abstract base type for all valid *contiguous* ranges.
 
     This is also an abstract base scalar type for :eql:type:`float32`,
     :eql:type:`float64`, :eql:type:`decimal`, :eql:type:`datetime` and

--- a/docs/stdlib/abstract.rst
+++ b/docs/stdlib/abstract.rst
@@ -63,8 +63,7 @@ Abstract types are used to describe polymorphic functions, otherwise known as
 Abstract Numeric Types
 ======================
 
-Abstract numeric types are used when wanting to extend off of
-:eql:type:`anyscalar`.
+These abstract numeric types extend :eql:type:`anyscalar`.
 
 .. eql:type:: std::anyint
 

--- a/docs/stdlib/abstract.rst
+++ b/docs/stdlib/abstract.rst
@@ -56,8 +56,8 @@ generic function to be applicable over a broad range of types.
     Represents a generic tuple.
 
     Similar to :eql:type:`anytype`, this type is used to denote a generic
-    tuple without going into detail of which components there are. This is
-    useful when defining polymorphic parameters in functions and operators.
+    tuple without detailing its constituents. This is useful when defining
+    polymorphic parameters in functions and operators.
 
 
 Abstract Numeric Types
@@ -99,8 +99,7 @@ Abstract numeric types are used when wanting to extend off of
 Abstract Range Types
 ====================
 
-Like abstract numeric types, :ref:`ranges <ref_std_range>` can also be
-specified.
+These types serve as the base types for all :ref:`ranges <ref_std_range>`.
 
 .. eql:type:: std::anypoint
 

--- a/docs/stdlib/abstract.rst
+++ b/docs/stdlib/abstract.rst
@@ -136,5 +136,5 @@ These types serve as the base types for all :ref:`ranges <ref_std_range>`.
     An abstract base type for all valid *contiguous* ranges.
 
     This is also an abstract base scalar type for :eql:type:`float32`,
-    :eql:type:`float64`, :eql:type:`decimal`, :eql:type:`datetime` and
+    :eql:type:`float64`, :eql:type:`decimal`, :eql:type:`datetime`, and
     :eql:type:`cal::local_datetime` types.

--- a/docs/stdlib/abstract.rst
+++ b/docs/stdlib/abstract.rst
@@ -71,7 +71,7 @@ Abstract numeric types are used when wanting to extend off of
     :index: any anytype int
 
     An abstract base scalar type for
-    :eql:type:`int16`, :eql:type:`int32` and :eql:type:`int64` types.
+    :eql:type:`int16`, :eql:type:`int32`, and :eql:type:`int64` types.
 
 
 ----------
@@ -93,7 +93,7 @@ Abstract numeric types are used when wanting to extend off of
     :index: any anytype
 
     An abstract base scalar type for
-    :eql:type:`anyint`, :eql:type:`anyfloat` and :eql:type:`decimal` types.
+    :eql:type:`anyint`, :eql:type:`anyfloat`, and :eql:type:`decimal` types.
 
 
 Abstract Range Types
@@ -124,7 +124,7 @@ These types serve as the base types for all :ref:`ranges <ref_std_range>`.
     An abstract base type for all valid *discrete* ranges.
 
     This is also an abstract base scalar type for :eql:type:`int32`,
-    :eql:type:`int64` and :eql:type:`cal::local_date` types.
+    :eql:type:`int64`, and :eql:type:`cal::local_date` types.
 
 
 ----------

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -300,10 +300,8 @@ Reference
 
     :index: fill
 
-    Returns *array* elements as a string joined by *delimiter*.
+    Returns an array of specified size, filled with specified value.
     
-    The new array will have *n* copies of the value passed for *val*:
-
     .. code-block:: edgeql-repl
 
         db> select array_fill(0, 5);

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -57,15 +57,13 @@ Arrays store expressions of the *same type* in an ordered list.
 Constructing arrays
 ^^^^^^^^^^^^^^^^^^^
 
-Array constructors are an expression that allow for a sequence of
-comma-separated expressions *of the same type* enclosed in square brackets.
-This will produce an array of the following:
+Arrays are constructed by placing multiple comma-separated expressions within
+square brackets. Here are a few examples:
 
 .. eql:synopsis::
 
     "[" <expr> [, ...] "]"
 
-You can then use these arrays in EdgeDB to access information.
 
 .. code-block:: edgeql-repl
 
@@ -77,8 +75,9 @@ You can then use these arrays in EdgeDB to access information.
 Empty arrays
 ^^^^^^^^^^^^
 
-An empty array can also be created, but it must be used with
-a type cast as EdgeDB cannot infer the type of an array with no elements:
+You can also create an empty array, but it must be done by providing the type
+information using type casting. EdgeDB cannot infer the type of an empty array
+created otherwise. Example:
 
 .. code-block:: edgeql-repl
 
@@ -100,7 +99,7 @@ Reference
 
     :index: array
 
-    Represents a one-dimensional array of an homogeneous ordered list.
+    Represents an ordered list of values of the same type.
 
     Array indexing will always start at zero. With the exception of other
     array types, any type may be used as the given element contained within.
@@ -159,13 +158,17 @@ Reference
 
 .. eql:operator:: arrayslice: array<anytype> [ int64 : int64 ] -> anytype
 
-    Slices an array of :eql:type:`anytype` containing :eql:type:`int64`.
+    Produces a sub-array from an existing array.
 
     This results in a representable reference of the array's elements.
 
-    Omitting the lower bound an array will default the result to zero.
-    Doing so to the upper bound will also default to the current size of the
-    array. The upper bound of an array is non-inclusive:
+    Omitting the lower bound of an array slice will default to a low bound of
+    zero.
+    Omitting the upper bound will default the upper bound to the length of the
+    array.
+    
+    The lower bound of an array slice is inclusive while the upper bound is
+    not.
 
     .. code-block:: edgeql-repl
 
@@ -178,8 +181,11 @@ Reference
         db> select [1, 2, 3][:-2];
         {[1]}
 
-    Referencing an array slice outside of the array's boundaries will result
-    in an empty array, unlike accessing an element with a direct index:
+    If your array slice boundaries do not include any valid index from the
+    array, the slice will produce an empty array. Slicing with a lower bound
+    less than the minimum index or a upper bound greater than the
+    maximum index are functionally equivalent to not specifying those bounds
+    for your slice.
 
     .. code-block:: edgeql-repl
 
@@ -194,7 +200,7 @@ Reference
 
 .. eql:operator:: arrayplus: array<anytype> ++ array<anytype> -> array<anytype>
 
-    Concatenates given arrays of :eql:type:`anytype` into one.
+    Concatenates two arrays of the same type into one.
 
     This results in a reference of both array's elements conjoined together:
 
@@ -240,7 +246,7 @@ Reference
     or ``{}`` (empty set) will be returned.
 
     This works the same as the :eql:op:`array indexing operator <arrayidx>`,
-    except that if the index is out of boundaries, an empty set of the array
+    except that if the index is out of bounds, an empty set of the array
     element's type is returned instead of raising an exception:
 
     .. code-block:: edgeql-repl
@@ -294,7 +300,9 @@ Reference
 
     :index: fill
 
-    Returns a new array of size ``n`` with the specified ``val``:
+    Returns a new array of a specified number of copies of the specified value.
+    
+    The new array will have *n* copies of the value passed for *val*.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -94,7 +94,7 @@ Reference
 
     :index: array
 
-    Represents an ordered list of values of the same type.
+    An ordered list of values of the same type.
 
     Array indexing will always start at zero.
 

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -24,7 +24,7 @@ Arrays
       - Comparison operators
 
     * - :eql:func:`len`
-        - Returns the number of elements in the array.
+      - Returns the number of elements in the array.
 
     * - :eql:func:`contains`
       - Checks if an element is in the array.

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -285,7 +285,7 @@ Reference
 
     :index: join array_to_string implode
 
-    Returns the elements of an *array* joined together with a *delimiter*:
+    Returns the elements of an array joined as a string by a delimiter.
 
     .. code-block:: edgeql-repl
 
@@ -320,7 +320,7 @@ Reference
                                      new: anytype) \
                   -> array<anytype>
 
-    Returns an array with all occurrences of ``old`` replaced by ``new``:
+    Returns an array with all occurrences of one value replaced by another.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -128,7 +128,7 @@ Reference
 
 .. eql:operator:: arrayidx: array<anytype> [ int64 ] -> anytype
 
-    Indexes an array of :eql:type:`anytype`:
+    Accesses the element of the array at a given index.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -60,11 +60,6 @@ Constructing arrays
 Arrays are constructed by placing multiple comma-separated expressions within
 square brackets. Here are a few examples:
 
-.. eql:synopsis::
-
-    "[" <expr> [, ...] "]"
-
-
 .. code-block:: edgeql-repl
 
     db> select [1, 2, 3];

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -24,7 +24,7 @@ Arrays
       - Comparison operators
 
     * - :eql:func:`len`
-      - Returns a number of elements in the array.
+        - Returns the number of elements in the array.
 
     * - :eql:func:`contains`
       - Checks if an element is in the array.
@@ -101,8 +101,10 @@ Reference
 
     Represents an ordered list of values of the same type.
 
-    Array indexing will always start at zero. With the exception of other
-    array types, any type may be used as the given element contained within.
+    Array indexing will always start at zero.
+
+    An array can contain any type except another array. In EdgeDB, arrays are
+    always one-dimensional.
 
     Array types are implicitly created from :ref:`array
     constructors <ref_std_array_constructor>` as seen here:
@@ -112,13 +114,18 @@ Reference
         db> select [1, 2];
         {[1, 2]}
 
-    The syntax of an array type's declaration can be found from :ref:`this
-    section <ref_datamodel_arrays>`.
+    The declaration of an array type will follow this syntax:
+
+    .. code-block:: edgeql
+
+        type Person {
+            property str_array -> array<str>;
+            property json_array -> array<json>;
+        }
 
     Please see also the list of standard :ref:`array
-    functions <ref_std_array>`, as well as generic functions such as
-    :eql:func:`len`.
-
+    functions <ref_std_array>`, as well as :ref:`generic functions
+    <ref_std_generic>` such as :eql:func:`len`.
 
 
 ----------
@@ -126,9 +133,7 @@ Reference
 
 .. eql:operator:: arrayidx: array<anytype> [ int64 ] -> anytype
 
-    Indexes an array of :eql:type:`anytype`.
-
-    This results in a representable reference of the array element specified:
+    Indexes an array of :eql:type:`anytype`:
 
     .. code-block:: edgeql-repl
 
@@ -137,7 +142,8 @@ Reference
         db> select [(x := 1, y := 1), (x := 2, y := 3.3)][1];
         {(x := 2, y := 3.3)}
 
-    This operator also allows accessing elements through negation.
+    This operator also allows accessing elements from the end of the array
+    using a negative index.
 
     .. code-block:: edgeql-repl
 
@@ -202,7 +208,8 @@ Reference
 
     Concatenates two arrays of the same type into one.
 
-    This results in a reference of both array's elements conjoined together:
+    This results in an array containing the elements of both of the
+    concatenated arrays:
 
     .. code-block:: edgeql-repl
 
@@ -219,7 +226,7 @@ Reference
 
     Returns an array made from all of the input set elements.
 
-    The ordering of the inputted set will be preserved if specified:
+    The ordering of the input set will be preserved if specified:
 
     .. code-block:: edgeql-repl
 
@@ -266,16 +273,14 @@ Reference
 
     :index: set array unpack
 
-    Returns the elements of an array as a set:
+    Returns the elements of an array as a set.
+
+    The returned set is not guaranteed to be ordered:
 
     .. code-block:: edgeql-repl
 
         db> select array_unpack([2, 3, 5]);
         {3, 2, 5}
-
-    .. note::
-
-        The returned set is not guaranteed to be ordered.
 
 
 ----------
@@ -285,7 +290,7 @@ Reference
 
     :index: join array_to_string implode
 
-    Returns the elements of an ``array`` joined together with a ``delimiter``:
+    Returns the elements of an *array* joined together with a *delimiter*:
 
     .. code-block:: edgeql-repl
 
@@ -300,9 +305,9 @@ Reference
 
     :index: fill
 
-    Returns a new array of a specified number of copies of the specified value.
+    Returns *array* elements as a string joined by *delimiter*.
     
-    The new array will have *n* copies of the value passed for *val*.
+    The new array will have *n* copies of the value passed for *val*:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/bool.rst
+++ b/docs/stdlib/bool.rst
@@ -153,11 +153,31 @@ The truth tables are as follows:
 ----------
 
 
-It is important to understand the difference between using
-``and``/``or`` and :eql:func:`all`/:eql:func:`any`. The difference is
-in how they handle ``{}``. Both ``and`` and ``or`` operators apply to
-the cross-product of their operands. Thus, if any of the operands are
-``{}``, the result will be that.
+``and``/``or`` and :eql:func:`all`/:eql:func:`any` differ in the way they
+handle an empty set (``{}``). Both ``and`` and ``or`` operators apply to the
+cross-product of their operands. If either operand is an empty set, the result
+will also be an empty set. For example:
+
+.. code-block:: edgeql-repl
+
+    db> select {true, false} and <bool>{};
+    {}
+    db> select true and <bool>{};
+    {}
+
+Operating on an empty set with :eql:func:`all`/:eql:func:`any` does *not* return
+an empty set:
+
+.. code-block:: edgeql-repl
+
+    db> select all(<bool>{});
+    {true}
+    db> select any(<bool>{});
+    {false}
+
+:eql:func:`all` returns ``true`` because the empty set contains no false values.
+:eql:func:`any` returns ``false`` because the empty set contains no true
+values.
 
 The :eql:func:`all` and :eql:func:`any` functions are generalized to apply to
 sets of values, including ``{}``. They have the following truth table:

--- a/docs/stdlib/bool.rst
+++ b/docs/stdlib/bool.rst
@@ -57,13 +57,13 @@ Booleans
     - :eql:op:`\!= <neq>`
     - :eql:op:`?= <coaleq>`
     - :eql:op:`?!= <coalneq>`
+    - :eql:op:`in` / :eql:op:`not in <in>`
     - :eql:op:`\< <lt>`
     - :eql:op:`\> <gt>`
     - :eql:op:`\<= <lteq>`
     - :eql:op:`\>= <gteq>`
 
-Some examples:
-    :eql:op`not in <in>` operations:
+    Some examples:
 
     .. code-block:: edgeql-repl
 
@@ -72,14 +72,14 @@ Some examples:
         db> select '!' IN {'hello', 'world'};
         {false}
 
-    It's possible to get a boolean by casting a :eql:type:`str` or :eql:type:`json`
-    value into it:
+    It's possible to get a boolean by casting a :eql:type:`str` or
+    :eql:type:`json` value into it:
 
     .. code-block:: edgeql-repl
 
-        db> select <json>true;
-        {'true'}
-        db> select <bool>'True';
+        db> select <bool>('true');
+        {true}
+        db> select <bool>to_json('true');
         {true}
 
     :ref:`Filter clauses <ref_eql_statements_select_filter>` must always

--- a/docs/stdlib/bool.rst
+++ b/docs/stdlib/bool.rst
@@ -40,7 +40,7 @@ Booleans
 
 .. eql:type:: std::bool
 
-    Represents a logical boolean type of either ``true`` or ``false``.
+    A boolean type of either ``true`` or ``false``.
 
     EdgeQL has case-insensitive keywords, including boolean literals:
 
@@ -51,8 +51,18 @@ Booleans
         db> select (False, false, FALSE);
         {(false, false, false)}
 
-    Boolean values may arise as a result of :ref:`logical <ref_std_logical>`
-    or :eql:op`comparison <eq>` checks, as well as :eql:op`in` and
+    These basic operators will always result in a boolean value:
+    
+    - :eql:op:`= <eq>`
+    - :eql:op:`\!= <neq>`
+    - :eql:op:`?= <coaleq>`
+    - :eql:op:`?!= <coalneq>`
+    - :eql:op:`\< <lt>`
+    - :eql:op:`\> <gt>`
+    - :eql:op:`\<= <lteq>`
+    - :eql:op:`\>= <gteq>`
+
+Some examples:
     :eql:op`not in <in>` operations:
 
     .. code-block:: edgeql-repl
@@ -62,8 +72,8 @@ Booleans
         db> select '!' IN {'hello', 'world'};
         {false}
 
-    It is also possible to :eql:op:`cast <cast>` between a :eql:type:`bool`,
-    :eql:type:`str` or :eql:type:`json` type:
+    It's possible to get a boolean by casting a :eql:type:`str` or :eql:type:`json`
+    value into it:
 
     .. code-block:: edgeql-repl
 
@@ -182,5 +192,5 @@ To understand the last line in the above truth table it's useful to
 remember that ``all({a, b}) = all(a) and all(b)`` and ``any({a, b}) =
 any(a) or any(b)``.
 
-For more customized handling of ``{}``, the :eql:op:`?? <coalesce>` operator
-should be used.
+For more customized handling of ``{}``, use the :eql:op:`?? <coalesce>`
+operator.

--- a/docs/stdlib/bool.rst
+++ b/docs/stdlib/bool.rst
@@ -109,7 +109,7 @@ Booleans
 
 .. eql:operator:: and: bool and bool -> bool
 
-    Evaluates ``true`` if both booleans are true:
+    Evaluates ``true`` if both booleans are ``true``.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/bool.rst
+++ b/docs/stdlib/bool.rst
@@ -86,7 +86,7 @@ Booleans
 
 .. eql:operator:: or: bool or bool -> bool
 
-    Logically differentiates the truthfulness between two booleans:
+    Evaluates ``true`` if either boolean is ``true``:
 
     .. code-block:: edgeql-repl
 
@@ -99,7 +99,7 @@ Booleans
 
 .. eql:operator:: and: bool and bool -> bool
 
-    Performs a logical coexistence check between two booleans:
+    Evaluates ``true`` if both booleans are true:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/bool.rst
+++ b/docs/stdlib/bool.rst
@@ -96,7 +96,7 @@ Booleans
 
 .. eql:operator:: or: bool or bool -> bool
 
-    Evaluates ``true`` if either boolean is ``true``:
+    Evaluates ``true`` if either boolean is ``true``.
 
     .. code-block:: edgeql-repl
 
@@ -122,7 +122,7 @@ Booleans
 
 .. eql:operator:: not: not bool -> bool
 
-    Logically negates a given boolean value:
+    Logically negates a given boolean value.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/bytes.rst
+++ b/docs/stdlib/bytes.rst
@@ -65,8 +65,8 @@ Bytes
         db> select contains(b'qwerty', b'42');
         {false}
 
-    It is possible to :eql:op:`cast <cast>` between bytes and
-    :eql:type:`json`. Bytes are represented as Base64-encoded strings in JSON.
+    You may :eql:op:`cast <cast>` a :eql:type:`json` value into bytes. Bytes
+    are represented as Base64-encoded strings in JSON.
 
     .. code-block:: edgeql-repl
 
@@ -80,10 +80,7 @@ Bytes
 
 .. eql:operator:: bytesidx: bytes [ int64 ] -> bytes
 
-    Indexes a set of bytes.
-
-    This results in a representable reference of the byte from the specified
-    index:
+    Accesses a byte at a given index from bytes:
 
     .. code-block:: edgeql-repl
 
@@ -96,10 +93,7 @@ Bytes
 
 .. eql:operator:: bytesslice: bytes [ int64 : int64 ] -> bytes
 
-    Slices a set of bytes between an :eql:type:`int64` range.
-
-    This results in a representable reference of bytes chosen in a given
-    range:
+    Produces a bytes value comprising a portion of the existing bytes value:
 
     .. code-block:: edgeql-repl
 
@@ -114,9 +108,9 @@ Bytes
 
 .. eql:operator:: bytesplus: bytes ++ bytes -> bytes
 
-    Concatenates two given sets of :eql:type:`bytes` into one.
+    Concatenates two bytes values into one.
 
-    This results in a reference of both bytesets conjoined together:
+    Example:
 
     .. code-block:: edgeql-repl
 
@@ -129,7 +123,7 @@ Bytes
 
 .. eql:function:: std::bytes_get_bit(bytes: bytes, nth: int64) -> int64
 
-    Returns the ``nth`` bit of ``bytes`` as a value of :eql:type:`int64`.
+    Returns the *nth* bit of ``bytes`` as a value of :eql:type:`int64`.
 
     When looking for the ``nth`` bit, this function will enumerate bits from
     least-to-most significant with each byte:

--- a/docs/stdlib/bytes.rst
+++ b/docs/stdlib/bytes.rst
@@ -48,7 +48,7 @@ Bytes
 
     .. note::
 
-      Bytes also have a special byte literal, ``b''``.
+      Bytes have a special byte literal, ``b''``.
 
     .. code-block:: edgeql-repl
 
@@ -123,10 +123,10 @@ Bytes
 
 .. eql:function:: std::bytes_get_bit(bytes: bytes, nth: int64) -> int64
 
-    Returns the *nth* bit of ``bytes`` as a value of :eql:type:`int64`.
+    Returns the specified bit of the bytes value.
 
-    When looking for the ``nth`` bit, this function will enumerate bits from
-    least-to-most significant with each byte:
+    When looking for the *nth* bit, this function will enumerate bits from
+    least-to-most significant in each byte.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/bytes.rst
+++ b/docs/stdlib/bytes.rst
@@ -80,7 +80,7 @@ Bytes
 
 .. eql:operator:: bytesidx: bytes [ int64 ] -> bytes
 
-    Accesses a byte at a given index from bytes:
+    Accesses a byte at a given index of a bytes value.
 
     .. code-block:: edgeql-repl
 
@@ -93,7 +93,7 @@ Bytes
 
 .. eql:operator:: bytesslice: bytes [ int64 : int64 ] -> bytes
 
-    Produces a bytes value comprising a portion of the existing bytes value:
+    Produces a bytes value comprising a portion of the existing bytes value.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/bytes.rst
+++ b/docs/stdlib/bytes.rst
@@ -44,11 +44,9 @@ Bytes
 
 .. eql:type:: std::bytes
 
-    Represents a sequence of bytes delineating raw data.
+    A sequence of bytes representing raw data.
 
-    .. note::
-
-      Bytes have a special byte literal, ``b''``.
+    Bytes can be represented as a literal using this syntax: ``b''``.
 
     .. code-block:: edgeql-repl
 
@@ -58,15 +56,17 @@ Bytes
         {b'Hello, world\x01'}
 
     Additionally, :ref:`generic <ref_std_generic>`
-    functions are able to act upon bytes:
+    functions are able to operate on bytes:
 
     .. code-block:: edgeql-repl
 
         db> select contains(b'qwerty', b'42');
         {false}
 
-    You may :eql:op:`cast <cast>` a :eql:type:`json` value into bytes. Bytes
-    are represented as Base64-encoded strings in JSON.
+    Bytes are represented as Base64-encoded strings in JSON. When you cast a
+    bytes value into JSON, that's what you'll get. In order to :eql:op:`cast
+    <cast>` a :eql:type:`json` value into bytes, it must be a Base64-encoded
+    string.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/bytes.rst
+++ b/docs/stdlib/bytes.rst
@@ -30,10 +30,10 @@ Bytes
       - Returns the number of bytes.
 
     * - :eql:func:`contains`
-      - Checks if the byte sequence contains a subsequence.
+      - Checks if the byte sequence contains a given subsequence.
 
     * - :eql:func:`find`
-      - Finds the index of the first occurrence in a subsequence.
+      - Finds the index of the first occurrence of a subsequence.
 
     * - :eql:func:`bytes_get_bit`
       - :eql:func-desc:`bytes_get_bit`

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -20,8 +20,8 @@ Constraints
             constraint expression on (__subject__[0] = 'A');
         }
 
-    You may also use expression constraints across multiple object properties to
-    further restrict which values may be stored:
+    You may also use expression constraints across multiple object properties
+    to further restrict which values may be stored:
 
     .. code-block:: sdl
 

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -9,7 +9,7 @@ Constraints
 
 .. eql:constraint:: std::expression on (expr)
 
-    Represents an arbitrary constraint expression.
+    A constraint based on an arbitrary boolean expression.
 
     The ``expression`` constraint may be used as in this example to create a
     custom scalar type:
@@ -123,8 +123,8 @@ Constraints
             constraint regexp(r'[A-Za-z]*');
         }
 
-    See :ref:`regular expression patterns <string_regexp>` for details
-    regarding further usage.
+    See our documentation on :ref:`regular expression patterns <string_regexp>`
+    for more information on those.
 
 .. eql:constraint:: std::exclusive
 

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -73,7 +73,7 @@ Constraints
 
 .. eql:constraint:: std::max_len_value(max: int64)
 
-    Specifies the maximum allowed length of a value from an :eql:type:`int64`:
+    Specifies the maximum allowed length of a value.
 
     .. code-block:: sdl
 
@@ -83,7 +83,7 @@ Constraints
 
 .. eql:constraint:: std::min_value(min: anytype)
 
-    Specifies the minimum allowed value of :eql:type:`anytype`:
+    Specifies the minimum allowed value.
 
     .. code-block:: sdl
 
@@ -103,7 +103,7 @@ Constraints
 
 .. eql:constraint:: std::min_len_value(min: int64)
 
-    Specifies the minimum allowed length of a value from an :eql:type:`int64`:
+    Specifies the minimum allowed length of a value.
 
     .. code-block:: sdl
 

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -66,10 +66,9 @@ Constraints
         scalar type maxex_100 extending int64 {
             constraint max_ex_value(100);
         }
-    .. note::
     
-    In the example above, in contrast to the ``max_value`` constraint, a value of
-    the ``maxex_100`` type cannot be ``100`` since the valid range of
+    In the example above, in contrast to the ``max_value`` constraint, a value
+    of the ``maxex_100`` type cannot be ``100`` since the valid range of
     ``max_ex_value`` does not include the value specified in the constraint.
 
 .. eql:constraint:: std::max_len_value(max: int64)

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -116,7 +116,6 @@ Constraints
     :index: regex regexp regular
 
     Limits to values with string representations matching a regular expression.
-    ``pattern``:
 
     .. code-block:: sdl
 

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -35,7 +35,9 @@ Constraints
 
 .. eql:constraint:: std::one_of(variadic members: anytype)
 
-    Specifies a list of :eql:type:`anytype` as one allowed value of
+    Specifies a list of allowed values.
+    
+    Example:
 
     .. code-block:: sdl
 
@@ -45,7 +47,9 @@ Constraints
 
 .. eql:constraint:: std::max_value(max: anytype)
 
-    Specifies the maximum allowed value of :eql:type:`anytype`:
+    Specifies the maximum allowed value.
+    
+    Example:
 
     .. code-block:: sdl
 
@@ -62,6 +66,11 @@ Constraints
         scalar type maxex_100 extending int64 {
             constraint max_ex_value(100);
         }
+    .. note::
+    
+    In the example above, in contrast to the ``max_value`` constraint, a value of
+    the ``maxex_100`` type cannot be ``100`` since the valid range of
+    ``max_ex_value`` does not include the value specified in the constraint.
 
 .. eql:constraint:: std::max_len_value(max: int64)
 

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -11,8 +11,8 @@ Constraints
 
     Represents an arbitrary constraint expression.
 
-    The ``expression`` constraint may be used to represent a custom scalar
-    type:
+    The ``expression`` constraint may be used as in this example to create a
+    custom scalar type:
 
     .. code-block:: sdl
 
@@ -20,8 +20,8 @@ Constraints
             constraint expression on (__subject__[0] = 'A');
         }
 
-    You may also use this constraint based on a couple of object properties to
-    further restrict how a value may be stored:
+    You may also use expression constraints across multiple object properties to
+    further restrict which values may be stored:
 
     .. code-block:: sdl
 
@@ -36,7 +36,6 @@ Constraints
 .. eql:constraint:: std::one_of(variadic members: anytype)
 
     Specifies a list of :eql:type:`anytype` as one allowed value of
-    ``members``:
 
     .. code-block:: sdl
 
@@ -56,8 +55,7 @@ Constraints
 
 .. eql:constraint:: std::max_ex_value(max: anytype)
 
-    Specifies the maximum allowed value of :eql:type:`anytype` as an open
-    interval:
+    Specifies a non-inclusive upper bound for the value.
 
     .. code-block:: sdl
 
@@ -87,8 +85,7 @@ Constraints
 
 .. eql:constraint:: std::min_ex_value(min: anytype)
 
-    Specifies the minimum allowed value of :eql:type:`anytype` as an open
-    interval:
+    Specifies a non-inclusive lower bound for the value.
 
     .. code-block:: sdl
 
@@ -110,7 +107,7 @@ Constraints
 
     :index: regex regexp regular
 
-    Specifies the allowed representation of a type by matching a given
+    Limits to values with string representations matching a regular expression.
     ``pattern``:
 
     .. code-block:: sdl

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -375,7 +375,7 @@ EdgeDB store and output timezone-aware values in UTC format.
         ...        <cal::relative_duration>'1 hour';
         {<cal::local_time>'23:00:00'}
 
-    If an arithmetic operation results in a day that is nonexistent in the
+    If an arithmetic operation results in a day that doesn't exist in the
     given month, the last day of the month will be used instead:
 
     .. code-block:: edgeql-repl

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -127,7 +127,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     the years 1 and 9999.
 
     Although many systems support the ISO8601 date/time formatting in theory,
-    practical application of formatting before year 1 and after 9999 tends to
+    practical application of formatting in-between years 1 through 9999 tends to
     be inconsistent. As such, dates outside this range are not reliably
     portable.
 
@@ -179,10 +179,10 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:type:: cal::local_datetime
 
-    Represents a date and time without a given timezone.
+    A type for representing a date and time without a timezone.
 
-    :eql:op:`Casting <cast>` is a simple way to obtain a value through an
-    expression:
+    :eql:op:`Casting <cast>` is a simple way to obtain a
+    :eql:type:`cal::local_datetime` value through an expression:
 
     .. code-block:: edgeql
 
@@ -190,7 +190,7 @@ EdgeDB store and output timezone-aware values in UTC format.
         select <cal::local_datetime>'2018-05-07T15:01:22';
 
     When casting :eql:type:`cal::local_datetime` from strings, the string must
-    follow the ISO8601 format with a timezone included.
+    follow the ISO8601 format with the timezone excluded:
 
     .. code-block:: edgeql-repl
 
@@ -212,7 +212,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     year 1 to 9999.
 
     For more information regarding interacting with this type, see
-    :eql:func:`datetime_get`, :eql:func:`cal::to_local_datetime` and
+    :eql:func:`datetime_get`, :eql:func:`cal::to_local_datetime`, and
     :eql:func:`to_str`.
 
 
@@ -221,7 +221,7 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:type:: cal::local_date
 
-    Represents a date without a given timezone.
+    A type for representing a date without a timezone.
 
     :eql:op:`Casting <cast>` is a simple way to obtain a
     :eql:type:`cal::local_date` value in an expression:
@@ -234,7 +234,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     in ISO8601 date format.
 
     For more information regarding interacting with this type, see
-    :eql:func:`datetime_get`, :eql:func:`cal::to_local_date` and
+    :eql:func:`datetime_get`, :eql:func:`cal::to_local_date`, and
     :eql:func:`to_str`.
 
 
@@ -243,7 +243,7 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:type:: cal::local_time
 
-    Represents a time without a given timezone.
+    A type for representing a time without a timezone.
 
     :eql:op:`Casting <cast>` is a simple way to obtain a
     :eql:type:`cal::local_time` value in an expression:
@@ -257,7 +257,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     follow the ISO8601 format.
 
     For more information regarding interacting with this type, see
-    :eql:func:`datetime_get`, :eql:func:`cal::to_local_time` and
+    :eql:func:`datetime_get`, :eql:func:`cal::to_local_time`, and
     :eql:func:`to_str`.
 
 
@@ -268,10 +268,10 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:type:: std::duration
 
-    Represents a timespan.
+    A type for representing a timespan.
 
     A :eql:type:`duration` is a fixed number of seconds and microseconds and
-    isn't adjusted by timezone, length of month or anything else in datetime
+    isn't adjusted by timezone, length of month, or anything else in datetime
     calculations.
 
     When converting from a string, only units of ``'microseconds'``,
@@ -308,15 +308,15 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:type:: cal::relative_duration
 
-    Represents a timespan relative to a given unit of time.
+    A type for representing a timespan relative to a given point in time.
 
     Unlike :eql:type:`std::duration`, :eql:type:`cal::relative_duration`
-    is an inprecise form of measurement. Months, days and seconds are used
-    to declare the relation of the time's duration.
+    is an imprecise form of measurement. When months and days are used, the same
+    relative duration could have a different absolute duration depending on the
+    date you're measuring from.
 
-    Note that the month specified share a correlation to their amount of days,
-    as how a leap year have 366 days. This behavior is noticable with
-    different years:
+    For example 2020 was a leap year and had 366 days. Notice how the number of
+    hours in each year below is different:
 
     .. code-block:: edgeql-repl
 
@@ -378,9 +378,9 @@ EdgeDB store and output timezone-aware values in UTC format.
       ...        <cal::relative_duration>"1 month";
       {<cal::local_datetime>'2021-02-28T15:00:00'}
 
-    For arithmetic operations using :eql:type:`cal::relative_duration`
+    For arithmetic operations involving a :eql:type:`cal::relative_duration`
     consisting of multiple components (units), higher-order components are
-    applied first, followed then by lower-order elements.
+    applied first followed by lower-order components.
 
     .. code-block:: edgeql-repl
 
@@ -388,9 +388,9 @@ EdgeDB store and output timezone-aware values in UTC format.
       ...        <cal::relative_duration>"1 month 1 day";
       {<cal::local_datetime>'2021-05-31T15:00:00'}
 
-    This behavior is different from adding up the same components separately
-    with higher-order units first then followed by lower-order, producing
-    the same result as seen above:
+    If you add the same components split into separate durations, adding the
+    higher-order units first followed by the lower-order units, the calculation
+    produces the same result as in the previous example:
 
     .. code-block:: edgeql-repl
 
@@ -399,8 +399,8 @@ EdgeDB store and output timezone-aware values in UTC format.
       ...        <cal::relative_duration>"1 day";
       {<cal::local_datetime>'2021-05-31T15:00:00'}
 
-    When the order of application is reversed, the resulting date/time may
-    produce a different result under some corner cases:
+    When the order of operations is reversed, the result may be different under
+    some corner cases:
 
     .. code-block:: edgeql-repl
 
@@ -470,17 +470,17 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:type:: cal::date_duration
 
-    Represents a timespan of a date.
+    A type for representing a timespan in days.
 
     .. note::
 
       This type is only available in EdgeDB 2.0 or later.
 
     This type is similar to :eql:type:`cal::relative_duration`, except it only
-    uses 2 units: months and days. This is the result of subtracting one
+    uses 2 units: months and days. It is the result of subtracting one
     :eql:type:`cal::local_date` from another. The purpose of this type is to
-    allow performing ``+`` and ``-`` operations on :eql:type:`cal::local_date`
-    and produce :eql:type:`cal::local_date` as the result:
+    allow performing ``+`` and ``-`` operations on a :eql:type:`cal::local_date`
+    and to produce a :eql:type:`cal::local_date` as the result:
 
     .. code-block:: edgeql-repl
 
@@ -505,7 +505,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     - ``'centuries'``
     - ``'millennia'``
 
-    **Units usage**
+    Units usage examples:
 
     .. code-block:: edgeql
 
@@ -515,8 +515,9 @@ EdgeDB store and output timezone-aware values in UTC format.
 
     In most cases, :eql:type:`cal::date_duration` is fully compatible with
     :eql:type:`cal::relative_duration` and shares the same general
-    behavior/caveats. Implicit type coercion will happen in the event
-    where only :eql:type:`cal::relative_duration` is expected.
+    behavior and caveats. EdgeDB will apply type coercion in the event it
+    expects a :eql:type:`cal::relative_duration` and finds a
+    :eql:type:`cal::date_duration` instead.
 
     For more information regarding interacting with this type, see
     :eql:func:`cal::to_date_duration` and :eql:op:`operators <dtminus>`.
@@ -548,7 +549,7 @@ EdgeDB store and output timezone-aware values in UTC format.
                               -> cal::local_datetime
                           cal::local_date + duration -> cal::local_datetime
 
-    Adds two variations of any date/time type into one.
+    Adds any two datetime or duration values.
 
     This operator is commutative.
 
@@ -596,9 +597,9 @@ EdgeDB store and output timezone-aware values in UTC format.
                            cal::relative_duration - duration\
                                 -> cal::relative_duration
 
-    Subtracts two variations of any date/time type to one.
+    Subtracts two compatible datetime or duration values.
 
-    This will also subtract the time interval and date/time of one another:
+    Examples:
 
     .. code-block:: edgeql-repl
 
@@ -662,7 +663,7 @@ EdgeDB store and output timezone-aware values in UTC format.
 
     :index: now
 
-    Returns the date and time of the start of a current transaction.
+    Returns the date and time of the start of the current transaction.
 
 
 ----------
@@ -672,7 +673,7 @@ EdgeDB store and output timezone-aware values in UTC format.
 
     :index: now
 
-    Returns the date and time of the start of a current statement.
+    Returns the date and time of the start of the current statement.
 
 
 ----------
@@ -682,12 +683,9 @@ EdgeDB store and output timezone-aware values in UTC format.
                   std::datetime_get(dt: cal::local_datetime, \
                                     el: str) -> float64
 
-    Returns the element of a date/time type from the specified ``el``.
+    Returns the element of a date/time given a unit name.
 
-    Extract a specific element of input datetime by name.
-
-    Only the :eql:type:`datetime` type has the following elements available
-    for extraction:
+    You may pass any of these unit names for *el*:
 
     - ``'epochseconds'`` - the number of seconds since 1970-01-01 00:00:00
       UTC (Unix epoch) for :eql:type:`datetime` or local time for
@@ -750,10 +748,9 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:function:: cal::time_get(dt: cal::local_time, el: str) -> float64
 
-    Returns the element of a :eql:type:`cal::local_time` type by a name.
+    Returns the element of a :eql:type:`cal::local_time` given a unit name.
 
-    The :eql:type:`cal::local_time` scalar has the following elements
-    available for extraction:
+    You may pass any of these unit names for *el*:
 
     ``'midnightseconds'``,
     ``'hour'``,
@@ -781,7 +778,7 @@ EdgeDB store and output timezone-aware values in UTC format.
 
 .. eql:function:: cal::date_get(dt: local_date, el: str) -> float64
 
-    Returns the element of a :eql:type:`cal::local_date` type by a name.
+    Returns the element of a :eql:type:`cal::local_date` given a unit name.
 
     The :eql:type:`cal::local_date` scalar has the following elements
     available for extraction:

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -619,6 +619,25 @@ EdgeDB store and output timezone-aware values in UTC format.
         ...   <duration>'2 hours';
         {-3600s}
 
+    When subtracting a :eql:type:`cal::local_date` type from another, the
+    result is given as a whole number of days using the
+    :eql:type:`cal::date_duration` type:
+
+    .. code-block:: edgeql-repl
+
+      db> select <cal::local_date>'2022-06-25' -
+      ...   <cal::local_date>'2019-02-01';
+      {<cal::date_duration>'P1240D'}
+
+    .. note::
+
+        Subtraction doesn't make sense for some type combinations. You couldn't
+        subtract a point in time from a duration, so neither can EdgeDB
+        (although the inverse — subtracting a duration from a point in time —
+        is perfectly fine). You also couldn't subtract a timezone-aware
+        datetime from a local one or vice versa. If you attempt any of these,
+        EdgeDB will raise an exception as shown in these examples.
+
     When subtracting a date/time object from a time interval, an exception
     will be raised:
 
@@ -636,16 +655,6 @@ EdgeDB store and output timezone-aware values in UTC format.
         db> select <datetime>'2019-01-01T01:02:03+00' -
         ...   <cal::local_datetime>'2019-02-01T01:02:03';
         QueryError: operator '-' cannot be applied to operands ...
-
-    When subtracting a :eql:type:`cal::local_date` type from another, the
-    result is given as a whole number of days using the
-    :eql:type:`cal::date_duration` type:
-
-    .. code-block:: edgeql-repl
-
-      db> select <cal::local_date>'2022-06-25' -
-      ...   <cal::local_date>'2019-02-01';
-      {<cal::date_duration>'P1240D'}
 
 
 ----------

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -171,7 +171,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     9999.
 
     For more information regarding interacting with this type, see
-    :eql:func:`datetime_get`, :eql:func:`to_datetime` and :eql:func:`to_str`.
+    :eql:func:`datetime_get`, :eql:func:`to_datetime`, and :eql:func:`to_str`.
 
 
 ----------
@@ -275,7 +275,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     calculations.
 
     When converting from a string, only units of ``'microseconds'``,
-    ``'milliseconds'``, ``'seconds'``, ``'minutes'`` and ``'hours'`` are
+    ``'milliseconds'``, ``'seconds'``, ``'minutes'``, and ``'hours'`` are
     valid:
 
     .. code-block:: edgeql
@@ -299,7 +299,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     :eql:type:`duration`.
 
     For more information regarding interacting with this type, see
-    :eql:func:`to_duration`, :eql:func:`to_str` and
+    :eql:func:`to_duration`, :eql:func:`to_str`, and
     :eql:op:`operators <dtminus>`.
 
 
@@ -461,7 +461,7 @@ EdgeDB store and output timezone-aware values in UTC format.
       {false}
 
     For more information regarding interacting with this type, see
-    :eql:func:`cal::to_relative_duration`, :eql:func:`to_str` and
+    :eql:func:`cal::to_relative_duration`, :eql:func:`to_str`, and
     :eql:op:`operators <dtminus>`.
 
 
@@ -851,7 +851,7 @@ EdgeDB store and output timezone-aware values in UTC format.
 
     - ``'day'`` - specifically the number of days recorded in the duration
 
-    The smallest category of time units, such as hours, minutes
+    The smallest category of time units, such as hours, minutes,
     and seconds:
 
     - ``'hour'`` - duration hours

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -300,7 +300,7 @@ EdgeDB store and output timezone-aware values in UTC format.
         db> select <cal::local_time>'22:00' + <duration>'1 hour';
         {<cal::local_time>'23:00:00'}
 
-    See functions :eql:func:`to_duration`, and :eql:func:`to_str` and
+    See functions :eql:func:`to_duration` and :eql:func:`to_str`, and
     date/time :eql:op:`operators <dtminus>` for more ways of working with
     :eql:type:`duration`.
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -127,8 +127,8 @@ EdgeDB store and output timezone-aware values in UTC format.
     the years 1 and 9999.
 
     Although many systems support the ISO8601 date/time formatting in theory,
-    practical application of formatting in-between years 1 through 9999 tends to
-    be inconsistent. As such, dates outside this range are not reliably
+    practical application of formatting in-between years 1 through 9999 tends
+    to be inconsistent. As such, dates outside this range are not reliably
     portable.
 
 
@@ -287,7 +287,8 @@ EdgeDB store and output timezone-aware values in UTC format.
         db> select <duration>'48 hours 45 minutes';
         {<duration>'48:45:00'}
         db> select <duration>'11 months';
-        edgedb error: InvalidValueError: invalid input syntax for type std::duration: '11 months'
+        edgedb error: InvalidValueError: invalid input syntax for type
+        std::duration: '11 months'
           Hint: Units bigger than hours cannot be used for std::duration.
 
     All date/time types support the ``+`` and ``-`` arithmetic operators
@@ -316,8 +317,8 @@ EdgeDB store and output timezone-aware values in UTC format.
 
     A type for representing a timespan relative to a given point in time.
 
-    Unlike :eql:type:`std::duration`, :eql:type:`cal::relative_duration`
-    is an imprecise form of measurement. When months and days are used, the same
+    Unlike :eql:type:`std::duration`, :eql:type:`cal::relative_duration` is an
+    imprecise form of measurement. When months and days are used, the same
     relative duration could have a different absolute duration depending on the
     date you're measuring from.
 
@@ -485,8 +486,9 @@ EdgeDB store and output timezone-aware values in UTC format.
     This type is similar to :eql:type:`cal::relative_duration`, except it only
     uses 2 units: months and days. It is the result of subtracting one
     :eql:type:`cal::local_date` from another. The purpose of this type is to
-    allow performing ``+`` and ``-`` operations on a :eql:type:`cal::local_date`
-    and to produce a :eql:type:`cal::local_date` as the result:
+    allow performing ``+`` and ``-`` operations on a
+    :eql:type:`cal::local_date` and to produce a :eql:type:`cal::local_date` as
+    the result:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -101,7 +101,7 @@ Dates and Times
 
 .. _ref_std_datetime_intro:
 
-EdgeDB has two varieties of date/time constructs:
+EdgeDB offers two ways of represnting date/time values:
 
 * a timezone-aware :eql:type:`std::datetime` type;
 
@@ -182,7 +182,7 @@ EdgeDB store and output timezone-aware values in UTC format.
     A type for representing a date and time without a timezone.
 
     :eql:op:`Casting <cast>` is a simple way to obtain a
-    :eql:type:`cal::local_datetime` value through an expression:
+    :eql:type:`cal::local_datetime` value in an expression:
 
     .. code-block:: edgeql
 
@@ -253,7 +253,7 @@ EdgeDB store and output timezone-aware values in UTC format.
         select <cal::local_time>'15:01:22.306916';
         select <cal::local_time>'15:01:22';
 
-    When casting :eql:type:`cal::local_time` from strings, the string must be
+    When casting :eql:type:`cal::local_time` from strings, the string must
     follow the ISO8601 format.
 
     For more information regarding interacting with this type, see
@@ -557,7 +557,7 @@ EdgeDB store and output timezone-aware values in UTC format.
                               -> cal::local_datetime
                           cal::local_date + duration -> cal::local_datetime
 
-    Adds any two datetime or duration values.
+    Adds a duration and any other datetime value.
 
     This operator is commutative.
 
@@ -650,13 +650,18 @@ EdgeDB store and output timezone-aware values in UTC format.
         QueryError: operator '-' cannot be applied to operands ...
 
     An exception will also be raised when trying to subtract a timezone-aware
-    :eql:type:`std::datetime` type to or from :eql:type:`cal::local_datetime`:
+    :eql:type:`std::datetime` type from :eql:type:`cal::local_datetime` or vice
+    versa:
 
     .. code-block:: edgeql-repl
 
         db> select <datetime>'2019-01-01T01:02:03+00' -
         ...   <cal::local_datetime>'2019-02-01T01:02:03';
-        QueryError: operator '-' cannot be applied to operands ...
+        QueryError: operator '-' cannot be applied to operands...
+        db> select <cal::local_datetime>'2019-02-01T01:02:03' -
+        ...   <datetime>'2019-01-01T01:02:03+00';
+        QueryError: operator '-' cannot be applied to operands...
+
 
 
 ----------

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -101,13 +101,13 @@ Dates and Times
 
 .. _ref_std_datetime_intro:
 
-In EdgeDB, there are two types of date/time constructs:
+EdgeDB has two varieties of date/time constructs:
 
 * a timezone-aware :eql:type:`std::datetime` type;
 
 * a set of "local" date/time types, not attached to any particular
-  timezone, such as :eql:type:`cal::local_datetime`,
-  :eql:type:`cal::local_date` and :eql:type:`cal::local_time`.
+  timezone: :eql:type:`cal::local_datetime`, :eql:type:`cal::local_date`, and
+   :eql:type:`cal::local_time`.
 
 There are two different ways of measuring duration:
 
@@ -116,15 +116,15 @@ There are two different ways of measuring duration:
 * :eql:type:`cal::relative_duration` for using fuzzy units like years,
   months and days in addition to absolute units.
 
-All referrable operators, functions and type casts are designed to maintain a
+All related operators, functions, and type casts are designed to maintain a
 strict separation between timezone-aware and "local" date/time values.
 
 EdgeDB store and output timezone-aware values in UTC format.
 
 .. note::
 
-    All date/time types are stricted to years between 1 and 999, including
-    their end points.
+    All date/time types are restricted to years between 1 and 9999, including
+    the years 1 and 9999.
 
     Although many systems support the ISO8601 date/time formatting in theory,
     practical application of formatting before year 1 and after 9999 tends to

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -278,11 +278,17 @@ EdgeDB store and output timezone-aware values in UTC format.
     ``'milliseconds'``, ``'seconds'``, ``'minutes'``, and ``'hours'`` are
     valid:
 
-    .. code-block:: edgeql
+    .. code-block:: edgeql-repl
 
-        select <duration>'45.6 seconds';
-        select <duration>'15 milliseconds';
-        select <duration>'48 hours 45 minutes';
+        db> select <duration>'45.6 seconds';
+        {<duration>'0:00:45.6'}
+        db> select <duration>'15 milliseconds';
+        {<duration>'0:00:00.015'}
+        db> select <duration>'48 hours 45 minutes';
+        {<duration>'48:45:00'}
+        db> select <duration>'11 months';
+        edgedb error: InvalidValueError: invalid input syntax for type std::duration: '11 months'
+          Hint: Units bigger than hours cannot be used for std::duration.
 
     All date/time types support the ``+`` and ``-`` arithmetic operators
     with durations:

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -406,7 +406,7 @@ EdgeDB store and output timezone-aware values in UTC format.
       ...        <cal::relative_duration>"1 day";
       {<cal::local_datetime>'2021-05-31T15:00:00'}
 
-    When the order of operations is reversed, the result may be different under
+    When the order of operations is reversed, the result may be different for
     some corner cases:
 
     .. code-block:: edgeql-repl

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -1051,7 +1051,7 @@ EdgeDB store and output timezone-aware values in UTC format.
 
     Another way to construct a the :eql:type:`datetime` value
     is to specify it in terms of its component parts: *year*, *month*,
-    *day*, *hour*, *min*, *sec*, and *timezone*
+    *day*, *hour*, *min*, *sec*, and *timezone*.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -107,7 +107,7 @@ EdgeDB has two varieties of date/time constructs:
 
 * a set of "local" date/time types, not attached to any particular
   timezone: :eql:type:`cal::local_datetime`, :eql:type:`cal::local_date`, and
-   :eql:type:`cal::local_time`.
+  :eql:type:`cal::local_time`.
 
 There are two different ways of measuring duration:
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -142,8 +142,8 @@ EdgeDB store and output timezone-aware values in UTC format.
     All dates must correspond to dates that exist in the proleptic Gregorian
     calendar.
 
-    :eql:op:`Casting <cast>` is a simple way to obtain a value through an
-    expression:
+    :eql:op:`Casting <cast>` is a simple way to obtain a :eql:type:`datetime`
+    value in an expression:
 
     .. code-block:: edgeql
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -101,7 +101,7 @@ Dates and Times
 
 .. _ref_std_datetime_intro:
 
-EdgeDB offers two ways of represnting date/time values:
+EdgeDB offers two ways of representing date/time values:
 
 * a timezone-aware :eql:type:`std::datetime` type;
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -415,7 +415,7 @@ EdgeDB store and output timezone-aware values in UTC format.
       ...        <cal::relative_duration>"1 month";
       {<cal::local_datetime>'2021-06-01T15:00:00'}
 
-    **Gotchas**
+    .. rubric:: Gotchas
 
     Due to the implementation of :eql:type`cal::relative_duration` logic,
     arithmetic operations may behave counterintuitively.

--- a/docs/stdlib/enum.rst
+++ b/docs/stdlib/enum.rst
@@ -14,7 +14,7 @@ Enums
     Represents an enumeration of values within an ordered list.
 
     An enumerator type can be declared in a schema definition by using
-    the :ref:`following syntax <ref_datamodel_enums>`:
+    the following syntax:
 
     .. code-block:: sdl
 

--- a/docs/stdlib/enum.rst
+++ b/docs/stdlib/enum.rst
@@ -11,7 +11,7 @@ Enums
 
     :index: enum
 
-    An enumeration of values within an ordered list.
+    An enumerated type is a data type consisting of an ordered list of values.
 
     An enum type can be declared in a schema definition by using the following
     syntax:

--- a/docs/stdlib/enum.rst
+++ b/docs/stdlib/enum.rst
@@ -13,22 +13,22 @@ Enums
 
     An enumeration of values within an ordered list.
 
-    An enumerator type can be declared in a schema definition by using
-    the following syntax:
+    An enum type can be declared in a schema definition by using the following
+    syntax:
 
     .. code-block:: sdl
 
         scalar type Color extending enum<Red, Green, Blue>;
 
-    Enumerated values can then be accessed directly:
+    Enum values can then be accessed directly:
 
     .. code-block:: edgeql-repl
 
         db> select Color.Red is Color;
         {true}
 
-    :eql:op:`Casting <cast>` can be used to obtain an
-    enumerable value in an expression:
+    :eql:op:`Casting <cast>` can be used to obtain an enum value in an
+    expression:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/enum.rst
+++ b/docs/stdlib/enum.rst
@@ -11,7 +11,7 @@ Enums
 
     :index: enum
 
-    Represents an enumeration of values within an ordered list.
+    An enumeration of values within an ordered list.
 
     An enumerator type can be declared in a schema definition by using
     the following syntax:

--- a/docs/stdlib/generic.rst
+++ b/docs/stdlib/generic.rst
@@ -46,8 +46,8 @@ Generic
 
 .. note::
 
-    In EdgeQL, any value can be compared to another as long as they are
-    both the same type.
+    In EdgeQL, any value can be compared to another as long as their types are
+    compatible.
 
 .. eql:operator:: eq: anytype = anytype -> bool
 
@@ -76,7 +76,7 @@ Generic
 
 .. eql:operator:: neq: anytype != anytype -> bool
 
-    Compares two values of :eql:type:`anytype` for inequality.
+    Compares two values of compatible types for inequality.
 
     This results in a :eql:type:`bool`:
 
@@ -123,8 +123,7 @@ Generic
 
 .. eql:operator:: coalneq: optional anytype ?!= optional anytype -> bool
 
-    Compares two potentially empty values of :eql:type:`anytype` for
-    inequality.
+    Compares two compatible potentially empty values for inequality.
 
     This works the same as a negated :eql:op:`\!= <neq>` operator, but also
     allows comparing an empty set (``{}`` ). Two empty sets are considered
@@ -188,8 +187,7 @@ Generic
 
 .. eql:operator:: lteq: anytype <= anytype -> bool
 
-    Produces true for two compatible values if the left one is equal or
-    smaller.
+    Produces true for two compatible values if the left is equal or smaller.
 
     This results in a :eql:type:`bool`:
 
@@ -212,8 +210,7 @@ Generic
 
 .. eql:operator:: gteq: anytype >= anytype -> bool
 
-    Produces true for two compatible values if the left one is equal or
-    greater.
+    Produces true for two compatible values if the left is equal or greater.
 
     This results in a :eql:type:`bool`:
 

--- a/docs/stdlib/generic.rst
+++ b/docs/stdlib/generic.rst
@@ -188,7 +188,8 @@ Generic
 
 .. eql:operator:: lteq: anytype <= anytype -> bool
 
-    Produces true for two compatible values if the left one is equal or smaller.
+    Produces true for two compatible values if the left one is equal or
+    smaller.
 
     This results in a :eql:type:`bool`:
 
@@ -211,7 +212,8 @@ Generic
 
 .. eql:operator:: gteq: anytype >= anytype -> bool
 
-    Produces true for two compatible values if the left one is equal or greater.
+    Produces true for two compatible values if the left one is equal or
+    greater.
 
     This results in a :eql:type:`bool`:
 

--- a/docs/stdlib/generic.rst
+++ b/docs/stdlib/generic.rst
@@ -294,8 +294,8 @@ Generic
         {true}
 
     When *haystack* is a :ref:`range <ref_std_range>`, the function will return
-    ``true`` if it contains either the specified sub-range or element, or
-    ``false`` otherwise.
+    ``true`` if it contains either the specified sub-range or element. The
+    function will return ``false`` otherwise.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/generic.rst
+++ b/docs/stdlib/generic.rst
@@ -51,9 +51,9 @@ Generic
 
 .. eql:operator:: eq: anytype = anytype -> bool
 
-    Compares two values of :eql:type:`anytype` for equality.
+    Compares two values of compatible types for equality.
 
-    This reuslts in a :eql:type:`bool`:
+    This results in a :eql:type:`bool`:
 
     .. code-block:: edgeql-repl
 
@@ -101,7 +101,7 @@ Generic
 
 .. eql:operator:: coaleq: optional anytype ?= optional anytype -> bool
 
-    Compares two potentially empty values of :eql:type:`anytype` for equality.
+    Compares two compatible potentially empty values for equality.
 
     This works the same as a regular :eql:op:`=<eq>` operator, but also allows
     comparing an empty ``{}`` set.  Two empty sets are considered equal.
@@ -127,7 +127,8 @@ Generic
     inequality.
 
     This works the same as a negated :eql:op:`\!= <neq>` operator, but also
-    allows comparing an empty ``{}`` set. Two empty sets are considered equal.
+    allows comparing an empty set (``{}`` ). Two empty sets are considered
+    equal.
 
     This results in a :eql:type:`bool`:
 
@@ -146,11 +147,9 @@ Generic
 
 .. eql:operator:: lt: anytype < anytype -> bool
 
-    Performs a less than value comparison with two valeues of
-    :eql:type:`anytype`.
+    Produces true for two compatible values if the left is the smaller value.
 
-    This results in a :eql:type:`bool` of ``true`` if the left operand
-    is less than the the right operand:
+    This results in a :eql:type:`bool`:
 
     .. code-block:: edgeql-repl
 
@@ -168,11 +167,9 @@ Generic
 
 .. eql:operator:: gt: anytype > anytype -> bool
 
-    Performs a greater than value comparison with two values of
-    :eql:type:`anytype`.
+    Produces true for two compatible values if the left is the larger value.
 
-    This results in a :eql:type:`bool` of ``true`` if the left operand
-    is greater than the the right operand:
+    This results in a :eql:type:`bool`:
 
     .. code-block:: edgeql-repl
 
@@ -191,11 +188,9 @@ Generic
 
 .. eql:operator:: lteq: anytype <= anytype -> bool
 
-    Performs a less than/equals comparison with two values of
-    :eql:type:`anytype`.
+    Produces true for two compatible values if the left one is equal or smaller.
 
-    This results in a :eql:type:`bool` of ``true`` if the left operand
-    is less than or the same value as the right operand:
+    This results in a :eql:type:`bool`:
 
     .. code-block:: edgeql-repl
 
@@ -216,11 +211,9 @@ Generic
 
 .. eql:operator:: gteq: anytype >= anytype -> bool
 
-    Performs a greater than/equals comparison with two values of
-    :eql:type:`anytype`.
+    Produces true for two compatible values if the left one is equal or greater.
 
-    This results in a :eql:type:`bool` of ``true`` if the left operand
-    is greater than or the same value as the right operand:
+    This results in a :eql:type:`bool`:
 
     .. code-block:: edgeql-repl
 
@@ -245,10 +238,10 @@ Generic
 
     :index: length count array
 
-    Returns an :eql:type:`int64` of counted values within a type.
+    Returns a count of a given value's constituents.
 
     This function works with the :eql:type:`str`, :eql:type:`bytes` and
-    :eql:type:`array` types. Strings and bytes will return a scalar value:
+    :eql:type:`array` types:
 
     .. code-block:: edgeql-repl
 
@@ -278,12 +271,11 @@ Generic
 
     :index: find strpos strstr position array
 
-    Returns :eql:type:`bool` for whether a ``haystack`` set has a ``needle``
-    value.
+    Returns true if the given sub-value exists within the given value.
 
-    When the ``haystack`` is a :eql:type:`str` or :eql:type:`bytes` type,
-    this function will return ``true`` if it contains ``needle`` as a
-    subsequence within it, and ``false`` otherwise:
+    When the *haystack* is a :eql:type:`str` or :eql:type:`bytes` value, this
+    function will return ``true`` if it contains *needle* as a subsequence
+    within it or ``false`` otherwise:
 
     .. code-block:: edgeql-repl
 
@@ -293,16 +285,17 @@ Generic
         db> select contains(b'qwerty', b'42');
         {false}
 
-    When ``haystack`` is an :eql:type:`array` type, this will return ``true``
-    if the array contains the specified element and ``false`` otherwise:
+    When *haystack* is an :eql:type:`array`, the function will return ``true``
+    if the array contains the element specified as *needle* or ``false``
+    otherwise:
 
     .. code-block:: edgeql-repl
 
         db> select contains([2, 5, 7, 2, 100], 2);
         {true}
 
-    When ``haystack`` is a :ref:`range <ref_std_range>`, this will return
-    ``true`` if it contains either the specified sub-range or element, and
+    When *haystack* is a :ref:`range <ref_std_range>`, the function will return
+    ``true`` if it contains either the specified sub-range or element, or
     ``false`` otherwise.
 
     .. code-block:: edgeql-repl
@@ -330,15 +323,13 @@ Generic
 
     :index: find strpos strstr position array
 
-    Returns the index of an element in a ``haystack`` set by the ``needle``
-    value.
+    Returns the index of a given sub-value in a given value.
 
-    When ``haystack`` is a :eql:type:`str` or :eql:type:`bytes` type, this
-    will return the index of the first (as well as only) occurring ``needle``
-    in it.
+    When *haystack* is a :eql:type:`str` or :eql:type:`bytes` value, the
+    function will return the index of the first occurrence of *needle* in it.
 
-    When ``haystack`` is an :eql:type:`array`, return the index of
-    the first occurrence of the specific *needle* element. For
+    When *haystack* is an :eql:type:`array`, this will return the index of the
+    the first occurrence of the element passed as *needle*. For
     :eql:type:`array` inputs it is also possible to provide an
     optional *from_pos* argument to specify the position from
     which to start the search.

--- a/docs/stdlib/generic.rst
+++ b/docs/stdlib/generic.rst
@@ -125,7 +125,7 @@ Generic
 
     Compares two compatible potentially empty values for inequality.
 
-    This works the same as a negated :eql:op:`\!= <neq>` operator, but also
+    This works the same as a regular :eql:op:`\!= <neq>` operator, but also
     allows comparing an empty set (``{}`` ). Two empty sets are considered
     equal.
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -93,10 +93,10 @@ be the same as the output of a :eql:stmt:`select expression <select>` in
     ...     filter .name = 'std::bool');
     {'{"name": "std::bool", "timestamp": "2019-04-02"}'}
 
-JSON values can also be cast back into scalars. Casting JSON is symmetrical:
-if a scalar value can be cast into JSON, a compatible JSON value can be cast
-into a scalar of that type. Some scalar types will have specific conditions
-for casting:
+JSON values can also be cast back into scalars. Casting JSON is symmetrical
+meaning that, if a scalar value can be cast into JSON, a compatible JSON value
+can be cast into a scalar of that type. Some scalar types will have specific
+conditions for casting:
 
 - JSON strings can be cast to a :eql:type:`str` type. Casting :eql:type:`uuid`
   and :ref:`date/time <ref_std_datetime>` types to JSON results in a JSON

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -195,8 +195,8 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     Produces a JSON value comprising a portion of the existing JSON value.
 
-    This results in :eql:type:`json`. Arrays and strings of JSON can be sliced
-    in the same manner as an :eql:type:`array`, producing a JSON type:
+    Arrays and strings of JSON can be sliced in the same manner as an
+    :eql:type:`array`, producing a :eql:type:`json` value:
 
     .. code-block:: edgeql-repl
 
@@ -219,12 +219,13 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
 .. eql:operator:: jsonplus: json ++ json -> json
 
-    Concatenates given types of :eql:type:`json` and :eql:type:`Object`
-    into one.
+    Concatenates two :eql:type:`json` arrays, objects, or string values into one.
 
-    This results in a reference of both array's elements conjoined together.
-    If there are mutual keys in the given :eql:type:`json`, the value of the
-    second one will be used instead:
+    The result is a new :eql:type:`json` value containing the elements of both
+    concatenated values. If concatenated objects have identical keys, the value
+    of the second one will be used.
+    
+    Examples:
     
     .. code-block:: edgeql-repl
 
@@ -243,7 +244,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
 .. eql:operator:: jsonobjdest: json [ str ] -> json
 
-    Accesses the value of a :eql:type:`json` from its :eql:type:`str` key:
+    Accesses an element of a :eql:type:`json` object given its key:
 
     This results in a :eql:type:`json` type. The fields of any JSON object may
     also be accessed via ``[]``:
@@ -271,7 +272,9 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     :index: json parse loads
 
-    Returns the value of the inputted :eql:type:`str` from a :eql:type:`json`:
+    Returns a :eql:type:`json` value parsed from the given :eql:type:`str`.
+    
+    Examples:
 
     .. code-block:: edgeql-repl
 
@@ -290,8 +293,8 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     Returns the elements of a JSON array as a set of :eql:type:`json`.
 
-    Calling this function on anything other than an array of :eql:type:`json`
-    will result in a runtime error:
+    Calling this function on anything other than an :eql:type:`json` array will
+    result in a runtime error.
 
     .. code-block:: edgeql-repl
 
@@ -311,9 +314,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     :index: safe navigation
 
-    Returns the value of a :eql:type:`json` at the end of the specified path.
-
-    This will otherwise provide an empty set containing no JSON.
+    Returns a value from a :eql:type:`json` object or array given its path.
 
     This function provides "safe" navigation of a JSON value. If the
     input path is a valid path for the input JSON object/array, the
@@ -387,7 +388,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ... );
         {'{"a": {"b": {"c": 42}}}'}
 
-    If ``create_if_missing`` is set to ``false``, a new path for the value
+    If *create_if_missing* is set to ``false``, a new path for the value
     won't be created:
 
     .. code-block:: edgeql-repl
@@ -406,9 +407,9 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ... );
         {'{"a": 10, "b": 20}'}
 
-    ``empty_treatment`` is an enumerable responsible for the behavior of the
-    function if an empty set is passed to ``new_value``. This will contain one
-    of the following values:
+    *empty_treatment* can be any value from the `JsonEmpty` enumeration. It
+    defines the behavior of the function if an empty set is passed as
+    *new_value*. `JsonEmpty` contains these values:
 
     - ``ReturnEmpty``: return empty set, default
     - ``ReturnTarget``: return ``target`` unmodified
@@ -459,8 +460,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 .. eql:function:: std::json_object_unpack(json: json) -> \
                   set of tuple<str, json>
 
-    Returns a set of key/value tuples that make up a :eql:type:`json`
-    object.
+    Returns the data in a :eql:type:`json` object as a set of key/value tuples.
 
     Calling this function on anything other than a JSON object will
     result in a runtime error.
@@ -482,11 +482,10 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     :index: type
 
-    Returns the type of the outermost :eql:type:`json` value as a
-    :eql:type:`str`.
+    Returns the :eql:type:`str` type of the outermost :eql:type:`json` value.
 
-    Possible return values are: ``'object'``, ``'array'``,
-    ``'string'``, ``'number'``, ``'boolean'`` and ``'null'``:
+    Possible return values are ``'object'``, ``'array'``,
+    ``'string'``, ``'number'``, ``'boolean'``, or ``'null'``:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -108,9 +108,9 @@ conditions for casting:
 - JSON booleans can be cast to a :eql:type:`bool` type.
 - JSON ``null`` is unique because it can be cast to an empty set (``{}``) of
   any type.
-- JSON arrays can be cast to an array, as long as it's homogeneous, does not
-  contain ``null`` as an element of the array, and does not contain another
-  array., as long as it's homogeneous and do not contain *null* as a value.
+- JSON arrays can be cast to any valid array type, as long as the JSON array 
+  is homogeneous, does not contain ``null`` as an element of the array, and 
+  does not contain another array.
 
 A named :eql:type:`tuple` is converted into a JSON object when cast as a
 :eql:type:`json` unlike a standard :eql:type:`tuple` which is converted into a
@@ -195,7 +195,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     Produces a JSON value comprising a portion of the existing JSON value.
 
-    Arrays and strings of JSON can be sliced in the same manner as an
+    JSON arrays and strings can be sliced in the same manner as an
     :eql:type:`array`, producing a :eql:type:`json` value:
 
     .. code-block:: edgeql-repl
@@ -293,7 +293,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     Returns the elements of a JSON array as a set of :eql:type:`json`.
 
-    Calling this function on anything other than an :eql:type:`json` array will
+    Calling this function on anything other than a JSON array will
     result in a runtime error.
 
     This function should be used only if the ordering of elements is not
@@ -482,7 +482,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     :index: type
 
-    Returns the :eql:type:`str` type of the outermost :eql:type:`json` value.
+    Returns the type of the outermost JSON value as a :eql:type:`str`.
 
     Possible return values are ``'object'``, ``'array'``,
     ``'string'``, ``'number'``, ``'boolean'``, or ``'null'``:

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -166,7 +166,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
 .. eql:operator:: jsonidx: json [ int64 ] -> json
 
-    Indexes an array or string of :eql:type:`json`.
+    Accesses the element of the JSON string or array at a given index.
 
     The operator produces the value at the given index as :eql:type:`json`.
     

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -80,7 +80,7 @@ Additionally, any :eql:type:`Object` in EdgeDB can be casted as a
 :eql:type:`json` type. This produces the same JSON value as the
 JSON-serialized result of that said object. Furthermore, this result will
 be the same as the output of a :eql:stmt:`select expression <select>` in
-*JSOM mode*, including the shape of that type:
+*JSON mode*, including the shape of that type:
 
 .. code-block:: edgeql-repl
 
@@ -133,16 +133,16 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         db> select <bool>to_json('true');
         {true}
 
-    A :eql:type:`json` type can also be casted as a :eql:type:`str` type,
-    but only when recognised as a JSON string:
+    A :eql:type:`json` value can also be cast as a :eql:type:`str` type, but
+    only when recognized as a JSON string:
 
     .. code-block:: edgeql-repl
 
         db> select <str>to_json('"something"');
         {'something'}
 
-    Casting a string array of JSON (``["a", "b", "c"]``) to a :eql:type:`str`
-    type will result in an error:
+    Casting a JSON array of strings (``["a", "b", "c"]``) to a :eql:type:`str`
+    will result in an error:
 
     .. code-block:: edgeql-repl
 
@@ -168,8 +168,9 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     Indexes an array or string of :eql:type:`json`.
 
-    This results in :eql:type:`json`. Contents of a JSON array or string can
-    also accessed through accessing an index from indices: (``[ int64 ]``)
+    The operator produces the value at the given index as :eql:type:`json`.
+    
+    Examples:
 
     .. code-block:: edgeql-repl
 
@@ -183,8 +184,8 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         {'null'}
 
     This may raise an exception if the specified index is not valid for the
-    base JSON value. To access an element that is potentially out of
-    boundaries, use :eql:func:`json_get`.
+    base JSON value. To access an index that is potentially out of bounds, use
+    :eql:func:`json_get`.
 
 
 ----------
@@ -192,7 +193,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
 .. eql:operator:: jsonslice: json [ int64 : int64 ] -> json
 
-    Indexes an array or string of :eql:type:`json`.
+    Produces a JSON value comprising a portion of the existing JSON value.
 
     This results in :eql:type:`json`. Arrays and strings of JSON can be sliced
     in the same manner as an :eql:type:`array`, producing a JSON type:

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -247,7 +247,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     Accesses an element of a :eql:type:`json` object given its key.
 
     This results in a :eql:type:`json` type. The fields of any JSON object may
-    also be accessed via ``[]``:
+    be accessed via ``[]``:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -93,29 +93,30 @@ be the same as the output of a :eql:stmt:`select expression <select>` in
     ...     filter .name = 'std::bool');
     {'{"name": "std::bool", "timestamp": "2019-04-02"}'}
 
-JSON values can also be casted back as a scalar type. Casting JSON is
-symmetrical: if a scalar type can be casted back into JSON, only that
-particular JSON type can be casted back into that scalar. Some scalar types
-will have specific conditions:
+JSON values can also be cast back into scalars. Casting JSON is symmetrical:
+if a scalar value can be cast into JSON, a compatible JSON value can be cast
+into a scalar of that type. Some scalar types will have specific conditions
+for casting:
 
-- JSON *strings* can be casted as a :eql:type:`str` type. Casting
-  :eql:type:`uuid` and :ref:`date/time types
-  <ref_std_datetime>` to JSON results in a JSON
+- JSON strings can be cast to a :eql:type:`str` type. Casting :eql:type:`uuid`
+  and :ref:`date/time <ref_std_datetime>` types to JSON results in a JSON
   string representing its original value. This means it is also possible to
-  cast a JSON string back to its original type. The value of the string must
-  also be properly formatted, otherwise an exception will be raised.
-- JSON *numbers* can be casted to any :ref:`numeric type <ref_std_numeric>`.
-- JSON *booleans* can be casted as a :eql:type:`bool`.
-- Nullified JSON is special as it can be casted as an empty set or ``{}`` of
-  :eql:type:`anytype`.
-- JSON *arrays* can be casted to any valid EdgeDB array, as long as it's
-  homogeneous and do not contain *null* as a value.
+  cast a JSON string back to those types. The value of the UUID or datetime
+  string must be properly formatted to successfully cast from JSON, otherwise
+  EdgeDB will raise an exception.
+- JSON numbers can be cast to any :ref:`numeric type <ref_std_numeric>`.
+- JSON booleans can be cast to a :eql:type:`bool` type.
+- JSON ``null`` is unique because it can be cast to an empty set (``{}``) of
+  any type.
+- JSON arrays can be cast to an array, as long as it's homogeneous, does not
+  contain ``null`` as an element of the array, and does not contain another
+  array., as long as it's homogeneous and do not contain *null* as a value.
 
-A *regular* :eql:type:`tuple` is converted into a JSON array when casted
-as a :eql:type:`json`, unlike a *named* :eql:type:`tuple` where it is
-converted into a JSON *object*. These casts are not reversible, however,
-i.e. it is not possible to cast a JSON value directly into a
-:eql:type:`tuple`.
+A named :eql:type:`tuple` is converted into a JSON object when cast as a
+:eql:type:`json` unlike a standard :eql:type:`tuple` which is converted into a
+JSON array. Unlike other casts to JSON, tuple casts to JSON are *not*
+reversible (i.e., it is not possible to cast a JSON value directly into a
+:eql:type:`tuple`).
 
 
 ----------
@@ -148,8 +149,9 @@ i.e. it is not possible to cast a JSON value directly into a
         db> select <str>to_json('["a", "b", "c"]');
         InvalidValueError: expected json string or null; got JSON array
 
-    For dumping or parsing the value of a :eql:type:`json` or :eql:type:`str`
-    type, use the :eql:func`to_json` or :eql:func:`to_str` functions:
+    Instead, use the :eql:func:`to_str` function to dump a JSON value to a
+    :eql:type:`str` value. Use the :eql:func`to_json` function to parse a JSON
+    string to a :eql:type:`json` value:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -67,7 +67,7 @@ own literal, and instead can be obtained by either casting a value to the
     db> select <json>'hello world';
     {'"hello world"'}
 
-Any value in EdgeDB can be casted to an :eql:type:`json` type as well:
+Any value in EdgeDB can be casted to a :eql:type:`json` type as well:
 
 .. code-block:: edgeql-repl
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -318,8 +318,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     This function provides "safe" navigation of a JSON value. If the
     input path is a valid path for the input JSON object/array, the
-    JSON value at the end of that path is returned. If the path cannot
-    be followed for any reason, the empty set is returned:
+    JSON value at the end of that path is returned:
 
     .. code-block:: edgeql-repl
 
@@ -330,8 +329,9 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ... }'), 'w', '1');
         {'"foo"'}
 
-    This is useful when certain structure of JSON data is assumed, but
-    cannot be reliably guaranteed:
+    This is useful when certain structure of JSON data is assumed, but cannot
+    be reliably guaranteed. If the path cannot be followed for any reason, the
+    empty set is returned:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -219,7 +219,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
 .. eql:operator:: jsonplus: json ++ json -> json
 
-    Concatenates two :eql:type:`json` arrays, objects, or string values into one.
+    Concatenates two :eql:type:`json` arrays, objects, or strings into one.
 
     The result is a new :eql:type:`json` value containing the elements of both
     concatenated values. If concatenated objects have identical keys, the value

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -124,7 +124,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
 .. eql:type:: std::json
 
-    Represents any arbitrary JSON data:
+    Arbitrary JSON data.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -342,8 +342,8 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ... }'), 'w', '2');
         {}
 
-    Also, a default value can be supplied by using the
-    :eql:op:`coalescence <coalesce>` operator:
+    If you want to supply your own default for the case where the path cannot
+    be followed, you can do so using the :eql:op:`coalesce` operator:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -67,7 +67,7 @@ function:
     db> select <json>'hello world';
     {'"hello world"'}
 
-Any value in EdgeDB can be casted to a :eql:type:`json` type as well:
+Any value in EdgeDB can be cast to a :eql:type:`json` type as well:
 
 .. code-block:: edgeql-repl
 
@@ -76,7 +76,7 @@ Any value in EdgeDB can be casted to a :eql:type:`json` type as well:
     db> select <json>cal::to_local_date(datetime_current(), 'UTC');
     {'"2019-04-02"'}
 
-Additionally, any :eql:type:`Object` in EdgeDB can be casted as a
+Additionally, any :eql:type:`Object` in EdgeDB can be cast as a
 :eql:type:`json` type. This produces the same JSON value as the
 JSON-serialized result of that said object. Furthermore, this result will
 be the same as the output of a :eql:stmt:`select expression <select>` in

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -296,14 +296,14 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     Calling this function on anything other than an :eql:type:`json` array will
     result in a runtime error.
 
+    This function should be used only if the ordering of elements is not
+    important, or when the ordering of the set is preserved (such as an
+    immediate input to an aggregate function).
+
     .. code-block:: edgeql-repl
 
         db> select json_array_unpack(to_json('[1, "a"]'));
         {'1', '"a"'}
-
-    This function should be only used if the ordering of elements are not
-    deemed important, or when the ordering of the set is preserved (such as an
-    immediate input to an aggregate function)
 
 
 ----------

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -278,10 +278,10 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
     .. code-block:: edgeql-repl
 
-        db> select to_json('[1, "hello", null]')[1];
-        {'"hello"'}
-        db> select to_json('{"hello": "world"}')['hello'];
-        {'"world"'}
+        db> select to_json('[1, "hello", null]');
+        {'[1, "hello", null]'}
+        db> select to_json('{"hello": "world"}');
+        {'{"hello": "world"}'}
 
 
 ----------

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -244,7 +244,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
 
 .. eql:operator:: jsonobjdest: json [ str ] -> json
 
-    Accesses an element of a :eql:type:`json` object given its key:
+    Accesses an element of a :eql:type:`json` object given its key.
 
     This results in a :eql:type:`json` type. The fields of any JSON object may
     also be accessed via ``[]``:

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -407,9 +407,9 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ... );
         {'{"a": 10, "b": 20}'}
 
-    *empty_treatment* can be any value from the `JsonEmpty` enumeration. It
+    *empty_treatment* can be any value from the ``JsonEmpty`` enumeration. It
     defines the behavior of the function if an empty set is passed as
-    *new_value*. `JsonEmpty` contains these values:
+    *new_value*. ``JsonEmpty``` contains these values:
 
     - ``ReturnEmpty``: return empty set, default
     - ``ReturnTarget``: return ``target`` unmodified

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -63,18 +63,18 @@ function:
 .. code-block:: edgeql-repl
 
     db> select to_json('{"hello": "world"}');
-    {'{"hello": "world"}'}
+    {Json("{\"hello\": \"world\"}")}
     db> select <json>'hello world';
-    {'"hello world"'}
+    {Json("\"hello world\"")}
 
 Any value in EdgeDB can be cast to a :eql:type:`json` type as well:
 
 .. code-block:: edgeql-repl
 
     db> select <json>2019;
-    {'2019'}
+    {Json("2019")}
     db> select <json>cal::to_local_date(datetime_current(), 'UTC');
-    {'"2019-04-02"'}
+    {Json("\"2022-11-21\"")}
 
 Additionally, any :eql:type:`Object` in EdgeDB can be cast as a
 :eql:type:`json` type. This produces the same JSON value as the
@@ -91,7 +91,7 @@ be the same as the output of a :eql:stmt:`select expression <select>` in
     ...             datetime_current(), 'UTC')
     ...     }
     ...     filter .name = 'std::bool');
-    {'{"name": "std::bool", "timestamp": "2019-04-02"}'}
+    {Json("{\"name\": \"std::bool\", \"timestamp\": \"2022-11-21\"}")}
 
 JSON values can also be cast back into scalars. Casting JSON is symmetrical
 meaning that, if a scalar value can be cast into JSON, a compatible JSON value
@@ -129,7 +129,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select <json>42;
-        {'42'}
+        {Json("42")}
         db> select <bool>to_json('true');
         {true}
 
@@ -156,7 +156,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select to_json('[1, "a"]');
-        {'[1, "a"]'}
+        {Json("[1, \"a\"]")}
         db> select to_str(<json>[1, 2]);
         {'[1, 2]'}
 
@@ -175,13 +175,13 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select <json>'hello'[1];
-        {'"e"'}
+        {Json("\"e\"")}
         db> select <json>'hello'[-1];
-        {'"o"'}
+        {Json("\"o\"")}
         db> select to_json('[1, "a", null]')[1];
-        {'"a"'}
+        {Json("\"a\"")}
         db> select to_json('[1, "a", null]')[-1];
-        {'null'}
+        {Json("null")}
 
     This may raise an exception if the specified index is not valid for the
     base JSON value. To access an index that is potentially out of bounds, use
@@ -201,17 +201,17 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select <json>'hello'[0:2];
-        {'"he"'}
+        {Json("\"he\"")}
         db> select <json>'hello'[2:];
-        {'"llo"'}
+        {Json("\"llo\"")}
         db> select to_json('[1, 2, 3]')[0:2];
-        {'[1, 2]'}
+        {Json("[1, 2]")}
         db> select to_json('[1, 2, 3]')[2:];
-        {'[3]'}
+        {Json("[3]")}
         db> select to_json('[1, 2, 3]')[:1];
-        {'[1]'}
+        {Json("[1]")}
         db> select to_json('[1, 2, 3]')[:-2];
-        {'[1]'}
+        {Json("[1]")}
 
 
 ----------
@@ -230,13 +230,13 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select to_json('[1, 2]') ++ to_json('[3]');
-        {'[1, 2, 3]'}
+        {Json("[1, 2, 3]")}
         db> select to_json('{"a": 1}') ++ to_json('{"b": 2}');
-        {'{"a": 1, "b": 2}'}
+        {Json("{\"a\": 1, \"b\": 2}")}
         db> select to_json('{"a": 1, "b": 2}') ++ to_json('{"b": 3}');
-        {'{"a": 1, "b": 3}'}
+        {Json("{\"a\": 1, \"b\": 3}")}
         db> select to_json('"123"') ++ to_json('"456"');
-        {'"123456"'}
+        {Json("\"123456\"")}
 
 
 ----------
@@ -252,13 +252,13 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select to_json('{"a": 2, "b": 5}')['b'];
-        {'5'}
+        {Json("5")}
         db> select j := <json>(schema::Type {
         ...     name,
         ...     timestamp := cal::to_local_date(datetime_current(), 'UTC')
         ... })
         ... filter j['name'] = <json>'std::bool';
-        {'{"name": "std::bool", "timestamp": "2019-04-02"}'}
+        {Json("{\"name\": \"std::bool\", \"timestamp\": \"2022-11-21\"}")}
 
     The field access operator ``[]`` will raise an exception if the
     specified field does not exist for the base JSON value. To access
@@ -279,9 +279,9 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select to_json('[1, "hello", null]');
-        {'[1, "hello", null]'}
+        {Json("[1, \"hello\", null]")}
         db> select to_json('{"hello": "world"}');
-        {'{"hello": "world"}'}
+        {Json("{\"hello\": \"world\"}")}
 
 
 ----------
@@ -303,7 +303,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
     .. code-block:: edgeql-repl
 
         db> select json_array_unpack(to_json('[1, "a"]'));
-        {'1', '"a"'}
+        {Json("1"), Json("\"a\"")}
 
 
 ----------
@@ -327,7 +327,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ...     "w": [2, "foo"],
         ...     "e": true
         ... }'), 'w', '1');
-        {'"foo"'}
+        {Json("\"foo\"")}
 
     This is useful when certain structure of JSON data is assumed, but cannot
     be reliably guaranteed. If the path cannot be followed for any reason, the
@@ -352,7 +352,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ...     "w": [2, "foo"],
         ...     "e": true
         ... }'), 'w', '2') ?? <json>'mydefault';
-        {'"mydefault"'}
+        {Json("\"mydefault\"")}
 
 
 ----------
@@ -380,13 +380,13 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ...   'a',
         ...   value := <json>true,
         ... );
-        {'{"a": true, "b": 20}'}
+        {Json("{\"a\": true, \"b\": 20}")}
         db> select json_set(
         ...   to_json('{"a": {"b": {}}}'),
         ...   'a', 'b', 'c',
         ...   value := <json>42,
         ... );
-        {'{"a": {"b": {"c": 42}}}'}
+        {Json("{\"a\": {\"b\": {\"c\": 42}}}")}
 
     If *create_if_missing* is set to ``false``, a new path for the value
     won't be created:
@@ -398,14 +398,14 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ...   'с',
         ...   value := <json>42,
         ... );
-        {'{"a": 10, "b": 20, "c": 42}'}
+        {Json("{\"a\": 10, \"b\": 20, \"с\": 42}")}
         db> select json_set(
         ...   to_json('{"a": 10, "b": 20}'),
         ...   'с',
         ...   value := <json>42,
         ...   create_if_missing := false,
         ... );
-        {'{"a": 10, "b": 20}'}
+        {Json("{\"a\": 10, \"b\": 20}")}
 
     *empty_treatment* can be any value from the ``JsonEmpty`` enumeration. It
     defines the behavior of the function if an empty set is passed as
@@ -431,7 +431,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ...   value := <json>{},
         ...   empty_treatment := JsonEmpty.ReturnTarget,
         ... );
-        {'{"a": 10, "b": 20}'}
+        {Json("{\"a\": 10, \"b\": 20}")}
         db> select json_set(
         ...   to_json('{"a": 10, "b": 20}'),
         ...   'a',
@@ -445,14 +445,14 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ...   value := <json>{},
         ...   empty_treatment := JsonEmpty.UseNull,
         ... );
-        {'{"a": null, "b": 20}'}
+        {Json("{\"a\": null, \"b\": 20}")}
         db> select json_set(
         ...   to_json('{"a": 10, "b": 20}'),
         ...   'a',
         ...   value := <json>{},
         ...   empty_treatment := JsonEmpty.DeleteKey,
         ... );
-        {'{"b": 20}'}
+        {Json("{\"b\": 20}")}
 
 ----------
 
@@ -472,8 +472,7 @@ reversible (i.e., it is not possible to cast a JSON value directly into a
         ...     "w": [2, "foo"],
         ...     "e": true
         ... }'));
-        {('e', 'true'), ('q', '1'), ('w', '[2, "foo"]')}
-
+        {('e', Json("true")), ('q', Json("1")), ('w', Json("[2, \"foo\"]"))}
 
 ----------
 

--- a/docs/stdlib/json.rst
+++ b/docs/stdlib/json.rst
@@ -55,10 +55,10 @@ JSON
 Constructing JSON Values
 ------------------------
 
-JSON in EdgeDB is a variation of
-:ref:`scalar types <ref_datamodel_scalar_types>`. This type doesn't have its
-own literal, and instead can be obtained by either casting a value to the
-:eql:type:`json` type, or by using the :eql:func:`to_json` function:
+JSON in EdgeDB is a :ref:`scalar type <ref_datamodel_scalar_types>`. This type
+doesn't have its own literal, and instead can be obtained by either casting a
+value to the :eql:type:`json` type, or by using the :eql:func:`to_json`
+function:
 
 .. code-block:: edgeql-repl
 

--- a/docs/stdlib/math.rst
+++ b/docs/stdlib/math.rst
@@ -36,7 +36,7 @@ Math
 
     :index: round
 
-    Returns a numerical value of ``x`` rounded up to its nearest integer:
+    Returns the given numeric value rounded up to its nearest integer.
 
     .. code-block:: edgeql-repl
 
@@ -56,7 +56,7 @@ Math
 
     :index: round
 
-    Returns a numerical value with ``x`` rounded down to its nearest integer:
+    Returns the given numeric value rounded down to its nearest integer.
 
     .. code-block:: edgeql-repl
 
@@ -75,7 +75,7 @@ Math
 
     :index: logarithm
 
-    Returns the natural logarithm of ``x``:
+    Returns the natural logarithm of the given value.
 
     .. code-block:: edgeql-repl
 
@@ -92,7 +92,7 @@ Math
 
     :index: logarithm
 
-    Returns the base-10 logarithm of ``x``:
+    Returns the base-10 logarithm of the given value:
 
     .. code-block:: edgeql-repl
 
@@ -106,7 +106,7 @@ Math
 
     :index: logarithm
 
-    Returns the logarithm of ``x`` by the specified ``base``:
+    Returns the logarithm of the given value to the specified base.
 
     .. code-block:: edgeql-repl
 
@@ -123,7 +123,7 @@ Math
 
     :index: average avg
 
-    Returns the arithmetic average/mean value of ``x``:
+    Returns the arithmetic mean (i.e., average) of the input set.
 
     .. code-block:: edgeql-repl
 
@@ -140,7 +140,7 @@ Math
 
     :index: average
 
-    Returns the sample standard deviation of ``x``:
+    Returns the sample standard deviation of the input set.
 
     .. code-block:: edgeql-repl
 
@@ -153,7 +153,7 @@ Math
 
     :index: average
 
-    Returns the population standard deviation of ``x``:
+    Returns the population standard deviation of the input set.
 
     .. code-block:: edgeql-repl
 
@@ -170,7 +170,7 @@ Math
 
     :index: average
 
-    Returns the sample variance of ``x``:
+    Returns the sample variance of the input set.
 
     .. code-block:: edgeql-repl
 
@@ -187,7 +187,7 @@ Math
 
     :index: average
 
-    Returns the population variance of ``x``:
+    Returns the population variance of the input set.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/math.rst
+++ b/docs/stdlib/math.rst
@@ -36,7 +36,7 @@ Math
 
     :index: round
 
-    Returns the given numeric value rounded up to its nearest integer.
+    Returns the given value rounded up to its nearest integer.
 
     .. code-block:: edgeql-repl
 
@@ -56,7 +56,7 @@ Math
 
     :index: round
 
-    Returns the given numeric value rounded down to its nearest integer.
+    Returns the given value rounded down to its nearest integer.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/math.rst
+++ b/docs/stdlib/math.rst
@@ -92,7 +92,7 @@ Math
 
     :index: logarithm
 
-    Returns the base-10 logarithm of the given value:
+    Returns the base-10 logarithm of the given value.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/math.rst
+++ b/docs/stdlib/math.rst
@@ -36,7 +36,7 @@ Math
 
     :index: round
 
-    Returns the given value rounded up to its nearest integer.
+    Returns the given value rounded up to the nearest integer.
 
     .. code-block:: edgeql-repl
 
@@ -56,7 +56,7 @@ Math
 
     :index: round
 
-    Returns the given value rounded down to its nearest integer.
+    Returns the given value rounded down to the nearest integer.
 
     .. code-block:: edgeql-repl
 
@@ -106,7 +106,7 @@ Math
 
     :index: logarithm
 
-    Returns the logarithm of the given value to the specified base.
+    Returns the logarithm of the given value in the specified base.
 
     .. code-block:: edgeql-repl
 
@@ -123,7 +123,7 @@ Math
 
     :index: average avg
 
-    Returns the arithmetic mean (i.e., average) of the input set.
+    Returns the arithmetic mean of the input set.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/math.rst
+++ b/docs/stdlib/math.rst
@@ -92,7 +92,7 @@ Math
 
     :index: logarithm
 
-    Returns the Base 10 logarithm of ``x``:
+    Returns the base-10 logarithm of ``x``:
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/math.rst
+++ b/docs/stdlib/math.rst
@@ -16,7 +16,7 @@ Math
 
     :index: absolute
 
-    Returns the absolute value of ``x``:
+    Returns the absolute value of the given value.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -765,8 +765,8 @@ from :eql:type:`str` and :eql:type:`json`.
     :index: parse bigint
 
     Returns a :eql:type:`bigint` value parsed from the given string.
-    
-    The function will use an optional format string passed as *fmt*. See the 
+
+    The function will use an optional format string passed as *fmt*. See the
     :ref:`number formatting options <ref_std_converters_number_fmt>` for help
     writing a format string.
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -511,7 +511,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: power pow
 
-    Produces the value of the left operand raised to the power of the right one.
+    Produces the value of the left operand to the power of the right one.
 
     .. code-block:: edgeql-repl
 
@@ -670,8 +670,8 @@ from :eql:type:`str` and :eql:type:`json`.
     Returns the result of a bitwise left-shift operation on an integer.
 
     The integer *val* is shifted by *n* bits to the left. The rightmost added
-    bits are all ``0``. Shifting an integer by a number of bits greater than the
-    bit size of the integer results in ``0``.
+    bits are all ``0``. Shifting an integer by a number of bits greater than
+    the bit size of the integer results in ``0``.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -471,9 +471,9 @@ from :eql:type:`str` and :eql:type:`json`.
     This is commonly referred to as a "modulo" operation.
 
 
-    This is the remainder from floor division. Just as is
-    the case with the :eql:op:`//<floordiv>` operator, the result type of
-    the remainder operator corresponds to the left operand's type:
+    This is the remainder from floor division. As with the
+    :eql:op:`//<floordiv>` operator, the result type produced by the remainder
+    operator is derived from the types of its operands.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -144,8 +144,8 @@ from :eql:type:`str` and :eql:type:`json`.
 
     Represents a 16-bit signed integer.
 
-    The value of an :eql:type:`int16` ranges from ``-32768`` to ``+32767``
-    (inclusive).
+    :eql:type:`int16` is capable of representing values from ``-32768`` to
+    ``+32767``, inclusive.
 
 
 ----------
@@ -212,14 +212,15 @@ from :eql:type:`str` and :eql:type:`json`.
 
     Represents an arbitrary precision integer.
 
-    In EdgeDB, the philosophy of :eql:type:`bigint` is that using this type
-    should be an explicit opt-in and not implicit. Once used, these values
-    should not be accidentally casted to a different numerical type that gives
-    less precision.
+    Our philosophy is that use of :eql:type:`bigint` should always be an
+    explicit opt-in and should never be implicit. Once used, these values
+    should not be accidentally cast to a different numerical type that could
+    lead to a loss of precision.
 
-    In addition with this, :ref:`our mathematical functions <ref_std_math>`
-    are designed to keep separation between big integer values and the
-    rest of our numerical types.
+    In keeping with this philosophy,
+    :ref:`our mathematical functions <ref_std_math>`
+    are designed to maintain separation between big integer values and the rest
+    of our numeric types.
 
     All of the following types can be explicitly cast into a
     :eql:type:`bigint` type:
@@ -233,8 +234,7 @@ from :eql:type:`str` and :eql:type:`json`.
     - :eql:type:`float64`
     - :eql:type:`decimal`
 
-    A :eql:type:`bigint` literal is also an integer literal, followed by
-    ``n``:
+    A :eql:type:`bigint` literal is an integer literal, followed by ``n``:
 
     .. code-block:: edgeql-repl
 
@@ -243,7 +243,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     To represent really big integers, it is possible to use the
     exponent notation (e.g. ``1e20n`` instead of ``100000000000000000000n``)
-    so as long as the exponent is positive and there is no dot anywhere:
+    as long as the exponent is positive and there is no dot anywhere:
 
     .. code-block:: edgeql-repl
 
@@ -263,11 +263,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     .. note::
 
-        Caution is advised when casting :eql:type:`bigint` values into
+        Use caution when casting :eql:type:`bigint` values into
         :eql:type:`json`. The JSON specification does not have a limit on
-        significant digits, so a big integer number can be losslessly
+        significant digits, so a :eql:type:`bigint` number can be losslessly
         represented in JSON. However, JSON decoders in many languages
-        will read all such numbers as some kind of 32 or 64-bit
+        will read all such numbers as some kind of 32-bit or 64-bit
         number type, which may result in errors or precision loss. If
         such loss is unacceptable, then consider casting the value
         into a :eql:type:`str` and decoding it on the client side into a more
@@ -283,14 +283,15 @@ from :eql:type:`str` and :eql:type:`json`.
 
     Represents any number of arbitrary precision.
 
-    In EdgeDB, the philosophy of :eql:type:`bigint` is that using this type
-    should be an explicit opt-in and not implicit. Once used, these values
-    should not be accidentally casted to a different numerical type that gives
-    less precision.
+    Our philosophy is that use of :eql:type:`decimal` should always be an
+    explicit opt-in and should never be implicit. Once used, these values
+    should not be accidentally cast to a different numerical type that could
+    lead to a loss of precision.
 
-    In addition to this, :ref:`our mathematical functions <ref_std_math>`
-    are designed to keep separation between decimal values and the rest of
-    our numerical types.
+    In keeping with this philosophy,
+    :ref:`our mathematical functions <ref_std_math>`
+    are designed to maintain separation between decimal values and the rest of
+    our numeric types.
 
     All of the following types can be explicitly cast into decimal:
     - :eql:type:`str`
@@ -326,9 +327,9 @@ from :eql:type:`str` and :eql:type:`json`.
 
     .. note::
 
-        Caution is advised when casting :eql:type:`decimal` values into
+        Use caution when casting :eql:type:`decimal` values into
         :eql:type:`json`. The JSON specification does not have a limit on
-        significant digits, so a decimal number can be losslessly
+        significant digits, so a :eql:type:`decimal` number can be losslessly
         represented in JSON. However, JSON decoders in many languages
         will read all such numbers as some kind of floating point
         values, which may result in precision loss. If such loss is
@@ -425,11 +426,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: floor divide division
 
-    Performs a floor based divison between two arbitrary numbers.
+    Performs floor-based division between two arbitrary numbers.
 
-    The result of this operation is rounded down to its nearest integer.
-    It is the equivalent to using regular division and then applying
-    :eql:func:`math::floor` to the result:
+    In floor-based division, the result of a standard division operation is
+    rounded down to its nearest integer. It is the equivalent to using regular
+    division and then applying :eql:func:`math::floor` to the result.
 
     .. code-block:: edgeql-repl
 
@@ -440,7 +441,8 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select -10 // 4;
         {-3}
 
-    This also works on :eql:type:`float <anyfloat>`, :eql:type:`bigint` and
+    Floor-based division works with integers as shown in the examples above,
+    but it also works on :eql:type:`float <anyfloat>`, :eql:type:`bigint`, and
     :eql:type:`decimal` types. The type of the result corresponds to
     the type of its operands:
 
@@ -453,7 +455,7 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select 37 // 11;
         {3}
 
-    Regular division, floor division and :eql:op:`%<mod>` operations are
+    Regular division, floor division, and :eql:op:`%<mod>` operations are
     related in the following way: ``A // B  =  (A - (A % B)) / B``.
 
 
@@ -464,10 +466,13 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: modulo mod division
 
-    Retrieves the remainder from a division operation. (modulo)
+    Returns the remainder after division of the operands.
+    
+    This is commonly referred to as a "modulo" operation.
 
-    This is also the remainder from floor division. Just as is
-    the case with the :eql:op:`//<floordiv>` operator, the resulting type of
+
+    This is the remainder from floor division. Just as is
+    the case with the :eql:op:`//<floordiv>` operator, the result type of
     the remainder operator corresponds to the left operand's type:
 
     .. code-block:: edgeql-repl
@@ -487,8 +492,8 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select 37 % 11;
         {4}
 
-    In regular division, the :eql:op:`//<floordiv>` and :eql:op:`%<mod>`
-    operators are related in the following way:
+    Regular division, :eql:op:`//<floordiv>` operations, and :eql:op:`%<mod>`
+    operations are related in the following way:
     ``A // B  =  (A - (A % B)) / B``.
 
     Modulo division by zero will result in an exception:
@@ -506,7 +511,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: power pow
 
-    Performs a power (exponential) operation by two arbitrary numbers:
+    Produces the value of the left operand raised to the power of the right one.
 
     .. code-block:: edgeql-repl
 
@@ -523,7 +528,7 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::round(value: decimal) -> decimal
                   std::round(value: decimal, d: int64) -> decimal
 
-    Returns a number from ``value`` rounded by its nearest integer.
+    Returns the given number rounded to its nearest value.
 
     There's a difference in how ties (which way ``0.5`` is rounded)
     are handled depending on the type of the inputted ``value``.
@@ -554,9 +559,8 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select round(2.5n);
         {3n}
 
-    Additionally, when rounding a :eql:type:`decimal` value, an
-    optional argument ``d`` may be provided to further specify what decimal
-    point the value must to be rounded to:
+    Additionally, when rounding a :eql:type:`decimal` value, you may pass the
+    optional argument *d* to specify the precision of the rounded result:
 
     .. code-block:: edgeql-repl
 
@@ -596,7 +600,7 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::bit_and(l: int32, r: int32) -> int32
                   std::bit_and(l: int64, r: int64) -> int64
 
-    Returns the result of a bitwise AND operator for two integers:
+    Returns the result of a bitwise AND operation for two integers.
 
     .. code-block:: edgeql-repl
 
@@ -611,7 +615,7 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::bit_or(l: int32, r: int32) -> int32
                   std::bit_or(l: int64, r: int64) -> int64
 
-    Returns the result of a bitwise OR operator for two integers.
+    Returns the result of a bitwise OR operation for two integers.
 
     .. code-block:: edgeql-repl
 
@@ -626,7 +630,7 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::bit_xor(l: int32, r: int32) -> int32
                   std::bit_xor(l: int64, r: int64) -> int64
 
-    Returns the result of an exclusive, bitwise OR operator for two integers:
+    Returns the result of an exclusive bitwise OR operation for two integers.
 
     .. code-block:: edgeql-repl
 
@@ -641,7 +645,7 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::bit_not(r: int32) -> int32
                   std::bit_not(r: int64) -> int64
 
-    Returns the result of a bitwise negation operator for two integers.
+    Returns the result of a bitwise negation operation for two integers.
 
     Bitwise negation for integers ends up similar to mathematical negation
     because typically the signed integers use "two's complement"
@@ -663,11 +667,11 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::bit_lshift(val: int32, n: int64) -> int32
                   std::bit_lshift(val: int64, n: int64) -> int64
 
-    Returns the result of a bitwise left-shift operator for two integers.
+    Returns the result of a bitwise left-shift operation on an integer.
 
-    The integer of ``val`` is shifted by ``n`` bits to the left. The rightmost
-    added bits are all ``0``. Shifting an integer by a number of bits larger
-    than the bit size of the integer results in ``0``:
+    The integer *val* is shifted by *n* bits to the left. The rightmost added
+    bits are all ``0``. Shifting an integer by a number of bits greater than the
+    bit size of the integer results in ``0``.
 
     .. code-block:: edgeql-repl
 
@@ -676,7 +680,7 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select bit_lshift(123, 65);
         {0}
 
-    It is possible to affect the sign bit by left-shifting an integer:
+    Left-shifting an integer can change the sign bit:
 
     .. code-block:: edgeql-repl
 
@@ -693,7 +697,7 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select bit_lshift(123, 4);
         {1968}
 
-    An exception will be raised when attempting to shift by a negative number
+    EdgeDB will raise an exception if you attempt to shift by a negative number
     of bits:
 
     .. code-block:: edgeql-repl
@@ -710,15 +714,13 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::bit_rshift(val: int32, n: int64) -> int32
                   std::bit_rshift(val: int64, n: int64) -> int64
 
-    Returns the result of a bitwise right-shift operator for
-    two integers.
+    Returns the result of a bitwise right-shift operator on an integer.
 
-    The integer of ``val`` is shifted by ``n`` bits to the right. In the
-    arithmetic, right-shifting the sign is preserved. This means that the
-    leftmost added bits are ``1`` or ``0`` depending on the sign bit.
-    Shifting an integer by a number of bits larger than the bit size of the
-    integer results in ``0`` for positive numbers and ``-1`` for negative
-    numbers:
+    The integer *val* is shifted by *n* bits to the right. In the arithmetic
+    right shift, the sign is preserved. This means that the leftmost added bits
+    are ``1`` or ``0`` depending on the sign bit. Shifting an integer by a
+    number of bits greater than the bit size of the integer results in ``0``
+    for positive numbers or ``-1`` for negative numbers.
 
     .. code-block:: edgeql-repl
 
@@ -745,7 +747,7 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select bit_rshift(-123, 4);
         {-8}
 
-    An exception will be raised when attempting to shift by a negative number
+    EdgeDB will raise an exception if you attempt to shift by a negative number
     of bits:
 
     .. code-block:: edgeql-repl
@@ -762,8 +764,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: parse bigint
 
-    Returns a :eql:type:`bigint` value from ``s`` with a possible format of
-    ``fmt``:
+    Returns a :eql:type:`bigint` value parsed from the given string.
+    
+    The function will use an optional format string passed as *fmt*. See the 
+    :ref:`number formatting options <ref_std_converters_number_fmt>` for help
+    writing a format string.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -710,7 +710,7 @@ from :eql:type:`str` and :eql:type:`json`.
                   std::bit_rshift(val: int32, n: int64) -> int32
                   std::bit_rshift(val: int64, n: int64) -> int64
 
-    Returns the result of a bitwise, arithemtic right-shift operator for
+    Returns the result of a bitwise right-shift operator for
     two integers.
 
     The integer of ``val`` is shifted by ``n`` bits to the right. In the

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -374,7 +374,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: unary minus subtract
 
-    Performs a logical negation of an arthimetic, arbitrarily numerical value:
+    Negates the value of a number.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -785,8 +785,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: parse decimal
 
-    Returns a :eql:type:`decimal` value from ``s`` with possible format of
-    ``fmt``:
+    Returns a :eql:type:`decimal` value parsed from the given string.
+
+    The function will use an optional format string passed as *fmt*. See the
+    :ref:`number formatting options <ref_std_converters_number_fmt>` for help
+    writing a format string.
 
     .. code-block:: edgeql-repl
 
@@ -797,9 +800,6 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select to_decimal('31st', '999th');
         {31.0n}
 
-    For more details on formatting see :ref:`here
-    <ref_std_converters_number_fmt>`.
-
 
 ------------
 
@@ -808,11 +808,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: parse int16
 
-    Returns an :eql:type:`int16` value from ``s`` with possible format of
-    ``fmt``:
+    Returns a :eql:type:`int16`  value parsed from the given string.
 
-    For more details on formatting see :ref:`here
-    <ref_std_converters_number_fmt>`.
+    The function will use an optional format string passed as *fmt*. See the
+    :ref:`number formatting options <ref_std_converters_number_fmt>` for help
+    writing a format string.
 
 
 ------------
@@ -822,11 +822,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: parse int32
 
-    Returns an :eql:type:`int32` value from ``s`` with possible format of
-    ``fmt``:
+    Returns a :eql:type:`int32`  value parsed from the given string.
 
-    For more details on formatting see :ref:`here
-    <ref_std_converters_number_fmt>`.
+    The function will use an optional format string passed as *fmt*. See the
+    :ref:`number formatting options <ref_std_converters_number_fmt>` for help
+    writing a format string.
 
 
 ------------
@@ -836,11 +836,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: parse int64
 
-    Returns an :eql:type:`int64` value from ``s`` with possible format of
-    ``fmt``:
+    Returns a :eql:type:`int64`  value parsed from the given string.
 
-    For more details on formatting see :ref:`here
-    <ref_std_converters_number_fmt>`.
+    The function will use an optional format string passed as *fmt*. See the
+    :ref:`number formatting options <ref_std_converters_number_fmt>` for help
+    writing a format string.
 
 
 ------------
@@ -850,11 +850,11 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: parse float32
 
-    Returns a :eql:type:`float32` value from ``s`` with possible format of
-    ``fmt``:
+    Returns a :eql:type:`float32`  value parsed from the given string.
 
-    For more details on formatting see :ref:`here
-    <ref_std_converters_number_fmt>`.
+    The function will use an optional format string passed as *fmt*. See the
+    :ref:`number formatting options <ref_std_converters_number_fmt>` for help
+    writing a format string.
 
 
 ------------
@@ -864,8 +864,8 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: parse float64
 
-    Returns a :eql:type:`float64` value from ``s`` with possible format of
-    ``fmt``:
+    Returns a :eql:type:`float64`  value parsed from the given string.
 
-    For more details on formatting see :ref:`here
-    <ref_std_converters_number_fmt>`.
+    The function will use an optional format string passed as *fmt*. See the
+    :ref:`number formatting options <ref_std_converters_number_fmt>` for help
+    writing a format string.

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -344,7 +344,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: plus add
 
-    Performs arithmetic addition between two arbitrary numbers:
+    Performs arithmetic addition between two arbitrary numbers.
 
     .. code-block:: edgeql-repl
 
@@ -359,7 +359,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: minus subtract
 
-    Performs arithmetic subtraction between two arbitrary numbers:
+    Performs arithmetic subtraction between two arbitrary numbers.
 
     .. code-block:: edgeql-repl
 
@@ -389,7 +389,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: multiply multiplication
 
-    Performs arithmetic multiplication between two arbitrary numbers:
+    Performs arithmetic multiplication between two arbitrary numbers.
 
     .. code-block:: edgeql-repl
 
@@ -404,7 +404,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: divide division
 
-    Performs arithmetic division between two arbitrary numbers:
+    Performs arithmetic division between two arbitrary numbers.
 
     .. code-block:: edgeql-repl
 
@@ -585,7 +585,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
 .. eql:function:: std::random() -> float64
 
-    Returns a pseudo-random number in the range of ``0.0 <= x < 1.0``:
+    Returns a pseudo-random number in the range of ``0.0 <= x < 1.0``.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -530,8 +530,8 @@ from :eql:type:`str` and :eql:type:`json`.
 
     Returns the given number rounded to its nearest value.
 
-    There's a difference in how ties (which way ``0.5`` is rounded)
-    are handled depending on the type of the inputted ``value``.
+    The function will round a ``.5`` value differently depending on the type of
+    the parameter passed.
 
     The :eql:type:`float64` tie is rounded to the nearest even number:
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -777,9 +777,6 @@ from :eql:type:`str` and :eql:type:`json`.
         db> select to_bigint('31st', '999th');
         {31n}
 
-    For more details on formatting see :ref:`here
-    <ref_std_converters_number_fmt>`.
-
 
 ------------
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -145,7 +145,7 @@ from :eql:type:`str` and :eql:type:`json`.
     A 16-bit signed integer.
 
     :eql:type:`int16` is capable of representing values from ``-32768`` to
-    ``+32767``, inclusive.
+    ``+32767`` (inclusive).
 
 
 ----------
@@ -374,7 +374,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: unary minus subtract
 
-    Negates the value of a number.
+    Produces the arithmetic negative of a number.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/numbers.rst
+++ b/docs/stdlib/numbers.rst
@@ -142,7 +142,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: int integer
 
-    Represents a 16-bit signed integer.
+    A 16-bit signed integer.
 
     :eql:type:`int16` is capable of representing values from ``-32768`` to
     ``+32767``, inclusive.
@@ -155,7 +155,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: int integer
 
-    Represents a 32-bit signed integer.
+    A 32-bit signed integer.
 
     The value of an :eql:type:`int32` ranges from ``-2147483648`` to
     ``+2147483647`` (inclusive).
@@ -168,7 +168,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: int integer
 
-    Represents a 64-bit signed integer.
+    A 64-bit signed integer.
 
     An integer value in range from ``-9223372036854775808`` to
     ``+9223372036854775807`` (inclusive).
@@ -181,7 +181,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: float
 
-    Represents a variable precision, inexact number.
+    A variable precision, inexact number.
 
     The minimal guaranteed precision is at least 6 decimal digits. The
     approximate range of a :eql:type:`float32` ranges from ``-3.4e+38`` to
@@ -195,7 +195,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: float double
 
-    Represents a variable precision, inexact number. Also see
+    A variable precision, inexact number. Also see
     :eql:type:`float32`.
 
     The minimal guaranteed precision is at least 15 decimal digits. The
@@ -210,7 +210,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: numeric bigint
 
-    Represents an arbitrary precision integer.
+    An arbitrary precision integer.
 
     Our philosophy is that use of :eql:type:`bigint` should always be an
     explicit opt-in and should never be implicit. Once used, these values
@@ -281,7 +281,7 @@ from :eql:type:`str` and :eql:type:`json`.
 
     :index: numeric float
 
-    Represents any number of arbitrary precision.
+    Any number of arbitrary precision.
 
     Our philosophy is that use of :eql:type:`decimal` should always be an
     explicit opt-in and should never be implicit. Once used, these values

--- a/docs/stdlib/objects.rst
+++ b/docs/stdlib/objects.rst
@@ -14,7 +14,7 @@ Base Objects
       - Root for user-defined object types
 
 
-:eql:type:`BaseObject` is the root of the object type hierarchy and all object
+:eql:type:`BaseObject` is the root of the object type hierarchy, and all object
 types in EdgeDB, including system types, extend it either directly or
 indirectly. User-defined object types extend from the :eql:type:`Object` type,
 which is a subtype of ``std::BaseObject``.

--- a/docs/stdlib/objects.rst
+++ b/docs/stdlib/objects.rst
@@ -14,10 +14,10 @@ Base Objects
       - Root for user-defined object types
 
 
-:eql:type:`BaseObject` is the root of the object type hierarchy and all
-object types in EdgeDB, including system types, whether extending it directly
-or indirectly. User-defined object types extend from the :eql:type:`Object`
-type, which is a subtype of ``std::BaseObject``.
+:eql:type:`BaseObject` is the root of the object type hierarchy and all object
+types in EdgeDB, including system types, extend it either directly or
+indirectly. User-defined object types extend from the :eql:type:`Object` type,
+which is a subtype of ``std::BaseObject``.
 
 
 ---------
@@ -25,7 +25,7 @@ type, which is a subtype of ``std::BaseObject``.
 
 .. eql:type:: std::BaseObject
 
-    Represents the root object of a type:
+    The root object type.
 
     .. code-block:: sdl
 
@@ -41,8 +41,8 @@ type, which is a subtype of ``std::BaseObject``.
             required readonly link __type__ -> schema::ObjectType;
         }
 
-    Some subtypes may override the ``id`` property, but only to validate
-    UUID generation functions. Currently, these include
+    Subtypes may override the ``id`` property, but only with a valid UUID
+    generation function. Currently, these are
     :eql:func:`uuid_generate_v1mc` and :eql:func:`uuid_generate_v4`.
 
 

--- a/docs/stdlib/objects.rst
+++ b/docs/stdlib/objects.rst
@@ -51,7 +51,7 @@ which is a subtype of ``std::BaseObject``.
 
 .. eql:type:: std::Object
 
-    Represents the root object of a type for all user-defined types:
+    The root object type for all user-defined types.
 
     .. code-block:: sdl
 

--- a/docs/stdlib/range.rst
+++ b/docs/stdlib/range.rst
@@ -40,7 +40,7 @@ For example:
     {range(2.2, 3.3, inc_lower := true, inc_upper := false)}
 
 Broadly there are two kinds of ranges: :eql:type:`discrete <anydiscrete>` and
-:eql:type:`contiguous <anycontiguous>`. The discrete ranges are:
+:eql:type:`contiguous <anycontiguous>`. The discrete ranges are
 ``range<int32>``, ``range<int64>``, and ``range<cal::local_date>``. All ranges
 over discrete types get normalized in a way where the lower bound is included
 (if present) and the upper bound is excluded:

--- a/docs/stdlib/range.rst
+++ b/docs/stdlib/range.rst
@@ -42,8 +42,8 @@ For example:
 Broadly there are two kinds of ranges: :eql:type:`discrete <anydiscrete>` and
 :eql:type:`contiguous <anycontiguous>`. The discrete ranges are
 ``range<int32>``, ``range<int64>``, and ``range<cal::local_date>``. All ranges
-over discrete types get normalized in a way where the lower bound is included
-(if present) and the upper bound is excluded:
+over discrete types get normalized such that the lower bound is included (if
+present) and the upper bound is excluded:
 
 .. code-block:: edgeql-repl
 

--- a/docs/stdlib/range.rst
+++ b/docs/stdlib/range.rst
@@ -101,7 +101,7 @@ each other (as long as the types are compatible):
 JSON representation
 ^^^^^^^^^^^^^^^^^^^
 
-Much like :ref:`arrays<ref_std_array>` and :ref:`tuples<ref_std_tuple>` the
+Much like :ref:`arrays<ref_std_array>` and :ref:`tuples<ref_std_tuple>`, the
 range types cannot be directly cast to a :eql:type:`str`, but instead can be
 cast into a :eql:type:`json` structure:
 

--- a/docs/stdlib/sequence.rst
+++ b/docs/stdlib/sequence.rst
@@ -50,6 +50,10 @@ Sequences
 
     Increments the given sequence to its next value and returns that value.
 
+    See the note on :ref:`specifying your sequence
+    <ref_std_specifying_sequence>` for best practices on supplying the *seq*
+    parameter.
+
     Sequence advancement is done atomically; each concurrent session and
     transaction will receive a distinct sequence value.
 
@@ -67,6 +71,10 @@ Sequences
                     seq: schema::ScalarType, val: int64) -> int64
 
     Resets a sequence to initial state or a given value, returning the value.
+
+    See the note on :ref:`specifying your sequence
+    <ref_std_specifying_sequence>` for best practices on supplying the *seq*
+    parameter.
 
     The single-parameter form resets the sequence to its initial state, where
     the next :eql:func:`sequence_next` call will return the first value in
@@ -87,6 +95,8 @@ Sequences
 
 
 ---------
+
+.. _ref_std_specifying_sequence:
 
 .. note::
 
@@ -117,8 +127,7 @@ Sequences
             select schema::ScalarType
             filter .name = <str>$seq_type_name
         )
-        select
-        sequence_next(SeqType);
+        select sequence_next(SeqType);
 
 
 .. warning::

--- a/docs/stdlib/sequence.rst
+++ b/docs/stdlib/sequence.rst
@@ -22,7 +22,7 @@ Sequences
 
 .. eql:type:: std::sequence
 
-    Represents an auto-incrementing sequence of the :eql:type:`int64` type.
+    An auto-incrementing sequence of :eql:type:`int64` values.
 
     This type can be used to create auto-incrementing :ref:`properties
     <ref_datamodel_props>`:
@@ -48,10 +48,10 @@ Sequences
 
 .. eql:function:: std::sequence_next(seq: schema::ScalarType) -> int64
 
-    Returns the next incrementation of a sequence to its next value.
+    Increments the given sequence to its next value and returns that value.
 
     Sequence advancement is done atomically; each concurrent session and
-    transaction will receive a distinct sequence value:
+    transaction will receive a distinct sequence value.
 
     .. code-block:: edgeql-repl
 
@@ -66,12 +66,13 @@ Sequences
                   std::sequence_reset( \
                     seq: schema::ScalarType, val: int64) -> int64
 
-    Returns the initial state of a sequence or a specified ``val``.
+    Resets a sequence to initial state or a given value, returning the value.
 
     The single-parameter form resets the sequence to its initial state, where
     the next :eql:func:`sequence_next` call will return the first value in
-    the sequence. The two-parameters form allows changing the last returned
-    value of the sequence:
+    the sequence. The two-parameter form allows you to set the current value of
+    the sequence. The next :eql:func:`sequence_next` call will return the value
+    after the one you passed to :eql:func:`sequence_reset`.
 
     .. code-block:: edgeql-repl
 
@@ -89,10 +90,10 @@ Sequences
 
 .. note::
 
-    Any sequence that can be called upon by either :eql:func:`sequence_next`
-    or :eql:func:`sequence_rest` functions are specified by a
+    To specify the sequence to be operated on by either
+    :eql:func:`sequence_next` or :eql:func:`sequence_reset`, you must pass a
     ``schema::ScalarType`` object. If the sequence argument is known ahead of
-    time and does not change, the recommended way to pass it is to use the
+    time and does not change, we recommend passing it by using the
     :eql:op:`introspect` operator:
 
     .. code-block:: edgeql
@@ -105,9 +106,9 @@ Sequences
     type from a given expression is tracked properly to guarantee schema
     referential integrity.
 
-    However, the operation of a sequence type is determined at runtime via. a
-    query argument. It must be queried from the ``schema::ScalarType`` object
-    directly:
+    It doesn't work in every use case, though. If in your use case, the
+    sequence type must be determined at run time via a query argument,
+    you will need to query it from the ``schema::ScalarType`` set directly:
 
     .. code-block:: edgeql
 

--- a/docs/stdlib/sequence.rst
+++ b/docs/stdlib/sequence.rst
@@ -39,8 +39,8 @@ Sequences
 
     A sequence is bound to the scalar type, not to the property, so
     if multiple properties use the same sequence, they will share the same
-    counter. For each distinct counter, a separate scalar type that is extending
-    :eql:type:`sequence` should be used.
+    counter. For each distinct counter, a separate scalar type that is
+    extending :eql:type:`sequence` should be used.
 
 
 ---------

--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -465,7 +465,7 @@ Sets
 
     :index: aggregate
 
-    Returns the number of elements in a set:
+    Returns the number of elements in a set.
 
     .. code-block:: edgeql-repl
 
@@ -586,7 +586,7 @@ Sets
 
     :index: aggregate
 
-    Returns the smallest value of ``values``:
+    Returns the smallest value in the given set.
 
     .. code-block:: edgeql-repl
 
@@ -601,7 +601,7 @@ Sets
 
     :index: aggregate
 
-    Returns the greatest value of ``values``:
+    Returns the largest value in the given set.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -530,8 +530,7 @@ Sets
 
     :index: aggregate
 
-    Returns a :eql:type:`bool` value with :eql:op:`or` applied to all
-    values.
+    Returns ``true`` if any of the values in the given set is ``true``.
 
     The result is ``true`` if any of the *values* are ``true``, with
     ``false`` returned otherwise.

--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -89,7 +89,7 @@ Sets
 
 .. eql:operator:: distinct: distinct set of anytype -> set of anytype
 
-    Gives back a set without repeating any elements.
+    Produces a set of all unique elements in the given set.
 
     ``distinct`` is a set operator that returns a new set where
     no member is equal to any other member.
@@ -108,10 +108,12 @@ Sets
 
     :index: intersection
 
-    Performs a logical check of membership for an element in a set.
+    Checks if a given element is a member of a given set.
 
-    Set membership operators ``in`` and ``not in`` test for each
-    element of ``A`` whether it is present in ``B``.
+    Set membership operators ``in`` and ``not in`` test whether each element of
+    the left operand is present in the right operand. This means supplying a
+    set as the left operand will produce a set of boolean results, one for each
+    element in the left operand.
 
     .. code-block:: edgeql-repl
 
@@ -143,8 +145,7 @@ Sets
     Merges two sets of :eql:type:`anytype` together as one.
 
     Since EdgeDB sets are formally multisets, :eql:op:`union` is a *multiset
-    sum*, so effectively it merges two multisets while keeping all of their
-    members.
+    sum*, effectively merging two multisets while keeping all of their members.
 
     For example, applying ``union`` to ``{1, 2, 2}`` and
     ``{2}``, results in ``{1, 2, 2, 2}``.
@@ -161,7 +162,7 @@ Sets
 
     :index: if else ifelse elif ternary
 
-    Conditionally determines a logical action:
+    Produces one of two possible results based on the outcome of a condition.
 
     .. eql:synopsis::
 

--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -168,10 +168,10 @@ Sets
 
         <left_expr> if <condition> else <right_expr>
 
-    If :eql:synopsis:`<condition>` is ``true``, then the value of the
-    ``if..else`` expression is the value of the :eql:synopsis:`<left_expr>`;
-    if the :eql:synopsis:`<condition>` is ``false``, however, then the result
-    will be the value of the :eql:synopsis:`<right_expr>`.
+    If the :eql:synopsis:`<condition>` is ``true``, the ``if...else``
+    expression produces the value of the :eql:synopsis:`<left_expr>`. If the
+    :eql:synopsis:`<condition>` is ``false``, however, the ``if...else``
+    expression produces the value of the :eql:synopsis:`<right_expr>`.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -275,7 +275,7 @@ Sets
 
     Determines whether a set is empty or not.
 
-    ``exists`` is an aggregate operator that returns a singleton set of
+    ``exists`` is an aggregate operator that returns a singleton set
     ``{true}`` if the input set is not empty, and returns ``{false}``
     otherwise:
 
@@ -292,7 +292,7 @@ Sets
 
     :index: is type intersection
 
-    Filters a set based on its type. Will return back :eql:type:`anytype`.
+    Filters a set based on its type. Will return back the specified type.
 
     The type intersection operator removes all elements from the input set
     that aren't of the specified type. Additionally, since it
@@ -353,16 +353,13 @@ Sets
     :index: multiplicity uniqueness
 
 
-    Returns :eql:type:`anytype` based on condition of if the set is distinct.
-
-    This checks the input set if it contains only unique elements, i.e a
-    *proper set*.
+    Checks that the input set contains only unique elements, i.e a *proper set*.
 
     If the input set contains duplicate elements, ``assert_distinct`` raises a
     ``ConstraintViolationError``. This function is useful as a runtime
     distinctness assertion in queries and computed expressions that should
     always return proper sets, but where static multiplicity inference is not
-    capable enough or outright impossible. An optional ``message`` named
+    capable enough or outright impossible. An optional *message* named
     argument can be used to customize the error message:
 
     .. code-block:: edgeql-repl
@@ -407,7 +404,7 @@ Sets
     as a runtime cardinality assertion in queries and computed
     expressions that should always return sets with at most a single
     element, but where static cardinality inference is not capable
-    enough or outright impossible. An optional ``message`` named argument
+    enough or outright impossible. An optional *message* named argument
     can be used to customize the error message.
 
     .. code-block:: edgeql-repl
@@ -440,7 +437,7 @@ Sets
     as a runtime existence assertion in queries and computed
     expressions that should always return sets with at least a single
     element, but where static cardinality inference is not capable
-    enough or outright impossible. An optional ``message`` named argument
+    enough or outright impossible. An optional *message* named argument
     can be used to customize the error message.
 
     .. code-block:: edgeql-repl
@@ -514,8 +511,8 @@ Sets
     Returns a :eql:type:`bool` value with :eql:op:`and` applied
     to all values.
 
-    The result is ``true`` if all of the ``values`` are ``true`` or the
-    set of ``values`` is ``{}``, with ``false`` returned otherwise.
+    The result is ``true`` if all of the *values* are ``true`` or the
+    set of *values* is ``{}``, with ``false`` returned otherwise.
 
     .. code-block:: edgeql-repl
 
@@ -536,7 +533,7 @@ Sets
     Returns a :eql:type:`bool` value with :eql:op:`or` applied to all
     values.
 
-    The result is ``true`` if any of the ``values`` are ``true``, with
+    The result is ``true`` if any of the *values* are ``true``, with
     ``false`` returned otherwise.
 
     .. code-block:: edgeql-repl


### PR DESCRIPTION
This Pull Request seeks to improve the Standard Library documentation by rewording content written under types, operators and functions to be more uniform with the rest. I am marking this as a draft due to the abundant size of these docs and the amount of typos/grammatical inconsistencies needed to account for.