### PR TITLE
Update .NET Client link in Get Started page

### DIFF
--- a/docs/intro/clients.rst
+++ b/docs/intro/clients.rst
@@ -36,11 +36,11 @@ libraries* for the following languages.
 - `Go <https://github.com/edgedb/edgedb-go>`_
 - `Python <https://github.com/edgedb/edgedb-python>`_
 - `Rust <https://github.com/edgedb/edgedb-rust>`_
+- `.NET <https://github.com/edgedb/edgedb-net>`_
 
 Unofficial (community-maintained) libraries are available for the following
 languages.
 
-- `.NET <https://github.com/quinchs/edgedb-dotnet>`_
 - `Elixir <https://github.com/nsidnev/edgedb-elixir>`_
 
 Usage


### PR DESCRIPTION
### Summary

The .NET EdgeDB Client link was referring to a public archive of the legacy EdgeDB client. This pull request updates the link to refer to the official.NET EdgeDB Client (see https://github.com/edgedb/edgedb-net) and addresses #4619.