### PR TITLE
Stop relying on hacks in ordering compiler enums.

### DIFF
--- a/edb/common/enum.py
+++ b/edb/common/enum.py
@@ -20,10 +20,23 @@
 from __future__ import annotations
 
 import enum
+import functools
 
 
 class StrEnum(str, enum.Enum):
     """A version of string enum with reasonable __str__."""
-
     def __str__(self):
         return self._value_
+
+
+@functools.total_ordering
+class OrderedEnumMixin():
+    @classmethod
+    @functools.lru_cache(None)
+    def _index_of(cls, value):
+        return list(cls).index(value)
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self._index_of(self) < self._index_of(other)
+        return NotImplemented

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -70,7 +70,7 @@ class CardinalityBound(int, enum.Enum):
         return self is CB_ONE
 
     def as_schema_cardinality(self) -> qltypes.SchemaCardinality:
-        if self is CB_MANY:
+        if self >= CB_MANY:
             return qltypes.SchemaCardinality.Many
         else:
             return qltypes.SchemaCardinality.One
@@ -84,7 +84,7 @@ class CardinalityBound(int, enum.Enum):
         cls,
         card: qltypes.SchemaCardinality
     ) -> CardinalityBound:
-        if card is qltypes.SchemaCardinality.Many:
+        if card >= qltypes.SchemaCardinality.Many:
             return CB_MANY
         else:
             return CB_ONE

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -69,13 +69,11 @@ class ContainerMultiplicityInfo(inf_ctx.MultiplicityInfo):
 def _max_multiplicity(
     args: Iterable[inf_ctx.MultiplicityInfo]
 ) -> inf_ctx.MultiplicityInfo:
-    # Coincidentally, the lexical order of multiplicity is opposite of
-    # order of multiplicity values.
     arg_list = [a.own for a in args]
     if not arg_list:
         max_mult = qltypes.Multiplicity.UNIQUE
     else:
-        max_mult = min(arg_list)
+        max_mult = max(arg_list)
 
     return inf_ctx.MultiplicityInfo(own=max_mult)
 

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -60,9 +60,6 @@ def _normalize_volatility(vol: InferredVolatility) -> Tuple[
 
 
 def _max_volatility(args: Iterable[InferredVolatility]) -> InferredVolatility:
-    # We rely on a happy coincidence that the lexical
-    # order of volatility constants coincides with the volatility
-    # level.
     arg_list = list(args)
     if not arg_list:
         return IMMUTABLE

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -77,7 +77,7 @@ class TransactionDeferMode(s_enum.StrEnum):
     NOT_DEFERRABLE = 'NOT DEFERRABLE'
 
 
-class SchemaCardinality(s_enum.StrEnum):
+class SchemaCardinality(s_enum.OrderedEnumMixin, s_enum.StrEnum):
     '''This enum is used to store cardinality in the schema.'''
     One = 'One'
     Many = 'Many'
@@ -157,7 +157,8 @@ _TUPLE_TO_CARD = {
 }
 
 
-class Volatility(s_enum.StrEnum):
+class Volatility(s_enum.OrderedEnumMixin, s_enum.StrEnum):
+    # Make sure that the values appear from least volatile to most volatile.
     Immutable = 'Immutable'
     Stable = 'Stable'
     Volatile = 'Volatile'
@@ -172,7 +173,8 @@ class Volatility(s_enum.StrEnum):
         return cls(name.title())
 
 
-class Multiplicity(s_enum.StrEnum):
+class Multiplicity(s_enum.OrderedEnumMixin, s_enum.StrEnum):
+    # Make sure that the values appear in ascending order.
     EMPTY = 'EMPTY'
     UNIQUE = 'UNIQUE'
     DUPLICATE = 'DUPLICATE'


### PR DESCRIPTION
Multiplicity, cardinality and volatility enums have an intrinsic order that is relevant for the compiler. The enum definition order is now used to determine how the `<` comparison works for various enum values.