### PR TITLE
Add `SHOULD_RETRY` tag to `IdleSessionTimeoutError`

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -100,7 +100,7 @@
 
 0x_04_06_00_00   SessionTimeoutError
 
-0x_04_06_01_00   IdleSessionTimeoutError
+0x_04_06_01_00   IdleSessionTimeoutError #SHOULD_RETRY
 
 0x_04_06_02_00   QueryTimeoutError
 


### PR DESCRIPTION
While this error might be received a lot before `Parse`/`Execute`, the race condition with these is still possible.