### PR TITLE
Fix several issues that manifest when using GROUP BY

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1664,6 +1664,8 @@ def should_materialize(
 
     typ = get_set_type(ir, ctx=ctx)
 
+    assert ir.path_scope_id is not None
+
     # For shape elements, we need to materialize when they reference
     # bindings that are visible from that point. This means that doing
     # WITH/FOR bindings internally is fine, but referring to
@@ -1674,15 +1676,24 @@ def should_materialize(
         materialize_visible
         and (vis := irutils.find_potentially_visible(
             ir,
-            ctx.env.scope_tree_nodes[not_none(ir.path_scope_id)],
+            ctx.env.scope_tree_nodes[ir.path_scope_id],
             ctx.env.scope_tree_nodes, skipped_bindings))
     ):
-        reasons.append(irast.MaterializeVisible(sets=vis))
+        reasons.append(irast.MaterializeVisible(
+            sets=vis, path_scope_id=ir.path_scope_id))
 
     if ptrcls and ptrcls in ctx.env.source_map:
         reasons += ctx.env.source_map[ptrcls].should_materialize
 
-    reasons += should_materialize_type(typ, ctx=ctx)
+    for r in should_materialize_type(typ, ctx=ctx):
+        # Rewrite visibility reasons from the typ to reflect this,
+        # the real bind point.
+        if isinstance(r, irast.MaterializeVolatile):
+            reasons.append(r)
+        else:
+            reasons.append(
+                irast.MaterializeVisible(
+                    sets=r.sets, path_scope_id=ir.path_scope_id))
 
     return reasons
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -635,6 +635,7 @@ class MaterializeVolatile(Base):
 class MaterializeVisible(Base):
     __ast_hidden__ = {'sets'}
     sets: typing.Set[typing.Tuple[PathId, Set]]
+    path_scope_id: int
 
 
 @markup.serializer.serializer.register(MaterializeVisible)

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -1727,7 +1727,10 @@ CARDS_DB = [
         "typ": "test::User"
     },
     {
-        "avatar": null,
+        "avatar": {
+            "@text": "Wow",
+            "id": "8153766e-c308-11eb-98b8-1b59432eef87"
+        },
         "awards": [],
         "deck": [
             {"@count": 1, "id": "81537667-c308-11eb-98b8-e7ee6a203949"},

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -1097,10 +1097,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ]
         )
 
-    @test.xerror('''
-        Can't find materialized set
-            ns~2@ns~6@ns~7@@(__derived__::GR@w~1).>key[IS std::str]
-    ''')
     async def test_edgeql_for_fake_group_02(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3077,10 +3077,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
-    @test.xerror('''
-        Fails assert not ir_set.is_materialized_ref
-        Broken in fix for #3898
-    ''')
     async def test_edgeql_scope_source_rebind_04(self):
         await self.assert_query_result(
             """
@@ -3320,7 +3316,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('Returns tags with all users')
+    @test.xerror("can't find materialized set")
     async def test_edgeql_scope_ref_outer_06b(self):
         # Same as above, basically, but with an extra shape on Bc
         # that causes trouble.

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -125,7 +125,7 @@ class TestModelSmokeTests(unittest.TestCase):
             r"""
             SELECT (User.name ++ User.avatar.name) ?? 'hm';
             """,
-            ['AliceDragon'],
+            {'AliceDragon', 'DaveDjinn'},
         )
 
     def test_model_optional_prop_06(self):


### PR DESCRIPTION
It is common to hit materialization when using GROUP BY. This fixes a
cluster of them.

1. When looking for a materialized pointer inside a source rvar
grabbing a pointer, discard any namespaces that are not on the source
path. unpack_rvar won't put those namespaces on the path, so we can't
either.
2. Explicitly track the binding scope for visibility materialization,
and use that when checking for visibility.

Fixes #3951. Fixes #4240. Fixes #4481.

Issues #3951 and #4240 depend on fix 1, #4481 depends on fix 2. Fix 2
also fixed two existing xerrored tests and turns one of the worst
remaining miscompiles into an ISE.