### PR TITLE
Fix changing a link to non-computed and single at the same time

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3083,8 +3083,9 @@ class CompositeMetaCommand(MetaCommand):
                 k for k, _ in self.inhview_updates if k not in to_recreate}
 
             for s in to_recreate:
-                self.recreate_inhview(
-                    schema, context, s, alter_ancestors=False)
+                if has_table(s, schema):
+                    self.recreate_inhview(
+                        schema, context, s, alter_ancestors=False)
 
             for s in to_alter:
                 if has_table(s, schema):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13315,6 +13315,27 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
             ]
         )
 
+    async def test_edgeql_ddl_adjust_computed_11(self):
+        await self.con.execute(r'''
+            CREATE TYPE default::Foo;
+            CREATE TYPE default::Bar {
+                CREATE LINK foos := (default::Foo);
+            };
+        ''')
+
+        # it's annoying that we need the using on the RESET CARDINALITY;
+        # maybe we should be able to know it isn't needed
+        await self.con.execute(r'''
+            ALTER TYPE default::Bar {
+                ALTER LINK foos {
+                    RESET EXPRESSION;
+                    RESET CARDINALITY using (<Foo>{});
+                    RESET OPTIONALITY;
+                    SET TYPE default::Foo;
+                };
+            }
+        ''')
+
     async def test_edgeql_ddl_captured_as_migration_01(self):
 
         await self.con.execute(r"""


### PR DESCRIPTION
The issue is that the link table gets schedule for an inhview update
when it is created with RESET EXPRESSION, but then once it is made
single, it doesn't actually have a table anymore.

Fix by gating recreate_inhvew in apply_scheduled_inhview_updates with
a has_table check, like we do for alter_inhview.

Fixes #4716