### PR TITLE
Fix handling of link properties named 'id'

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1097,9 +1097,8 @@ def _normalize_view_ptr_expr(
         )
 
     # Prohibit invalid operations on id and __type__
-    ptrcls_sn = ptrcls.get_shortname(ctx.env.schema)
     id_access = (
-        ptrcls_sn.name == 'id'
+        ptrcls.is_id_pointer(ctx.env.schema)
         and (
             not ctx.env.options.allow_user_specified_id
             or not exprtype.is_mutation()
@@ -1110,6 +1109,7 @@ def _normalize_view_ptr_expr(
         and (id_access or ptrcls.is_protected_pointer(ctx.env.schema))
         and not from_default
     ):
+        ptrcls_sn = ptrcls.get_shortname(ctx.env.schema)
         if is_polymorphic:
             msg = (f'cannot access {ptrcls_sn.name} on a polymorphic '
                    f'shape element')

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -784,7 +784,7 @@ def is_id_ptrref(ptrref: irast.BasePointerRef) -> bool:
     """Return True if *ptrref* describes the id property."""
     return (
         str(ptrref.std_parent_name) == 'std::id'
-    )
+    ) and not ptrref.source_ptr
 
 
 def is_computable_ptrref(ptrref: irast.BasePointerRef) -> bool:

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -685,7 +685,7 @@ class Pointer(referencing.ReferencedInheritingObject,
     def is_special_pointer(self, schema: s_schema.Schema) -> bool:
         return self.get_shortname(schema).name in {
             'source', 'target', 'id'
-        }
+        } and (self.is_id_pointer(schema) or self.is_endpoint_pointer(schema))
 
     def is_property(self, schema: s_schema.Schema) -> bool:
         raise NotImplementedError

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3241,6 +3241,29 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
         """)
 
+    async def test_edgeql_ddl_link_property_09(self):
+        await self.con.execute("""
+            create type T;
+            create type S {
+                create multi link x -> T {
+                    create property id -> str;
+                    create index on (__subject__@id);
+                }
+            };
+            insert T;
+            insert S { x := (select T { @id := "lol" }) };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                select S { x: {id, @id} }
+            """,
+            [{'x': [{'id': str, '@id': "lol"}]}],
+            # The python bindings seem to misbehave when there is
+            # linkprop and a regular prop with the same name
+            json_only=True,
+        )
+
     async def test_edgeql_ddl_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,


### PR DESCRIPTION
Link props named 'id' were being misidentified as special pointers,
and so didn't trigger the creation of link tables properly.

Fixes #4237.