### PR TITLE
Document `future`.

### DIFF
--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -268,7 +268,7 @@ policies. This means that they can affect each other in various ways. Because
 of this great care needs to be taken when creating access policies based on
 objects other than the ones they are defined on. For example:
 
-.. code-block:: sdl-diff
+.. code-block:: sdl
 
     global current_user_id -> uuid;
     global current_user := (
@@ -277,11 +277,11 @@ objects other than the ones they are defined on. For example:
 
     type User {
       required property email -> str { constraint exclusive; };
-      required property is_admin -> bool;
+      required property is_admin -> bool { default := false };
 
       access policy admin_only
         allow all
-        using (global current_user.is_admin);
+        using (global current_user.is_admin ?? false);
     }
 
     type BlogPost {
@@ -303,20 +303,22 @@ making the current user able to see their own ``User`` record.
 
 .. warning::
 
-  Starting with the upcoming EdgeDB 3.0 access policy restrictions do **not**
+  Starting with the upcoming EdgeDB 3.0, access policy restrictions will
+  **not**
   apply to any access policy expression. This means that when reasoning about
   access policies it is no longer necesary to take other policies into
-  account. Instead all data is visible for the purpose of *defining* an access
+  account. Instead, all data is visible for the purpose of *defining* an access
   policy.
 
-  This change is done to simplify reasoning about access policies. Since those
-  who have access to modifying the schema can remove unwanted access policies,
-  no additional security is provided by applying access policies to each
-  other's expressions.
+  This change is being made to simplify reasoning about access
+  policies and to allow certain patterns to be express
+  efficiently. Since those who have access to modifying the schema can
+  remove unwanted access policies, no additional security is provided
+  by applying access policies to each other's expressions.
 
-  It is possible to enable this :ref:`future <ref_eql_sdl_future>` behavior in
-  EdgeDB 2.x by adding the following to the schema: ``using future
-  nonrecursive_access_policies;``.
+  It is possible (and recommended) to enable this :ref:`future
+  <ref_eql_sdl_future>` behavior in EdgeDB 2.6 and later by adding the
+  following to the schema: ``using future nonrecursive_access_policies;``.
 
 
 Examples
@@ -461,4 +463,3 @@ Here's a policy that limits the number of blog posts a ``User`` can post.
   * - **See also**
   * - :ref:`SDL > Access policies <ref_eql_sdl_access_policies>`
   * - :ref:`DDL > Access policies <ref_eql_ddl_access_policies>`
-

--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -263,7 +263,8 @@ algorithm for resolving these policies.
    of ``select``, ``insert``, ``update read``, ``update write``, and
    ``delete``.
 
-The access policies affect the values visible in expressions of *other* access
+Currently, by default the access policies affect the values visible
+in expressions of *other* access
 policies. This means that they can affect each other in various ways. Because
 of this great care needs to be taken when creating access policies based on
 objects other than the ones they are defined on. For example:
@@ -300,6 +301,7 @@ won't be able to see their own posts. The above issue can be remedied by
 making the current user able to see their own ``User`` record.
 
 .. _ref_datamodel_access_policies_nonrecursive:
+.. _nonrecursive:
 
 .. warning::
 
@@ -318,7 +320,7 @@ making the current user able to see their own ``User`` record.
 
   It is possible (and recommended) to enable this :ref:`future
   <ref_eql_sdl_future>` behavior in EdgeDB 2.6 and later by adding the
-  following to the schema: ``using future nonrecursive_access_policies;``.
+  following to the schema: ``using future nonrecursive_access_policies;``
 
 
 Examples

--- a/docs/datamodel/future.rst
+++ b/docs/datamodel/future.rst
@@ -1,0 +1,49 @@
+.. _ref_datamodel_future:
+
+===============
+Future Behavior
+===============
+
+Any time that we add new functionality to EdgeDB we strive to do it in the
+least disruptive way possible. Deprecation warnings, documentation and guides
+can help make these transiotions smoother, but sometimes the changes are just
+too big, especially if they affect already existing functionality. It is often
+inconvenient dealing with these changes at the same time as upgrading to a new
+major version of EdgeDB. To help with this transition we introduce
+:ref:`future <ref_eql_sdl_future>` specification.
+
+The purpose of this specification is to provide a way to try out and ease into
+an upcoming feature before a major release. Sometimes enabling future behavior
+is necessary to fix some current issues. Other times enabling future behavior
+can simply provide a way to test out the feature before it gets released, to
+make sure that the current project codebase is compatible and well-behaved. It
+provides a longer timeframe for adopting a new feature and for catching bugs
+that arise from the change in behavior.
+
+The ``future`` specification is intended to help with transitions between
+major releases. Once a feature is released this specification is no longer
+necessary to enable that feature and it will be removed from the schema during
+the upgrade process.
+
+Once some behavior is available as a ``future`` all new :ref:`projects
+<ref_intro_projects>` enable this behavior by default when initializing an
+empty database. It is possible to explicitly disable the ``future`` feature by
+removing it from the schema, but it is not recommended unless the feature is
+causing some issues which cannot be fixed otherwise. Existing projects don't
+change their behavior by default, the ``future`` specification needs to be
+added to the schema by the developer in order to gain early access to it.
+
+At the moment there is only one ``future`` available:
+
+- ``nonrecursive_access_policies``: makes access policies :ref:`non-recursive
+  <ref_datamodel_access_policies_nonrecursive>` and simplifies policy
+  interactions.
+
+
+.. list-table::
+  :class: seealso
+
+  * - **See also**
+  * - :ref:`SDL > Future Behavior <ref_eql_sdl_future>`
+  * - :eql:stmt:`DDL > CREATE FUTURE <create future>`
+  * - :eql:stmt:`DDL > DROP FUTURE <drop future>`

--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -24,6 +24,7 @@ Schema
     functions
     inheritance
     extensions
+    future
     comparison
 
 

--- a/docs/reference/ddl/future.rst
+++ b/docs/reference/ddl/future.rst
@@ -1,0 +1,81 @@
+.. _ref_eql_ddl_future:
+
+===============
+Future Behavior
+===============
+
+This section describes the DDL commands pertaining to
+:ref:`future <ref_datamodel_future>`.
+
+
+Create future
+=============
+
+:eql-statement:
+
+Enable a particular future behavior for the current schema.
+
+.. eql:synopsis::
+
+    create future <FutureBehavior> ";"
+
+There's a :ref:`corresponding SDL declaration <ref_eql_sdl_future>`
+for enabling a future behavior, which is the recommended way of doing this.
+
+Description
+-----------
+
+The command ``create future`` enables the specified future behavior for
+the current database.
+
+Examples
+--------
+
+Enable simpler non-recursive access policy behavior :ref:`non-recursive access
+policy <ref_datamodel_access_policies_nonrecursive>` for the current schema:
+
+.. code-block:: edgeql
+
+    create future nonrecursive_access_policies;
+
+
+drop future
+===========
+
+:eql-statement:
+
+
+Stop importing future behavior prior to the EdgeDB version in which it appears.
+
+.. eql:synopsis::
+
+    drop future <FutureBehavior> ";"
+
+
+Description
+-----------
+
+The command ``drop future`` disables a currently active future behavior for
+the current database. However, this is only possible for versions of EdgeDB
+when the behavior in question is not officially introduced. Once a particular
+behavior is introduced as the standard behavior in an EdgeDB release, it
+cannot be disabled. Running this command will simply denote that no special
+action is needed to enable it in this case.
+
+
+Examples
+--------
+
+Disable simpler non-recursive access policy behavior :ref:`non-recursive
+access policy <ref_datamodel_access_policies_nonrecursive>` for the current
+schema. This will make access policy restrictions apply to the expressions
+defining other access policies:
+
+.. code-block:: edgeql
+
+    drop future nonrecursive_access_policies;
+
+
+Once EdgeDB 3.0 is released there is no more need for enabling non-recursive
+access policy behavior anymore. So the above command will simply indicate that
+the databse no longer does anything non-standard.

--- a/docs/reference/ddl/index.rst
+++ b/docs/reference/ddl/index.rst
@@ -20,6 +20,7 @@ DDL
     access_policies
     functions
     extensions
+    future
     migrations
 
 :edb-alt-title: Data Definition Language

--- a/docs/reference/sdl/future.rst
+++ b/docs/reference/sdl/future.rst
@@ -1,0 +1,37 @@
+.. _ref_eql_sdl_future:
+
+===============
+Future Behavior
+===============
+
+This section describes the SDL commands pertaining to
+:ref:`future <ref_datamodel_future>`.
+
+
+Syntax
+------
+
+Declare that the current schema enables a particular future behavior.
+
+.. sdl:synopsis::
+
+    using future <FutureBehavior> ";"
+
+
+Description
+-----------
+
+Future behavior declaration must be outside any :ref:`module block
+<ref_eql_sdl_modules>` since this behavior affects the entire database and not
+a specific module.
+
+
+Examples
+--------
+
+Enable simpler non-recursive access policy behavior :ref:`non-recursive access
+policy <ref_datamodel_access_policies_nonrecursive>` for the current schema:
+
+.. code-block:: sdl
+
+    using extension nonrecursive_access_policies;

--- a/docs/reference/sdl/index.rst
+++ b/docs/reference/sdl/index.rst
@@ -84,3 +84,4 @@ to the previous migration:
     access_policies
     functions
     extensions
+    future


### PR DESCRIPTION
Document what the `future` specification is and how it's intended to be used. Add the `nonrecursive_access_policies` future behavior to the docs.

Explain the current access policy behavior and the behavior we expect in EdgeDB 3.0.