### PR TITLE
Fix UNLESS CONFLICT ON for a not-inserted property

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -393,6 +393,10 @@ def compile_conflict_select(
             select_ir, force_reassign=True, ctx=ectx)
         assert isinstance(select_ir, irast.Set)
 
+    # If we have an empty set, remake it with the right type
+    if isinstance(select_ir, irast.EmptySet):
+        select_ir = setgen.new_empty_set(stype=subject_typ, ctx=ctx)
+
     return select_ir, always_check, from_parent
 
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -106,7 +106,7 @@ def new_set(
     return ir_set
 
 
-def new_empty_set(*, stype: Optional[s_types.Type]=None, alias: str,
+def new_empty_set(*, stype: Optional[s_types.Type]=None, alias: str='e',
                   ctx: context.ContextLevel,
                   srcctx: Optional[
                       parsing.ParserContext]=None) -> irast.Set:

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3275,6 +3275,16 @@ class TestInsert(tb.QueryTestCase):
             q, [], variables={'n': "2"},
         )
 
+    async def test_edgeql_insert_unless_conflict_26(self):
+        # Test unless conflict on a property not actually mentioned
+        await self.con.execute('''
+            INSERT Person {
+              name := "Colin"
+            }
+            UNLESS CONFLICT ON .case_name
+            ELSE (Person)
+        ''')
+
     async def test_edgeql_insert_dependent_01(self):
         query = r'''
             SELECT (


### PR DESCRIPTION
We were generating an anytype in our select and then getting confused
on the backend.

Found trying to reproduce #4350.