### PR TITLE
Properly propagate creation and deletion of extensions

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -955,11 +955,17 @@ class Compiler:
         create_db = None
         drop_db = None
         create_db_template = None
+        create_ext = None
+        drop_ext = None
         if isinstance(stmt, qlast.DropDatabase):
             drop_db = stmt.name.name
         elif isinstance(stmt, qlast.CreateDatabase):
             create_db = stmt.name.name
             create_db_template = stmt.template.name if stmt.template else None
+        elif isinstance(stmt, qlast.CreateExtension):
+            create_ext = stmt.name.name
+        elif isinstance(stmt, qlast.DropExtension):
+            drop_ext = stmt.name.name
 
         if debug.flags.delta_execute:
             debug.header('Delta Script')
@@ -977,6 +983,8 @@ class Compiler:
             create_db=create_db,
             drop_db=drop_db,
             create_db_template=create_db_template,
+            create_ext=create_ext,
+            drop_ext=drop_ext,
             has_role_ddl=isinstance(stmt, qlast.RoleCommand),
             ddl_stmt_id=ddl_stmt_id,
             user_schema=current_tx.get_user_schema_if_updated(),
@@ -1881,6 +1889,8 @@ class Compiler:
                 unit.create_db = comp.create_db
                 unit.drop_db = comp.drop_db
                 unit.create_db_template = comp.create_db_template
+                unit.create_ext = comp.create_ext
+                unit.drop_ext = comp.drop_ext
                 unit.has_role_ddl = comp.has_role_ddl
                 unit.ddl_stmt_id = comp.ddl_stmt_id
                 if comp.user_schema is not None:

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -132,6 +132,8 @@ class DDLQuery(BaseQuery):
     single_unit: bool = False
     create_db: Optional[str] = None
     drop_db: Optional[str] = None
+    create_ext: Optional[str] = None
+    drop_ext: Optional[str] = None
     create_db_template: Optional[str] = None
     has_role_ddl: bool = False
     ddl_stmt_id: Optional[str] = None
@@ -254,6 +256,10 @@ class QueryUnit:
     # a template database to create the database. The server should
     # close all inactive unused pooled connections to the template db.
     create_db_template: Optional[str] = None
+
+    # If non-None, contains names of created/deleted extensions.
+    create_ext: Optional[Set[str]] = None
+    drop_ext: Optional[Set[str]] = None
 
     # If non-None, the DDL statement will emit data packets marked
     # with the indicated ID.

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -31,6 +31,7 @@ cpdef enum SideEffects:
     RoleChanges = 1 << 3
     GlobalSchemaChanges = 1 << 4
     DatabaseChanges = 1 << 5
+    ExtensionChanges = 1 << 6
 
 
 @cython.final
@@ -86,6 +87,7 @@ cdef class Database:
         readonly object extensions
 
     cdef schedule_config_update(self)
+    cdef schedule_extensions_update(self)
 
     cdef _invalidate_caches(self)
     cdef _cache_compiled_query(self, key, query_unit)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -184,6 +184,9 @@ cdef class Database:
     cdef schedule_config_update(self):
         self._index._server._on_local_database_config_change(self.name)
 
+    cdef schedule_extensions_update(self):
+        self._index._server._on_database_extensions_changes(self.name)
+
     cdef _set_and_signal_new_user_schema(
         self,
         new_schema,
@@ -830,6 +833,9 @@ cdef class DatabaseConnectionView:
             if query_unit.has_role_ddl:
                 side_effects |= SideEffects.RoleChanges
                 self._db._index._server._fetch_roles()
+            if query_unit.create_ext or query_unit.drop_ext:
+                side_effects |= SideEffects.ExtensionChanges
+                self._db.schedule_extensions_update()
         else:
             if new_types:
                 self._in_tx_new_types.update(new_types)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1955,6 +1955,8 @@ cdef class PGConnection:
                     self.server._on_global_schema_change()
                 elif event == 'database-changes':
                     self.server._on_remote_database_changes()
+                elif event == 'extension-changes':
+                    self.server._on_database_extensions_changes()
                 elif event == 'ensure-database-not-used':
                     dbname = event_payload['dbname']
                     self.server._on_remote_database_quarantine(dbname)

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -381,6 +381,14 @@ def signal_side_effects(dbv, side_effects):
             interruptable=False,
         )
 
+    if side_effects & dbview.SideEffects.ExtensionChanges:
+        server.create_task(
+            server._signal_sysevent(
+                'extension-changes',
+            ),
+            interruptable=False,
+        )
+
 
 async def parse_execute_json(
     db: dbview.Database,

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -19,10 +19,7 @@
 
 from __future__ import annotations
 
-import contextlib
-import http.client
 import json
-import ssl
 import urllib.parse
 import urllib.request
 
@@ -35,70 +32,10 @@ from edb.common import assert_data_shape
 from . import server
 
 
-class StubbornHttpConnection(http.client.HTTPSConnection):
-
-    def close(self):
-        # Don't actually close the connection.  This allows us to
-        # test keep-alive and "Connection: close" headers.
-        pass
-
-    def true_close(self):
-        http.client.HTTPConnection.close(self)
-
-
 bag = assert_data_shape.bag
 
 
-class BaseHttpTest:
-    tls_context: ssl.SSLContext
-
-    @classmethod
-    def get_api_path(cls):
-        raise NotImplementedError
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.tls_context = ssl.create_default_context(
-            ssl.Purpose.SERVER_AUTH,
-            cafile=cls.get_connect_args()['tls_ca_file'],
-        )
-        cls.tls_context.check_hostname = False
-
-        cls.http_host, cls.http_port = cls.con.connected_addr()
-        api_path = cls.get_api_path()
-        cls.http_addr = f'https://{cls.http_host}:{cls.http_port}{api_path}'
-
-    @contextlib.contextmanager
-    def http_con(self):
-        con = StubbornHttpConnection(
-            self.http_host, self.http_port, context=self.tls_context
-        )
-        con.connect()
-        try:
-            yield con
-        finally:
-            con.true_close()
-
-    def http_con_send_request(self, con, params: dict, *, path=''):
-        con.request(
-            'GET',
-            f'{self.http_addr}/{path}'  # type: ignore
-            f'?{urllib.parse.urlencode(params)}')
-
-    def http_con_read_response(self, con):
-        resp = con.getresponse()
-        resp_body = resp.read()
-        resp_headers = {k.lower(): v.lower() for k, v in resp.getheaders()}
-        return resp_body, resp_headers, resp.status
-
-    def http_con_request(self, con, params: dict, *, path=''):
-        self.http_con_send_request(con, params, path=path)
-        return self.http_con_read_response(con)
-
-
-class BaseHttpExtensionTest(BaseHttpTest):
+class BaseHttpExtensionTest(server.QueryTestCase):
 
     @classmethod
     def get_extension_name(cls):
@@ -109,7 +46,7 @@ class BaseHttpExtensionTest(BaseHttpTest):
         return cls.get_extension_name()
 
     @classmethod
-    def get_api_path(cls):
+    def get_api_prefix(cls):
         extpath = cls.get_extension_path()
         dbname = cls.get_database_name()
         return f'/db/{dbname}/{extpath}'
@@ -132,7 +69,7 @@ class BaseHttpExtensionTest(BaseHttpTest):
         super().tearDownClass()
 
 
-class EdgeQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
+class EdgeQLTestCase(BaseHttpExtensionTest):
 
     @classmethod
     def get_extension_name(cls):
@@ -202,7 +139,7 @@ class EdgeQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
         return res
 
 
-class GraphQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
+class GraphQLTestCase(BaseHttpExtensionTest):
 
     @classmethod
     def get_extension_name(cls):

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -24,13 +24,12 @@ import edgedb
 from edgedb import scram
 
 from edb import protocol
-from edb.testbase import http as tb
 from edb.testbase import server as tb_server
 
 
-class BaseTestHttpAuth(tb.BaseHttpTest, tb_server.ConnectedTestCase):
+class BaseTestHttpAuth(tb_server.ConnectedTestCase):
     @classmethod
-    def get_api_path(cls) -> str:
+    def get_api_prefix(cls) -> str:
         return "/auth"
 
     def _scram_auth(self, user, password):

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -25,7 +25,7 @@ import urllib
 from edb.testbase import http as tb
 
 
-class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
+class TestHttpNotebook(tb.BaseHttpExtensionTest):
 
     # EdgeQL/HTTP queries cannot run in a transaction
     TRANSACTION_ISOLATION = False

--- a/tests/test_http_system_api.py
+++ b/tests/test_http_system_api.py
@@ -17,14 +17,13 @@
 #
 
 
-from edb.testbase import http as tb
 from edb.testbase import server as tb_server
 
 
-class TestHttpSystemAPI(tb.BaseHttpTest, tb_server.ConnectedTestCase):
+class TestHttpSystemAPI(tb_server.ConnectedTestCase):
 
     @classmethod
-    def get_api_path(cls) -> str:
+    def get_api_prefix(cls) -> str:
         return '/server'
 
     def test_http_sys_api_status(self):


### PR DESCRIPTION
`CREATE EXTENSION` (and `DROP` too) are currently happily ignored by the
adjacent servers, but also, in some cases even by the local server.