### PR TITLE
Make index names in postgres include the id of the index

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_10_05_00_01
+EDGEDB_CATALOG_VERSION = 2022_10_07_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -24,7 +24,6 @@ from typing import *
 
 from edb.common import ordered
 
-from .. import common
 from ..common import qname as qn
 from ..common import quote_ident as qi
 from ..common import quote_literal as ql
@@ -71,13 +70,11 @@ class Index(tables.InheritableTableObject):
         self.unique = unique
         self.exprs = exprs
 
-        if self.name_in_catalog != self.name:
-            self.add_metadata('fullname', self.name)
+        self.add_metadata('fullname', self.name)
 
     @property
     def name_in_catalog(self):
-        return common.edgedb_name_to_pg_name(
-            self.table_name[1] + '__' + self.name)
+        return self.name
 
     def add_columns(self, columns):
         for col in columns:

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4318,7 +4318,7 @@ class LinkMetaCommand(CompositeMetaCommand, PointerMetaCommand):
         ct = dbops.CreateTable(table=table)
 
         index_name = common.edgedb_name_to_pg_name(
-            str(link.get_name(schema)) + 'target_id_default_idx')
+            str(link.id) + '_target_key')
         index = dbops.Index(index_name, new_table_name, unique=False)
         index.add_columns([tgt_col])
         ci = dbops.CreateIndex(index)


### PR DESCRIPTION
Currently index names include the *name* of the index, plus some other
stuff. The result of this is that they are long enough to need to get
hashed. Just make it based on the id, like we do with most things.

The upshot of this is that it will make it much easier for EXPLAIN to
figure out which index is being discussed.