### PR TITLE
Fix direct use of `__subject__` from insert access policies

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -708,10 +708,11 @@ def process_insert_body(
         if iterator is not None:
             pathctx.put_path_bond(select, iterator.path_id)
 
-    pathctx._put_path_output_var(
-        select, ir_stmt.subject.path_id, aspect='identity',
-        var=pgast.ColumnRef(name=['id']), env=ctx.env,
-    )
+    for aspect in ('value', 'identity'):
+        pathctx._put_path_output_var(
+            select, ir_stmt.subject.path_id, aspect=aspect,
+            var=pgast.ColumnRef(name=['id']), env=ctx.env,
+        )
 
     # Put the select that builds the tuples to insert into its own CTE.
     # We do this for two reasons:

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -529,6 +529,24 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             };
             ''')
 
+    async def test_edgeql_policies_12(self):
+        await self.con.query('''
+            create global cur_user_obj := (
+                select User filter .name = global cur_user);
+            alter type User {
+                create access policy allow_self_obj
+                   allow all
+                   using (__subject__ ?= global cur_user_obj);
+            }
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r"access policy violation on insert of default::User"):
+            await self.con.query('''
+                insert User { name := 'whatever' }
+            ''')
+
     async def test_edgeql_policies_order_01(self):
         await self.con.execute('''
             insert CurOnly { name := "!" }


### PR DESCRIPTION
We were populating the `identity` aspect but needed to also populate
`value` in order for certain operations (like equality) to work.

Fixes #4733.