### PR TITLE
Avoid ISE when pickling DynamicRangeVar

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -303,6 +303,13 @@ class DynamicRangeVar(PathRangeVar):
     def query(self) -> BaseRelation:
         raise AssertionError('cannot retrieve query from a dynamic range var')
 
+    # pickling is broken here, oh well
+    def __getstate__(self) -> typing.Any:
+        return ()
+
+    def __setstate__(self, state: typing.Any) -> None:
+        self.dynamic_get_path = None  # type: ignore
+
 
 class TypeName(ImmutableBase):
     """Type in definitions and casts."""


### PR DESCRIPTION
We won't be able to *do* anything useful with the DynamicRangeVar
after unpickling, but that's probably fine.

Makes us at least produce a better ISE in #4677...