### PR TITLE
Use @> for std::contains with array parameters

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_03_30_00_00
+EDGEDB_CATALOG_VERSION = 2023_03_30_00_01
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     from edb.schema import pointers as s_pointers
     from edb.ir import pathid
 
+    SourceOrPathId = Union[s_types.Type, s_pointers.Pointer, pathid.PathId]
+
 
 @dataclass
 class GlobalCompilerOptions:
@@ -122,8 +124,9 @@ class CompilerOptions(GlobalCompilerOptions):
 
     #: A set of schema types and links that should be treated
     #: as singletons in the context of this compilation.
+    #: If a tuple is provided, the boolean argument indicates it is optional.
     singletons: Collection[
-        Union[s_types.Type, s_pointers.Pointer, pathid.PathId]
+        Union[SourceOrPathId, tuple[SourceOrPathId, bool]]
     ] = frozenset()
 
     #: Type references that should be remaped to another type.  This

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -102,7 +102,7 @@ def init_context(
             ctx.iterator_path_ids |= {path_id}
 
         # If we installed any optional singletons, run the rest of the
-        # compmilation under a fence to protect them.
+        # compilation under a fence to protect them.
         if had_optional:
             ctx.path_scope = ctx.path_scope.attach_fence()
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -87,11 +87,24 @@ def init_context(
         # references as singletons for the purposes of the overall
         # expression cardinality inference, so we set up the scope
         # tree in the necessary fashion.
-        for singleton in options.singletons:
+        had_optional = False
+        for singleton_ent in options.singletons:
+            singleton, optional = (
+                singleton_ent if isinstance(singleton_ent, tuple)
+                else (singleton_ent, False)
+            )
+            had_optional |= optional
             path_id = compile_anchor('__', singleton, ctx=ctx).path_id
-            ctx.env.path_scope.attach_path(path_id, context=None)
-            ctx.env.singletons.append(path_id)
+            ctx.env.path_scope.attach_path(
+                path_id, optional=optional, context=None)
+            if not optional:
+                ctx.env.singletons.append(path_id)
             ctx.iterator_path_ids |= {path_id}
+
+        # If we installed any optional singletons, run the rest of the
+        # compmilation under a fence to protect them.
+        if had_optional:
+            ctx.path_scope = ctx.path_scope.attach_fence()
 
     for orig, remapped in options.type_remaps.items():
         rset = compile_anchor('__', remapped, ctx=ctx)
@@ -138,6 +151,8 @@ def fini_expression(
     *,
     ctx: context.ContextLevel,
 ) -> irast.Command:
+
+    ctx.path_scope = ctx.env.path_scope
 
     ir = eta_expand.eta_expand_ir(ir, toplevel=True, ctx=ctx)
 

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -547,11 +547,20 @@ std::contains(haystack: array<anytype>, needle: anytype) -> std::bool
         'A polymorphic function to test if a sequence contains a certain element.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT
-        CASE
-            WHEN "needle" IS NULL THEN NULL
-            ELSE array_position("haystack", "needle") IS NOT NULL
-        END;
+	SELECT "haystack" @> ARRAY["needle"]
+    $$;
+};
+
+
+CREATE FUNCTION
+std::contains(haystack: array<anytype>, needle: array<anytype>) -> std::bool
+{
+    CREATE ANNOTATION std::description :=
+        'A polymorphic function to test if a sequence contains all elements 
+		another sequence.';
+    SET volatility := 'Immutable';
+    USING SQL $$
+	SELECT "haystack" @> "needle"
     $$;
 };
 

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -546,21 +546,11 @@ std::contains(haystack: array<anytype>, needle: anytype) -> std::bool
     CREATE ANNOTATION std::description :=
         'A polymorphic function to test if a sequence contains a certain element.';
     SET volatility := 'Immutable';
+    # Postgres only manages to inline this function if it isn't marked strict,
+    # and we want it to be inlined so that pg::gin indexes work with it.
+    SET impl_is_strict := false;
     USING SQL $$
 	SELECT "haystack" @> ARRAY["needle"]
-    $$;
-};
-
-
-CREATE FUNCTION
-std::contains(haystack: array<anytype>, needle: array<anytype>) -> std::bool
-{
-    CREATE ANNOTATION std::description :=
-        'A polymorphic function to test if a sequence contains all elements 
-		another sequence.';
-    SET volatility := 'Immutable';
-    USING SQL $$
-	SELECT "haystack" @> "needle"
     $$;
 };
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1666,7 +1666,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
             if (
                 self.has_attribute_value("code")
                 or self.has_attribute_value("nativecode")
-            ):
+            ) and not self.has_attribute_value('impl_is_strict'):
                 self.set_attribute_value(
                     'impl_is_strict',
                     _params_are_all_required_singletons(cp, schema),

--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -104,6 +104,9 @@ type Object {
     property c_length_3 -> constraint_length_2 {
         constraint min_len_value(10);
     }
+    property c_one_of -> str {
+        constraint one_of('foo', 'bar');
+    }
 
     property c_minmax -> constraint_minmax;
     property c_ex_minmax -> constraint_minmax_2;


### PR DESCRIPTION
At the moment, EdgeDB uses `array_position` in `std::contains` when the haystack is an array. This change modifies `std::contains` to use the `@>` operator; this improves performance in the presence of indexes that support the `array_ops` operator class.