### PR TITLE
Fix SET REQUIRED USING when combined with access policies

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4123,6 +4123,7 @@ class PointerMetaCommand(MetaCommand):
                 context,
                 conv_expr,
                 target_as_singleton=target_as_singleton,
+                no_query_rewrites=True,
             )
             ir = conv_expr.irast
 
@@ -4145,6 +4146,7 @@ class PointerMetaCommand(MetaCommand):
                     schema=orig_schema,
                 ),
                 target_as_singleton=target_as_singleton,
+                no_query_rewrites=True,
             )
 
             ir = conv_expr.irast

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1590,6 +1590,7 @@ class Query(Command):
                 schema,
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,
+                    apply_query_rewrites=False,
                 )
             )
         return schema

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1315,6 +1315,7 @@ class PointerCommandOrFragment(
         singleton_result_expected: bool = False,
         target_as_singleton: bool = False,
         expr_description: Optional[str] = None,
+        no_query_rewrites: bool = False,
     ) -> s_expr.Expression:
         singletons: List[Union[s_types.Type, Pointer]] = []
 
@@ -1369,7 +1370,9 @@ class PointerCommandOrFragment(
                 anchors={qlast.Source().name: source},
                 path_prefix_anchor=qlast.Source().name,
                 singletons=singletons,
-                apply_query_rewrites=not context.stdmode,
+                apply_query_rewrites=(
+                    not context.stdmode and not no_query_rewrites
+                ),
                 track_schema_ref_exprs=track_schema_ref_exprs,
                 in_ddl_context_name=in_ddl_context_name,
             ),
@@ -2221,6 +2224,7 @@ class SetPointerType(
                     expr=self.cast_expr,
                     target_as_singleton=True,
                     singleton_result_expected=True,
+                    no_query_rewrites=True,
                     expr_description=(
                         f'the USING clause for the alteration of {vn}'
                     ),
@@ -2400,6 +2404,7 @@ class AlterPointerUpperCardinality(
                     expr=self.conv_expr,
                     target_as_singleton=False,
                     singleton_result_expected=True,
+                    no_query_rewrites=True,
                     expr_description=(
                         f'the USING clause for the alteration of {vn}'
                     ),
@@ -2614,6 +2619,7 @@ class AlterPointerLowerCardinality(
                     expr=self.fill_expr,
                     target_as_singleton=True,
                     singleton_result_expected=new_card.is_single(),
+                    no_query_rewrites=True,
                     expr_description=(
                         f'the USING clause for the alteration of {vn}'
                     ),

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12047,6 +12047,29 @@ type default::Foo {
             }]
         )
 
+    async def test_edgeql_ddl_create_migration_02(self):
+        await self.con.execute('''
+CREATE MIGRATION m1kmv2mcizpj2twxlxxerkgngr2fkto7wnjd6uig3aa3x67dykvspq
+    ONTO initial
+{
+  CREATE GLOBAL default::foo -> std::bool;
+  CREATE TYPE default::Foo {
+      CREATE ACCESS POLICY foo
+          ALLOW ALL USING ((GLOBAL default::foo ?? true));
+  };
+};
+        ''')
+
+        await self.con.execute('''
+CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
+    ONTO m1kmv2mcizpj2twxlxxerkgngr2fkto7wnjd6uig3aa3x67dykvspq
+{
+  CREATE TYPE default::X;
+
+  INSERT Foo;
+};
+        ''')
+
     async def test_edgeql_ddl_naked_backlink_in_computable(self):
         await self.con.execute('''
             CREATE TYPE User {


### PR DESCRIPTION
We need to disable access policies when running this kind of DDL
command.

Fixes #4551.