### PR TITLE
Skip inserting assert_exists on required links inside access policies bodies

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -850,7 +850,8 @@ def needs_rewrite_existence_assertion(
     """
 
     return bool(
-        ptrcls.get_required(ctx.env.schema)
+        not ctx.suppress_rewrites
+        and ptrcls.get_required(ctx.env.schema)
         and direction == PtrDir.Outbound
         and (target := ptrcls.get_target(ctx.env.schema))
         and ctx.env.type_rewrites.get((target, False))


### PR DESCRIPTION
When policies evaluation is suppressed, we don't need to worry about
required links being broken.

The fix was verified manually; the added test is to make sure this
didn't prevent the check from being added *later*, where it *is*
needed.