### PR TITLE
Fix inheritance code block example

### DIFF
--- a/docs/edgeql/sets.rst
+++ b/docs/edgeql/sets.rst
@@ -288,15 +288,15 @@ and ``TVShow``.
 
 .. code-block:: sdl
 
-  type Media {
+  abstract type Media {
     required property title -> str;
   }
 
-  type Movie {
+  type Movie extending Media {
     property release_year -> int64;
   }
 
-  type TVShow {
+  type TVShow extending Media {
     property num_seasons -> int64;
   }
 


### PR DESCRIPTION
The code block was missing the definition of the abstract type and the extension
[https://www.edgedb.com/docs/edgeql/sets#inheritance](https://www.edgedb.com/docs/edgeql/sets#inheritance)

![image](https://user-images.githubusercontent.com/40857565/197017672-3ab3a008-20b9-4fad-8a95-d17ad176920a.png)
