### PR TITLE
Multiple fixes to the docs sphinx build

### DIFF
--- a/docs/clients/dart/index.rst
+++ b/docs/clients/dart/index.rst
@@ -1,0 +1,7 @@
+====
+Dart
+====
+
+The documentation for the Dart client is automatically generated
+from https://github.com/edgedb/edgedb-dart by the build
+pipeline of the edgedb.com website.

--- a/docs/clients/dotnet/index.rst
+++ b/docs/clients/dotnet/index.rst
@@ -1,0 +1,7 @@
+====
+.NET
+====
+
+The documentation for the .NET client is automatically generated
+from https://github.com/edgedb/edgedb-net/tree/dev/docs by the build
+pipeline of the edgedb.com website.

--- a/docs/clients/go/index.rst
+++ b/docs/clients/go/index.rst
@@ -1,0 +1,7 @@
+==
+Go
+==
+
+The documentation for the Go client is automatically generated
+from https://github.com/edgedb/edgedb-go by the build pipeline of
+the edgedb.com website.

--- a/docs/clients/js/index.rst
+++ b/docs/clients/js/index.rst
@@ -1,0 +1,10 @@
+.. _edgedb-js-intro:
+.. _edgedb-js-qb:
+
+==========
+JavaScript
+==========
+
+The documentation for the JavaScript client is automatically pulled
+from https://github.com/edgedb/edgedb-js/tree/master/docs by the
+build pipeline of the edgedb.com website.

--- a/docs/clients/python/index.rst
+++ b/docs/clients/python/index.rst
@@ -1,0 +1,9 @@
+.. _edgedb-python-intro:
+
+======
+Python
+======
+
+The documentation for the Python client is automatically pulled
+from https://github.com/edgedb/edgedb-python/tree/master/docs by the
+build pipeline of the edgedb.com website.

--- a/edb/tools/docs/cli.py
+++ b/edb/tools/docs/cli.py
@@ -23,6 +23,8 @@ from typing import *
 
 from edb.tools.pygments.edgeql import EdgeQLLexer
 
+import pygments.lexers
+
 from sphinx import domains as s_domains
 from sphinx.directives import code as s_code
 
@@ -52,8 +54,13 @@ class CLIDomain(s_domains.Domain):
 
 
 def setup_domain(app):
-    app.add_lexer("cli", EdgeQLLexer())
-    app.add_lexer("cli-synopsis", EdgeQLLexer())
+    # Dummy lexers; the actual highlighting is implemented
+    # in the edgedb.com website code.
+    app.add_lexer("txt", pygments.lexers.TextLexer)
+    app.add_lexer("bash", pygments.lexers.TextLexer)
+
+    app.add_lexer("cli", EdgeQLLexer)
+    app.add_lexer("cli-synopsis", EdgeQLLexer)
 
     app.add_role(
         'cli:synopsis',

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -205,6 +205,7 @@ import importlib
 import re
 
 import lxml.etree
+import pygments.lexers
 import pygments.lexers.special
 
 from typing import *
@@ -1191,10 +1192,15 @@ class StatementTransform(s_transforms.SphinxTransform):
 
 
 def setup_domain(app):
-    app.add_lexer("edgeql", EdgeQLLexer())
-    app.add_lexer("edgeql-repl", EdgeQLLexer())
-    app.add_lexer("edgeql-synopsis", EdgeQLLexer())
-    app.add_lexer("edgeql-result", pygments.lexers.special.TextLexer())
+    # Dummy lexers; the actual highlighting is implemented
+    # in the edgedb.com website code.
+    app.add_lexer("sdl-diff", pygments.lexers.TextLexer)
+    app.add_lexer("edgeql-diff", pygments.lexers.TextLexer)
+
+    app.add_lexer("edgeql", EdgeQLLexer)
+    app.add_lexer("edgeql-repl", EdgeQLLexer)
+    app.add_lexer("edgeql-synopsis", EdgeQLLexer)
+    app.add_lexer("edgeql-result", pygments.lexers.special.TextLexer)
 
     app.add_role(
         'eql:synopsis',

--- a/edb/tools/docs/graphql.py
+++ b/edb/tools/docs/graphql.py
@@ -23,5 +23,5 @@ from edb.tools.pygments.graphql import GraphQLLexer
 
 
 def setup_domain(app):
-    app.add_lexer("graphql", GraphQLLexer())
-    app.add_lexer("graphql-schema", GraphQLLexer())
+    app.add_lexer("graphql", GraphQLLexer)
+    app.add_lexer("graphql-schema", GraphQLLexer)

--- a/edb/tools/docs/js.py
+++ b/edb/tools/docs/js.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 from docutils import nodes as d_nodes
 from docutils.parsers.rst import directives  # type: ignore
 
+import pygments.lexers
+
 from sphinx import addnodes as s_nodes
 from sphinx.domains import javascript as js
 from sphinx.locale import _
@@ -143,4 +145,11 @@ class JSDomain(js.JavaScriptDomain):
 
 
 def setup_domain(app):
+    # Dummy lexers; the actual highlighting is implemented
+    # in the edgedb.com website code.
+    app.add_lexer("tsx", pygments.lexers.TextLexer)
+    app.add_lexer("tsx-diff", pygments.lexers.TextLexer)
+    app.add_lexer("typescript-diff", pygments.lexers.TextLexer)
+    app.add_lexer("javascript-diff", pygments.lexers.TextLexer)
+
     app.add_domain(JSDomain, override=True)

--- a/edb/tools/docs/sdl.py
+++ b/edb/tools/docs/sdl.py
@@ -52,8 +52,8 @@ class SDLDomain(s_domains.Domain):
 
 
 def setup_domain(app):
-    app.add_lexer("sdl", EdgeQLLexer())
-    app.add_lexer("sdl-synopsis", EdgeQLLexer())
+    app.add_lexer("sdl", EdgeQLLexer)
+    app.add_lexer("sdl-synopsis", EdgeQLLexer)
 
     app.add_role(
         'sdl:synopsis',

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -476,6 +476,7 @@ class TestDocSnippets(unittest.TestCase):
                     sys.executable,
                     '-m', 'sphinx',
                     '-n',
+                    '-W',  # fail on warnings
                     '-b', 'xml',
                     '-q',
                     '-D', 'master_doc=index',


### PR DESCRIPTION
* Setup "classes" of lexers, not instances, per new Sphinx API

* Add dummy doc pages for JS, Dart, Go, Python, Dotnet clients; those will be overrided by the edgedb.com docs pipeline with proper docs from the respective client repos.

* Add dummy lexers for some of the languages we know how to highlight in the website code.

* Make the `test_doc_full_build` test strict -- fail on all warnings.

As the result of all of this, `make doc` now works.