### PR TITLE
Add more specific `DuplicateMigrationError` error

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -95,6 +95,7 @@
 0x_04_05_02_08   DuplicateFunctionDefinitionError
 0x_04_05_02_09   DuplicateConstraintDefinitionError
 0x_04_05_02_0A   DuplicateCastDefinitionError
+0x_04_05_02_0B   DuplicateMigrationError
 
 ####
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -63,6 +63,7 @@ __all__ = base.__all__ + (  # type: ignore
     'DuplicateFunctionDefinitionError',
     'DuplicateConstraintDefinitionError',
     'DuplicateCastDefinitionError',
+    'DuplicateMigrationError',
     'SessionTimeoutError',
     'IdleSessionTimeoutError',
     'QueryTimeoutError',
@@ -307,6 +308,10 @@ class DuplicateConstraintDefinitionError(DuplicateDefinitionError):
 
 class DuplicateCastDefinitionError(DuplicateDefinitionError):
     _code = 0x_04_05_02_0A
+
+
+class DuplicateMigrationError(DuplicateDefinitionError):
+    _code = 0x_04_05_02_0B
 
 
 class SessionTimeoutError(QueryError):

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -429,6 +429,10 @@ class Schema(abc.ABC):
     def has_module(self, module: str) -> bool:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def has_migration(self, name: str) -> bool:
+        raise NotImplementedError
+
     def get_children(
         self,
         scls: so.Object_T,
@@ -1387,6 +1391,9 @@ class FlatSchema(Schema):
     def has_module(self, module: str) -> bool:
         return self.get_global(s_mod.Module, module, None) is not None
 
+    def has_migration(self, name: str) -> bool:
+        return self.get_global(s_migrations.Migration, name, None) is not None
+
     def get_objects(
         self,
         *,
@@ -1899,6 +1906,12 @@ class ChainedSchema(Schema):
         return (
             self._base_schema.has_module(module)
             or self._top_schema.has_module(module)
+        )
+
+    def has_migration(self, name: str) -> bool:
+        return (
+            self._base_schema.has_migration(name)
+            or self._top_schema.has_migration(name)
         )
 
     def get_objects(


### PR DESCRIPTION
Motivation: it simplifies implementation of applying migrations by the client bindings.

Downsides: we have to check whether hash of migration is consistent then check whether migration exists and the last step is to check the parent migration. Previously we have given feedback that parent is invalid first. Which was occasionally helpful for editing migrations by hand.

Note: this can possibly be backported to 2.x. But I'm not sure what language bindings will be throwing until errors in the bindings are regenerated.