### PR TITLE
Make ast.visitor.find_children more convenient and better typed

### DIFF
--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -30,8 +30,15 @@ class SkipNode(Exception):
     pass
 
 
-def find_children(node, test_func, *args,
-                  terminate_early=False, **kwargs):
+_T = TypeVar('_T')
+
+
+def find_children(
+    node: base.AST | Collection[base.AST],
+    type: Type[_T],
+    test_func: Optional[Callable[[_T], bool]] = None,
+    terminate_early=False,
+) -> list[_T]:
     visited = set()
     result = []
 
@@ -50,7 +57,7 @@ def find_children(node, test_func, *args,
             visited.add(node)
 
         try:
-            if test_func(node, *args, **kwargs):
+            if isinstance(node, type) and (not test_func or test_func(node)):
                 result.append(node)
                 if terminate_early:
                     return True
@@ -68,13 +75,7 @@ def find_children(node, test_func, *args,
         return False
 
     _find_children(node)
-    if terminate_early:
-        if result:
-            return result[0]
-        else:
-            return None
-    else:
-        return result
+    return result
 
 
 class NodeVisitor:

--- a/edb/edgeql/compiler/group.py
+++ b/edb/edgeql/compiler/group.py
@@ -224,8 +224,7 @@ def infer_group_aggregates(
     *,
     ctx: context.ContextLevel,
 ) -> None:
-    flt = lambda n: isinstance(n, irast.GroupStmt)
-    groups: List[irast.GroupStmt] = ast_visitor.find_children(ir, flt)
+    groups = ast_visitor.find_children(ir, irast.GroupStmt)
     for stmt in groups:
         visitor = FindAggregatingUses(
             stmt.group_binding.path_id,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -365,8 +365,7 @@ def compile_InternalGroupQuery(
                     grouping_stype, expr.grouping_alias, ctx=topctx)
 
         # Check that the by clause is legit
-        by_refs: List[qlast.ObjectRef] = ast.find_children(
-            stmt.by, lambda n: isinstance(n, qlast.ObjectRef))
+        by_refs = ast.find_children(stmt.by, qlast.ObjectRef)
         for by_ref in by_refs:
             if by_ref.name not in stmt.using:
                 raise errors.InvalidReferenceError(

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -303,11 +303,10 @@ def _fixup_materialized_sets(
     ir: irast.Base, *, ctx: context.ContextLevel
 ) -> List[irast.Set]:
     # Make sure that all materialized sets have their views compiled
-    flt = lambda n: isinstance(n, irast.Stmt)
-    children: List[irast.Stmt] = ast_visitor.find_children(ir, flt)
+    children = ast_visitor.find_children(ir, irast.Stmt)
     for nobe in ctx.env.source_map.values():
         if nobe.irexpr:
-            children += ast_visitor.find_children(nobe.irexpr, flt)
+            children += ast_visitor.find_children(nobe.irexpr, irast.Stmt)
 
     to_clear = []
     for stmt in ordered.OrderedSet(children):
@@ -388,8 +387,8 @@ def _fixup_materialized_sets(
 def _find_visible_binding_refs(
     ir: irast.Base, *, ctx: context.ContextLevel
 ) -> List[irast.Set]:
-    flt = lambda n: isinstance(n, irast.Set) and n.is_visible_binding_ref
-    children: List[irast.Set] = ast_visitor.find_children(ir, flt)
+    children = ast_visitor.find_children(
+        ir, irast.Set, lambda n: n.is_visible_binding_ref)
     return children
 
 

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -133,11 +133,7 @@ def inline_anchors(
 
 
 def find_paths(ql: qlast.Base) -> List[qlast.Path]:
-    paths: List[qlast.Path] = ast.find_children(
-        ql,
-        lambda x: isinstance(x, qlast.Path),
-    )
-    return paths
+    return ast.find_children(ql, qlast.Path)
 
 
 def find_subject_ptrs(ast: qlast.Base) -> Set[str]:
@@ -195,7 +191,8 @@ def contains_dml(ql_expr: qlast.Base) -> bool:
     if isinstance(ql_expr, dml_types):
         return True
 
-    res = ast.find_children(ql_expr, lambda x: isinstance(x, dml_types),
+    res = ast.find_children(ql_expr, qlast.Query,
+                            lambda x: isinstance(x, dml_types),
                             terminate_early=True)
 
     return bool(res)

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -45,8 +45,7 @@ def get_longest_paths(ir: irast.Base) -> Set[irast.Set]:
     result = set()
     parents = set()
 
-    flt = lambda n: isinstance(n, irast.Set) and n.expr is None
-    ir_sets = ast.find_children(ir, flt)
+    ir_sets = ast.find_children(ir, irast.Set, lambda n: n.expr is None)
     for ir_set in ir_sets:
         result.add(ir_set)
         if ir_set.rptr:
@@ -57,16 +56,13 @@ def get_longest_paths(ir: irast.Base) -> Set[irast.Set]:
 
 def get_parameters(ir: irast.Base) -> Set[irast.Parameter]:
     """Return all parameters found in *ir*."""
-    result: Set[irast.Parameter] = set()
-    flt = lambda n: isinstance(n, irast.Parameter)
-    result.update(ast.find_children(ir, flt))
-    return result
+    return set(ast.find_children(ir, irast.Parameter))
 
 
 def is_const(ir: irast.Base) -> bool:
     """Return True if the given *ir* expression is constant."""
-    flt = lambda n: isinstance(n, irast.Set) and n.expr is None and n is not ir
-    ir_sets = ast.find_children(ir, flt)
+    flt = lambda n: n.expr is None and n is not ir
+    ir_sets = ast.find_children(ir, irast.Set, flt)
     variables = get_parameters(ir)
     return not ir_sets and not variables
 
@@ -452,7 +448,6 @@ def find_potentially_visible(
 
 
 def contains_set_of_op(ir: irast.Base) -> bool:
-    flt = (lambda n: isinstance(n, irast.Call)
-           and any(x == ft.TypeModifier.SetOfType
-                   for x in n.params_typemods))
-    return bool(ast.find_children(ir, flt, terminate_early=True))
+    flt = (lambda n: any(x == ft.TypeModifier.SetOfType
+                         for x in n.params_typemods))
+    return bool(ast.find_children(ir, irast.Call, flt, terminate_early=True))

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -381,8 +381,7 @@ def fini_toplevel(
         # Find the used parameters by searching the query, so we don't
         # get confused if something has been compiled but then omitted
         # from the output for some reason.
-        flt = lambda n: isinstance(n, pgast.ParamRef)
-        param_refs: List[pgast.ParamRef] = ast_visitor.find_children(stmt, flt)
+        param_refs = ast_visitor.find_children(stmt, pgast.ParamRef)
 
         used = {param_ref.number for param_ref in param_refs}
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -73,9 +73,8 @@ class ConstraintMech:
     @classmethod
     def _edgeql_tree_to_exprdata(cls, sql_expr, is_multicol=False, refs=None):
         if refs is None:
-            flt = (
-                lambda n: isinstance(n, pg_ast.ColumnRef) and len(n.name) == 1)
-            refs = set(ast.find_children(sql_expr, flt))
+            refs = set(ast.find_children(
+                sql_expr, pg_ast.ColumnRef, lambda n: len(n.name) == 1))
 
         plain_expr = codegen.SQLSourceGenerator.to_source(sql_expr)
 
@@ -133,8 +132,8 @@ class ConstraintMech:
 
         # Find all field references
         #
-        flt = lambda n: isinstance(n, pg_ast.ColumnRef) and len(n.name) == 1
-        refs = set(ast.find_children(sql_expr, flt))
+        refs = set(ast.find_children(
+            sql_expr, pg_ast.ColumnRef, lambda n: len(n.name) == 1))
 
         if isinstance(subject, s_scalars.ScalarType):
             # Domain constraint, replace <scalar_name> with VALUE

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -193,7 +193,7 @@ class IndexCommand(
 
         expr_qual = cls._name_qual_from_exprs(schema, exprs)
 
-        ptrs = ast.find_children(astnode, lambda n: isinstance(n, qlast.Ptr))
+        ptrs = ast.find_children(astnode, qlast.Ptr)
         ptr_name_qual = '_'.join(ptr.ptr.name for ptr in ptrs)
         if not ptr_name_qual:
             ptr_name_qual = 'idx'

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1212,8 +1212,7 @@ class Compiler:
                             # it into the actual query, so filter them out.
                             used_placeholders = {
                                 p.name for p in ast.find_children(
-                                    ddl_ast,
-                                    lambda n: isinstance(n, qlast.Placeholder))
+                                    ddl_ast, qlast.Placeholder)
                             }
                             required_user_input = tuple(
                                 (k, v) for k, v in (

--- a/tests/common/test_ast.py
+++ b/tests/common/test_ast.py
@@ -286,6 +286,5 @@ class ASTFindChildrenTests(unittest.TestCase):
                     tast.UnaryOp(op='-', operand=tast.Constant(value=3))]),
             ],
         )
-        flt = lambda n: isinstance(n, tast.Constant)
-        children = visitor.find_children(node, flt)
+        children = visitor.find_children(node, tast.Constant)
         assert {x.value for x in children} == {2, 3}

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -117,9 +117,10 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
         ''')
         child = ast_visitor.find_children(
             sql,
-            lambda x: isinstance(x, pgast.SelectStmt) and x.sort_clause,
+            pgast.SelectStmt,
+            lambda x: bool(x.sort_clause),
             terminate_early=True
-        )
+        )[0]
 
         # Make sure that a simple order by on a property is not compiled
         # as a subquery in the ORDER BY, which pg fails to use an index for.
@@ -135,9 +136,10 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
         ''')
         child = ast_visitor.find_children(
             sql,
-            lambda x: isinstance(x, pgast.SelectStmt) and x.sort_clause,
+            pgast.SelectStmt,
+            lambda x: bool(x.sort_clause),
             terminate_early=True
-        )
+        )[0]
 
         # Make sure that a simple order by on a property is not compiled
         # as a subquery in the ORDER BY, which pg fails to use an index for.
@@ -188,9 +190,10 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
         ''')
         child = ast_visitor.find_children(
             tree,
-            lambda x: isinstance(x, pgast.SelectStmt) and x.group_clause,
+            pgast.SelectStmt,
+            lambda x: bool(x.group_clause),
             terminate_early=True
-        )
+        )[0]
         group_sql = pg_compiler.run_codegen(child, pretty=True)
 
         # We want no array_agg in the group - it should just be able


### PR DESCRIPTION
Every call to ast.visitor.find_children passes a predicate that calls
`isinstance`, and many of them pass a predicate that *only* calls
isinstance.

Take advantage of this pattern by adding a required type argument that
is now used to test the type of nodes before calling the
(now-optional) predicate function.

Then we can use that type argument to give precise types to the
predicate function and the output.

Drop the behavior where terminate_early would return an Optional[T]
instead of a List[T] since it is annoying to type (requires overloads)
and almost all the call sites are really just testing for existence
anyway.