### PR TITLE
Fix arrays of ranges when used as argument types

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_10_11_00_00
+EDGEDB_CATALOG_VERSION = 2022_10_17_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -72,6 +72,12 @@ type_to_range_name_map = {
     ('float8',): ('edgedb', 'float64_range_t'),
     ('edgedb', 'timestamptz_t'): ('edgedb', 'datetime_range_t'),
     ('edgedb', 'timestamp_t'): ('edgedb', 'local_datetime_range_t'),
+    # cal::local_date uses the built-in daterange instead of a custom
+    # one that actually uses edgedb.date_t as its subtype. This is
+    # because cal::local_date is discrete, and its range type should
+    # get canonicalized. Defining a canonicalization function for a
+    # custom range is a big hassle, and daterange already has the
+    # correct canonicalization function
     ('edgedb', 'date_t'): ('daterange',),
 }
 

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -266,6 +266,7 @@ def generate_structure(schema: s_schema.Schema) -> SchemaReflectionParts:
         '''
             CREATE FUNCTION sys::_get_pg_type_for_edgedb_type(
                 typeid: std::uuid,
+                kind: std::str,
                 elemid: OPTIONAL std::uuid,
             ) -> std::int64 {
                 USING SQL FUNCTION 'edgedb.get_pg_type_for_edgedb_type';

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -424,16 +424,19 @@ def _build_object_mutation_shape(
             and not issubclass(mcls, s_types.CollectionExprAlias)
             and not cmd.get_attribute_value('abstract')
         ):
+            kind = f'"schema::{mcls.__name__}"'
+
             if issubclass(mcls, (s_types.Array, s_types.Range)):
                 assignments.append(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
                     f'<uuid>$__{var_prefix}id, '
+                    f'{kind}, '
                     f'<uuid>$__{var_prefix}element_type)'
                 )
             else:
                 assignments.append(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
-                    f'<uuid>$__{var_prefix}id, <uuid>{{}})'
+                    f'<uuid>$__{var_prefix}id, {kind}, <uuid>{{}})'
                 )
             variables[f'__{var_prefix}id'] = json.dumps(
                 str(cmd.get_attribute_value('id')))

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1038,6 +1038,7 @@ async def _init_stdlib(
             SET {
                 backend_id := sys::_get_pg_type_for_edgedb_type(
                     .id,
+                    .__type__.name,
                     <uuid>{}
                 )
             }
@@ -1057,6 +1058,7 @@ async def _init_stdlib(
             SET {
                 backend_id := sys::_get_pg_type_for_edgedb_type(
                     .id,
+                    .__type__.name,
                     .element_type.id,
                 )
             }

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -6615,6 +6615,15 @@ aa \
             variables=(None,),
         )
 
+    async def test_edgeql_expr_range_38(self):
+        # Test array of range as argument
+        await self.con.query(
+            '''
+            select <array<range<int64>>>$0
+            ''',
+            [edgedb.Range(0, 10)],
+        )
+
     async def test_edgeql_expr_cannot_assign_dunder_type_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'cannot assign to __type__'):


### PR DESCRIPTION
The backend OID computation for ranges introduced in #4463 doesn't
work properly, because it always instead grabs the type of an *array*
of the element type, not the type of the range. Pass the kind of type
being resolved as an additional argument to the OID resolution function,
so that we can distinguish properly.

We then also need to do the range OID resolution based on our
type_to_range_name_map, instead of based on the rngsubtype field,
since date_t uses daterange instead of a dedicated range.