### PR TITLE
Bump edgedb-python dependency version

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -12,7 +12,7 @@
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 <%- endmacro %>
 
 <% macro _init_venv() -%>

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11.0-rc.2'
+          python-version: '3.10.0'
 
       - name: Install Python deps
         run: |

--- a/.github/workflows/test-pool.yml
+++ b/.github/workflows/test-pool.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Generate requirements.txt
       run: |

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     # Build virtualenv
 
@@ -324,7 +324,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     # Build virtualenv
 
@@ -368,7 +368,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -572,7 +572,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -824,7 +824,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -1042,7 +1042,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -1248,7 +1248,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     # Build virtualenv
 
@@ -350,7 +350,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     # Build virtualenv
 
@@ -330,7 +330,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -405,7 +405,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -540,7 +540,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11.0-rc.2'
+        python-version: '3.10.0'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -663,7 +663,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11.0-rc.2'
+          python-version: '3.10.0'
 
       - name: Install Python deps
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "EdgeDB Server"
 requires-python = '>=3.10.0'
 dynamic = ["entry-points", "version"]
 dependencies = [
-    'edgedb==0.24.0',
+    'edgedb==0.25.0a1',
 
     'httptools>=0.3.0',
     'immutables>=0.18',
@@ -76,7 +76,7 @@ requires = [
     "wheel",
 
     "parsing ~= 2.0",
-    'edgedb == 0.24.0',
+    'edgedb==0.25.0a1',
 ]
 # Custom backend needed to set up build-time sys.path because
 # setup.py needs to import `edb.buildmeta`.

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2461,10 +2461,10 @@ class TestInsert(tb.QueryTestCase):
 
         res = await self.con.query(query2, "test2")
         res2 = await self.con.query(query2, "test2")
-        self.assertEqual(res, res2)
+        self.assertEqual([x.id for x in res], [x.id for x in res2])
 
         res3 = await self.con.query(query2, "test3")
-        self.assertNotEqual(res, res3)
+        self.assertNotEqual([x.id for x in res], [x.id for x in res3])
 
     async def test_edgeql_insert_unless_conflict_02(self):
         async with self.assertRaisesRegexTx(
@@ -2602,10 +2602,10 @@ class TestInsert(tb.QueryTestCase):
 
         res = await self.con.query(query2, "test2")
         res2 = await self.con.query(query2, "test2")
-        self.assertEqual(res, res2)
+        self.assertEqual([x.id for x in res], [x.id for x in res2])
 
         res3 = await self.con.query(query2, "test3")
-        self.assertNotEqual(res, res3)
+        self.assertNotEqual([x.id for x in res], [x.id for x in res3])
 
     async def test_edgeql_insert_unless_conflict_05(self):
         await self.con.execute(r'''
@@ -2739,7 +2739,7 @@ class TestInsert(tb.QueryTestCase):
         res2 = await self.con.query_single(query)
 
         self.assertNotEqual(res1.id, res2.id)
-        self.assertEqual(res1.person, res2.person)
+        self.assertEqual(res1.person.id, res2.person.id)
 
     async def test_edgeql_insert_unless_conflict_09(self):
         query = r'''

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -1058,7 +1058,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         # The deck shape ought to contain just the correlated element
         for row in res:
-            self.assertEqual(row[0].deck, [row[1]])
+            self.assertEqual(len(row[0].deck), 1)
+            self.assertEqual(row[0].deck[0].id, row[1].id)
 
     async def test_edgeql_scope_tuple_16(self):
         await self.assert_query_result(

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -837,7 +837,8 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             SELECT ((SELECT O {m}), (SELECT O {m}));
         """)
 
-        self._check_crossproduct([(row[0].m, row[1].m) for row in res])
+        self._check_crossproduct(
+            [(tuple(row[0].m), tuple(row[1].m)) for row in res])
 
     async def test_edgeql_volatility_select_hard_objects_07(self):
         # now let's try it with a multi prop

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -558,8 +558,9 @@ class TestServerProto(tb.QueryTestCase):
                 ]))
 
             with self.assertRaisesRegex(
-                    edgedb.InterfaceError,
-                    r'query_single\(\) as it returns a multiset'):
+                edgedb.InterfaceError,
+                r'query_single\(\) as it may return more than one element'
+            ):
                 await self.con.query_single('SELECT {1, 2}')
 
             await self.con.query_single('SELECT <int64>{}')
@@ -2537,8 +2538,9 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
             for _ in range(5):
                 self.assertEqual(
-                    await con1.query(query),
-                    other)
+                    [x.id for x in await con1.query(query)],
+                    [x.id for x in other],
+                )
 
         finally:
             await con2.aclose()
@@ -2573,8 +2575,9 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
             for _ in range(5):
                 self.assertEqual(
-                    await con1.query(query),
-                    foo)
+                    [x.id for x in await con1.query(query)],
+                    [x.id for x in foo],
+                )
 
             await con2.execute(f'''
                 DELETE (SELECT {typename});
@@ -2594,8 +2597,9 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
             for _ in range(5):
                 self.assertEqual(
-                    await con1.query(query),
-                    bar)
+                    [x.id for x in await con1.query(query)],
+                    [x.id for x in bar],
+                )
 
         finally:
             await con2.aclose()


### PR DESCRIPTION
It stopped making objects compared by `id` and got rid of `Set`, so
some tests needed fixed.