### PR TITLE
In reordered SQL codegen, don't indent the bodies of UNION

### DIFF
--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -160,7 +160,8 @@ class SQLSourceGenerator(codegen.SourceGenerator):
             self.write('(')
             if self.reordered:
                 self.new_lines = 1
-                self.indentation += 1
+                if not node.op:
+                    self.indentation += 1
 
         if node.ctes:
             self.gen_ctes(node.ctes)
@@ -283,7 +284,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
         if parenthesize:
             self.new_lines = 1
-            if self.reordered:
+            if self.reordered and not node.op:
                 self.indentation -= 1
             self.write(')')
 


### PR DESCRIPTION
We sometimes produce a big union, and it usually seems preferable to
have it formatted in a flat manner, instead of deeply indenting the
first components.

It might be better to understand nesting structure better and only
skip indenting when it is a basic left associative union, and not if
there is more interesting structure?