### PR TITLE
Set fail-fast: false on our main CI matrix

### DIFF
--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -100,6 +100,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         shard: [
              1/16,  2/16,  3/16,  4/16,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -385,6 +385,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         shard: [
              1/16,  2/16,  3/16,  4/16,


### PR DESCRIPTION
This will let all the jobs finish, so we collect all the errors.