### PR TITLE
fix: sql null without a type

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1196,6 +1196,13 @@ def _get_path_output(
             if alias is None:
                 alias = get_path_output_alias(path_id, aspect, env=env)
 
+            if isinstance(ref, pgast.NullConstant):
+                pg_type = pg_types.pg_type_from_ir_typeref(path_id.target)
+
+                ref = pgast.TypeCast(
+                    arg=ref, type_name=pgast.TypeName(name=pg_type)
+                )
+
             restarget = pgast.ResTarget(
                 name=alias, val=ref, ser_safe=getattr(ref, 'ser_safe', False))
             rel.target_list.append(restarget)

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -83,6 +83,13 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
                     or (global cur_user in .name) ?? false
                 );
             };
+
+            create type Message {
+                create link attachment -> Issue;
+                create access policy has_attachment
+                    allow all
+                    using (count(.attachment) > 0);
+            };
         '''
     ]
 
@@ -471,6 +478,11 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
                 insert X { name := "!" }
                 unless conflict on (.name) else (select X)
             ''')
+
+    async def test_edgeql_policies_10(self):
+        # see issue https://github.com/edgedb/edgedb/issues/4646
+        async with self.assertRaisesRegexTx(edgedb.AccessPolicyError, ''):
+            await self.con.execute('insert Message {}')
 
     async def test_edgeql_policies_order_01(self):
         await self.con.execute('''


### PR DESCRIPTION
Closes #4646

The problem were NULLs originating from default property values and then being compared to some id. Because it was a NULL literal, type could not be inferred and has defaulted to text (god knows why).

This is the effect of the change:
```diff
  WITH "t~1" AS NOT MATERIALIZED (...),
  "ins_contents~1" AS (
      SELECT
          ('969ff6ab-642e-11ed-8df3-9ba7c8b2e471') :: uuid AS __type__,
          "uuid_id~2"."expr~14_value~1" AS id,
-         NULL AS "sender_identity~1",
+         (NULL) :: uuid AS "sender_identity~1",
-         NULL AS "recipient_identity~1"
+         (NULL) :: uuid AS "recipient_identity~1"
      FROM ...
  ),
  "policy~1" AS MATERIALIZED (
      ...
      JOIN edgedbpub."969ee548-642e-11ed-879c-7fc8724f4c98_t" AS "User~1"
          ON ("q~2"."sender_identity~2" = "User~1".id)
      ...
  )
  ...
```