### PR TITLE
Make newly created linkprops get added to the relevant alias types

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -776,7 +776,7 @@ class Pointer(referencing.ReferencedInheritingObject,
         refdict: so.RefDict,
     ) -> bool:
         object_type = self.get_source(schema)
-        if isinstance(object_type, s_types.Type):
+        if isinstance(object_type, s_types.Type) and refdict.attr != 'pointers':
             return not object_type.is_view(schema)
         else:
             return True

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -778,7 +778,7 @@ class Pointer(referencing.ReferencedInheritingObject,
         object_type = self.get_source(schema)
         if isinstance(object_type, s_types.Type):
             return (
-                not object_type.is_view(schema) or refdict.attr != 'pointers')
+                not object_type.is_view(schema) or refdict.attr == 'pointers')
         else:
             return True
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -776,8 +776,9 @@ class Pointer(referencing.ReferencedInheritingObject,
         refdict: so.RefDict,
     ) -> bool:
         object_type = self.get_source(schema)
-        if isinstance(object_type, s_types.Type) and refdict.attr != 'pointers':
-            return not object_type.is_view(schema)
+        if isinstance(object_type, s_types.Type):
+            return (
+                not object_type.is_view(schema) or refdict.attr != 'pointers')
         else:
             return True
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11140,6 +11140,19 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         """)
 
+    async def test_edgeql_migration_alias_linkprop_01(self):
+        await self.migrate(r"""
+            alias UserAlias := User;
+
+            type User {
+              multi link ml -> Target {
+                property lp -> str;
+              };
+            }
+
+            type Target;
+        """)
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
This was manifesting as #4483, where we were inferring the schema
incorrectly since declarative was producing DDL that created the
view and *then* the link property, which did not match the DDL
that ordering produced.

Fixes #4483.