### PR TITLE
Disable RESET SCHEMA test

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11466,6 +11466,11 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
             await con2.aclose()
 
     async def test_edgeql_migration_reset_schema(self):
+        self.skipTest('''
+            RESET SCHEMA TO INITIAL leaves database in broken state.
+            See #4766.
+        ''')
+
         await self.migrate(r'''
             type Bar;
 


### PR DESCRIPTION
As discussed in #4766, RESET SCHEMA TO INITIAL leaves the database in
a broken state. Disable the test for now, since it causes a *lot* of
trouble in NOCREATEDB mode.