### PR TITLE
Implement some mild hacks to allow testing SQL translator

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1371,6 +1371,10 @@ class DescribeStmt(Statement):
     options: Options
 
 
+class SQLDebugStmt(Statement):
+    source: str
+
+
 #
 # SDL
 #

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -41,6 +41,10 @@ class Stmt(Nonterm):
         # DESCRIBE
         self.val = kids[0].val
 
+    def reduce_SqlDebugStmt(self, *kids):
+        # DESCRIBE
+        self.val = kids[0].val
+
     def reduce_ExprStmt(self, *kids):
         self.val = kids[0].val
 
@@ -174,6 +178,14 @@ class DescribeFormat(Nonterm):
                 options={'VERBOSE': qlast.Flag(
                     name='VERBOSE', val=True, context=kids[2].context)}
             ),
+        )
+
+
+class SqlDebugStmt(Nonterm):
+    def reduce_debug(self, *kids):
+        """%reduce DESCRIBE ALTER SCONST"""
+        self.val = qlast.SQLDebugStmt(
+            source=kids[2].clean_value,
         )
 
 

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -1088,6 +1088,14 @@ def trace_DescribeStmt(
 
 
 @trace.register
+def trace_SQLDebugStmt(
+    node: qlast.SQLDebugStmt, *,
+    ctx: TracerContext,
+) -> None:
+    pass
+
+
+@trace.register
 def trace_Placeholder(
     node: qlast.Placeholder,
     *,

--- a/edb/server/compiler/status.py
+++ b/edb/server/compiler/status.py
@@ -189,3 +189,8 @@ def _describe(ql):
 @get_status.register(qlast.Rename)
 def _rename(ql):
     return f'RENAME'.encode()
+
+
+@get_status.register(qlast.SQLDebugStmt)
+def _sql_hack(ql):
+    return f'SQL'.encode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ test = [
     'flake8-bugbear~=21.4.3',
     'pycodestyle~=2.7.0',
     'pyflakes~=2.3.1',
+    'asyncpg~=0.25.0',
 
     # Needed for test_docs_sphinx_ext
     'requests-xml~=0.2.3',

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,37 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+from edb.testbase import server as tb
+
+
+class TestSQL(tb.SQLQueryTestCase):
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'issues.esdl')
+
+    async def test_sql_01(self):
+        res = await self.squery('''
+            select 1, 2, 3
+        ''')
+        self.assertEqual(
+            res,
+            [(1, 2, 3)],
+        )


### PR DESCRIPTION
Make 'DESCRIBE ALTER <string literal>' interpret string literal as raw
SQL source, rewrite it as necessary (TODO!) and return the textual
result.

I went with DESCRIBE ALTER as the (totally nonsensical) keyword for
this because I didn't want to have to adjust any keywords, it worked,
and the presence of ALTER prevents the query normalizer from
extracting the string constant.

Then also add a test class that executes SQL queries by getting the
pgaddr from dev-mode connection settings, running DESCRIBE ALTER to
get a rewritten query, and then using asyncpg to directly query the
underlying postgres instance.

The core virture of this approach is that we'll be able write test
cases, then swap out the implementation of SQLQueryTestCase and keep
using the same test cases.

Maybe we actually want to use psycopg instead, since it may be a
smoother path to transitioning the tests directly speak the pg
protocol to the edgedb server?

This is obviously a hack, but I think it is a mild enough one that it
is mergeable (unlike the previous version that invoked psql).