### PR TITLE
Add wrappers for many more bytes functions

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_11_04_00_00
+EDGEDB_CATALOG_VERSION = 2022_11_15_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/lib/std/30-bytesfuncs.edgeql
+++ b/edb/lib/std/30-bytesfuncs.edgeql
@@ -32,6 +32,86 @@ std::bytes_get_bit(bytes: std::bytes, num: int64) -> std::int64
 };
 
 
+CREATE FUNCTION
+std::bytes_convert_from(bytes: std::bytes, src_encoding: std::str) -> std::str
+{
+    CREATE ANNOTATION std::description :=
+        'Convert *bytes* to a string using *src_encoding*';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'convert_from';
+};
+
+
+CREATE FUNCTION
+std::bytes_convert_to(str: std::str, dest_encoding: std::str) -> std::bytes
+{
+    CREATE ANNOTATION std::description :=
+        'Convert *str* to bytes using *dest_encoding*';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'convert_to';
+};
+
+
+CREATE FUNCTION
+std::bytes_encode(bytes: std::bytes, format: std::str) -> std::str
+{
+    CREATE ANNOTATION std::description :=
+        'Encode *bytes* into a textual representation';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'encode';
+};
+
+
+CREATE FUNCTION
+std::bytes_decode(str: std::str, format: std::str) -> std::bytes
+{
+    CREATE ANNOTATION std::description :=
+        'Decode a textual representation of a binary string';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'decode';
+};
+
+
+CREATE FUNCTION
+std::sha224(bytes: std::bytes) -> std::bytes
+{
+    CREATE ANNOTATION std::description :=
+        'Compute the SHA-224 hash of *bytes*';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'sha224';
+};
+
+
+CREATE FUNCTION
+std::sha256(bytes: std::bytes) -> std::bytes
+{
+    CREATE ANNOTATION std::description :=
+        'Compute the SHA-256 hash of *bytes*';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'sha256';
+};
+
+
+CREATE FUNCTION
+std::sha384(bytes: std::bytes) -> std::bytes
+{
+    CREATE ANNOTATION std::description :=
+        'Compute the SHA-384 hash of *bytes*';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'sha384';
+};
+
+
+
+CREATE FUNCTION
+std::sha512(bytes: std::bytes) -> std::bytes
+{
+    CREATE ANNOTATION std::description :=
+        'Compute the SHA-512 hash of *bytes*';
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'sha512';
+};
+
 
 ## Byte string operators
 ## ---------------------


### PR DESCRIPTION
This exposes:
 * convert_from
 * convert_to
 * encode
 * decode
 * sha{224,256,384,512}

I kept all of their names, but prefixed the non-SHA ones with
`bytes_`.  I'm not confident in either of those decisions and so would
be happy to have discussion on that.

We'll need to add some tests and documentation, but I'm putting this
PR up in advance of that because I want to use a hash function to
generate deterministic "random" numbers for testing purposes.