### PR TITLE
Add example of TS/JS transaction w/ querybuilder

### DIFF
--- a/docs/edgeql/transactions.rst
+++ b/docs/edgeql/transactions.rst
@@ -42,10 +42,23 @@ under the hood.
 TypeScript/JS
 ^^^^^^^^^^^^^
 
+Using an EdgeQL query string:
+
 .. code-block:: typescript
 
   client.transaction(async tx => {
     await tx.execute(`insert Fish { name := 'Wanda' };`);
+  });
+
+Using the querybuilder:
+
+.. code-block:: typescript
+
+  const query = e.insert(e.Fish, {
+    name: 'Wanda'
+  });
+  client.transaction(async tx => {
+    await query.run(tx);
   });
 
 Full documentation at `Client Libraries > TypeScript/JS


### PR DESCRIPTION
A user created a repo comparing a task model implementation in Knex and EdgeDB. User was under the impression it was not possible to use the querybuilder with transactions. This is part of an effort to better communicate that it is possible.

See https://discord.com/channels/841451783728529451/1038780233458909324/1039094288354652180

Companion to https://github.com/edgedb/edgedb-js/pull/482