### PR TITLE
bump aysncpg version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ test = [
     'flake8-bugbear~=21.4.3',
     'pycodestyle~=2.7.0',
     'pyflakes~=2.3.1',
-    'asyncpg~=0.25.0',
+    'asyncpg~=0.26.0',
 
     # Needed for test_docs_sphinx_ext
     'requests-xml~=0.2.3',


### PR DESCRIPTION
I cannot get asyncpg to build when running:

```
pip install -v -e ".[test]"
```

Error:
```
  x86_64-linux-gnu-gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -I/home/aljaz/EdgeDB/venv/include -I/usr/include/python3.11 -c asyncpg/pgproto/pgproto.c -o build/temp.linux-x86_64-cpython-311/asyncpg/pgproto/pgproto.o -O2 -fsigned-char -Wall -Wsign-compare -Wconversion
  asyncpg/pgproto/pgproto.c:223:12: fatal error: longintrepr.h: No such file or directory
    223 |   #include "longintrepr.h"
        |            ^~~~~~~~~~~~~~~
  compilation terminated.
  error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
  error: subprocess-exited-with-error

  × Building wheel for asyncpg (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.

  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /home/aljaz/EdgeDB/venv/bin/python3.11 /home/aljaz/EdgeDB/venv/lib/python3.11/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /tmp/tmpp6c7pndk
  cwd: /tmp/pip-install-j3k3oedm/asyncpg_64ce56300b3a495cb511d67d708f72f0
  Building wheel for asyncpg (pyproject.toml) ... error
  ERROR: Failed building wheel for asyncpg
```

Which is same issue as https://github.com/MagicStack/uvloop/issues/450

Solution is to bump cython via bumping asyncpg version.