### PR TITLE
Fix conflict checks on UPDATE to unions

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -479,6 +479,28 @@ def concretify(
     return t
 
 
+def get_all_concrete(
+    stype: s_objtypes.ObjectType, *, ctx: context.ContextLevel
+) -> set[s_objtypes.ObjectType]:
+    if stype.get_intersection_of(ctx.env.schema):
+        # TODO: We should enumerate all object types in the intersection
+        # maybe in concretify, though?
+        raise errors.UnsupportedFeatureError(
+            'DML statements on intersections are not implemented yet',
+        )
+
+    if union := stype.get_union_of(ctx.env.schema):
+        return {
+            x
+            for t in union.objects(ctx.env.schema)
+            for x in get_all_concrete(t, ctx=ctx)
+        }
+    return {stype} | {
+        x for x in stype.descendants(ctx.env.schema)
+        if x.is_material_object_type(ctx.env.schema)
+    }
+
+
 class TypeIntersectionResult(NamedTuple):
 
     stype: s_types.Type

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5098,6 +5098,29 @@ class TestInsert(tb.QueryTestCase):
                 update X set { foo := "!" };
             ''')
 
+    async def test_edgeql_insert_update_cross_type_conflict_16(self):
+        await self.con.execute('''
+            CREATE TYPE Foo {
+                CREATE REQUIRED PROPERTY name -> str {
+                    CREATE CONSTRAINT exclusive;
+                };
+            };
+            CREATE TYPE Bar EXTENDING Foo;
+            CREATE TYPE Baz EXTENDING Foo;
+
+            INSERT Bar { name := "bar" };
+            INSERT Baz { name := "baz" };
+        ''')
+
+        query = r'''
+            UPDATE {Bar, Baz} FILTER true SET { name := "!" };
+        '''
+
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
     async def test_edgeql_insert_and_update_01(self):
         # INSERTing something that would violate a constraint while
         # fixing the violation is still supposed to be an error.


### PR DESCRIPTION
Updates to unions had been broken (see #2383), and at some point they
got accidentally fixed, but without making conflicts actually work.

Two parts to this fix:
1. Look into unions when expanding out types during conflict compilation.
2. Don't lose include_ancestors when processing unions in type_to_typeref,
which was causing the type overlays to miss what was going on once
the compilation was fixed.

Also fix a silly issue where we would generate pure self checks during
an update, joining an update CTE to itself.