### PR TITLE
Add `EXCEPT` and `INTERSECT` set operators.

### DIFF
--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -30,7 +30,6 @@ pub const UNRESERVED_KEYWORDS: &[&str] = &[
     "desc",
     "deny",
     "empty",
-    "except",
     "expression",
     "extension",
     "final",
@@ -102,6 +101,15 @@ pub const UNRESERVED_KEYWORDS: &[&str] = &[
     "version",
     "view",
     "write",
+];
+
+
+pub const PARTIAL_RESERVED_KEYWORDS: &[&str] = &[
+    // Keep in sync with `tokenizer::is_keyword`
+    "except",
+    "intersect",
+    "union",
+    // Keep in sync with `tokenizer::is_keyword`
 ];
 
 
@@ -193,7 +201,6 @@ pub const CURRENT_RESERVED_KEYWORDS: &[&str] = &[
     "true",
     "typeof",
     "update",
-    "union",
     "variadic",
     "with",
     // Keep in sync with `tokenizer::is_keyword`

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -923,7 +923,6 @@ pub fn is_keyword(s: &str) -> bool {
         | "true"
         | "typeof"
         | "update"
-        | "union"
         | "variadic"
         | "with"
           // Keep in sync with keywords::CURRENT_RESERVED_KEYWORDS
@@ -963,6 +962,12 @@ pub fn is_keyword(s: &str) -> bool {
         | "window"
         | "never"
           // Keep in sync with keywords::FUTURE_RESERVED_KEYWORDS
+        // # Partial reserved keywords #
+          // Keep in sync with keywords::PARTIAL_RESERVED_KEYWORDS
+        | "except"
+        | "intersect"
+        | "union"
+          // Keep in sync with keywords::PARTIAL_RESERVED_KEYWORDS
         => true,
         _ => false,
     }

--- a/edb/edgeql-rust/src/keywords.rs
+++ b/edb/edgeql-rust/src/keywords.rs
@@ -6,6 +6,7 @@ pub struct AllKeywords {
     pub current: PyObject,
     pub future: PyObject,
     pub unreserved: PyObject,
+    pub partial: PyObject,
 }
 
 
@@ -28,10 +29,15 @@ pub fn get_keywords(py: Python) -> PyResult<AllKeywords> {
         .iter()
         .map(|x| *x).map(&intern)
         .collect::<Result<Vec<_>,_>>()?;
+    let partial = keywords::PARTIAL_RESERVED_KEYWORDS
+        .iter()
+        .map(|x| *x).map(&intern)
+        .collect::<Result<Vec<_>,_>>()?;
     Ok(AllKeywords {
         current: py_frozenset.call(py, (PyList::new(py, &current),), None)?,
         unreserved: py_frozenset.call(py, (PyList::new(py, &unreserved),), None)?,
         future: py_frozenset.call(py, (PyList::new(py, &future),), None)?,
+        partial: py_frozenset.call(py, (PyList::new(py, &partial),), None)?,
     })
 }
 

--- a/edb/edgeql-rust/src/lib.rs
+++ b/edb/edgeql-rust/src/lib.rs
@@ -35,6 +35,7 @@ py_module_initializer!(
             py_fn!(py, offset_of_line(text: &str, line: usize)))?;
         m.add(py, "Hasher", py.get_type::<hash::Hasher>())?;
         m.add(py, "unreserved_keywords", keywords.unreserved)?;
+        m.add(py, "partial_reserved_keywords", keywords.partial)?;
         m.add(py, "future_reserved_keywords", keywords.future)?;
         m.add(py, "current_reserved_keywords", keywords.current)?;
         Ok(())

--- a/edb/edgeql-rust/src/tokenizer.rs
+++ b/edb/edgeql-rust/src/tokenizer.rs
@@ -14,7 +14,8 @@ use num_bigint::ToBigInt;
 use edgeql_parser::tokenizer::{TokenStream, Kind, is_keyword, SpannedToken};
 use edgeql_parser::tokenizer::{MAX_KEYWORD_LENGTH};
 use edgeql_parser::position::Pos;
-use edgeql_parser::keywords::{CURRENT_RESERVED_KEYWORDS, UNRESERVED_KEYWORDS};
+use edgeql_parser::keywords::{PARTIAL_RESERVED_KEYWORDS, UNRESERVED_KEYWORDS};
+use edgeql_parser::keywords::{CURRENT_RESERVED_KEYWORDS};
 use edgeql_parser::keywords::{FUTURE_RESERVED_KEYWORDS};
 use edgeql_parser::helpers::unquote_string;
 use crate::errors::TokenizerError;
@@ -334,6 +335,9 @@ impl Tokens {
         };
         // 'EOF'
         for kw in UNRESERVED_KEYWORDS.iter() {
+            res.add_kw(py, kw);
+        }
+        for kw in PARTIAL_RESERVED_KEYWORDS.iter() {
             res.add_kw(py, kw);
         }
         for kw in CURRENT_RESERVED_KEYWORDS.iter() {

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -78,6 +78,18 @@ def _max_multiplicity(
     return inf_ctx.MultiplicityInfo(own=max_mult)
 
 
+def _min_multiplicity(
+    args: Iterable[inf_ctx.MultiplicityInfo]
+) -> inf_ctx.MultiplicityInfo:
+    arg_list = [a.own for a in args]
+    if not arg_list:
+        min_mult = qltypes.Multiplicity.UNIQUE
+    else:
+        min_mult = min(arg_list)
+
+    return inf_ctx.MultiplicityInfo(own=min_mult)
+
+
 def _common_multiplicity(
     args: Iterable[irast.Base],
     *,
@@ -404,6 +416,15 @@ def __infer_oper_call(
                 pass
 
         return result
+
+    elif op_name == 'std::EXCEPT':
+        # EXCEPT will produce multiplicity no greater than that of its first
+        # argument.
+        return mult[0]
+
+    elif op_name == 'std::INTERSECT':
+        # INTERSECT will produce the minimum multiplicity of its arguments.
+        return _min_multiplicity((mult[0], mult[1]))
 
     elif op_name == 'std::DISTINCT':
         if mult[0] == EMPTY:

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -214,7 +214,7 @@ class InnerDDLStmtBlock(parsing.ListNonterm, element=InnerDDLStmt,
 
 
 class PointerName(Nonterm):
-    def reduce_NodeName(self, *kids):
+    def reduce_PtrNodeName(self, *kids):
         self.val = kids[0].val
 
     def reduce_DUNDERTYPE(self, *kids):
@@ -1312,7 +1312,7 @@ class DropIndexStmt(Nonterm):
 #
 class CreatePropertyStmt(Nonterm):
     def reduce_CreateProperty(self, *kids):
-        r"""%reduce CREATE ABSTRACT PROPERTY NodeName OptExtendingSimple \
+        r"""%reduce CREATE ABSTRACT PROPERTY PtrNodeName OptExtendingSimple \
                     OptCreateCommandsBlock \
         """
         self.val = qlast.CreateProperty(
@@ -1342,7 +1342,7 @@ commands_block(
 class AlterPropertyStmt(Nonterm):
     def reduce_AlterProperty(self, *kids):
         r"""%reduce \
-            ALTER ABSTRACT PROPERTY NodeName \
+            ALTER ABSTRACT PROPERTY PtrNodeName \
             AlterPropertyCommandsBlock \
         """
         self.val = qlast.AlterProperty(
@@ -1356,7 +1356,7 @@ class AlterPropertyStmt(Nonterm):
 #
 class DropPropertyStmt(Nonterm):
     def reduce_DropProperty(self, *kids):
-        r"""%reduce DROP ABSTRACT PROPERTY NodeName"""
+        r"""%reduce DROP ABSTRACT PROPERTY PtrNodeName"""
         self.val = qlast.DropProperty(
             name=kids[3].val
         )
@@ -1598,7 +1598,7 @@ commands_block(
 class CreateLinkStmt(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
-            CREATE ABSTRACT LINK NodeName OptExtendingSimple \
+            CREATE ABSTRACT LINK PtrNodeName OptExtendingSimple \
             OptCreateLinkCommandsBlock \
         """
         self.val = qlast.CreateLink(
@@ -1638,7 +1638,7 @@ commands_block(
 class AlterLinkStmt(Nonterm):
     def reduce_AlterLink(self, *kids):
         r"""%reduce \
-            ALTER ABSTRACT LINK NodeName \
+            ALTER ABSTRACT LINK PtrNodeName \
             AlterLinkCommandsBlock \
         """
         self.val = qlast.AlterLink(
@@ -1663,7 +1663,7 @@ commands_block(
 class DropLinkStmt(Nonterm):
     def reduce_DropLink(self, *kids):
         r"""%reduce \
-            DROP ABSTRACT LINK NodeName \
+            DROP ABSTRACT LINK PtrNodeName \
             OptDropLinkCommandsBlock \
         """
         self.val = qlast.DropLink(

--- a/edb/edgeql/parser/grammar/keywords.py
+++ b/edb/edgeql/parser/grammar/keywords.py
@@ -25,8 +25,9 @@ from typing import *
 from edb import _edgeql_rust
 
 
-keyword_types = range(1, 4)
-UNRESERVED_KEYWORD, RESERVED_KEYWORD, TYPE_FUNC_NAME_KEYWORD = keyword_types
+keyword_types = range(1, 5)
+(UNRESERVED_KEYWORD, RESERVED_KEYWORD, TYPE_FUNC_NAME_KEYWORD,
+ PARTIAL_RESERVED_KEYWORD) = keyword_types
 
 unreserved_keywords = _edgeql_rust.unreserved_keywords
 future_reserved_keywords = _edgeql_rust.future_reserved_keywords
@@ -34,6 +35,12 @@ reserved_keywords = (
     future_reserved_keywords |
     _edgeql_rust.current_reserved_keywords
 )
+# These keywords can be used in pretty much all the places where they are
+# preceeded by a reserved keyword or some other disambiguating token like `.`,
+# `.<`, or `@`.
+#
+# In practice we mainly relax their usage as link/property names.
+partial_reserved_keywords = _edgeql_rust.partial_reserved_keywords
 
 
 def _check_keywords():
@@ -62,6 +69,8 @@ edgeql_keywords = {k: (tok_name(k), UNRESERVED_KEYWORD)
                    for k in unreserved_keywords}
 edgeql_keywords.update({k: (tok_name(k), RESERVED_KEYWORD)
                         for k in reserved_keywords})
+edgeql_keywords.update({k: (tok_name(k), PARTIAL_RESERVED_KEYWORD)
+                        for k in partial_reserved_keywords})
 
 
 by_type: Dict[int, dict] = {typ: {} for typ in keyword_types}

--- a/edb/edgeql/parser/grammar/precedence.py
+++ b/edb/edgeql/parser/grammar/precedence.py
@@ -30,7 +30,11 @@ class Precedence(parsing.Precedence, assoc='fail', metaclass=PrecedenceMeta):
     pass
 
 
-class P_UNION(Precedence, assoc='left', tokens=('UNION',)):
+class P_UNION(Precedence, assoc='left', tokens=('UNION', 'EXCEPT',)):
+    pass
+
+
+class P_INTERSECT(Precedence, assoc='left', tokens=('INTERSECT',)):
     pass
 
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -575,7 +575,7 @@ class IndexDeclarationShort(Nonterm):
 #
 class PropertyDeclaration(Nonterm):
     def reduce_CreateProperty(self, *kids):
-        r"""%reduce ABSTRACT PROPERTY NodeName OptExtendingSimple \
+        r"""%reduce ABSTRACT PROPERTY PtrNodeName OptExtendingSimple \
                     CreateSDLCommandsBlock \
         """
         self.val = qlast.CreateProperty(
@@ -588,7 +588,7 @@ class PropertyDeclaration(Nonterm):
 
 class PropertyDeclarationShort(Nonterm):
     def reduce_CreateProperty(self, *kids):
-        r"""%reduce ABSTRACT PROPERTY NodeName OptExtendingSimple"""
+        r"""%reduce ABSTRACT PROPERTY PtrNodeName OptExtendingSimple"""
         self.val = qlast.CreateProperty(
             name=kids[2].val,
             bases=kids[3].val,
@@ -644,7 +644,7 @@ class ConcretePropertyBlock(Nonterm):
 
     def reduce_CreateRegularProperty(self, *kids):
         """%reduce
-            PROPERTY ShortNodeName OptExtendingSimple
+            PROPERTY PathNodeName OptExtendingSimple
             OptPtrTarget CreateConcretePropertySDLCommandsBlock
         """
         target, cmds = self._extract_target(
@@ -658,7 +658,7 @@ class ConcretePropertyBlock(Nonterm):
 
     def reduce_CreateRegularQualifiedProperty(self, *kids):
         """%reduce
-            PtrQuals PROPERTY ShortNodeName OptExtendingSimple
+            PtrQuals PROPERTY PathNodeName OptExtendingSimple
             OptPtrTarget CreateConcretePropertySDLCommandsBlock
         """
         target, cmds = self._extract_target(
@@ -674,7 +674,7 @@ class ConcretePropertyBlock(Nonterm):
 
     def reduce_CreateOverloadedProperty(self, *kids):
         """%reduce
-            OVERLOADED OptPtrQuals PROPERTY ShortNodeName OptExtendingSimple
+            OVERLOADED OptPtrQuals PROPERTY PathNodeName OptExtendingSimple
             OptPtrTarget CreateConcretePropertySDLCommandsBlock
         """
         target, cmds = self._extract_target(
@@ -693,7 +693,7 @@ class ConcretePropertyBlock(Nonterm):
 class ConcretePropertyShort(Nonterm):
     def reduce_CreateRegularProperty(self, *kids):
         """%reduce
-            PROPERTY ShortNodeName OptExtendingSimple PtrTarget
+            PROPERTY PathNodeName OptExtendingSimple PtrTarget
         """
         self.val = qlast.CreateConcreteProperty(
             name=kids[1].val,
@@ -703,7 +703,7 @@ class ConcretePropertyShort(Nonterm):
 
     def reduce_CreateRegularQualifiedProperty(self, *kids):
         """%reduce
-            PtrQuals PROPERTY ShortNodeName OptExtendingSimple PtrTarget
+            PtrQuals PROPERTY PathNodeName OptExtendingSimple PtrTarget
         """
         self.val = qlast.CreateConcreteProperty(
             name=kids[2].val,
@@ -715,7 +715,7 @@ class ConcretePropertyShort(Nonterm):
 
     def reduce_CreateOverloadedProperty(self, *kids):
         """%reduce
-            OVERLOADED OptPtrQuals PROPERTY ShortNodeName OptExtendingSimple
+            OVERLOADED OptPtrQuals PROPERTY PathNodeName OptExtendingSimple
             OptPtrTarget
         """
         self.val = qlast.CreateConcreteProperty(
@@ -729,7 +729,7 @@ class ConcretePropertyShort(Nonterm):
 
     def reduce_CreateComputableProperty(self, *kids):
         """%reduce
-            PROPERTY ShortNodeName ASSIGN Expr
+            PROPERTY PathNodeName ASSIGN Expr
         """
         self.val = qlast.CreateConcreteProperty(
             name=kids[1].val,
@@ -738,7 +738,7 @@ class ConcretePropertyShort(Nonterm):
 
     def reduce_CreateQualifiedComputableProperty(self, *kids):
         """%reduce
-            PtrQuals PROPERTY ShortNodeName ASSIGN Expr
+            PtrQuals PROPERTY PathNodeName ASSIGN Expr
         """
         self.val = qlast.CreateConcreteProperty(
             name=kids[2].val,
@@ -768,7 +768,7 @@ sdl_commands_block(
 class LinkDeclaration(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
-            ABSTRACT LINK NodeName OptExtendingSimple \
+            ABSTRACT LINK PtrNodeName OptExtendingSimple \
             CreateLinkSDLCommandsBlock \
         """
         self.val = qlast.CreateLink(
@@ -782,7 +782,7 @@ class LinkDeclaration(Nonterm):
 class LinkDeclarationShort(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
-            ABSTRACT LINK NodeName OptExtendingSimple"""
+            ABSTRACT LINK PtrNodeName OptExtendingSimple"""
         self.val = qlast.CreateLink(
             name=kids[2].val,
             bases=kids[3].val,
@@ -839,7 +839,7 @@ class ConcreteLinkBlock(Nonterm):
 
     def reduce_CreateRegularLink(self, *kids):
         """%reduce
-            LINK ShortNodeName OptExtendingSimple
+            LINK PathNodeName OptExtendingSimple
             OptPtrTarget CreateConcreteLinkSDLCommandsBlock
         """
         target, cmds = self._extract_target(
@@ -854,7 +854,7 @@ class ConcreteLinkBlock(Nonterm):
 
     def reduce_CreateRegularQualifiedLink(self, *kids):
         """%reduce
-            PtrQuals LINK ShortNodeName OptExtendingSimple
+            PtrQuals LINK PathNodeName OptExtendingSimple
             OptPtrTarget CreateConcreteLinkSDLCommandsBlock
         """
         target, cmds = self._extract_target(
@@ -871,7 +871,7 @@ class ConcreteLinkBlock(Nonterm):
 
     def reduce_CreateOverloadedLink(self, *kids):
         """%reduce
-            OVERLOADED OptPtrQuals LINK ShortNodeName OptExtendingSimple
+            OVERLOADED OptPtrQuals LINK PathNodeName OptExtendingSimple
             OptPtrTarget CreateConcreteLinkSDLCommandsBlock
         """
         target, cmds = self._extract_target(
@@ -892,7 +892,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateRegularLink(self, *kids):
         """%reduce
-            LINK ShortNodeName OptExtendingSimple
+            LINK PathNodeName OptExtendingSimple
             PtrTarget
         """
         self.val = qlast.CreateConcreteLink(
@@ -903,7 +903,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateRegularQualifiedLink(self, *kids):
         """%reduce
-            PtrQuals LINK ShortNodeName OptExtendingSimple
+            PtrQuals LINK PathNodeName OptExtendingSimple
             PtrTarget
         """
         self.val = qlast.CreateConcreteLink(
@@ -916,7 +916,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateOverloadedLink(self, *kids):
         """%reduce
-            OVERLOADED OptPtrQuals LINK ShortNodeName OptExtendingSimple
+            OVERLOADED OptPtrQuals LINK PathNodeName OptExtendingSimple
             OptPtrTarget
         """
         self.val = qlast.CreateConcreteLink(
@@ -930,7 +930,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateComputableLink(self, *kids):
         """%reduce
-            LINK ShortNodeName ASSIGN Expr
+            LINK PathNodeName ASSIGN Expr
         """
         self.val = qlast.CreateConcreteLink(
             name=kids[1].val,
@@ -939,7 +939,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateQualifiedComputableLink(self, *kids):
         """%reduce
-            PtrQuals LINK ShortNodeName ASSIGN Expr
+            PtrQuals LINK PathNodeName ASSIGN Expr
         """
         self.val = qlast.CreateConcreteLink(
             is_required=kids[0].val.required,

--- a/edb/lib/std/25-setoperators.edgeql
+++ b/edb/lib/std/25-setoperators.edgeql
@@ -77,6 +77,24 @@ std::`UNION` (s1: SET OF anytype, s2: SET OF anytype) -> SET OF anytype {
 
 
 CREATE INFIX OPERATOR
+std::`EXCEPT` (s1: SET OF anytype, s2: SET OF anytype) -> SET OF anytype {
+    CREATE ANNOTATION std::identifier := 'except';
+    CREATE ANNOTATION std::description := 'Multiset difference.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
+std::`INTERSECT` (s1: SET OF anytype, s2: SET OF anytype) -> SET OF anytype {
+    CREATE ANNOTATION std::identifier := 'intersect';
+    CREATE ANNOTATION std::description := 'Multiset intersection.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
 std::`??` (l: OPTIONAL anytype, r: SET OF anytype) -> SET OF anytype {
     CREATE ANNOTATION std::identifier := 'coalesce';
     CREATE ANNOTATION std::description := 'Coalesce.';

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3160,6 +3160,97 @@ class TestExpressions(tb.QueryTestCase):
             [1, 1, 2, 3, 4, 4, 4],
         )
 
+    async def test_edgeql_expr_set_04(self):
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} except 2
+                order by _;
+            """,
+            [1, 3, 4],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} except 2 except 4
+                order by _;
+            """,
+            [1, 3],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} except {1, 2}
+                order by _;
+            """,
+            [3, 4],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} except {4, 5}
+                order by _;
+            """,
+            [1, 2, 3],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} except {5, 6}
+                order by _;
+            """,
+            [1, 2, 3, 4],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 1, 1, 2, 2, 3} except {1, 3, 3, 2}
+                order by _;
+            """,
+            [1, 1, 2],
+        )
+
+    async def test_edgeql_expr_set_06(self):
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} intersect 2
+                order by _;
+            """,
+            [2],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ :=
+                    {1, 2, 3, 4} intersect {2, 3, 4} intersect {2, 4}
+                order by _;
+            """,
+            [2, 4],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} intersect {5, 6}
+                order by _;
+            """,
+            [],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 2, 3, 4} intersect 4
+                order by _;
+            """,
+            [4],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select _ := {1, 1, 1, 2, 2, 3} intersect {1, 3, 3, 2, 2, 5}
+                order by _;
+            """,
+            [1, 2, 2, 3],
+        )
+
     async def test_edgeql_expr_array_01(self):
         await self.assert_query_result(
             r'''SELECT [1];''',

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -998,3 +998,52 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         ONE
         """
+
+    def test_edgeql_ir_card_inference_114(self):
+        """
+        select 1 + (2 intersect 3)
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_115(self):
+        """
+        select 1 + (2 intersect {3, 4})
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_116(self):
+        """
+        select 1 + ({2, 3} intersect {3, 4})
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_117(self):
+        """
+        select 1 + ({2, 3} intersect <int64>{})
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_118(self):
+        """
+        select 1 + (2 except 3)
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_119(self):
+        """
+        select 1 + (2 except {3, 4})
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_120(self):
+        """
+        select 1 + ({2, 3} except {3, 4})
+% OK %
+        MANY
+        """

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -770,3 +770,59 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         DUPLICATE
         """
+
+    def test_edgeql_ir_mult_inference_82(self):
+        """
+        select 1 union 1
+% OK %
+        DUPLICATE
+        """
+
+    def test_edgeql_ir_mult_inference_83(self):
+        """
+        select 1 + (2 intersect 3)
+% OK %
+        UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_84(self):
+        """
+        select 1 + (2 intersect {3, 3})
+% OK %
+        UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_85(self):
+        """
+        select 1 + ({2, 2} intersect {3, 3})
+% OK %
+        DUPLICATE
+        """
+
+    def test_edgeql_ir_mult_inference_86(self):
+        """
+        select {2, 2} intersect <int64>{}
+% OK %
+        EMPTY
+        """
+
+    def test_edgeql_ir_mult_inference_87(self):
+        """
+        select 1 + (2 except 3)
+% OK %
+        UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_88(self):
+        """
+        select 1 + (2 except {3, 3})
+% OK %
+        UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_89(self):
+        """
+        select 1 + ({2, 2} except {3, 3})
+% OK %
+        DUPLICATE
+        """

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1727,6 +1727,78 @@ aa';
         SELECT sys::Database;
         """
 
+    def test_edgeql_syntax_shape_65(self):
+        """
+        select Foo{union};
+        select Foo{except};
+        select Foo{intersect};
+        """
+
+    def test_edgeql_syntax_shape_66(self):
+        """
+        select Foo {
+            bar: {
+                @union,
+                @except,
+                @intersect,
+            }
+        };
+        """
+
+    def test_edgeql_syntax_shape_67(self):
+        """
+        select Foo {
+            [is Bar].union,
+            [is Bar].except,
+            [is Bar].intersect,
+        };
+        """
+
+    def test_edgeql_syntax_shape_68(self):
+        """
+        select Foo {
+            union := 1,
+            except := 1,
+            intersect := 1
+        };
+        """
+
+    def test_edgeql_syntax_shape_69(self):
+        """
+        select Foo {
+            required union := 1,
+            required except := 1,
+            required intersect := 1
+        };
+        """
+
+    def test_edgeql_syntax_shape_70(self):
+        """
+        select Foo {
+            optional union := 1,
+            optional except := 1,
+            optional intersect := 1
+        };
+        """
+
+    def test_edgeql_syntax_shape_71(self):
+        """
+        select Foo {
+            single union := 1,
+            single except := 1,
+            single intersect := 1
+        };
+        """
+
+    def test_edgeql_syntax_shape_72(self):
+        """
+        select Foo {
+            multi union := 1,
+            multi except := 1,
+            multi intersect := 1
+        };
+        """
+
     def test_edgeql_syntax_struct_01(self):
         """
         SELECT (
@@ -2105,6 +2177,19 @@ aa';
     def test_edgeql_syntax_path_31(self):
         """
         SELECT $ a;
+        """
+
+    def test_edgeql_syntax_path_32(self):
+        """
+        select Foo.union.except.intersect;
+        select Foo.<union[is Foo].<except[is Foo].<intersect[is Foo];
+        """
+
+    def test_edgeql_syntax_path_33(self):
+        """
+        select Foo.bar@union;
+        select Foo.bar@except;
+        select Foo.bar@intersect;
         """
 
     def test_edgeql_syntax_type_interpretation_01(self):
@@ -2797,6 +2882,61 @@ aa';
     def test_edgeql_syntax_set_06(self):
         """
         SELECT DISTINCT ({1, 2, 2, 3});
+        """
+
+    def test_edgeql_syntax_set_07(self):
+        """
+        SELECT ((1 UNION 2) UNION 3);
+        """
+
+    def test_edgeql_syntax_set_08(self):
+        """
+        SELECT 1 EXCEPT 2 EXCEPT 3;
+
+% OK %
+
+        SELECT ((1 EXCEPT 2) EXCEPT 3);
+        """
+
+    def test_edgeql_syntax_set_09(self):
+        """
+        SELECT 1 EXCEPT 2 UNION 3;
+
+% OK %
+
+        SELECT ((1 EXCEPT 2) UNION 3);
+        """
+
+    def test_edgeql_syntax_set_10(self):
+        """
+        SELECT (1 EXCEPT (2 UNION 3));
+        """
+
+    def test_edgeql_syntax_set_11(self):
+        """
+        SELECT 1 INTERSECT 2 INTERSECT 3;
+
+% OK %
+
+        SELECT ((1 INTERSECT 2) INTERSECT 3);
+        """
+
+    def test_edgeql_syntax_set_12(self):
+        """
+        SELECT 1 UNION 2 INTERSECT 3;
+
+% OK %
+
+        SELECT (1 UNION (2 INTERSECT 3));
+        """
+
+    def test_edgeql_syntax_set_13(self):
+        """
+        SELECT 1 INTERSECT 2 EXCEPT 3 INTERSECT 4 UNION 5;
+
+% OK %
+
+        SELECT (((1 INTERSECT 2) EXCEPT (3 INTERSECT 4)) UNION 5);
         """
 
     def test_edgeql_syntax_insert_01(self):
@@ -4960,6 +5100,20 @@ aa';
         ALTER ABSTRACT PROPERTY prop RESET default;
         """
 
+    def test_edgeql_syntax_ddl_property_07(self):
+        """
+        create abstract property union;
+        alter abstract property union reset default;
+        drop abstract property union;
+        """
+
+    def test_edgeql_syntax_ddl_link_01(self):
+        """
+        create abstract link union;
+        alter abstract link union reset default;
+        drop abstract link union;
+        """
+
     def test_edgeql_syntax_ddl_module_01(self):
         """
         CREATE MODULE foo;
@@ -5245,6 +5399,26 @@ aa';
         """
         CREATE TYPE `123` {
             CREATE PROPERTY `456` -> str;
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_24(self):
+        """
+        ALTER TYPE mymod::Foo {
+            ALTER LINK union {
+                USING (SELECT Object);
+            };
+            ALTER PROPERTY except {
+                USING (1312);
+            };
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_25(self):
+        """
+        ALTER TYPE mymod::Foo {
+            DROP LINK union;
+            DROP PROPERTY except;
         };
         """
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1999,6 +1999,26 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """
 
+    def test_schema_computed_05(self):
+        """
+            type User {
+                required property name -> str;
+
+                property val_e := {'alice', 'billie'} except .name;
+                property val_i := {'alice', 'billie'} intersect .name;
+            }
+        """
+
+    def test_schema_alias_01(self):
+        """
+            type User {
+                required property name -> str;
+            }
+
+            alias val_e := {'alice', 'billie'} except User.name;
+            alias val_i := {'alice', 'billie'} intersect User.name;
+        """
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -617,6 +617,58 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         };
         """
 
+    def test_eschema_syntax_type_33(self):
+        """
+        module default {
+            type Foo0 {
+                property union -> str;
+                link except -> Object;
+            };
+            type Foo1 {
+                required property union -> str;
+                required link except -> Object;
+            };
+            type Foo2 {
+                optional property union -> str;
+                optional link except -> Object;
+            };
+        };
+        """
+
+    def test_eschema_syntax_type_34(self):
+        """
+        module default {
+            type Foo1 {
+                multi property union -> str;
+                multi link except -> Object;
+            };
+            type Foo2 {
+                single property union -> str;
+                single link except -> Object;
+            };
+        };
+        """
+
+    def test_eschema_syntax_type_35(self):
+        """
+        module default {
+            type Foo {
+                property union extending except -> str;
+            };
+        };
+        """
+
+    def test_eschema_syntax_type_36(self):
+        """
+        module default {
+            type Foo {
+                link union extending except -> Object {
+                    property intersect -> str;
+                };
+            };
+        };
+        """
+
     def test_eschema_syntax_link_target_type_01(self):
         """
         module test {
@@ -1065,6 +1117,13 @@ abstract property test::foo {
         };
         """
 
+    def test_eschema_syntax_property_06(self):
+        """
+        module test {
+            abstract property union extending except;
+        };
+        """
+
     def test_eschema_syntax_link_01(self):
         """
         module test {
@@ -1204,6 +1263,22 @@ abstract property test::foo {
             type Foo {
                 link mod::name to std::str;
             }
+        };
+        """
+
+    def test_eschema_syntax_property_13(self):
+        """
+        module test {
+            abstract link union extending except;
+        };
+        """
+
+    def test_eschema_syntax_property_14(self):
+        """
+        module test {
+            abstract link union extending intersect {
+                property except -> str;
+            };
         };
         """
 


### PR DESCRIPTION
The `EXCEPT` and `INTERSECT` operators serve to complete the basic multiset functionality. They operate on multisets taking element multiplicty into account and so they cannot be easily substituted by a `FILTER` clause.

Fixes #4392