### PR TITLE
Fix collection type using DDL and set global in notebook protocol

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2015,7 +2015,7 @@ class Compiler:
             if ql.scope is qltypes.ConfigScope.SESSION:
                 capability = enums.Capability.SESSION_CONFIG
             elif ql.scope is qltypes.ConfigScope.GLOBAL:
-                capability = enums.Capability.SESSION_CONFIG
+                capability = enums.Capability.SET_GLOBAL
             else:
                 capability = enums.Capability.PERSISTENT_CONFIG
             return (

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -38,6 +38,9 @@ class Capability(enum.IntFlag):
     TRANSACTION       = 1 << 2    # noqa
     DDL               = 1 << 3    # noqa
     PERSISTENT_CONFIG = 1 << 4    # noqa
+    # SET_GLOBAL should also be implied by SESSION_CONFIG, for
+    # backward compatability reasons
+    SET_GLOBAL        = 1 << 5    # noqa
 
     ALL               = 0xFFFF_FFFF_FFFF_FFFF  # noqa
 
@@ -64,6 +67,7 @@ CAPABILITY_TITLES = {
     Capability.TRANSACTION: 'transaction control commands',
     Capability.DDL: 'DDL commands',
     Capability.PERSISTENT_CONFIG: 'configuration commands',
+    Capability.SET_GLOBAL: 'set global',
 }
 
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -121,12 +121,18 @@ DEF SERVER_HEADER_CAPABILITIES = 0x1001
 DEF ALL_CAPABILITIES = 0xFFFFFFFFFFFFFFFF
 
 
+cdef uint64_t CAP_SESSION_CONFIG = enums.Capability.SESSION_CONFIG
+cdef uint64_t CAP_SET_GLOBAL = enums.Capability.SET_GLOBAL
+
+
 def parse_capabilities_header(value: bytes) -> uint64_t:
     if len(value) != 8:
         raise errors.BinaryProtocolError(
             f'capabilities header must be exactly 8 bytes'
         )
     cdef uint64_t mask = hton.unpack_uint64(cpython.PyBytes_AS_STRING(value))
+    if mask & CAP_SESSION_CONFIG:
+        mask |= CAP_SET_GLOBAL
     return mask
 
 

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -33,8 +33,10 @@ from edb.common import markup
 from edb.server import compiler
 from edb.server import defines as edbdef
 from edb.server.compiler import OutputFormat
+from edb.server.compiler import dbstate
 from edb.server.compiler import enums
-from edb.server.protocol cimport args_ser
+# from edb.server.protocol cimport args_ser
+from edb.server.protocol import execute as p_execute
 from edb.server.dbview cimport dbview
 from edb.server.protocol cimport frontend
 
@@ -49,7 +51,8 @@ cdef tuple CURRENT_PROTOCOL = edbdef.CURRENT_PROTOCOL
 
 ALLOWED_CAPABILITIES = (
     enums.Capability.MODIFICATIONS |
-    enums.Capability.DDL
+    enums.Capability.DDL |
+    enums.Capability.SET_GLOBAL
 )
 
 
@@ -153,7 +156,7 @@ cdef class NotebookConnection(frontend.FrontendConnection):
 
 
 async def execute(db, server, queries: list):
-    dbv = await server.new_dbview(
+    dbv: dbview.DatabaseConnectionView = await server.new_dbview(
         dbname=db.name,
         query_cache=False,
         protocol_version=edbdef.CURRENT_PROTOCOL,
@@ -184,6 +187,9 @@ async def execute(db, server, queries: list):
                 })
             else:
                 query_unit = unit_or_error
+                query_unit_group = dbstate.QueryUnitGroup()
+                query_unit_group.append(query_unit)
+
                 if query_unit.capabilities & ~ALLOWED_CAPABILITIES:
                     raise query_unit.capabilities.make_error(
                         ALLOWED_CAPABILITIES,
@@ -194,23 +200,17 @@ async def execute(db, server, queries: list):
                         raise errors.QueryError(
                             'cannot use query parameters in tutorial')
 
-                    if bind_data is None:
-                        bind_data = args_ser.recode_bind_args(
-                            dbv,
-                            dbview.CompiledQuery(query_unit_group=query_unit),
-                            b'',
-                        )
-
                     fe_conn = NotebookConnection()
 
-                    await pgcon.parse_execute(
-                        query=query_unit,
-                        fe_conn=fe_conn,
-                        bind_data=bind_data,
-                        use_prep_stmt=False,
-                        state=None,
-                        dbver=dbv.dbver,
+                    dbv.start_implicit(query_unit)
+
+                    compiled = dbview.CompiledQuery(
+                        query_unit_group=query_unit_group)
+                    await p_execute.execute(
+                        pgcon, dbv, compiled, b'', fe_conn=fe_conn,
+                        skip_start=True,
                     )
+
                 except Exception as ex:
                     if debug.flags.server:
                         markup.dump(ex)

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -35,7 +35,6 @@ from edb.server import defines as edbdef
 from edb.server.compiler import OutputFormat
 from edb.server.compiler import dbstate
 from edb.server.compiler import enums
-# from edb.server.protocol cimport args_ser
 from edb.server.protocol import execute as p_execute
 from edb.server.dbview cimport dbview
 from edb.server.protocol cimport frontend


### PR DESCRIPTION
The collection type in DDL fixes some issues we've had with updating
the tutorial to use the latest edgedb, where a function taking
variadic args failed.

The approach to fixing it was to use the execute module instead of
trying to handle things directly.

Since this got us most of the way to having globals work in the
tutorial, I also got that working. The main snag there was the
capabilities system, which treats SET GLOBAL as a session
configuration command. This is true, but probably too strict: add a
new capabilities flag for SET GLOBAL, but make it implied by the
session config command, so as to not break protocol compatability.