### PR TITLE
Do a better job detecting when we need a concrete union

### DIFF
--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -511,3 +511,19 @@ class TestDelete(tb.QueryTestCase):
                 'name': 'child of abstract 2'
             }],
         )
+
+    async def test_edgeql_delete_then_union(self):
+        await self.con.execute(r"""
+            INSERT DeleteTest2 { name := 'x' };
+            INSERT DeleteTest2 { name := 'y' };
+        """)
+
+        await self.assert_query_result(
+            r"""
+            with
+            delete1 := assert_exists((delete DeleteTest2 filter .name = 'x')),
+            delete2 := assert_exists((delete DeleteTest2 filter .name = 'y')),
+            select {delete1, delete2};
+            """,
+            [{}, {}],
+        )


### PR DESCRIPTION
I think some more love is needed to cleaning up the details of
TypeRef/PointerRef, but for now this is expedient.

Fixes #4475.