### PR TITLE
fix: indexing of an empty set

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_11_01_00_00
+EDGEDB_CATALOG_VERSION = 2022_11_04_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1980,12 +1980,16 @@ class ArrayIndexWithBoundsFunction(dbops.Function):
     """Get an array element or raise an out-of-bounds exception."""
 
     text = '''
-        SELECT edgedb.raise_on_null(
-            val[edgedb._normalize_array_index(index, array_upper(val, 1))],
-            'array_subscript_error',
-            msg => 'array index ' || index::text || ' is out of bounds',
-            detail => detail
-        )
+        SELECT CASE WHEN val IS NULL THEN
+            NULL
+        ELSE
+            edgedb.raise_on_null(
+                val[edgedb._normalize_array_index(index, array_upper(val, 1))],
+                'array_subscript_error',
+                msg => 'array index ' || index::text || ' is out of bounds',
+                detail => detail
+            )
+        END
     '''
 
     def __init__(self) -> None:

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -5303,6 +5303,54 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             variables=(None,),
         )
 
+        await self.assert_query_result(
+            r'''
+                select (<optional array<int32>>$0)[2];
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select (<optional str>$0)[2];
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select to_json(<optional str>$0)[2];
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select (<optional array<int32>>$0)[1:2];
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select (<optional str>$0)[1:2];
+            ''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select to_json(<optional str>$0)[1:2];
+            ''',
+            [],
+            variables=(None,),
+        )
+
     async def test_edgeql_select_bigint_index_01(self):
 
         big_pos = str(2**40)


### PR DESCRIPTION
With #4479, stdlib's array indexing has been made non strict, which makes this produce an error:
```
select re_match(r"foo", 'other name')[0];
```
instead of an empty set.

This PR fixes that and adds tests for all kinds of indexing and slicing or empty sets.