### PR TITLE
Support passing tuples as arguments to queries

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -53,6 +53,7 @@ from . import inference
 from . import pathctx
 from . import setgen
 from . import stmt
+from . import tuple_args
 from . import typegen
 
 from . import func  # NOQA
@@ -539,25 +540,6 @@ def compile_TypeCast(
     elif isinstance(expr.expr, qlast.Parameter):
         pt = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
 
-        if (
-            (pt.is_tuple(ctx.env.schema) or pt.is_anytuple(ctx.env.schema))
-            and not ctx.env.options.func_params
-        ):
-            raise errors.QueryError(
-                'cannot pass tuples as query parameters',
-                context=expr.expr.context,
-            )
-
-        if (
-            pt.contains_array_of_tuples(ctx.env.schema)
-            and not ctx.env.options.func_params
-        ):
-            raise errors.QueryError(
-                'cannot pass collections with tuple elements'
-                ' as query parameters',
-                context=expr.expr.context,
-            )
-
         param_name = expr.expr.name
         if expr.cardinality_mod:
             if expr.cardinality_mod == qlast.CardinalityModifier.Optional:
@@ -617,11 +599,17 @@ def compile_TypeCast(
                     context=expr.expr.context)
 
         if param_name not in ctx.env.query_parameters:
+            sub_params = None
+            if ex_param and ex_param.sub_params:
+                sub_params = tuple_args.finish_sub_params(
+                    ex_param.sub_params, ctx=ctx)
+
             ctx.env.query_parameters[param_name] = irast.Param(
                 name=param_name,
                 required=required,
                 schema_type=pt,
                 ir_type=typeref,
+                sub_params=sub_params,
             )
 
         return param

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -56,6 +56,7 @@ from . import pathctx
 from . import setgen
 from . import viewgen
 from . import schemactx
+from . import tuple_args
 from . import typegen
 
 
@@ -163,14 +164,21 @@ def fini_expression(
 
     ctx.path_scope.validate_unique_ids()
 
-    # Infer cardinalities of type rewrites
-    for rw in ctx.env.type_rewrites.values():
-        if isinstance(rw, irast.Set):
-            inference.infer_cardinality(
-                rw, scope_tree=ctx.path_scope, ctx=inf_ctx
-            )
-            inference.infer_multiplicity(
-                rw, scope_tree=ctx.path_scope, ctx=inf_ctx)
+    # Infer cardinalities and multiplicities of various sets in side tables
+    extra_exprs = []
+    extra_exprs += [
+        rw for rw in ctx.env.type_rewrites.values()
+        if isinstance(rw, irast.Set)
+    ]
+    extra_exprs += [
+        p.sub_params.decoder_ir for p in ctx.env.query_parameters.values()
+        if p.sub_params and p.sub_params.decoder_ir
+    ]
+    for extra in extra_exprs:
+        inference.infer_cardinality(
+            extra, scope_tree=ctx.path_scope, ctx=inf_ctx)
+        inference.infer_multiplicity(
+            extra, scope_tree=ctx.path_scope, ctx=inf_ctx)
 
     # ConfigSet and ConfigReset don't like being part of a Set
     if isinstance(ir.expr, (irast.ConfigSet, irast.ConfigReset)):
@@ -260,9 +268,19 @@ def fini_expression(
     assert isinstance(ir, irast.Set)
     source_map = {k: v for k, v in ctx.env.source_map.items()
                   if isinstance(k, s_pointers.Pointer)}
-    params = list(ctx.env.query_parameters.values())
-    if params and params[0].name.isdecimal():
-        params.sort(key=lambda x: int(x.name))
+    lparams = [
+        p for p in ctx.env.query_parameters.values()
+        if not p.is_sub_param
+    ]
+    if lparams and lparams[0].name.isdecimal():
+        lparams.sort(key=lambda x: int(x.name))
+    params = []
+    # Now flatten it out, including all sub_params, making sure subparams
+    # appear in the right order.
+    for p in lparams:
+        params.append(p)
+        if p.sub_params:
+            params.extend(p.sub_params.params)
 
     result = irast.Statement(
         expr=ir,
@@ -768,11 +786,15 @@ def preprocess_script(
 
         target_typeref = typegen.type_to_typeref(target_stype, env=ctx.env)
         required = cast.cardinality_mod != qlast.CardinalityModifier.Optional
+
+        sub_params = tuple_args.create_sub_params(
+            name, required, typeref=target_typeref, pt=target_stype, ctx=ctx)
         params[name] = irast.Param(
             name=name,
             required=required,
             schema_type=target_stype,
             ir_type=target_typeref,
+            sub_params=sub_params,
         )
 
     if params:

--- a/edb/edgeql/compiler/tuple_args.py
+++ b/edb/edgeql/compiler/tuple_args.py
@@ -1,0 +1,386 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""Implementation of tuple argument decoding compiler.
+
+Postgres does not support passing records (tuples in edgeql) as query
+parameters, and so we need to go to some length to work around this.
+
+All of the trickyness here comes from the interaction with arrays;
+without arrays, we could just split a tuple into multiple parameters.
+The singly-nested case is also still fairly simple: turn an array of
+tuples into multiple parallel arrays, such that `array<tuple<str, int64>>`
+becomes `array<str>` and `array<int64>`.
+
+The doubly-nested case, in which the tuple itself contains an array
+(for example, `array<tuple<str, array<int64>>>`), is trickier:
+Postgres does not allow nested arrays (except if there is an intervening
+record type).
+
+The key insight to resolve this dilemma is that a nested array type
+`array<array<T>>` can be transformed into two non-nested arrays with
+types `array<T>` and `array<int32>`, where the `array<T>` contains all
+of the elements of the nested arrays flattened out and the
+`array<int>` contains the indexes into the flattened array indicating where
+each of the outer arrays begins.
+
+As an example, consider a parameter of type `array<tuple<str, array<int64>>>`,
+with the value:
+[
+    ('foo', [100]),
+    ('bar', [101, 102]),
+    ('baz', [103, 104, 105]),
+]
+We will encode this into three arguments, with types `array<str>`,
+`array<int32>`, and `array<int64>`, with values:
+  ['foo', 'bar', 'baz']
+  [0, 1, 3, 6]
+  [100, 101, 102, 103, 104, 105]
+
+
+The encoding algorithm is straightforward: we traverse the type and
+the input data in tandem, appending data into the appropriate argument
+arrays and tracking array lengths. This is implemented our cython
+protocol server, in edb.server.protocol.args_ser, and operates directly
+on the wire encodings.
+
+The decoding needs to be done as part of the SQL query we execute, so
+we generate an EdgeQL query that decodes to the proper type. The generated
+code operates in a top-down manner, looping over the arrays and constructing
+the value in a single pass.
+
+The code we generate for our running example could look something like:
+  with v0 := <array<str>>$0, v1 := <array<int32>>$1, v2 := <array<int64>>$2,
+  for i in range_unpack(range(0, len(v0))) union (
+    (
+      v0[i],
+      array_agg((for j in range_unpack(v1[i], v1[i + 1]) union (v2[i]))),
+    )
+  )
+In this case, since the nested array is simply an array of a scalar, we can
+do an optimization and use slicing instead of an array_agg+for:
+  with v0 := <array<str>>$0, v1 := <array<int32>>$1, v2 := <array<int64>>$2,
+  for i in range_unpack(range(0, len(v0))) union (
+    (
+      v0[i],
+      v2[v1[i] : v1[i + 1]],
+    )
+  )
+
+The decoder queries will get placed in a CTE in the generated SQL.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from typing import *
+
+from edb import errors
+
+from edb.ir import ast as irast
+from edb.ir import typeutils as irtypeutils
+
+from edb.schema import name as sn
+from edb.schema import types as s_types
+from edb.schema import utils as s_utils
+
+from edb.edgeql import ast as qlast
+
+from . import context
+from . import dispatch
+from . import typegen
+
+if TYPE_CHECKING:
+    from edb.schema import schema as s_schema
+
+# Since we process tuple types recusively in our cython server, insert
+# a recursion depth check here, to be confident that this won't blow
+# our C stack. (Though in practice I would expect anything that might
+# blow it to blow the python stack while compiling the translation.)
+MAX_NESTING = 20
+
+
+def _lmost_is_array(typ: irast.ParamTransType) -> bool:
+    while isinstance(typ, irast.ParamTuple):
+        typ = typ.typs[0]
+    return isinstance(typ, irast.ParamArray)
+
+
+def translate_type(
+    typeref: irast.TypeRef, *,
+    schema: s_schema.Schema,
+) -> tuple[irast.ParamTransType, tuple[irast.TypeRef, ...]]:
+    """Translate the type of a tuple-containing param to multiple params.
+
+    This computes a list of parameter types, as well as a
+    ParamTransType that clones the type information but augments each
+    node in the type with indexes that correspond to which parameter
+    data is drawn from. This is used to drive the encoder and the
+    decoder generator.
+    """
+
+    typs: list[irast.TypeRef] = []
+
+    def trans(
+        typ: irast.TypeRef, in_array: bool, depth: int
+    ) -> irast.ParamTransType:
+        if depth > MAX_NESTING:
+            raise errors.QueryError(
+                f'type of parameter is too deeply nested')
+
+        start = len(typs)
+
+        if irtypeutils.is_array(typ):
+            # If our array is appearing already inside another array,
+            # we need to add an extra parameter
+            if in_array:
+                int_typeref = schema.get(
+                    sn.QualName('std', 'int32'), type=s_types.Type)
+                nschema, array_styp = s_types.Array.from_subtypes(
+                    schema, [int_typeref])
+                typs.append(irtypeutils.type_to_typeref(nschema, array_styp))
+
+            return irast.ParamArray(
+                typeref=typ,
+                idx=start,
+                typ=trans(typ.subtypes[0], in_array=True, depth=depth + 1),
+            )
+
+        elif irtypeutils.is_tuple(typ):
+            # HACK: We don't bother dealing with named tuples. We just
+            # generate anonymous tuples and it all still works out.
+            return irast.ParamTuple(
+                typeref=typ,
+                idx=start,
+                typs=tuple(
+                    trans(t, in_array=in_array, depth=depth + 1)
+                    for t in typ.subtypes
+                ),
+            )
+
+        else:
+            nt = typ
+            # If this appears in an array, the param needs to be an array
+            if in_array:
+                nschema, styp = irtypeutils.ir_typeref_to_type(schema, typ)
+                nschema, styp = s_types.Array.from_subtypes(nschema, [styp])
+                nt = irtypeutils.type_to_typeref(nschema, styp)
+            typs.append(nt)
+            return irast.ParamScalar(typeref=typ, idx=start)
+
+    t = trans(typeref, in_array=False, depth=0)
+    return t, tuple(typs)
+
+
+def _ref_to_ast(
+    typeref: irast.TypeRef, *, ctx: context.ContextLevel
+) -> qlast.TypeExpr:
+    ctx.env.schema, styp = irtypeutils.ir_typeref_to_type(
+        ctx.env.schema, typeref)
+    return s_utils.typeref_to_ast(ctx.env.schema, styp)
+
+
+def _get_alias(
+    name: str, *, ctx: context.ContextLevel
+) -> Tuple[str, qlast.Path]:
+    alias = ctx.aliases.get(name)
+    return alias, qlast.Path(
+        steps=[qlast.ObjectRef(name=alias)],
+    )
+
+
+def _plus_const(expr: qlast.Expr, val: int) -> qlast.Expr:
+    if val == 0:
+        return expr
+    return qlast.BinOp(
+        left=expr,
+        op='+',
+        right=qlast.IntegerConstant(value=str(val)),
+    )
+
+
+def _index(expr: qlast.Expr, idx: qlast.Expr) -> qlast.Indirection:
+    return qlast.Indirection(arg=expr, indirection=[qlast.Index(index=idx)])
+
+
+def make_decoder(
+    ptyp: irast.ParamTransType,
+    qparams: tuple[irast.Param, ...],
+    *,
+    ctx: context.ContextLevel,
+) -> qlast.Expr:
+    """Generate a decoder for tuple parameters.
+
+    More details in the module docstring.
+    """
+    params: list[qlast.Expr] = [
+        qlast.TypeCast(
+            expr=qlast.Parameter(name=param.name),
+            type=_ref_to_ast(param.ir_type, ctx=ctx),
+        )
+        for param in qparams
+    ]
+
+    def mk(typ: irast.ParamTransType, idx: Optional[qlast.Expr]) -> qlast.Expr:
+        if isinstance(typ, irast.ParamScalar):
+            expr = params[typ.idx]
+            if idx is not None:
+                expr = _index(expr, idx)
+            return expr
+
+        elif isinstance(typ, irast.ParamTuple):
+            return qlast.Tuple(elements=[mk(t, idx=idx) for t in typ.typs])
+
+        elif isinstance(typ, irast.ParamArray):
+            inner_idx_alias, inner_idx = _get_alias('idx', ctx=ctx)
+
+            lo: qlast.Expr
+            hi: qlast.Expr
+            if idx is None:
+                lo = qlast.IntegerConstant(value='0')
+                hi = qlast.FunctionCall(
+                    func=('__std__', 'len'), args=[params[typ.idx]])
+                # If the leftmost element inside a toplevel array is
+                # itself an array, subtract 1 from the length (since
+                # array params have an extra element). We also need to
+                # call `max` to prevent generating an invalid range.
+                if _lmost_is_array(typ.typ):
+                    hi = qlast.FunctionCall(
+                        func=('__std__', 'max'), args=[
+                            qlast.Set(elements=[lo, _plus_const(hi, -1)])])
+            else:
+                lo = _index(params[typ.idx], idx)
+                hi = _index(params[typ.idx], _plus_const(idx, 1))
+
+            # If the contents is just a scalar, then we can take
+            # values directly from the scalar array parameter, without
+            # needing to iterate over the array directly.
+            # This is an optimization, and not necessary for correctness.
+            if isinstance(typ.typ, irast.ParamScalar):
+                sub = params[typ.typ.idx]
+                # If we are in an array, do a slice
+                if idx is not None:
+                    sub = qlast.Indirection(
+                        arg=sub,
+                        indirection=[qlast.Slice(start=lo, stop=hi)],
+                    )
+                return sub
+
+            sub_expr = mk(typ.typ, idx=inner_idx)
+
+            # For some reason, this is much faster if force the range to
+            # be over int64 instead of int32.
+            lo = qlast.TypeCast(
+                expr=lo,
+                type=qlast.TypeName(
+                    maintype=qlast.ObjectRef(module='__std__', name='int64')
+                ),
+            )
+
+            loop = qlast.ForQuery(
+                iterator_alias=inner_idx_alias,
+                # TODO: Using _gen_series would be marginally faster,
+                # but it isn't actually available in distributions
+                # iterator=qlast.FunctionCall(
+                #     func=('__std__', '_gen_series'),
+                #     args=[lo, _plus_const(hi, -1)],
+                # ),
+                iterator=qlast.FunctionCall(
+                    func=('__std__', 'range_unpack'), args=[
+                        qlast.FunctionCall(
+                            func=('__std__', 'range'),
+                            args=[lo, hi],
+                        )
+                    ]
+                ),
+                result=sub_expr,
+            )
+            res: qlast.Expr = qlast.FunctionCall(
+                func=('__std__', 'array_agg'), args=[loop],
+            )
+
+            # If the param is optional, and we are still at the
+            # top-level, insert a filter so that our aggregate doesn't
+            # create something from nothing.
+            if not qparams[typ.idx].required and idx is None:
+                res = qlast.SelectQuery(
+                    result=res,
+                    where=qlast.UnaryOp(op='EXISTS', operand=params[typ.idx]),
+                )
+
+            return res
+
+        else:
+            raise AssertionError(f'bogus type {typ}')
+
+    decoder = mk(ptyp, idx=None)
+
+    return decoder
+
+
+def create_sub_params(
+    name: str, required: bool, typeref: irast.TypeRef, pt: s_types.Type,
+    *,
+    ctx: context.ContextLevel,
+) -> Optional[irast.SubParams]:
+    """Create sub parameters for a new param, if needed.
+
+    We need to do this if there is a tuple in the type.
+    """
+    if not (
+        (
+            pt.is_tuple(ctx.env.schema)
+            or pt.is_anytuple(ctx.env.schema)
+            or pt.contains_array_of_tuples(ctx.env.schema)
+        )
+        and not ctx.env.options.func_params
+        and not ctx.env.options.json_parameters
+    ):
+        return None
+
+    pdt, arg_typs = translate_type(typeref, schema=ctx.env.schema)
+    params = tuple([
+        irast.Param(
+            name=f'__edb_decoded_{name}_{i}__',
+            required=required,
+            ir_type=arg_typeref,
+            schema_type=typegen.type_from_typeref(arg_typeref, env=ctx.env),
+        )
+        for i, arg_typeref in enumerate(arg_typs)
+    ])
+
+    decode_ql = make_decoder(pdt, params, ctx=ctx)
+
+    return irast.SubParams(
+        trans_type=pdt, decoder_edgeql=decode_ql, params=params)
+
+
+def finish_sub_params(
+    subps: irast.SubParams, *, ctx: context.ContextLevel,
+) -> Optional[irast.SubParams]:
+    """Finalize the subparams by compiling the IR in the proper context.
+
+    We can't just compile it when doing create_sub_params, since that is
+    called from preprocessing and so is shared between queries.
+    """
+    with ctx.newscope(fenced=True) as subctx:
+        decode_ir = dispatch.compile(subps.decoder_edgeql, ctx=subctx)
+
+    return dataclasses.replace(subps, decoder_ir=decode_ir)

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -238,6 +238,14 @@ def collapse_type_intersection_rptr(
     return ind_prefix, ptrs
 
 
+def type_from_typeref(
+    t: irast.TypeRef,
+    env: context.Environment,
+) -> s_types.Type:
+    env.schema, styp = irtyputils.ir_typeref_to_type(env.schema, t)
+    return styp
+
+
 def type_to_typeref(
     t: s_types.Type,
     env: context.Environment,

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -459,6 +459,9 @@ class Param:
     #: whether parameter is required
     required: bool
 
+    #: index in the "logical" arg map
+    logical_index: int
+
 
 class Query(ReturningQuery):
     """Generic superclass representing a query."""

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -100,6 +100,9 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: SQL query hierarchy
     rel_hierarchy: Dict[pgast.Query, pgast.Query]
 
+    #: CTEs representing decoded parameters
+    param_ctes: Dict[str, pgast.CommonTableExpr]
+
     #: CTEs representing schema types, when rewritten based on access policy
     type_ctes: Dict[RewriteKey, pgast.CommonTableExpr]
 
@@ -223,6 +226,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.stmt = NO_STMT
             self.rel = NO_STMT
             self.rel_hierarchy = {}
+            self.param_ctes = {}
             self.type_ctes = {}
             self.pending_type_ctes = set()
             self.dml_stmts = {}
@@ -260,6 +264,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.stmt = prevlevel.stmt
             self.rel = prevlevel.rel
             self.rel_hierarchy = prevlevel.rel_hierarchy
+            self.param_ctes = prevlevel.param_ctes
             self.type_ctes = prevlevel.type_ctes
             self.pending_type_ctes = prevlevel.pending_type_ctes
             self.dml_stmts = prevlevel.dml_stmts

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -122,11 +122,16 @@ def compile_Parameter(
     result: pgast.BaseParamRef
     is_decimal: bool = expr.name.isdecimal()
 
+    params = [p for p in ctx.env.query_params if p.name == expr.name]
+    param = params[0] if params else None
+
     if not is_decimal and ctx.env.use_named_params:
         result = pgast.NamedParamRef(
             name=expr.name,
             nullable=not expr.required,
         )
+    elif param and param.sub_params:
+        return relgen.process_encoded_param(param, ctx=ctx)
     else:
         index = ctx.argmap[expr.name].index
         result = pgast.ParamRef(number=index, nullable=not expr.required)

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -179,6 +179,7 @@ class Param:
     required: bool
     array_type_id: Optional[uuid.UUID]
     outer_idx: int
+    sub_params: Optional[tuple[list[Optional[uuid.UUID]], tuple]]
 
 
 #############################
@@ -269,6 +270,7 @@ class QueryUnit:
     in_type_data: bytes = sertypes.NULL_TYPE_DESC
     in_type_id: bytes = sertypes.NULL_TYPE_ID.bytes
     in_type_args: Optional[List[Param]] = None
+    in_type_args_real_count: int = 0
     globals: Optional[List[str]] = None
 
     # Set only when this unit contains a CONFIGURE INSTANCE command.
@@ -332,6 +334,7 @@ class QueryUnitGroup:
     in_type_data: bytes = sertypes.NULL_TYPE_DESC
     in_type_id: bytes = sertypes.NULL_TYPE_ID.bytes
     in_type_args: Optional[List[Param]] = None
+    in_type_args_real_count: int = 0
     globals: Optional[List[str]] = None
 
     units: List[QueryUnit] = dataclasses.field(default_factory=list)
@@ -360,6 +363,7 @@ class QueryUnitGroup:
         self.in_type_data = query_unit.in_type_data
         self.in_type_id = query_unit.in_type_id
         self.in_type_args = query_unit.in_type_args
+        self.in_type_args_real_count = query_unit.in_type_args_real_count
         if query_unit.globals is not None:
             if self.globals is None:
                 self.globals = []

--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -33,6 +33,7 @@ from edb.server.pgproto.pgproto cimport (
     frb_init,
     frb_read,
     frb_get_len,
+    frb_slice_from,
 )
 
 
@@ -61,7 +62,7 @@ cdef recode_bind_args_for_script(
         bind_data = WriteBuffer.new()
         bind_data.write_int32(0x00010001)
 
-        num_args = len(query_unit.in_type_args or ())
+        num_args = query_unit.in_type_args_real_count
         num_args += _count_globals(query_unit)
 
         if compiled.first_extra is not None:
@@ -138,7 +139,7 @@ cdef WriteBuffer recode_bind_args(
             f"invalid argument count, "
             f"expected: {decl_args}, got: {recv_args}")
 
-    num_args = recv_args
+    num_args = qug.in_type_args_real_count
     if compiled.first_extra is not None:
         assert recv_args == compiled.first_extra, \
             f"argument count mismatch {recv_args} != {compiled.first_extra}"
@@ -156,13 +157,25 @@ cdef WriteBuffer recode_bind_args(
 
             frb_read(&in_buf, 4)  # reserved
             in_len = hton.unpack_int32(frb_read(&in_buf, 4))
-            out_buf.write_int32(in_len)
-
             if in_len < 0:
                 # This means argument value is NULL
                 if param.required:
                     raise errors.QueryError(
                         f"parameter ${param.name} is required")
+
+            # If the param has encoded tuples, we need to decode them
+            # and reencode them as arrays of scalars.
+            if param.sub_params:
+                # HACK: Rewind the frb, since _decode_tuple_args needs the
+                # length present.
+                frb_read(&in_buf, -4)
+
+                tids, trans_typ = param.sub_params
+                _decode_tuple_args(
+                    dbv, &in_buf, out_buf, in_len, tids, trans_typ)
+                continue
+
+            out_buf.write_int32(in_len)
 
             if in_len > 0:
                 data = frb_read(&in_buf, in_len)
@@ -192,6 +205,139 @@ cdef WriteBuffer recode_bind_args(
         out_buf.write_int32(0x00010001)
 
     return out_buf
+
+
+cdef WriteBuffer _decode_tuple_args_core(
+    FRBuffer* in_buf,
+    out_bufs: tuple[WriteBuffer],
+    counts: list[int],
+    acounts: list[int],
+    trans_typ: tuple,
+    in_array: bool,
+):
+    # Recurse over the types and the input data, collecting the
+    # arguments into the various out_bufs. See
+    # edb.edgeql.compiler.tuple_args for more discussion.
+
+    cdef:
+        ssize_t in_len
+        WriteBuffer buf
+        ssize_t cnt
+        ssize_t idx
+        ssize_t num
+        ssize_t tag
+        FRBuffer sub_buf
+
+    tag = trans_typ[0]
+    idx = trans_typ[1]
+
+    in_len = hton.unpack_int32(frb_read(in_buf, 4))
+    buf = out_bufs[idx]
+
+    if in_len < 0:
+        raise errors.QueryError("invalid NULL inside type")
+
+    frb_slice_from(&sub_buf, in_buf, in_len)
+
+    if tag == 0:  # scalar
+        buf.write_int32(in_len)
+        data = frb_read(&sub_buf, in_len)
+        buf.write_cstr(data, in_len)
+        if in_array:
+            counts[idx] += 1
+
+    elif tag == 1:  # tuple
+        cnt = <uint32_t>hton.unpack_int32(frb_read(&sub_buf, 4))
+        num = len(trans_typ) - 2
+        if cnt != num:
+            raise errors.QueryError(
+                f"tuple length mismatch: {cnt} vs {num}")
+        for idx in range(num):
+            typ = trans_typ[idx + 2]
+            frb_read(&sub_buf, 4)
+            _decode_tuple_args_core(
+                &sub_buf, out_bufs, counts, acounts, typ, in_array)
+
+    elif tag == 2:  # array
+        frb_read(&sub_buf, 4)  # ndims
+        frb_read(&sub_buf, 4)  # flags
+        frb_read(&sub_buf, 4)  # reserved
+        cnt = <uint32_t>hton.unpack_int32(frb_read(&sub_buf, 4))
+        frb_read(&sub_buf, 4)  # bound
+
+        # For nested arrays, we need to produce an array containing
+        # the start/end indexes in the flattened array.
+        if in_array:
+            # If this is the first element, put in the 0
+            if acounts[idx] == -1:
+                counts[idx] += 1
+                acounts[idx] = 0
+                buf.write_int32(4)
+                buf.write_int32(0)
+            counts[idx] += 1
+            acounts[idx] += cnt
+            buf.write_int32(4)
+            buf.write_int32(acounts[idx])
+
+        styp = trans_typ[2]
+        for _ in range(cnt):
+            _decode_tuple_args_core(
+                &sub_buf, out_bufs, counts, acounts, styp, True)
+
+    if frb_get_len(&sub_buf):
+        raise RuntimeError('unexpected trailing data in buffer')
+
+
+cdef WriteBuffer _decode_tuple_args(
+    dbv: dbview.DatabaseConnectionView,
+    FRBuffer* in_buf,
+    out_buf: WriteBuffer,
+    in_len: ssize_t,
+    tids: list,
+    trans_typ: object,
+):
+    # PERF: Can we use real arrays, instead of python lists?
+    cdef:
+        const char *data
+        list buffers
+        list counts
+        list acounts
+        WriteBuffer buf
+
+    if in_len < 0:
+        # For a NULL argument, fill out *every* one of our args with NULL
+        for _ in tids:
+            out_buf.write_int32(in_len)
+        return
+
+    buffers = []
+    counts = []
+    acounts = []
+    for maybe_tid in tids:
+        buf = WriteBuffer.new()
+        counts.append(0 if maybe_tid else -1)
+        acounts.append(-1)
+        buffers.append(buf)
+
+    _decode_tuple_args_core(
+        in_buf, tuple(buffers), counts, acounts, trans_typ, False)
+
+    # zip all of the buffers we have collected into up
+    # PERF: or should we just index?
+    for maybe_tid, count, buf in zip(tids, counts, buffers):
+        if maybe_tid:
+            ndims = 1
+            out_buf.write_int32(12 + 8 * ndims + buf.len())
+            # ndimensions + flags
+            array_tid = dbv.resolve_backend_type_id(maybe_tid)
+            out_buf.write_int32(1)
+            out_buf.write_int32(0)
+            out_buf.write_int32(<int32_t>array_tid)
+
+            out_buf.write_int32(<int32_t>count)
+            out_buf.write_int32(1)
+
+        out_buf.write_buffer(buf)
 
 
 cdef _inject_globals(


### PR DESCRIPTION
The key technique is to decompose a tuple parameter into multiple
parameters, one for each scalar component. Arrays of tuples are
essentially transposed into a tuple of arrays, and then decomposed.
Nested arrays are handled by flattening the array and adding an
`array<int32>` parameter that stores the start/end of each subarray.
Details are in the doc string for `tuple_args.py`.

In terms of data flow, the client sends properly encoded tuples, which
we encode in the server. We generate edgeql to convert the encoded data
into the correct types, and insert that into CTEs in the query.

Fixes #2326.