### PR TITLE
Avoid pulling tag contents into computed version name

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -505,7 +505,7 @@ def get_version_from_scm(root: pathlib.Path) -> str:
         ver = f'{incremented_ver}.dev{commits_on_branch}'
 
     proc = subprocess.run(
-        ['git', 'rev-parse', '--verify', '--quiet', 'HEAD'],
+        ['git', 'rev-parse', '--verify', '--quiet', 'HEAD^{commit}'],
         stdout=subprocess.PIPE,
         universal_newlines=True,
         check=True,


### PR DESCRIPTION
Doing a `git show` on a signed tag will output the full tag message,
*even if* `--format` was specified asking for limited information.

Avoid this by making sure to run on the commit pointed to by the tag,
instead of the tag itself.