### PR TITLE
improve error when compiling pointer default

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1585,15 +1585,22 @@ class PointerCommand(
 
         self._validate_computables(schema, context)
 
-        scls = self.scls
+        scls: Pointer = self.scls
         if not scls.get_owned(schema):
             return
 
-        default_expr = scls.get_default(schema)
+        default_expr: Optional[s_expr.Expression] = scls.get_default(schema)
 
         if default_expr is not None:
+
+            source_context = self.get_attribute_source_context('default')
+
             if default_expr.irast is None:
-                default_expr = default_expr.compiled(default_expr, schema)
+                try:
+                    default_expr = default_expr.compiled(default_expr, schema)
+                except errors.QueryError as e:
+                    e.set_source_context(source_context)
+                    raise
 
             assert isinstance(default_expr.irast, irast.Statement)
 
@@ -1607,7 +1614,6 @@ class PointerCommand(
             ptr_target = scls.get_target(schema)
             assert ptr_target is not None
 
-            source_context = self.get_attribute_source_context('default')
             if default_type.is_view(default_schema):
                 raise errors.SchemaDefinitionError(
                     f'default expression may not include a shape',


### PR DESCRIPTION
Add context to error message so instead of:

```
edgedb> create type Foo { create property x -> str; create property y -> str { set default := .x }; };
error: QueryError: could not resolve partial path 
  ┌─ query:1:1
  │
1 │ create type Foo { create property x -> str; create property y -> str { set default := .x }; };
  │ ^^ error
```

... we get:
```
edgedb> create type Foo { create property x -> str; create property y -> str { set default := .x }; };
error: QueryError: partial path cannot be used here
  ┌─ query:1:72
  │
1 │ create type Foo { create property x -> str; create property y -> str { set default := .x }; };
  │                                                                        ^^^^^^^^^^^^^^^^^ error
```

A start for #4473