### PR TITLE
Fix generated_by field for DDLStatement migrations

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -864,11 +864,14 @@ class Compiler:
                 body=qlast.NestedQLBlock(
                     commands=[stmt],
                 ),
-                generated_by=qlast.Path(steps=[
-                    qlast.ObjectRef(name='MigrationGeneratedBy',
-                                    module='schema'),
-                    qlast.Ptr(ptr=qlast.ObjectRef(name='DDLStatement')),
-                ]),
+                commands=[qlast.SetField(
+                    name='generated_by',
+                    value=qlast.Path(steps=[
+                        qlast.ObjectRef(name='MigrationGeneratedBy',
+                                        module='schema'),
+                        qlast.Ptr(ptr=qlast.ObjectRef(name='DDLStatement')),
+                    ]),
+                )],
             )
             return self._compile_and_apply_ddl_stmt(ctx, cm)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12071,15 +12071,15 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
         ''')
 
     async def test_edgeql_ddl_create_migration_03(self):
-        await self.con.execute(f'''
+        await self.con.execute('''
             CREATE MIGRATION
-            {{
+            {
                 SET message := "migration2";
                 SET generated_by := schema::MigrationGeneratedBy.DevMode;
-                CREATE TYPE Type2 {{
+                CREATE TYPE Type2 {
                     CREATE PROPERTY field2 -> int32;
-                }};
-            }};
+                };
+            };
         ''')
 
         await self.assert_query_result(
@@ -12088,6 +12088,18 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
             FILTER .message = "migration2"
             ''',
             [{'generated_by': 'DevMode'}]
+        )
+
+        await self.con.execute(f'''
+            CREATE TYPE Type3
+        ''')
+
+        await self.assert_query_result(
+            '''
+            SELECT schema::Migration { generated_by }
+            FILTER .script like "%Type3%"
+            ''',
+            [{'generated_by': 'DDLStatement'}]
         )
 
     async def test_edgeql_ddl_naked_backlink_in_computable(self):


### PR DESCRIPTION
I think it got left behind in a refactor.