### PR TITLE
Fix SET REQUIRED on newly created properties with alias subtypes

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1848,6 +1848,7 @@ class CreatePointer(
             )
         ):
             cmd.set_attribute_value('from_alias', True)
+            cmd.set_object_aux_data('from_alias', True)
 
         return cmd
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -14705,6 +14705,17 @@ type default::Foo {
             [{}],
         )
 
+    async def test_edgeql_ddl_alias_and_create_set_required(self):
+        await self.con.execute(r"""
+            create type T;
+            create alias A := T;
+            alter type T {
+                create required property bar -> str {
+                    set required using ('!')
+                }
+            };
+        """)
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
`pgsql/delta` relies on `from_alias` in aux_data to determine whether
to perform various operations on pointers, so make sure it gets set on
newly created pointers on aliases.

Fixes #4382.

As a follow up I think that it might be an improvement to see if we
can ditch the whole `aux_data` mechanism.