### PR TITLE
Make the IR pickleable

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -322,7 +322,6 @@ def compile_ast_fragment_to_ir(
         schema_ref_exprs=None,
         new_coll_types=frozenset(),
         scope_tree=ctx.path_scope,
-        source_map={},
         type_rewrites={},
         singletons=[],
     )

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -267,8 +267,6 @@ def fini_expression(
     group.infer_group_aggregates(ir, ctx=ctx)
 
     assert isinstance(ir, irast.Set)
-    source_map = {k: v for k, v in ctx.env.source_map.items()
-                  if isinstance(k, s_pointers.Pointer)}
     lparams = [
         p for p in ctx.env.query_parameters.values()
         if not p.is_sub_param
@@ -288,7 +286,6 @@ def fini_expression(
         params=params,
         globals=list(ctx.env.query_globals.values()),
         views=ctx.view_nodes,
-        source_map=source_map,
         scope_tree=ctx.env.path_scope,
         cardinality=cardinality,
         volatility=volatility,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -680,7 +680,6 @@ class Statement(Command):
         typing.Dict[so.Object, typing.Set[qlast.Base]]]
     new_coll_types: typing.FrozenSet[s_types.Collection]
     scope_tree: ScopeTreeNode
-    source_map: typing.Dict[s_pointers.Pointer, ComputableInfo]
     dml_exprs: typing.List[qlast.Base]
     type_rewrites: typing.Dict[typing.Tuple[uuid.UUID, bool], Set]
     singletons: typing.List[PathId]

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -106,6 +106,24 @@ class ScopeTreeNode:
         self.is_group = False
         self._parent: Optional[weakref.ReferenceType[ScopeTreeNode]] = None
 
+    FIELDS = (
+        'unique_id', 'path_id', 'fenced', 'unnest_fence', 'factoring_fence',
+        'factoring_allowlist', 'optional', 'children', 'namespaces',
+        'is_group',
+    )
+
+    def __getstate__(self) -> Any:
+        res = self.__dict__.copy()
+        del res['_parent']
+        return res
+
+    def __setstate__(self, state: Any) -> None:
+        for f, val in state.items():
+            setattr(self, f, val)
+        self._parent = None
+        for child in self.children:
+            child._parent = weakref.ref(self)
+
     def __repr__(self) -> str:
         name = 'ScopeFenceNode' if self.fenced else 'ScopeTreeNode'
         return (f'<{name} {self.path_id!r} at {id(self):0x}>')


### PR DESCRIPTION
This is in furtherance of EXPLAIN, where we want to be able to hang
onto the IR to do some analysis of it.

This means making ScopeTreeNode pickleable by omitting and then
recomputing the _parent weakref and dropping the unused source_map
field which contained some dodgy stuff.