### PR TITLE
[Docs] Fix TypeScript equivalent for nested inserts

### DIFF
--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -283,7 +283,7 @@ are easily achieved with subqueries.
       title := 'Doctor Strange 2',
       release_year := 2022,
       director := (insert Person {
-        name := "Sam Raimi"
+        name := 'Sam Raimi'
       })
     };
 

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -291,7 +291,10 @@ are easily achieved with subqueries.
 
     const query = e.insert(e.Movie, {
       title: 'Doctor Strange 2',
-      release_year: 2022
+      release_year: 2022,
+      director: e.insert(e.Person, {
+        name: 'Sam Raimi'
+      })
     });
 
     const result = await query.run(client);


### PR DESCRIPTION
Fixes TypeScript nested insert equivalent missing the nested insert for `director` as found by "ata" in the Discord.