### PR TITLE
Fix putting a statement as the body of an access policy

### DIFF
--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -465,16 +465,16 @@ class OnSourceDeleteStmt(Nonterm):
 
 
 class OptWhenBlock(Nonterm):
-    def reduce_WHEN_LPAREN_Expr_RPAREN(self, *kids):
-        self.val = kids[2].val
+    def reduce_WHEN_ParenExpr(self, *kids):
+        self.val = kids[1].val
 
     def reduce_empty(self, *kids):
         self.val = None
 
 
 class OptUsingBlock(Nonterm):
-    def reduce_USING_LPAREN_Expr_RPAREN(self, *kids):
-        self.val = kids[2].val
+    def reduce_USING_ParenExpr(self, *kids):
+        self.val = kids[1].val
 
     def reduce_empty(self, *kids):
         self.val = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3342,6 +3342,30 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_access_policy_parens_01(self):
+        schema = r'''
+        type Foo {
+            access policy test
+              when (with y := 1, select y = 1)
+              allow all
+              using (with x := 1, select x = 1)
+        };
+        '''
+
+        self._assert_migration_consistency(schema)
+
+    def test_schema_access_policy_parens_02(self):
+        schema = r'''
+        type Foo {
+            access policy test
+              when ((with y := 1, select y = 1))
+              allow all
+              using ((with x := 1, select x = 1))
+        };
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_migrations_equivalence_01(self):
         self._assert_migration_equivalence([r"""
             type Base;


### PR DESCRIPTION
Currently it isn't (by oversight) allowed. The particularly bad part,
though, is that while you can fix the parse by wrapping the statement
in parens, the DDL codegen will lose the parens again.

The easiest way to work around this is probably wrapping it in braces,
so it is a set literal.