### PR TITLE
Don't incorrectly evaluate DML access policies when elements are also DML

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -837,6 +837,11 @@ def compile_policy_check(
         ictx.ptr_rel_overlays[None].update(
             ictx.ptr_rel_overlays[ir_stmt])
 
+        ictx.type_rel_overlays = ctx.type_rel_overlays.copy()
+        ictx.type_rel_overlays[None] = ictx.type_rel_overlays[None].copy()
+        ictx.type_rel_overlays[None].update(
+            ictx.type_rel_overlays[ir_stmt])
+
         dml_rvar = relctx.rvar_for_rel(dml_cte, ctx=ctx)
         relctx.include_rvar(ictx.rel, dml_rvar, path_id=subject_id, ctx=ictx)
 

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -517,6 +517,18 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(edgedb.AccessPolicyError, ''):
             await self.con.execute('insert Message {}')
 
+    async def test_edgeql_policies_11(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r"access policy violation on insert of default::Issue"):
+            await self.con.query('''
+            insert Issue {
+                name := '', body := '',
+                status := (select Status filter .name = 'Open'), number := '',
+                owner := (insert User { name := "???" }),
+            };
+            ''')
+
     async def test_edgeql_policies_order_01(self):
         await self.con.execute('''
             insert CurOnly { name := "!" }


### PR DESCRIPTION
We currently copy over the pointer overlays, but we need to copy the
type overlays also.