### PR TITLE
Fix bug if server crashes while applying object-creating patch

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -498,7 +498,7 @@ def prepare_patch(
 
     # Pure SQL patches are simple
     if kind == 'sql':
-        return (patch, update), (), schema
+        return (patch, update), (), {}
 
     assert kind == 'edgeql'
 
@@ -554,7 +554,7 @@ def prepare_patch(
         WHERE key = 'stdschema'
     '''
 
-    return (patch, update), (schema_update,), schema
+    return (patch, update), (schema_update,), {'stdschema': schema}
 
 
 class StdlibBits(NamedTuple):

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -357,8 +357,8 @@ async def _create_edgedb_template_database(
     return dbid
 
 
-async def _store_static_bin_cache(
-    ctx: BootstrapContext,
+async def _store_static_bin_cache_conn(
+    conn: pgcon.PGConnection,
     key: str,
     data: bytes,
 ) -> None:
@@ -371,7 +371,15 @@ async def _store_static_bin_cache(
         )
     """
 
-    await _execute(ctx.conn, text)
+    await _execute(conn, text)
+
+
+async def _store_static_bin_cache(
+    ctx: BootstrapContext,
+    key: str,
+    data: bytes,
+) -> None:
+    await _store_static_bin_cache_conn(ctx.conn, key, data)
 
 
 async def _store_static_text_cache(


### PR DESCRIPTION
When applying a patch, we compile the patch once, apply it to every
user and template db, and *then* apply it to the system db, which
serves to keep everything in sync.

However, if the server crashes after applying a patch to a user db,
but before it is applied to the system db, the patch will get
recompiled before we can apply it to the system db.

Currently, if a patch creates a new object (for example a function, or
a new object type in the introspection schema), this recompilation
will cause the object to have a different id in the system db and the
user db. Since the system db provides the std schema, this will cause
breakage whenever trying to use the object.

Fix this by recording the patches in the database and replaying them
from there when available, instead of recompiling.

No current patches we have shipped in our 2.x branch are vulnerable to
this problem, but some patches we probably will ship in the future
would be.

Tested by creating a patch that adds a function and causing the server
to crash before running the patch on the system db.