### PR TITLE
Put all of the DROP DATABASEs in the test suite behind a retry loop

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -577,6 +577,30 @@ def _extract_background_errors(metrics: str) -> str | None:
         return None
 
 
+async def drop_db(conn, dbname):
+    # The retry loop below masks connection abort races.
+    # The current implementation of edgedb-python aborts
+    # connections when it gets a CancelledError.  This creates
+    # a situation in which the server might still have not
+    # realized that the connection went away, and will raise
+    # an ExecutionError on DROP DATABASE below complaining
+    # about the database still being in use.
+    # See issue #4567.
+    #
+    # A better fix would be for edgedb-python to learn to
+    # aclose() gracefully or implement protocol-level
+    # cancellation that guarantees consensus on the server
+    # connection state.
+    async for tr in TestCase.try_until_succeeds(
+        ignore=edgedb.ExecutionError,
+        timeout=30
+    ):
+        async with tr:
+            await conn.execute(
+                f'DROP DATABASE {dbname};'
+            )
+
+
 class ClusterTestCase(BaseHTTPTestCase):
 
     BASE_TEST_CLASS = True
@@ -1067,29 +1091,8 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
                 elif class_set_up == 'run' or cls.uses_database_copies():
                     dbname = qlquote.quote_ident(cls.get_database_name())
 
-                    # The retry loop below masks connection abort races.
-                    # The current implementation of edgedb-python aborts
-                    # connections when it gets a CancelledError.  This creates
-                    # a situation in which the server might still have not
-                    # realized that the connection went away, and will raise
-                    # an ExecutionError on DROP DATABASE below complaining
-                    # about the database still being in use.
-                    #
-                    # A better fix would be for edgedb-python to learn to
-                    # aclose() gracefully or implement protocol-level
-                    # cancellation that guarantees consensus on the server
-                    # connection state.
-                    async def drop_db():
-                        async for tr in cls.try_until_succeeds(
-                            ignore=edgedb.ExecutionError,
-                            timeout=30
-                        ):
-                            async with tr:
-                                await cls.admin_conn.execute(
-                                    f'DROP DATABASE {dbname};'
-                                )
-
-                    cls.loop.run_until_complete(drop_db())
+                    cls.loop.run_until_complete(
+                        drop_db(cls.admin_conn, dbname))
 
             finally:
                 try:
@@ -1271,7 +1274,7 @@ class DumpCompatTestCaseMeta(TestCaseMeta):
                 self.run_cli('-d', dbname, 'restore', str(dumpfn))
                 con2 = await self.connect(database=dbname)
             except Exception:
-                await self.con.execute(f'DROP DATABASE {qdbname}')
+                await drop_db(self.con, qdbname)
                 raise
 
             oldcon = self.__class__.con
@@ -1282,14 +1285,7 @@ class DumpCompatTestCaseMeta(TestCaseMeta):
                 self.__class__.con = oldcon
                 await con2.aclose()
 
-                # The connection might not *actually* be closed on the db
-                # side yet. This is probably a bug, but hack around it
-                # with a retry loop. Without this, the test would flake
-                # a lot.
-                async for tr in self.try_until_succeeds(
-                        ignore=edgedb.ExecutionError):
-                    async with tr:
-                        await self.con.execute(f'DROP DATABASE {qdbname}')
+                await drop_db(self.con, qdbname)
 
         for entry in dumps_dir.iterdir():
             if not entry.is_file() or not entry.name.endswith(".dump"):
@@ -1343,7 +1339,7 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
                 self.run_cli('-d', tgt_dbname, 'restore', f.name)
                 con2 = await self.connect(database=tgt_dbname)
             except Exception:
-                await self.con.execute(f'DROP DATABASE {q_tgt_dbname}')
+                await drop_db(self.con, q_tgt_dbname)
                 raise
 
         oldcon = self.con
@@ -1353,7 +1349,7 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
         finally:
             self.__class__.con = oldcon
             await con2.aclose()
-            await self.con.execute(f'DROP DATABASE {q_tgt_dbname}')
+            await drop_db(self.con, q_tgt_dbname)
 
 
 def get_test_cases_setup(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -52,7 +52,7 @@ class TestDatabase(tb.ConnectedTestCase):
 
             await conn.aclose()
         finally:
-            await self.con.execute('DROP DATABASE mytestdb;')
+            await tb.drop_db(self.con, 'mytestdb')
 
     async def test_database_create_02(self):
         with self.assertRaisesRegex(
@@ -74,7 +74,7 @@ class TestDatabase(tb.ConnectedTestCase):
                     r'database "databasename" already exists'):
                 await self.con.execute('CREATE DATABASE databasename;')
         finally:
-            await self.con.execute('DROP DATABASE databasename;')
+            await tb.drop_db(self.con, 'databasename')
 
     async def test_database_drop_01(self):
         if not self.has_create_database:

--- a/tests/test_dump_basic.py
+++ b/tests/test_dump_basic.py
@@ -95,7 +95,7 @@ class TestDumpBasics(tb.DatabaseTestCase, tb.CLITestCaseMixin):
                 self.run_cli('-d', restored_dbname, 'restore', f.name)
                 con2 = await self.connect(database=restored_dbname)
             except Exception:
-                await self.con.execute(f'DROP DATABASE {restored_dbname}')
+                await tb.drop_db(self.con, restored_dbname)
                 raise
 
         try:
@@ -117,4 +117,4 @@ class TestDumpBasics(tb.DatabaseTestCase, tb.CLITestCaseMixin):
             self.assertEqual(hasher.digest(), expected_hash)
         finally:
             await con2.aclose()
-            await self.con.execute(f'DROP DATABASE {restored_dbname}')
+            await tb.drop_db(self.con, restored_dbname)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8361,7 +8361,7 @@ type default::Foo {
         con = await self.connect()
         try:
             if self.has_create_database:
-                await con.execute("""DROP DATABASE test_role_05""")
+                await tb.drop_db(con, 'test_role_05')
         finally:
             await con.aclose()
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2214,13 +2214,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                     await con2.query("select 1")
                     await con2.aclose()
 
-            async for tr in self.try_until_succeeds(
-                ignore=edgedb.ExecutionError,
-            ):
-                async with tr:
-                    await self.con.execute('''
-                        DROP DATABASE test_db_prop;
-                    ''')
+            await tb.drop_db(self.con, 'test_db_prop')
 
             # Now, recreate the DB and try the other way around
             con2 = await sd.connect(
@@ -2242,13 +2236,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                     await con1.query("select 1")
                     await con1.aclose()
 
-            async for tr in self.try_until_succeeds(
-                ignore=edgedb.ExecutionError,
-            ):
-                async with tr:
-                    await con2.execute('''
-                        DROP DATABASE test_db_prop;
-                    ''')
+            await tb.drop_db(con2, 'test_db_prop')
 
             await con2.aclose()
 
@@ -2388,15 +2376,11 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 finally:
                     await con2.aclose()
 
-                await con1.execute(f'''
-                    DROP DATABASE {db};
-                ''')
+                await tb.drop_db(con1, db)
                 cleanup = False
         finally:
             if cleanup:
-                await con1.execute(f'''
-                    DROP DATABASE {db};
-                ''')
+                await tb.drop_db(con1, db)
 
     async def test_server_proto_query_cache_invalidate_01(self):
         typename = 'CacheInv_01'


### PR DESCRIPTION
This works around #4567.