### PR TITLE
Fix SET GLOBAL capabilities

### DIFF
--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -38,9 +38,6 @@ class Capability(enum.IntFlag):
     TRANSACTION       = 1 << 2    # noqa
     DDL               = 1 << 3    # noqa
     PERSISTENT_CONFIG = 1 << 4    # noqa
-    # SET_GLOBAL should also be implied by SESSION_CONFIG, for
-    # backward compatability reasons
-    SET_GLOBAL        = 1 << 5    # noqa
 
     ALL               = 0xFFFF_FFFF_FFFF_FFFF  # noqa
 
@@ -67,7 +64,6 @@ CAPABILITY_TITLES = {
     Capability.TRANSACTION: 'transaction control commands',
     Capability.DDL: 'DDL commands',
     Capability.PERSISTENT_CONFIG: 'configuration commands',
-    Capability.SET_GLOBAL: 'set global',
 }
 
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -121,18 +121,12 @@ DEF SERVER_HEADER_CAPABILITIES = 0x1001
 DEF ALL_CAPABILITIES = 0xFFFFFFFFFFFFFFFF
 
 
-cdef uint64_t CAP_SESSION_CONFIG = enums.Capability.SESSION_CONFIG
-cdef uint64_t CAP_SET_GLOBAL = enums.Capability.SET_GLOBAL
-
-
 def parse_capabilities_header(value: bytes) -> uint64_t:
     if len(value) != 8:
         raise errors.BinaryProtocolError(
             f'capabilities header must be exactly 8 bytes'
         )
     cdef uint64_t mask = hton.unpack_uint64(cpython.PyBytes_AS_STRING(value))
-    if mask & CAP_SESSION_CONFIG:
-        mask |= CAP_SET_GLOBAL
     return mask
 
 

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -50,8 +50,7 @@ cdef tuple CURRENT_PROTOCOL = edbdef.CURRENT_PROTOCOL
 
 ALLOWED_CAPABILITIES = (
     enums.Capability.MODIFICATIONS |
-    enums.Capability.DDL |
-    enums.Capability.SET_GLOBAL
+    enums.Capability.DDL
 )
 
 


### PR DESCRIPTION
In #4605, in an attempt to fix SET GLOBAL for the notebook protocol, I
made SET GLOBAL use its own capabilities flag while attempting to
maintain backward compatability. I screwed up in both directions,
though, breaking JS client tests that wanted SET GLOBAL disabled
when SESSION_CONFIG was cleared, and (much worse) breaking SET GLOBAL
from the cli.

Roll back that mechanism and just hack the notebook into being able to
handle it.

It's kind of shocking to me that nobody has reported this. We should
try to get this out in a release ASAP. (Though maybe a better fast fix
would be on the CLI side?).