### PR TITLE
Clarify the `duration_get` function

### DIFF
--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -967,7 +967,7 @@ EdgeDB stores and outputs timezone-aware values in UTC.
     .. code-block:: edgeql-repl
 
         db> select duration_get(
-        ...   <cal::relative_duration>''20 hours 3600 seconds', 'hour');
+        ...   <cal::relative_duration>'20 hours 3600 seconds', 'hour');
         {21}
 
     Seconds and smaller units always return remaining time in that unit after
@@ -976,10 +976,10 @@ EdgeDB stores and outputs timezone-aware values in UTC.
     .. code-block:: edgeql-repl
 
         db> select duration_get(
-        ...   <cal::relative_duration>''20 hours 3600 seconds', 'seconds');
+        ...   <cal::relative_duration>'20 hours 3600 seconds', 'seconds');
         {0}
         db> select duration_get(
-        ...   <cal::relative_duration>''20 hours 3630 seconds', 'seconds');
+        ...   <cal::relative_duration>'20 hours 3630 seconds', 'seconds');
         {30}
 
     Normalization and truncation may help you deal with this. If your use case

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -982,6 +982,15 @@ EdgeDB stores and outputs timezone-aware values in UTC.
         ...   <cal::relative_duration>''20 hours 3630 seconds', 'seconds');
         {30}
 
+    Normalization and truncation may help you deal with this. If your use case
+    allows for making assumptions about the duration of a month or a day, you
+    can make those conversions for yourself using the
+    :eql:func:`cal::duration_normalize_hours` or
+    :eql:func:`cal::duration_normalize_days` functions. If you got back a
+    duration as a result of a datetime calculation and don't need the level of
+    granularity you have, you can truncate the value with
+    :eql:func:`duration_truncate`.
+
 ----------
 
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -865,14 +865,14 @@ EdgeDB stores and outputs timezone-aware values in UTC.
       and :eql:type:`cal::date_duration` for durations longer than a day,
       because a month is assumed to be 30 days exactly.
 
-    The :eql:type:`duration` scalar only has the smallest units available
-    for extraction.
+    The :eql:type:`duration` scalar has only ``'hour'`` and smaller units
+    available for extraction.
 
     The :eql:type:`cal::relative_duration` scalar has all of the units
     available for extraction.
 
-    The :eql:type:`cal::date_duration` scalar only has the largest and middle
-    size units available for extraction.
+    The :eql:type:`cal::date_duration` scalar only has ``'date'`` and larger
+    units available for extraction.
 
     .. code-block:: edgeql-repl
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -860,10 +860,10 @@ EdgeDB stores and outputs timezone-aware values in UTC.
 
     Additionally, it's possible to convert a given duration into seconds:
 
-    - ``'totalseconds'`` - the number of seconds represented by the
-      duration. It will be approximate for :eql:type:`cal::relative_duration`
-      and :eql:type:`cal::date_duration` for durations longer than a day,
-      because a month is assumed to be 30 days exactly.
+    - ``'totalseconds'`` - the number of seconds represented by the duration.
+      It will be approximate for :eql:type:`cal::relative_duration` and
+      :eql:type:`cal::date_duration` for units ``'month'`` or larger because a
+      month is assumed to be 30 days exactly.
 
     The :eql:type:`duration` scalar has only ``'hour'`` and smaller units
     available for extraction.

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -410,7 +410,7 @@ EdgeDB stores and outputs timezone-aware values in UTC.
       ...        <cal::relative_duration>"1 month";
       {<cal::local_datetime>'2021-06-01T15:00:00'}
 
-    **Gotchas**
+    .. rubric:: Gotchas
 
     Due to the implementation of ``relative_duration`` logic, arithmetic
     operations may behave counterintuitively.
@@ -903,7 +903,7 @@ EdgeDB stores and outputs timezone-aware values in UTC.
         ...   <duration>'30 hours', 'totalseconds');
         {108000}
 
-    **Gotchas**
+    .. rubric:: Gotchas
 
     When you use this function to return an element of a duration, the value
     will be returned only as the number of that specific unit defined in the

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -906,8 +906,15 @@ EdgeDB stores and outputs timezone-aware values in UTC.
     .. rubric:: Gotchas
 
     This function will provide you with a calculated total for the unit passed
-    as ``el``, but only within the given "size class" of the unit. The size
-    classes are as follows:
+    as ``el``, but only within the given "size class" of the unit. These size
+    classes exist because they are logical breakpoints that we can't reliably
+    convert values across. A month might be 30 days long, or it might be 28 or
+    29 or 31. A day is generally 24 hours, but with daylight savings, it might
+    be longer or shorter.
+
+    As a result, it's impossible to convert across these lines in a way that
+    works in every situation. For some use cases, assuming a 30 day month works
+    fine. For others, it might not. The size classes are as follows:
 
     - ``'month'`` and larger
     - ``'day'``

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -924,13 +924,10 @@ EdgeDB stores and outputs timezone-aware values in UTC.
     will return only the number of days expressed as ``N days`` in your
     duration. It will not add another day to the returned count for every 24
     hours (defined as ``24 hours``) in the duration, nor will it consider the
-    months' constituent day counts in the returned value.
-
-    Specifying ``'decade'`` for ``el`` will total up all decades represented in
-    units ``'month'`` and larger, but it will not add a decade's worth of days
-    to the returned value as an additional decade. On the other end of the unit
-    spectrum, passing ``'hour'`` for ``el`` will not add a day's worth of hours
-    for each day in your duration.
+    months' constituent day counts in the returned value. Specifying
+    ``'decade'`` for ``el`` will total up all decades represented in units
+    ``'month'`` and larger, but it will not add a decade's worth of days to the
+    returned value as an additional decade.
 
     In this example, the duration represents more than a day's time, but since
     ``'day'`` and ``'hour'`` are in different size classes, the extra day

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -827,7 +827,7 @@ EdgeDB stores and outputs timezone-aware values in UTC.
                   std::duration_get(dt: cal::date_duration, \
                                     el: str) -> float64
 
-    Return a specific element of input duration given a unit name.
+    Returns the element of a duration given a unit name.
 
     .. note::
 


### PR DESCRIPTION
The behavior of `duration_get` is inconsistent. For duration elements month or larger, the units are aggregated to return the final value. For duration elements smaller than month, only the literal value expressed in the duration for that unit is returned. Since this behavior could be unexpected, we need additional documentation around it.