### PR TITLE
Fewer selects

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -109,6 +109,8 @@ class flags(metaclass=FlagsMeta):
     edgeql_compile_sql_reordered_text = Flag(
         doc="Dump generated SQL-like text that might better reflect scoping.")
 
+    edgeql_disable_sql_inlining = Flag(doc="Disable inlining of SQL SELECTs")
+
     edgeql_disable_normalization = Flag(
         doc="Disable EdgeQL normalization (constant extraction etc)")
 

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -51,7 +51,8 @@ class Base(ast.AST):
 
     def dump_sql(self) -> None:
         from edb.common.debug import dump_sql
-        dump_sql(self, reordered=True, pretty=True)
+
+        dump_sql(self, reordered=True, pretty=True, inlining=False)
 
 
 class ImmutableBase(ast.ImmutableASTMixin, Base):

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -103,12 +103,12 @@ class AttrFlagManager:
 
 class SQLSourceGenerator(codegen.SourceGenerator):
     def __init__(  # type: ignore
-        self, *args, reordered=False, inlining=True, **kwargs
+        self, *args, reordered=False, **kwargs
     ):
         super().__init__(*args, **kwargs)
         self.param_index: dict[object, int] = {}
         self.reordered = reordered
-        self.inlining = inlining
+        self.inlining = not debug.flags.edgeql_disable_sql_inlining
         self.as_scalar = False
 
     @classmethod
@@ -125,7 +125,6 @@ class SQLSourceGenerator(codegen.SourceGenerator):
                 node,
                 indent_with=indent_with,
                 reordered=reordered,
-                inlining=not debug.flags.edgeql_disable_sql_inlining,
                 add_line_information=add_line_information,
                 pretty=pretty,
             )

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -209,9 +209,8 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         if self.inlining:
             # inline trivial SELECT statements
             if self.as_scalar:
-                if len(node.target_list) == 1 and astutils.select_is_trivial(
-                    node
-                ):
+                single_target = len(node.target_list) == 1
+                if single_target and astutils.select_is_trivial(node):
                     target = node.target_list[0]
                     if not target.indirection:
                         self.visit(target.val)
@@ -987,6 +986,8 @@ def try_inline_projection_select(
         if value_name in input_values
     ]
     if len(target_list) != len(inner.subquery.target_list):
+        return None
+    if len(target_list) != len(output_targets):
         return None
 
     return pgast.SelectStmt(

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -449,6 +449,10 @@ def select_is_simple(stmt: pgast.SelectStmt) -> bool:
     )
 
 
+def select_is_trivial(stmt: pgast.SelectStmt) -> bool:
+    return not stmt.from_clause and select_is_simple(stmt)
+
+
 def is_row_expr(expr: pgast.BaseExpr) -> bool:
     while True:
         if isinstance(expr, (pgast.RowExpr, pgast.ImplicitRowExpr)):


### PR DESCRIPTION
This proof of concept does two things:

- inline simple query projections
  ```sql
      FROM (
          FROM base_table
          SELECT/*<pg.SelectStmt at 0x7faa6d59a680>*/
              base_table.base_x AS x,
              base_table.base_y AS y,
              base_table.base_z AS z,
              base_table.base_u AS u
      ) AS inner_table
      SELECT/*<pg.SelectStmt at 0x7faa6d59a3b0>*/
          inner_table.x AS a,
          inner_table.z AS b,
          inner_table.y AS c
  ```
  ... is inlined as ...
  ```sql
      FROM base_table
      SELECT/*<pg.SelectStmt at 0x7fdc8a0480d0>*/
          base_table.base_x AS a,
          base_table.base_y AS c,
          base_table.base_z AS b
  ```

- inline trivial scalar SELECTS

  ```SELECT * FROM x LIMIT (SELECT 100)```
  ... is inlined as ...
  ```SELECT * FROM x LIMIT 100```

As a benchmark, this changes the last part of query generated for `insert Movie { title: 'The Godfather' }` from:
```sql
    FROM "m~1" AS "m~2"
    SELECT/*<pg.SelectStmt at 0x7f2d32824dc0>*/
        ((
            FROM LATERAL (
                FROM LATERAL (
                    FROM LATERAL (
                        FROM LATERAL (
                            FROM LATERAL (
                                SELECT/*<pg.SelectStmt at 0x7f2d31e57c40>*/
                                    "m~2"."__type___identity~2" AS "__type___identity~3"
                            ) AS "q~2"
                            JOIN LATERAL (
                                FROM "t~1" AS "t~2"
                                SELECT/*<pg.SelectStmt at 0x7f2d31e56dd0>*/
                                    "t~2"."expr~10_identity~1" AS "expr~10_identity~2",
                                    "t~2"."name_value~2" AS "name_value~3"
                            ) AS "q~3"
                                ON ("q~2"."__type___identity~3" = "q~3"."expr~10_identity~2")
                            SELECT/*<pg.SelectStmt at 0x7f2d31e56ec0>*/
                                "q~3"."name_value~3" AS "name_value~4"
                        ) AS "q~4"
                        SELECT/*<pg.SelectStmt at 0x7f2d31e56980>*/
                            "q~4"."name_value~4" AS "name_value~5"
                    ) AS "str_name~2"
                    SELECT/*<pg.SelectStmt at 0x7f2d31c2e380>*/
                        "str_name~2"."name_value~5" AS "name_value~6"
                    LIMIT (
                        SELECT/*<pg.SelectStmt at 0x7f2d32c14490>*/
                            (101)::int8 AS "expr~11_value~1"
                    )
                ) AS "expr-12~2"
                SELECT/*<pg.SelectStmt at 0x7f2d31c2cc40>*/
                    "expr-12~2"."name_value~6" AS "expr~12_value~1"
                LIMIT (
                    SELECT/*<pg.SelectStmt at 0x7f2d31c2e4d0>*/
                        (101)::int8 AS "expr~13_value~1"
                )
            ) AS "str___tname__~2"
            SELECT/*<pg.SelectStmt at 0x7f2d31c2f730>*/
                "str___tname__~2"."expr~12_value~1" AS "__tname___serialized~1"
        ), "m~2"."Movie_value~1") AS "Movie_serialized~1"

```
... to ...
```sql
    FROM "m~1" AS "m~2"
    SELECT/*<pg.SelectStmt at 0x7f898c9bedd0>*/
        ((
            FROM LATERAL (
                FROM LATERAL (
                    FROM LATERAL (
                        SELECT/*<pg.SelectStmt at 0x7f898a030670>*/
                            "m~2"."__type___identity~2" AS "__type___identity~3"
                    ) AS "q~2"
                    JOIN LATERAL (
                        FROM "t~1" AS "t~2"
                        SELECT/*<pg.SelectStmt at 0x7f898a031ed0>*/
                            "t~2"."expr~10_identity~1" AS "expr~10_identity~2",
                            "t~2"."name_value~2" AS "name_value~3"
                    ) AS "q~3"
                        ON ("q~2"."__type___identity~3" = "q~3"."expr~10_identity~2")
                    SELECT/*<pg.SelectStmt at 0x7f8989fb2320>*/
                        "q~3"."name_value~3" AS "name_value~5"
                ) AS "str_name~2"
                SELECT/*<pg.SelectStmt at 0x7f8989fb3220>*/
                    "str_name~2"."name_value~5" AS "name_value~6"
                LIMIT (101)::int8
            ) AS "expr-12~2"
            SELECT/*<pg.SelectStmt at 0x7f8989fb2380>*/
                "expr-12~2"."name_value~6" AS "__tname___serialized~1"
            LIMIT (101)::int8
        ), "m~2"."Movie_value~1") AS "Movie_serialized~1"
```

The question a this point is: is it worth it? This does produce simpler SQL, but adds more surface for strange bugs.

There are probably a few things I didn't think about, so a least one test will fail and for this to work perfectly, I'd have to really handle all cases and refactor the code into something maintainable.