### PR TITLE
Fix failure when a rebase doesn't change the set of ancestors

### DIFF
--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -3120,7 +3120,9 @@ class InheritingObject(SubclassableObject):
             # Trim these from the base alter since they are redundant
             # and clog up debug output.
             delta.discard(not_none(delta._get_attribute_set_cmd('bases')))
-            delta.discard(not_none(delta._get_attribute_set_cmd('ancestors')))
+            # ancestors might not be in the delta, if it didn't change
+            if anc := delta._get_attribute_set_cmd('ancestors'):
+                delta.discard(anc)
 
             delta.add(rebase_cmd)
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11153,6 +11153,23 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             type Target;
         """)
 
+    async def test_edgeql_migration_lift_01(self):
+        await self.migrate(r"""
+            abstract type A;
+            abstract type B;
+
+            abstract type Foo extending A;
+            type Bar extending Foo, B;
+        """)
+
+        await self.migrate(r"""
+            abstract type A;
+            abstract type B;
+
+            abstract type Foo extending A, B;
+            type Bar extending Foo;
+        """)
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
ancestors might not appear in a rebase induced delta if the set of
ancestors did not change (which can happen if something has just been
moved in the tree). Don't choke on this.

Fixes #4502.