### PR TITLE
Disable restore-keys for cython extension builds

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -79,8 +79,6 @@
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-v4-
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v2
@@ -181,8 +179,6 @@
       with:
         path: ${{ env.BUILD_TEMP }}/edb
         key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-build-v3-
 
     - name: Build Cython extensions
       env:

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -102,8 +102,6 @@ jobs:
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-v4-
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v2
@@ -204,8 +202,6 @@ jobs:
       with:
         path: ${{ env.BUILD_TEMP }}/edb
         key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-build-v3-
 
     - name: Build Cython extensions
       env:

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -100,8 +100,6 @@ jobs:
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-v4-
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v2
@@ -202,8 +200,6 @@ jobs:
       with:
         path: ${{ env.BUILD_TEMP }}/edb
         key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-build-v3-
 
     - name: Build Cython extensions
       env:

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -102,8 +102,6 @@ jobs:
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-v4-
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v2
@@ -204,8 +202,6 @@ jobs:
       with:
         path: ${{ env.BUILD_TEMP }}/edb
         key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-build-v3-
 
     - name: Build Cython extensions
       env:

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -100,8 +100,6 @@ jobs:
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-v4-
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v2
@@ -202,8 +200,6 @@ jobs:
       with:
         path: ${{ env.BUILD_TEMP }}/edb
         key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-build-v3-
 
     - name: Build Cython extensions
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,8 +113,6 @@ jobs:
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-v4-
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v2
@@ -215,8 +213,6 @@ jobs:
       with:
         path: ${{ env.BUILD_TEMP }}/edb
         key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
-        restore-keys: |
-          edb-ext-build-v3-
 
     - name: Build Cython extensions
       env:


### PR DESCRIPTION
Cython incremental builds seem to be unreliable?