### PR TITLE
Allow WITH MODULE in ddl in CREATE MIGRATION

### DIFF
--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -315,7 +315,7 @@ class NestedQLBlockStmt(Nonterm):
     def reduce_Stmt(self, *kids):
         self.val = kids[0].val
 
-    def reduce_InnerDDLStmt(self, *kids):
+    def reduce_OptWithDDLStmt(self, *kids):
         self.val = kids[0].val
 
     def reduce_SetFieldStmt(self, *kids):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3985,6 +3985,13 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_create_migration_10(self):
+        """
+        CREATE APPLIED MIGRATION m123123123 ONTO m134134134 {
+            WITH MODULE x CREATE TYPE Foo;
+        };
+        """
+
     def test_edgeql_syntax_ddl_create_extension_package_01(self):
         """
         CREATE EXTENSION PACKAGE foo VERSION '1.0';


### PR DESCRIPTION
This is important because those could appear in dumps of databases
that did manual DDL using WITH MODULE.