### PR TITLE
Fix links to schema::ObjectType breaking DROP TYPE

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13811,6 +13811,17 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
             [],
         )
 
+    async def test_edgeql_ddl_link_policy_implicit_01(self):
+        await self.con.execute("""
+            create type T;
+            create type X {
+                create link foo -> schema::ObjectType;
+            };
+        """)
+        await self.con.execute("""
+            drop type T;
+        """)
+
     async def test_edgeql_ddl_dupe_link_storage_01(self):
         await self.con.execute(r"""
 


### PR DESCRIPTION
The issue is that we were mishandling links that had a restrict policy
that was inherited but that was not explicitly set on the base
link. We would not update the endpoint triggers when they changed, but
we *would* include them in the endpoint triggers when something else
caused a change.

The result of this is that a new `__type__` link being created or
deleted would not cause an adjustment, but an explicit link being
created to schema::ObjectType would cause the trigger to be recreated
with all `__type__` pointers explicitly listed. This meant that when
this explicit link got created, all existing object types would become
undroppable, since they are mentioned in this trigger spuriously.

Fix that.
While at it, make an implicit dependency on the string ordering of
LinkTargetDeleteAction explicit.

Fixes #4644.

If you are affected by this bug, once this patch is applied, you can
fix your database either by doing a dump/restore or by creating and
then deleting a link to schema::ObjectType.