### PR TITLE
Rename TypeRef.descendants to children

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -621,7 +621,7 @@ def compile_UpdateQuery(
         stmt._material_type = typeutils.type_to_typeref(
             ctx.env.schema,
             mat_stype,
-            include_descendants=True,
+            include_children=True,
             include_ancestors=True,
             cache=ctx.env.type_ref_cache,
         )
@@ -751,7 +751,7 @@ def compile_DeleteQuery(
         stmt._material_type = typeutils.type_to_typeref(
             ctx.env.schema,
             mat_stype,
-            include_descendants=True,
+            include_children=True,
             include_ancestors=True,
             cache=ctx.env.type_ref_cache,
         )

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -245,7 +245,7 @@ def type_to_typeref(
     schema = env.schema
     cache = env.type_ref_cache
     expr_type = t.get_expr_type(env.schema)
-    include_descendants = (
+    include_children = (
         expr_type is s_types.ExprType.Update
         or expr_type is s_types.ExprType.Delete
     )
@@ -257,7 +257,7 @@ def type_to_typeref(
     return irtyputils.type_to_typeref(
         schema,
         t,
-        include_descendants=include_descendants,
+        include_children=include_children,
         include_ancestors=include_ancestors,
         cache=cache,
     )

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -111,9 +111,9 @@ class ViewShapeMetadata(Base):
 
 
 class TypeRef(ImmutableBase):
-    # Hide ancestors and descendants from debug spew because they are
+    # Hide ancestors and children from debug spew because they are
     # incredibly noisy.
-    __ast_hidden__ = {'ancestors', 'descendants'}
+    __ast_hidden__ = {'ancestors', 'children'}
 
     # The id of the referenced type
     id: uuid.UUID
@@ -126,9 +126,9 @@ class TypeRef(ImmutableBase):
     # If this is a scalar type, base_type would be the highest
     # non-abstract base type.
     base_type: typing.Optional[TypeRef] = None
-    # A set of type descendant descriptors, if necessary for
+    # A set of type children descriptors, if necessary for
     # this type description.
-    descendants: typing.Optional[typing.FrozenSet[TypeRef]] = None
+    children: typing.Optional[typing.FrozenSet[TypeRef]] = None
     # A set of type ancestor descriptors, if necessary for
     # this type description.
     ancestors: typing.Optional[typing.FrozenSet[TypeRef]] = None


### PR DESCRIPTION
This is the correct name for what it actually is.