### PR TITLE
Fix using WITH-bound DML from an UPDATE in an ELSE clause

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -299,6 +299,10 @@ class DynamicRangeVar(PathRangeVar):
 
     dynamic_get_path: DynamicRangeVarFunc
 
+    @property
+    def query(self) -> BaseRelation:
+        raise AssertionError('cannot retrieve query from a dynamic range var')
+
 
 class TypeName(ImmutableBase):
     """Type in definitions and casts."""

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -91,6 +91,8 @@ def init_dml_stmt(
     range_cte: Optional[pgast.CommonTableExpr]
     range_rvar: Optional[pgast.RelRangeVar]
 
+    clauses.compile_dml_bindings(ir_stmt, ctx=ctx)
+
     if isinstance(ir_stmt, (irast.UpdateStmt, irast.DeleteStmt)):
         # UPDATE and DELETE operate over a range, so generate
         # the corresponding CTE and connect it to the DML statements.

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -165,6 +165,8 @@ def _compile_group(
         ctx: context.CompilerContextLevel,
         parent_ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
+    clauses.compile_dml_bindings(stmt, ctx=ctx)
+
     query = ctx.stmt
 
     # Compile a GROUP BY into a subquery, along with all the aggregations

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -46,15 +46,7 @@ def compile_SelectStmt(
     parent_ctx = ctx
     with parent_ctx.substmt() as ctx:
         # Common setup.
-        for binding in (stmt.bindings or ()):
-            # If something we are WITH binding contains DML, we want to
-            # compile it *now*, in the context of its initial appearance
-            # and not where the variable is used. This will populate
-            # dml_stmts with the CTEs, which will be picked up when the
-            # variable is referenced.
-            if irutils.contains_dml(binding):
-                with ctx.substmt() as bctx:
-                    dispatch.compile(binding, ctx=bctx)
+        clauses.compile_dml_bindings(stmt, ctx=ctx)
 
         query = ctx.stmt
 


### PR DESCRIPTION
More generally, always process DML containing bindings at the point
the statement is compiled and not when the binding is first
referenced. Currently we handle this properly for SELECT but not for
other statements.

As a result of not handling that right, we were first compiling a
WITH-bound insert in the context of an UNLESS CONFLICT clause
containing an UPDATE and then trying to reuse it in the INSERT
that the UPDATE was hanging off of, which broke.

Fixes #4577.