### PR TITLE
Allow JWT token auth in binary protocol

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -43,7 +43,6 @@ MIB = 1024 * 1024
 RAM_MIB_PER_CONN = 100
 TLS_CERT_FILE_NAME = "edbtlscert.pem"
 TLS_KEY_FILE_NAME = "edbprivkey.pem"
-JWE_KEY_FILE_NAME = "edbjwekeys.pem"
 JWS_KEY_FILE_NAME = "edbjwskeys.pem"
 
 
@@ -198,7 +197,6 @@ class ServerConfig(NamedTuple):
     tls_cert_mode: ServerTlsCertMode
 
     jws_key_file: pathlib.Path
-    jwe_key_file: pathlib.Path
     jose_key_mode: JOSEKeyMode
 
     default_auth_method: ServerAuthMethods
@@ -730,11 +728,8 @@ _server_options = [
     click.option(
         '--jwe-key-file',
         type=PathPath(),
-        envvar="EDGEDB_SERVER_JWE_KEY_FILE",
         hidden=True,
-        help='Specifies a path to a file containing a private key in PEM '
-             'format used to decrypt JWE tokens. The file could also contain '
-             'a public key to encrypt JWE tokens for local testing.'),
+        help='Deprecated: no longer in use.'),
     click.option(
         '--jose-key-mode',
         type=click.Choice(
@@ -745,13 +740,12 @@ _server_options = [
         default='default',
         help='Specifies what to do when the JOSE keys are either not '
              'specified or are missing.  When set to "require_file", the JOSE '
-             'keys must be specified in the --jws-key-file and --jwe-key-file '
-             'options and both must exist.  When set to "generate", 2 new key '
-             'pairs will be generated and placed in the path specified by '
-             '--jwe-key-file/--jws-key-file, if those are set, otherwise the '
-             f'generated key pairs are stored as `{JWE_KEY_FILE_NAME}` and '
-             f'`{JWS_KEY_FILE_NAME}` in the data directory, or, if the server '
-             'is running with --backend-dsn, in a subdirectory of '
+             'keys must be specified in the --jws-key-file and the file must '
+             'exist.  When set to "generate", a new key pair will be '
+             'generated and placed in the path specified by --jws-key-file, '
+             'if those are set, otherwise the generated key pairs are stored '
+             f'as `{JWS_KEY_FILE_NAME}` in the data directory, or, if the '
+             'server is running with --backend-dsn, in a subdirectory of '
              '--runstate-dir.\n\nThe default is "require_file" when the '
              '--security option is set to "strict", and "generate" when the '
              '--security option is set to "insecure_dev_mode"'),
@@ -1133,28 +1127,10 @@ def parse_args(**kwargs: Any):
             )
         kwargs['jws_key_file'] = jws_key_file
 
-    if not kwargs['jwe_key_file']:
-        if kwargs['data_dir']:
-            jwe_key_file = kwargs['data_dir'] / JWE_KEY_FILE_NAME
-        elif generate_jose:
-            jwe_key_file = pathlib.Path('<runstate>') / JWE_KEY_FILE_NAME
-        else:
-            abort(
-                "no JWE key specified and JOSE keys auto-generation"
-                " has not been requested; see help for --jose-key-mode",
-                exit_code=11,
-            )
-        kwargs['jwe_key_file'] = jwe_key_file
-
     if not kwargs['bootstrap_only'] and not generate_jose:
         if not kwargs['jws_key_file'].exists():
             abort(
                 f"JWS key file \"{kwargs['jws_key_file']}\" does not exist"
-            )
-
-        if not kwargs['jwe_key_file'].exists():
-            abort(
-                f"JWE key file \"{kwargs['jwe_key_file']}\" does not exist"
             )
 
     if (
@@ -1163,15 +1139,6 @@ def parse_args(**kwargs: Any):
     ):
         abort(
             f"JWT key file \"{kwargs['jws_key_file']}\""
-            " is not a regular file"
-        )
-
-    if (
-        kwargs['jwe_key_file'].exists() and
-        not kwargs['jwe_key_file'].is_file()
-    ):
-        abort(
-            f"JWE key file \"{kwargs['jwe_key_file']}\""
             " is not a regular file"
         )
 

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1126,6 +1126,7 @@ def parse_args(**kwargs: Any):
                 exit_code=11,
             )
         kwargs['jws_key_file'] = jws_key_file
+    del kwargs['jwe_key_file']
 
     if not kwargs['bootstrap_only'] and not generate_jose:
         if not kwargs['jws_key_file'].exists():

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -220,16 +220,11 @@ async def _run_server(
                 tls_cert_newly_generated = True
 
         jws_keys_newly_generated = False
-        jwe_keys_newly_generated = False
         if args.jose_key_mode is srvargs.JOSEKeyMode.Generate:
             assert args.jws_key_file is not None
-            assert args.jwe_key_file is not None
             if not args.jws_key_file.exists():
                 generate_jwk(args.jws_key_file)
                 jws_keys_newly_generated = True
-            if not args.jwe_key_file.exists():
-                generate_jwk(args.jwe_key_file)
-                jwe_keys_newly_generated = True
 
         if args.bootstrap_only:
             if args.startup_script and new_instance:
@@ -242,12 +237,7 @@ async def _run_server(
         ss.init_tls(
             args.tls_cert_file, args.tls_key_file, tls_cert_newly_generated)
 
-        ss.init_jwcrypto(
-            args.jws_key_file,
-            args.jwe_key_file,
-            jws_keys_newly_generated,
-            jwe_keys_newly_generated,
-        )
+        ss.init_jwcrypto(args.jws_key_file, jws_keys_newly_generated)
 
         def load_configuration(_signum):
             logger.info("reloading configuration")
@@ -255,7 +245,7 @@ async def _run_server(
                 if args.readiness_state_file:
                     ss.reload_readiness_state(args.readiness_state_file)
                 ss.reload_tls(args.tls_cert_file, args.tls_key_file)
-                ss.load_jwcrypto(args.jws_key_file, args.jwe_key_file)
+                ss.load_jwcrypto(args.jws_key_file)
             except Exception:
                 logger.critical(
                     "Unexpected error occurred during reload configuration; "
@@ -624,16 +614,6 @@ async def run_server(
                         args = args._replace(
                             jws_key_file=pathlib.Path(
                                 str(args.jws_key_file).replace(
-                                    '<runstate>', int_runstate_dir)
-                            ),
-                        )
-                    if (
-                        args.jwe_key_file
-                        and '<runstate>' in str(args.jwe_key_file)
-                    ):
-                        args = args._replace(
-                            jwe_key_file=pathlib.Path(
-                                str(args.jwe_key_file).replace(
                                     '<runstate>', int_runstate_dir)
                             ),
                         )

--- a/edb/server/protocol/auth/scram.py
+++ b/edb/server/protocol/auth/scram.py
@@ -63,10 +63,7 @@ def handle_request(scheme, auth_str, response, server):
         response.close_connection = True
         return
 
-    if (
-        not server.get_jwe_key().has_public
-        or not server.get_jws_key().has_private
-    ):
+    if not server.get_jws_key().has_private:
         response.body = b"Server doesn't support HTTP SCRAM authentication"
         response.status = http.HTTPStatus.FORBIDDEN
         response.close_connection = True
@@ -284,27 +281,15 @@ def get_scram_verifier(user, server):
 
 
 def generate_jwt_token(user, server):
-    rolerec = server.get_roles().get(user)
-    if rolerec is None or rolerec["password"] is None:
-        raise ValueError(f"invalid user: {user!r}")
-    ekey = server.get_jwe_key()
     skey = server.get_jws_key()
 
     namespace = "edgedb.server"
     token = jwt.JWT(
         header={"alg": "ES256" if skey["kty"] == "EC" else "RS256"},
         claims={
-            f"{namespace}.roles": {user: rolerec["password"]},
+            f"{namespace}.roles": [user],
             "iat": int(time.time()),
         },
     )
     token.make_signed_token(skey)
-    encrypted_token = jwt.JWT(
-        header={
-            "alg": "ECDH-ES" if ekey["kty"] == "EC" else "RSA-OAEP-256",
-            "enc": "A256GCM",
-        },
-        claims=token.serialize(),
-    )
-    encrypted_token.make_encrypted_token(ekey)
-    return encrypted_token.serialize().encode("ascii")
+    return token.serialize().encode("ascii")

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -494,7 +494,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             # token in the HTTP header has higher priority than
             # the ClientHandshake message, under the scenario of
             # binary protocol over HTTP
-            token = self._extract_token_in_auth_data()
+            token = self._extract_token_from_auth_data()
             if token is None:
                 token = params.get('token')
             self._auth_jwt(user, token)
@@ -618,7 +618,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         if user not in roles:
             raise errors.AuthenticationError('authentication failed')
 
-    def _extract_token_in_auth_data(self):
+    def _extract_token_from_auth_data(self):
         if not self._auth_data:
             raise errors.AuthenticationError(
                 'authentication failed: no authorization data provided')

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -670,7 +670,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         if not claims.get(f"{namespace}.any_role"):
             token_roles = claims.get(f"{namespace}.roles")
-            if not isinstance(token_roles, dict):
+            if not isinstance(token_roles, list):
                 raise errors.AuthenticationError(
                     f'authentication failed: malformed claims section in JWT'
                     f' expected mapping in "role_names"'

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -185,6 +185,8 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
                 f'message: "database"'
             )
 
+        token = params.get('token')
+
         logger.debug('received connection request by %s to database %s',
                      user, database)
 
@@ -214,7 +216,7 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
         if authmethod_name == 'SCRAM':
             await self._auth_scram(user)
         elif authmethod_name == 'JWT':
-            self._auth_jwt(user)
+            self._auth_jwt(user, token)
         elif authmethod_name == 'Trust':
             self._auth_trust(user)
         else:

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -214,7 +214,7 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
         if authmethod_name == 'SCRAM':
             await self._auth_scram(user)
         elif authmethod_name == 'JWT':
-            token = self._extract_token_in_auth_data()
+            token = self._extract_token_from_auth_data()
             self._auth_jwt(user, token)
         elif authmethod_name == 'Trust':
             self._auth_trust(user)

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -214,7 +214,8 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
         if authmethod_name == 'SCRAM':
             await self._auth_scram(user)
         elif authmethod_name == 'JWT':
-            self._auth_jwt(user)
+            token = self._extract_token_in_auth_data()
+            self._auth_jwt(user, token)
         elif authmethod_name == 'Trust':
             self._auth_trust(user)
         else:

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -185,8 +185,6 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
                 f'message: "database"'
             )
 
-        token = params.get('token')
-
         logger.debug('received connection request by %s to database %s',
                      user, database)
 
@@ -216,7 +214,7 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
         if authmethod_name == 'SCRAM':
             await self._auth_scram(user)
         elif authmethod_name == 'JWT':
-            self._auth_jwt(user, token)
+            self._auth_jwt(user)
         elif authmethod_name == 'Trust':
             self._auth_trust(user)
         else:

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -852,10 +852,7 @@ class ParallelTextTestRunner:
                 os.environ["EDGEDB_SERVER_TLS_CERT_FILE"] = str(cert_file)
                 os.environ["EDGEDB_SERVER_TLS_KEY_FILE"] = str(key_file)
 
-            if (
-                not os.environ.get("EDGEDB_SERVER_JWS_KEY_FILE")
-                or not os.environ.get("EDGEDBV_SERVER_JWE_KEY_FILE")
-            ):
+            if not os.environ.get("EDGEDB_SERVER_JWS_KEY_FILE"):
                 jwk_file = pathlib.Path(tempdir.name) / "jwk.pem"
                 if self.verbosity >= 1:
                     self._echo(
@@ -864,11 +861,7 @@ class ParallelTextTestRunner:
                     )
                 tb.generate_jwk(jwk_file)
 
-                if not os.environ.get("EDGEDB_SERVER_JWS_KEY_FILE"):
-                    os.environ["EDGEDB_SERVER_JWS_KEY_FILE"] = str(jwk_file)
-
-                if not os.environ.get("EDGEDB_SERVER_JWE_KEY_FILE"):
-                    os.environ["EDGEDB_SERVER_JWE_KEY_FILE"] = str(jwk_file)
+                os.environ["EDGEDB_SERVER_JWS_KEY_FILE"] = str(jwk_file)
 
         if lang_setup:
             tb_lang.run_test_cases_setup(lang_setup, jobs=self.num_workers)


### PR DESCRIPTION
The token should be included in the ClientHandshake message, under a new connection parameter named "token".