### PR TITLE
Fix casting empty sets to standard library enum types

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     ]
 
 STD_MODULES = (
+    sn.UnqualName('__std_derived__'),
     sn.UnqualName('std'),
     sn.UnqualName('schema'),
     sn.UnqualName('math'),

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2783,6 +2783,23 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 SELECT <array<foo>><array<bar>>['test']
             """)
 
+    async def test_edgeql_casts_std_enum_01(self):
+        await self.assert_query_result(
+            '''
+            select <schema::Cardinality>{}
+            ''',
+            [],
+        )
+
+    async def test_edgeql_casts_json_set_02(self):
+        await self.assert_query_result(
+            '''
+            select <tuple<str>>json_set(
+                to_json('["b"]'), "0", value := <json>"a");
+            ''',
+            [('a',)],
+        )
+
     async def test_edgeql_casts_all_null(self):
         # For *every* concrete cast, try casting a value we know
         # will be represented as NULL.


### PR DESCRIPTION
When making up path_ids for empty sets, we need to keep track of
whether the actual type came from a standard library module, so that
we can propertly figure out whether it is in edgedbstd or edgedbpub.

The issue where this first came up was when casting the result of
json_set: an optional wrapper is being inserted for the
`empty_treatment` argument in this cast case. (That seems like its own
performance bug, too.)

Fixes #4530.