### PR TITLE
Only apply filter cardinality inference to unique sets

### DIFF
--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1047,3 +1047,19 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         MANY
         """
+
+    def test_edgeql_ir_card_inference_121(self):
+        """
+        with X := {User, User},
+        select X filter .name = 'Alice'
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_122(self):
+        """
+        with X := {User, User},
+        update X filter .name = 'Alice' set { }
+% OK %
+        MANY
+        """


### PR DESCRIPTION
Otherwise we can improperly assume a set with duplicates is single,
even though a filter might be selecting multiple duplicate elements.

Fixes #4762.