### PR TITLE
Loosen the rules on "would change the interpretation"

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2639,16 +2639,11 @@ class TestExpressions(tb.QueryTestCase):
             """)
 
     async def test_edgeql_expr_paths_05(self):
-        # `Issue.number` in FILTER is illegal because it shares a
-        # prefix `Issue` with `Issue.id` which is defined in an outer
-        # scope.
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r"'Issue.number' changes the interpretation of 'Issue'"):
-            await self.con.execute(r"""
-                SELECT Issue.id
-                FILTER Issue.number > '2';
-            """)
+        # This is OK because Issue.id is a property, not a link
+        await self.con.execute(r"""
+            SELECT Issue.id
+            FILTER Issue.number > '2';
+        """)
 
     async def test_edgeql_expr_paths_06(self):
         # `Issue.number` in the shape is illegal because it shares a

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -86,9 +86,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         UPDATE User.deck SET { name := User.name }
         """
 
-    @tb.must_fail(errors.QueryError,
-                  "reference to 'U.r' changes the interpretation",
-                  line=6, col=58)
     def test_edgeql_ir_scope_tree_bad_05(self):
         """
         WITH
@@ -98,3 +95,4 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 users := array_agg((SELECT U.id ORDER BY U.r LIMIT 10))
             )
         """
+        # This one is fine now, since it is a property

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -7692,3 +7692,13 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         """, __typenames__=True)
         for row in res:
             self.assertEqual(row.__tname__, "default::User")
+
+    async def test_edgeql_select_paths_01(self):
+        # This is OK because Issue.id is a property, not a link
+        await self.assert_query_result(
+            r'''
+                SELECT Issue.name
+                FILTER Issue.number > '2';
+            ''',
+            tb.bag(["Repl tweak.", "Regression."]),
+        )


### PR DESCRIPTION
It should be OK to let a clause cause a path prefix to be factored out
if the path it is being factored from only contains properties, like
  `select Issue.name filter Issue.number > '2'`

We still want to disallow it if there are links, such as
  `select Issue.owner filter Issue.number > '2'`
since factoring would mean that .owner no longer gets deduplicated.