### PR TITLE
Check for invalid arrays at the protocol level

### DIFF
--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -166,7 +166,7 @@ cdef WriteBuffer recode_bind_args(
             if in_len < 0:
                 # This means argument value is NULL
                 if param.required:
-                    raise errors.InputDataError(
+                    raise errors.QueryError(
                         f"parameter ${param.name} is required")
 
             # If the param has encoded tuples, we need to decode them


### PR DESCRIPTION
Currently we allow array arguments containing NULL and with unexpected
dims and bounds. Check and prevent this.

Fixes #4405.

Performance impact seemed negligable.