### PR TITLE
nice errors for inline enums

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1367,7 +1367,9 @@ class Schema(SDL):
 #
 
 
-def get_targets(target: typing.Union[None, TypeExpr, Expr]):
+def get_targets(
+    target: typing.Union[None, TypeExpr, Expr]
+) -> typing.List[typing.Union[TypeExpr, Expr]]:
     if target is None:
         return []
     elif isinstance(target, TypeOp):

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1730,7 +1730,7 @@ class PointerCommand(
 
             new_targets = [
                 utils.ast_to_type_shell(
-                    t,
+                    t,  # type: ignore
                     metaclass=s_types.Type,
                     modaliases=context.modaliases,
                     schema=schema,
@@ -1745,7 +1745,7 @@ class PointerCommand(
             )
         elif targets:
             target_expr = targets[0]
-            if isinstance(target_expr, qlast.TypeName):
+            if isinstance(target_expr, qlast.TypeExpr):
                 target_ref = utils.ast_to_type_shell(
                     target_expr,
                     metaclass=s_types.Type,

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -272,8 +272,12 @@ class AnonymousEnumTypeShell(s_types.TypeShell[ScalarType]):
         self.elements = list(elements)
 
     def resolve(self, schema: s_schema.Schema) -> ScalarType:
-        raise NotImplementedError(
-            f'cannot resolve {self.__class__.__name__!r}'
+        raise errors.InvalidPropertyDefinitionError(
+            'this type cannot be anonymous',
+            details=(
+                'you may want define this enum first:\n\n'
+                '  scalar type MyEnum extending enum<...>;'
+            ),
         )
 
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2963,6 +2963,9 @@ def materialize_type_in_attribute(
                     context=srcctx,
                 )
             raise
+        except errors.InvalidPropertyDefinitionError as e:
+            e.set_source_context(srcctx)
+            raise
     elif not isinstance(type_ref, Type):
         raise AssertionError(
             f'unexpected value in type attribute {attrname!r} of '

--- a/tests/test_edgeql_enums.py
+++ b/tests/test_edgeql_enums.py
@@ -284,3 +284,16 @@ class TestEdgeQLEnums(tb.QueryTestCase):
                 edgedb.InvalidValueError,
                 r'expected JSON string or null; got JSON number'):
             await self.con.execute("SELECT <color_enum_t><json>12")
+
+    async def test_edgeql_enums_anonymous(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidPropertyDefinitionError,
+            r'this type cannot be anonymous',
+        ):
+            await self.con.execute(
+                """
+                create type X {
+                    create property tier -> enum<"Basic", "Common", "Rare">;
+                }
+                """
+            )


### PR DESCRIPTION
Closes #4398.

- fix an issue with SQL toposorting of TypeExpr
- nice error reporting for inline enums:

```
(venv) ➜  drs-edge-db edb cli migration create
error: this type cannot be anonymous
   ┌─ dbschema/default.esdl:15:22
   │
15 │     property tier -> enum<"Basic", "Common", "Epic", "Legendary", "Rare">;
   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error
   │
   = you may want define this enum first:
     
       scalar type MyEnum extending enum<...>;

edgedb error: cannot proceed until .esdl files are fixed
```
