### PR TITLE
Fix DML access policies that use shapes internally

### DIFF
--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -38,6 +38,7 @@ def find_children(
     type: Type[_T],
     test_func: Optional[Callable[[_T], bool]] = None,
     terminate_early=False,
+    extra_skips: AbstractSet[str] = frozenset(),
 ) -> list[_T]:
     visited = set()
     result = []
@@ -45,6 +46,11 @@ def find_children(
     def _find_children(node):
         if isinstance(node, (tuple, list, set, frozenset)):
             for n in node:
+                if _find_children(n):
+                    return True
+            return False
+        elif isinstance(node, dict):
+            for n in node.values():
                 if _find_children(n):
                     return True
             return False
@@ -66,7 +72,7 @@ def find_children(
 
         for field, value in base.iter_fields(node, include_meta=False):
             field_spec = node._fields[field]
-            if field_spec.hidden:
+            if field_spec.hidden or field_spec.name in extra_skips:
                 continue
 
             if _find_children(value):

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -322,13 +322,16 @@ def _fixup_materialized_sets(
     ir: irast.Base, *, ctx: context.ContextLevel
 ) -> List[irast.Set]:
     # Make sure that all materialized sets have their views compiled
-    children = ast_visitor.find_children(ir, irast.Stmt)
+    skips = {'materialized_sets'}
+    children = ast_visitor.find_children(ir, irast.Stmt, extra_skips=skips)
     for nobe in ctx.env.source_map.values():
         if nobe.irexpr:
-            children += ast_visitor.find_children(nobe.irexpr, irast.Stmt)
+            children += ast_visitor.find_children(
+                nobe.irexpr, irast.Stmt, extra_skips=skips)
     for node in ctx.env.type_rewrites.values():
         if isinstance(node, irast.Set):
-            children += ast_visitor.find_children(node, irast.Stmt)
+            children += ast_visitor.find_children(
+                node, irast.Stmt, extra_skips=skips)
 
     to_clear = []
     for stmt in ordered.OrderedSet(children):

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -849,10 +849,10 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
     async def test_edgeql_policies_internal_shape_01(self):
         await self.con.execute('''
             alter type Issue {
-                create access policy foo_1 deny select using (
+                create access policy foo_1 deny all using (
                     not exists (select .watchers { foo := .todo }
                                 filter .foo.name = "x"));
-                create access policy foo_2 deny select using (
+                create access policy foo_2 deny all using (
                     not exists (select .watchers { todo }
                                 filter .todo.name = "x"));
              };
@@ -864,6 +864,15 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             ''',
             [],
         )
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            "access policy violation on insert",
+        ):
+            await self.con.execute('''
+                insert Issue {
+                    name := '', body := '', status := {}, number := '',
+                    owner := {}};
+            ''')
 
     async def test_edgeql_policies_messages(self):
         await self.con.execute(


### PR DESCRIPTION
It was fixed for select policies in #4555, but it remained broken for
DML. The root cause here was actually different, though, and was
caused by find_children not descending into dicts.