### PR TITLE
Fix correlation issue related to factoring_allowlist

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -613,7 +613,10 @@ def declare_view(
     pinned_pid_ns = path_id_namespace
 
     with ctx.newscope(fenced=True) as subctx:
-        subctx.path_scope.factoring_fence = factoring_fence
+        if factoring_fence:
+            subctx.path_scope.factoring_fence = True
+            subctx.path_scope.factoring_allowlist.update(ctx.iterator_path_ids)
+
         if path_id_namespace is not None:
             subctx.path_id_namespace = path_id_namespace
 

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -756,10 +756,10 @@ class ScopeTreeNode:
 
             if node is not self:
                 ans_finfo = node.fence_info
-                parent_fence = node.parent_fence
-                if (parent_fence is not None
-                        and any(_paths_equal(path_id, wl, namespaces)
-                                for wl in parent_fence.factoring_allowlist)):
+                if any(
+                    _paths_equal(path_id, wl, namespaces)
+                    for wl in node.factoring_allowlist
+                ):
                     ans_finfo = FenceInfo(
                         unnest_fence=ans_finfo.unnest_fence,
                         factoring_fence=False,

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5695,3 +5695,20 @@ class TestInsert(tb.QueryTestCase):
                 notes := (select Note { foo := 0 })
             };
         ''')
+
+    async def test_edgeql_insert_bogus_correlation_typenames(self):
+        # This was being rejected with a correlation error
+        query = r'''
+            for l2 in <int64>{} union (
+                with
+                  subs := (select Subordinate filter .name = '')
+                insert InsertTest {
+                  subordinates := subs,
+                  l2 := l2,
+                }
+            );
+        '''
+
+        await self.con._fetchall(
+            query, __typenames__=True,
+        )


### PR DESCRIPTION
When trying to reproduce looking at #4496, I got bogus "correlated
set" errors when running with typename injection on. The root of the
issue was that something related to the typename injection was causing
there to be an extra fence in between where factoring_fence was set
for an INSERT and the allegedly parent fence where the current
iterators were placed in the factoring_allowlist.

I fixed this by reworking things such that factoring_allowlist applies
to a factoring_fence on the *same* node, not on child nodes.