### PR TITLE
Refactor remove pgast NamedParamRef

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -392,21 +392,11 @@ class TupleVar(TupleVarBase):
         self.typeref = typeref
 
 
-class BaseParamRef(ImmutableBaseExpr):
-    pass
-
-
-class ParamRef(BaseParamRef):
+class ParamRef(ImmutableBaseExpr):
     """Query parameter ($0..$n)."""
 
     # Number of the parameter.
     number: int
-
-
-class NamedParamRef(BaseParamRef):
-    """Named query parameter."""
-
-    name: str
 
 
 class ResTarget(ImmutableBaseExpr):

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -656,9 +656,6 @@ class SQLSourceGenerator(codegen.SourceGenerator):
     def visit_ParamRef(self, node: pgast.ParamRef) -> None:
         self.write('$', str(node.number))
 
-    def visit_NamedParamRef(self, node: pgast.NamedParamRef) -> None:
-        self.write(common.quote_ident(node.name))
-
     def visit_RowExpr(self, node: pgast.RowExpr) -> None:
         self.write('ROW(')
         self.visit_list(node.args, newlines=False)

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -119,15 +119,15 @@ def compile_Parameter(
         expr: irast.Parameter, *,
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
-    result: pgast.BaseParamRef
+    result: pgast.BaseExpr
     is_decimal: bool = expr.name.isdecimal()
 
     params = [p for p in ctx.env.query_params if p.name == expr.name]
     param = params[0] if params else None
 
     if not is_decimal and ctx.env.use_named_params:
-        result = pgast.NamedParamRef(
-            name=expr.name,
+        result = pgast.ColumnRef(
+            name=(expr.name, ),
             nullable=not expr.required,
         )
     elif param and param.sub_params:

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -289,7 +289,7 @@ def _build_keyword(name: str) -> Builder[pgast.Keyword]:
     return lambda n, c: pgast.Keyword(name=name, context=_build_context(n, c))
 
 
-def _build_param_ref(n: Node, c: Context) -> pgast.BaseParamRef:
+def _build_param_ref(n: Node, c: Context) -> pgast.ParamRef:
     return pgast.ParamRef(number=n["number"], context=_build_context(n, c))
 
 


### PR DESCRIPTION
Pgsql does not support named params.
Our node was here only to serve as a a simple ColumnRef.
