### PR TITLE
Make unused param insertion in the sql compiler more reliable

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -459,8 +459,6 @@ class Param:
     #: whether parameter is required
     required: bool
 
-    used: bool = False
-
 
 class Query(ReturningQuery):
     """Generic superclass representing a query."""

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -129,8 +129,6 @@ def compile_Parameter(
         )
     else:
         index = ctx.argmap[expr.name].index
-        ctx.argmap[expr.name].used = True
-
         result = pgast.ParamRef(number=index, nullable=not expr.required)
 
     return pgast.TypeCast(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5643,3 +5643,11 @@ class TestInsert(tb.QueryTestCase):
             [{'id': str}],
             always_typenames=True,
         )
+
+    async def test_edgeql_insert_pointless_shape_elements_01(self):
+        await self.con.execute('''
+            insert Person {
+                name := "test",
+                notes := (select Note { foo := 0 })
+            };
+        ''')


### PR DESCRIPTION
Currently we mark a parameter as used when we see it during traversal,
but there are cases where we can compile a subtree that doesn't end up
actually making it into the output.

Instead, determine the used parameters by a look through the AST.

Fixes #1801.