### PR TITLE
Track the origin of schemas stored in an expression

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_11_15_00_00
+EDGEDB_CATALOG_VERSION = 2022_11_28_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -392,7 +392,7 @@ class Parser:
         """
         raise NotImplementedError
 
-    def reset_parser(self, input):
+    def reset_parser(self, input, filename=None):
         if not self.parser:
             self.lexer = self.get_lexer()
             self.parser = parsing.Lr(self.get_parser_spec())
@@ -400,15 +400,15 @@ class Parser:
             self.parser.verbose = self.get_debug()
 
         self.parser.reset()
-        self.lexer.setinputstr(input)
+        self.lexer.setinputstr(input, filename=filename)
 
     def process_lex_token(self, mod, tok):
         return mod.TokenMeta.for_lex_token(tok.kind())(
             self.parser, tok.text(), tok.value(), self.context(tok))
 
-    def parse(self, input):
+    def parse(self, input, filename=None):
         try:
-            self.reset_parser(input)
+            self.reset_parser(input, filename=filename)
             mod = self.get_parser_spec_module()
 
             tok = self.lexer.token()

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1352,7 +1352,7 @@ def computable_ptr_set(
                 raise errors.InternalServerError(
                     f'{ptrcls_sn!r} is not a computed pointer')
 
-            comp_qlexpr = qlparser.parse(comp_expr.text)
+            comp_qlexpr = comp_expr.qlast
             assert isinstance(comp_qlexpr, qlast.Expr), 'expected qlast.Expr'
             schema_qlexpr = comp_qlexpr
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -40,7 +40,6 @@ from edb.schema import sources as s_sources
 from edb.schema import types as s_types
 
 from edb.edgeql import ast as qlast
-from edb.edgeql import parser as qlparser
 
 from edb.common.ast import visitor as ast_visitor
 from edb.common import ordered
@@ -707,7 +706,7 @@ def _declare_view_from_schema(
         subctx.expr_exposed = context.Exposure.UNEXPOSED
         view_expr = viewcls.get_expr(ctx.env.schema)
         assert view_expr is not None
-        view_ql = qlparser.parse(view_expr.text)
+        view_ql = view_expr.qlast
         viewcls_name = viewcls.get_name(ctx.env.schema)
         assert isinstance(view_ql, qlast.Expr), 'expected qlast.Expr'
         view_set = declare_view(view_ql, alias=viewcls_name,

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -46,11 +46,14 @@ def append_module_aliases(tree, aliases):
     return tree
 
 
-def parse_fragment(source: Union[qltokenizer.Source, str]) -> qlast.Expr:
+def parse_fragment(
+    source: Union[qltokenizer.Source, str],
+    filename: Optional[str]=None,
+) -> qlast.Expr:
     if isinstance(source, str):
         source = qltokenizer.Source.from_string(source)
     parser = qlparser.EdgeQLExpressionParser()
-    res = parser.parse(source)
+    res = parser.parse(source, filename=filename)
     assert isinstance(res, qlast.Expr)
     return res
 

--- a/edb/edgeql/parser/grammar/rust_lexer.py
+++ b/edb/edgeql/parser/grammar/rust_lexer.py
@@ -35,11 +35,16 @@ class EdgeQLLexer(object):
     def __init__(self):
         self.filename = None  # TODO
 
-    def setinputstr(self, source: Union[str, tokenizer.Source]) -> None:
+    def setinputstr(
+        self,
+        source: Union[str, tokenizer.Source],
+        filename: Optional[str]=None,
+    ) -> None:
         if isinstance(source, str):
             source = tokenizer.Source.from_string(source)
 
         self.inputstr = source.text()
+        self.filename = filename
         self.tokens = deque(source.tokens())
         self.end_of_input = self.tokens[-1].end()
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2497,9 +2497,12 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         value = self._resolve_attr_value(
             raw_value, attr_name, field, schema)
 
-        if (isinstance(value, s_expr.Expression)
-                and not value.is_compiled()):
-            value = self.compile_expr_field(schema, context, field, value)
+        if isinstance(value, s_expr.Expression):
+            if not value.is_compiled():
+                value = self.compile_expr_field(schema, context, field, value)
+
+            if id := self.get_attribute_value('id'):
+                value.set_origin(id, attr_name)
 
         return value
 
@@ -2888,8 +2891,9 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
             self.update_field_status(schema, context)
             self.validate_create(schema, context)
 
-        props = self.get_resolved_attributes(schema, context)
         metaclass = self.get_schema_metaclass()
+
+        props = self.get_resolved_attributes(schema, context)
         schema, self.scls = metaclass.create_in_schema(schema, **props)
 
         if not props.get('id'):


### PR DESCRIPTION
Track what object/field an expression is stored in and propagate this
information into context fields. It then should be possible to use
this in error reporting and explain.

We store the id and the field name; we store id instead of name
because once these values are reported to a client, id is more useful:
the client can't query based on the internal name.