### PR TITLE
Add an expand_inhviews debug flag that forces views to get expanded

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -112,6 +112,9 @@ class flags(metaclass=FlagsMeta):
     edgeql_disable_normalization = Flag(
         doc="Disable EdgeQL normalization (constant extraction etc)")
 
+    edgeql_expand_inhviews = Flag(
+        doc="Force the EdgeQL compiler to expand inhviews *always*")
+
     graphql_compile = Flag(
         doc="Debug GraphQL compiler.")
 

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -73,6 +73,11 @@ class GlobalCompilerOptions:
     #: definitions.
     func_params: Optional[s_func.ParameterLikeList] = None
 
+    #: Should the backend compiler expand out inheritance views instead of
+    #: using them. This is needed by EXPLAIN to maintain alias names in
+    #: the query plan.
+    expand_inhviews: bool = False
+
     #: The name that can be used in a "DML is disallowed in ..."
     #: error. When this is not None, any DML should cause an error.
     in_ddl_context_name: Optional[str] = None

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -32,6 +32,7 @@ from edb.ir import utils as irutils
 
 from edb.schema import abc as s_abc
 from edb.schema import pointers as s_pointers
+from edb.schema import objtypes as s_objtypes
 from edb.schema import types as s_types
 from edb.schema import utils as s_utils
 
@@ -268,6 +269,10 @@ def type_to_typeref(
     include_children = (
         expr_type is s_types.ExprType.Update
         or expr_type is s_types.ExprType.Delete
+        or (
+            env.options.expand_inhviews
+            and isinstance(t, s_objtypes.ObjectType)
+        )
     )
     include_ancestors = (
         expr_type is s_types.ExprType.Insert

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -309,6 +309,7 @@ def type_to_typeref(
                 _typeref(child, include_children=True)
                 for child in t.children(schema)
                 if not child.get_is_derived(schema)
+                and not child.is_compound_type(schema)
             )
         else:
             children = None

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -52,6 +52,7 @@ def compile_ir_to_sql_tree(
     singleton_mode: bool = False,
     use_named_params: bool = False,
     expected_cardinality_one: bool = False,
+    expand_inhviews: bool = False,
     external_rvars: Optional[
         Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
     ] = None,
@@ -95,6 +96,7 @@ def compile_ir_to_sql_tree(
             type_rewrites=type_rewrites,
             ignore_object_shapes=ignore_shapes,
             explicit_top_cast=explicit_top_cast,
+            expand_inhviews=expand_inhviews,
             singleton_mode=singleton_mode,
             scope_tree_nodes=scope_tree_nodes,
             external_rvars=external_rvars,
@@ -145,6 +147,7 @@ def compile_ir_to_sql(
     singleton_mode: bool=False,
     use_named_params: bool=False,
     expected_cardinality_one: bool=False,
+    expand_inhviews: bool = False,
     pretty: bool=True,
     backend_runtime_params: Optional[pgparams.BackendRuntimeParams]=None,
 ) -> Tuple[str, Dict[str, pgast.Param]]:
@@ -158,6 +161,7 @@ def compile_ir_to_sql(
         use_named_params=use_named_params,
         expected_cardinality_one=expected_cardinality_one,
         backend_runtime_params=backend_runtime_params,
+        expand_inhviews=expand_inhviews,
     )
 
     if (  # pragma: no cover

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -52,7 +52,14 @@ def get_volatility_ref(
     if not ref:
         rvar = relctx.maybe_get_path_rvar(
             stmt, path_id, aspect='value', ctx=ctx)
-        if rvar and isinstance(rvar.query, pgast.ReturningQuery):
+        if (
+            rvar
+            and isinstance(rvar.query, pgast.ReturningQuery)
+            # Expanded inhviews might be unions, which can't naively have
+            # a row_number stuck on; they should be safe to just grab
+            # the path_id value from, though
+            and rvar.tag != 'expanded-inhview'
+        ):
             # If we are selecting from a nontrivial subquery, manually
             # add a volatility ref based on row_number. We do it
             # manually because the row number isn't /really/ the

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -401,6 +401,7 @@ class Environment:
         expected_cardinality_one: bool,
         ignore_object_shapes: bool,
         singleton_mode: bool,
+        expand_inhviews: bool,
         explicit_top_cast: Optional[irast.TypeRef],
         query_params: List[irast.Param],
         type_rewrites: Dict[RewriteKey, irast.Set],
@@ -417,6 +418,7 @@ class Environment:
         self.expected_cardinality_one = expected_cardinality_one
         self.ignore_object_shapes = ignore_object_shapes
         self.singleton_mode = singleton_mode
+        self.expand_inhviews = expand_inhviews
         self.explicit_top_cast = explicit_top_cast
         self.query_params = query_params
         self.type_rewrites = type_rewrites

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1365,6 +1365,8 @@ def range_for_material_objtype(
 
     relation: Union[pgast.Relation, pgast.CommonTableExpr]
 
+    assert isinstance(typeref.name_hint, sn.QualName)
+
     key = (typeref.id, include_descendants)
     if (
         not ignore_rewrites
@@ -1373,6 +1375,7 @@ def range_for_material_objtype(
         and not for_mutation
     ):
 
+        type_rel: pgast.BaseRelation | pgast.CommonTableExpr
         if (type_cte := ctx.type_ctes.get(key)) is None:
             with ctx.newrel() as sctx:
                 sctx.pending_type_ctes.add(key)
@@ -1383,18 +1386,28 @@ def range_for_material_objtype(
                 sctx.ptr_rel_overlays = collections.defaultdict(
                     lambda: collections.defaultdict(list))
                 dispatch.visit(rewrite, ctx=sctx)
-                type_cte = pgast.CommonTableExpr(
-                    name=ctx.env.aliases.get('t'),
-                    query=sctx.rel,
-                    materialized=False,
-                )
-                ctx.type_ctes[key] = type_cte
+                # If we are expanding inhviews, we also expand type
+                # rewrites, so don't populate type_ctes. The normal
+                # case is to stick it in a CTE and cache that, though.
+                if ctx.env.expand_inhviews:
+                    type_rel = sctx.rel
+                else:
+                    type_cte = pgast.CommonTableExpr(
+                        name=ctx.env.aliases.get('t'),
+                        query=sctx.rel,
+                        materialized=False,
+                    )
+                    ctx.type_ctes[key] = type_cte
+                    type_rel = type_cte
+        else:
+            type_rel = type_cte
 
         with ctx.subrel() as sctx:
-            cte_rvar = pgast.RelRangeVar(
-                relation=type_cte,
+            cte_rvar = rvar_for_rel(
+                type_rel,
                 typeref=typeref,
-                alias=pgast.Alias(aliasname=env.aliases.get('t'))
+                alias=env.aliases.get('t'),
+                ctx=ctx,
             )
             pathctx.put_path_id_map(sctx.rel, path_id, rewrite.path_id)
             include_rvar(
@@ -1403,8 +1416,48 @@ def range_for_material_objtype(
             )
             rvar = rvar_for_rel(
                 sctx.rel, lateral=lateral, typeref=typeref, ctx=sctx)
+
+    # When we are compiling a query for EXPLAIN, expand out type references
+    # to an explicit union of all the types, rather than relying on the
+    # inheritance views. This allows postgres to actually give us back the
+    # alias names that we use for relations, which we use to track which
+    # parts of the query are being referred to.
+    elif (
+        ctx.env.expand_inhviews
+        and include_descendants
+        and not for_mutation
+        and typeref.children is not None
+
+        # HACK: This is a workaround for #4491
+        and typeref.name_hint.module not in {'cfg', 'sys'}
+    ):
+        ops = []
+        for subref in [typeref, *irtyputils.get_typeref_descendants(typeref)]:
+            rvar = range_for_material_objtype(
+                subref, path_id, lateral=lateral,
+                include_descendants=False,
+                include_overlays=False,
+                ignore_rewrites=ignore_rewrites,  # XXX: Is this right?
+                ctx=ctx,
+            )
+            qry = pgast.SelectStmt(from_clause=[rvar])
+            sub_path_id = path_id
+            pathctx.put_path_value_rvar(qry, sub_path_id, rvar, env=env)
+            pathctx.put_path_source_rvar(qry, sub_path_id, rvar, env=env)
+
+            ops.append(('union', qry))
+
+        rvar = range_from_queryset(
+            ops,
+            typeref.name_hint,
+            lateral=lateral,
+            path_id=path_id,
+            typeref=typeref,
+            tag='expanded-inhview',
+            ctx=ctx,
+        )
+
     else:
-        assert isinstance(typeref.name_hint, sn.QualName)
 
         table_schema_name, table_name = common.get_objtype_backend_name(
             typeref.id,
@@ -1416,7 +1469,7 @@ def range_for_material_objtype(
             catenate=False,
         )
 
-        if typeref.name_hint.module in {'cfg', 'sys'}:
+        if typeref.name_hint.module in {'cfg', 'sys'} and include_descendants:
             # Redirect all queries to schema tables to edgedbss
             table_schema_name = 'edgedbss'
 
@@ -1771,7 +1824,29 @@ def range_for_ptrref(
         overlays = get_ptr_rel_overlays(
             ptrref, dml_source=dml_source, ctx=ctx)
 
-    for src_ptrref in refs:
+    include_descendants = not ptrref.union_is_concrete
+
+    assert isinstance(ptrref.out_source.name_hint, sn.QualName)
+    # expand_inhviews helps support EXPLAIN. see
+    # range_for_material_objtype for details.
+    lrefs: List[irast.BasePointerRef]
+    if (
+        ctx.env.expand_inhviews
+        and include_descendants
+        and not for_mutation
+
+        # HACK: This is a workaround for #4491
+        and ptrref.out_source.name_hint.module not in {'sys', 'cfg'}
+    ):
+        include_descendants = False
+        lrefs = []
+        for ref in list(refs):
+            lrefs.extend(ref.descendants())
+            lrefs.append(ref)
+    else:
+        lrefs = list(refs)
+
+    for src_ptrref in lrefs:
         assert isinstance(src_ptrref, irast.PointerRef), \
             "expected regular PointerRef"
 
@@ -1797,7 +1872,7 @@ def range_for_ptrref(
         table = table_from_ptrref(
             src_ptrref,
             ptr_info,
-            include_descendants=not ptrref.union_is_concrete,
+            include_descendants=include_descendants,
             for_mutation=for_mutation,
             ctx=ctx,
         )
@@ -1814,17 +1889,21 @@ def range_for_ptrref(
 
         set_ops.append(('union', qry))
 
-        overlays = get_ptr_rel_overlays(
-            src_ptrref, dml_source=dml_source, ctx=ctx)
-        if overlays and not for_mutation:
-            # We need the identity var for semi_join to work and
-            # the source rvar so that linkprops can be found here.
-            if path_id:
-                target_ref = qry.target_list[1].val
-                pathctx.put_path_identity_var(
-                    qry, path_id, var=target_ref, env=ctx.env)
-                pathctx.put_path_source_rvar(
-                    qry, path_id, table, env=ctx.env)
+        # We need the identity var for semi_join to work and
+        # the source rvar so that linkprops can be found here.
+        if path_id:
+            target_ref = qry.target_list[1].val
+            pathctx.put_path_identity_var(
+                qry, path_id, var=target_ref, env=ctx.env)
+            pathctx.put_path_source_rvar(
+                qry, path_id, table, env=ctx.env)
+
+        # Only fire off the overlays at the end of each expanded inhview.
+        # This only matters when we are doing expand_inhviews, and prevents
+        # us from repeating the overlays many times in that case.
+        if src_ptrref in refs and not for_mutation:
+            overlays = get_ptr_rel_overlays(
+                src_ptrref, dml_source=dml_source, ctx=ctx)
 
             for op, cte, cte_path_id in overlays:
                 rvar = rvar_for_rel(cte, ctx=ctx)
@@ -1889,6 +1968,7 @@ def range_for_pointer(
 def rvar_for_rel(
     rel: Union[pgast.BaseRelation, pgast.CommonTableExpr],
     *,
+    alias: Optional[str] = None,
     typeref: Optional[irast.TypeRef] = None,
     lateral: bool = False,
     colnames: Optional[List[str]] = None,
@@ -1901,7 +1981,7 @@ def rvar_for_rel(
         colnames = []
 
     if isinstance(rel, pgast.Query):
-        alias = ctx.env.aliases.get(rel.name or 'q')
+        alias = alias or ctx.env.aliases.get(rel.name or 'q')
 
         rvar = pgast.RangeSubselect(
             subquery=rel,
@@ -1910,7 +1990,7 @@ def rvar_for_rel(
             typeref=typeref,
         )
     else:
-        alias = ctx.env.aliases.get(rel.name or '')
+        alias = alias or ctx.env.aliases.get(rel.name or '')
 
         rvar = pgast.RelRangeVar(
             relation=rel,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -792,6 +792,12 @@ def process_set_as_link_property_ref(
                 {spec.id for spec in rptr_specialization}
                 if rptr_specialization is not None else None
             )
+            if ctx.env.expand_inhviews and ptr_ids and rptr_specialization:
+                ptr_ids.update(
+                    x.id for spec in rptr_specialization
+                    for x in spec.descendants()
+                    if isinstance(x, irast.PointerRef)
+                )
 
             def cb(subquery: pgast.Query) -> None:
                 if isinstance(subquery, pgast.SelectStmt):

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1111,6 +1111,11 @@ def _get_compile_options(
             ctx, 'apply_access_policies'),
         allow_user_specified_id=_get_config_val(
             ctx, 'allow_user_specified_id') or ctx.schema_reflection_mode,
+        expand_inhviews=(
+            debug.flags.edgeql_expand_inhviews
+            and not ctx.bootstrap_mode
+            and not ctx.schema_reflection_mode
+        ),
         testmode=_get_config_val(ctx, '__internal_testmode'),
         devmode=_is_dev_instance(ctx),
     )
@@ -1161,11 +1166,12 @@ def _compile_ql_query(
     current_tx = ctx.state.current_tx()
 
     schema = current_tx.get_schema(ctx.compiler_state.std_schema)
+    options = _get_compile_options(ctx)
     ir = qlcompiler.compile_ast_to_ir(
         ql,
         schema=schema,
         script_info=script_info,
-        options=_get_compile_options(ctx),
+        options=options,
     )
 
     result_cardinality = enums.cardinality_from_ir_value(ir.cardinality)
@@ -1180,6 +1186,7 @@ def _compile_ql_query(
         expected_cardinality_one=ctx.expected_cardinality_one,
         output_format=_convert_format(ctx.output_format),
         backend_runtime_params=ctx.backend_runtime_params,
+        expand_inhviews=options.expand_inhviews,
     )
 
     if (


### PR DESCRIPTION
This helps lay the groundwork for EXPLAIN: when referring to views (or
non-materialized CTEs), postgres's EXPLAIN output does not refer to
the alias names in our compiled query. We need it to use those alias
names, though, in order to correspond query plan nodes with parts of
our query.