### PR TITLE
Delete *all* of the types created by an alias

### DIFF
--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -106,17 +106,58 @@ class AliasLikeCommand(
 
     # Generic code
 
+    @classmethod
+    def _get_created_types(
+        cls,
+        scls: so.QualifiedObject_T,
+        schema: s_schema.Schema,
+    ) -> set[s_types.Type]:
+        objs = set()
+
+        typ = cls.get_type(scls, schema)
+        our_name = typ.get_name(schema)
+        assert isinstance(our_name, sn.QualName)
+        name_prefix = f'__{our_name.name}__'
+
+        # XXX: This is pretty unfortunate from a performance
+        # perspective, and not technically correct either.
+        # For 3.x we should track this information in the objects
+        # (or possibly instead ensure we do not put any types in the schema
+        # that are not directly part of the output type.)
+        for obj in schema.get_objects(exclude_stdlib=True, type=s_types.Type):
+            name = obj.get_name(schema)
+            if (
+                obj.get_alias_is_persistent(schema)
+                and isinstance(name, sn.QualName)
+                and name.module == our_name.module
+                and name.name.startswith(name_prefix)
+            ):
+                objs.add(obj)
+
+        return objs
+
     def _delete_alias_type(
         self,
         scls: so.QualifiedObject_T,
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> sd.DeleteObject[s_types.Type]:
+        created = self._get_created_types(scls, schema)
+
         alias_type = self.get_type(scls, schema)
         drop_type = alias_type.init_delta_command(
             schema, sd.DeleteObject)
         subcmds = drop_type._canonicalize(schema, context, alias_type)
         drop_type.update(subcmds)
+
+        for dep_type in created:
+            drop_dep = dep_type.init_delta_command(
+                schema, sd.DeleteObject, if_exists=True)
+            subcmds = drop_dep._canonicalize(schema, context, dep_type)
+            drop_dep.update(subcmds)
+
+            drop_type.add(drop_dep)
+
         return drop_type
 
     @classmethod
@@ -204,10 +245,20 @@ class AliasLikeCommand(
         is_alter: bool = False,
         parser_context: Optional[parsing.ParserContext] = None,
     ) -> Tuple[sd.Command, s_types.TypeShell[s_types.Type], s_expr.Expression]:
+        pschema = schema
+
+        # On alters, remove all the existing objects from the schema before
+        # trying to compile again.
+        if is_alter:
+            drop_cmd = self._delete_alias_type(
+                self.scls, schema, context)
+            with context.suspend_dep_verification():
+                pschema = drop_cmd.apply(pschema, context)
+
         ir = compile_alias_expr(
             expr.qlast,
             classname,
-            schema,
+            pschema,
             context,
             parser_context=parser_context,
         )
@@ -223,7 +274,7 @@ class AliasLikeCommand(
             prev_ir = compile_alias_expr(
                 prev_expr.qlast,
                 classname,
-                schema,
+                pschema,
                 context,
                 parser_context=parser_context,
             )
@@ -443,12 +494,6 @@ def compile_alias_expr(
 
     if not isinstance(expr, qlast.Statement):
         expr = qlast.SelectQuery(result=expr)
-
-    existing = schema.get(classname, type=s_types.Type, default=None)
-    if existing is not None:
-        drop_cmd = existing.init_delta_command(schema, sd.DeleteObject)
-        with context.suspend_dep_verification():
-            schema = drop_cmd.apply(schema, context)
 
     ir = qlcompiler.compile_ast_to_ir(
         expr,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3825,7 +3825,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             );
         """])
 
-    @test.xerror('''
+    @test.xfail('''
         This wants to transmute an object type into an alias. It
         produces DDL, but the DDL doesn't really make any sense. We
         are going to probably need to add DDL syntax to accomplish
@@ -4660,6 +4660,70 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type User extending Named {
                   property asdf := .name ++ "!";
             }
+        """])
+
+    def test_schema_migrations_equivalence_56a(self):
+        self._assert_migration_equivalence([r"""
+            type User {
+                required property name -> str;
+            };
+
+            alias TwoUsers := (
+                select User {
+                    initial := .name[0],
+                } order by .name limit 2
+            );
+        """])
+
+    def test_schema_migrations_equivalence_56b(self):
+        self._assert_migration_equivalence([r"""
+            type User {
+                required property name -> str;
+            };
+
+            global TwoUsers := (
+                select User {
+                    initial := .name[0],
+                } order by .name limit 2
+            );
+        """])
+
+    def test_schema_migrations_equivalence_57a(self):
+        self._assert_migration_equivalence([r"""
+            type User {
+                required property name -> str;
+            };
+
+            alias TwoUsers := (
+                select User {
+                    initial := .name[0],
+                } order by .name limit 2
+            );
+        """, r"""
+            type User {
+                required property name -> str;
+            };
+
+            alias TwoUsers := (User);
+        """])
+
+    def test_schema_migrations_equivalence_57b(self):
+        self._assert_migration_equivalence([r"""
+            type User {
+                required property name -> str;
+            };
+
+            global TwoUsers := (
+                select User {
+                    initial := .name[0],
+                } order by .name limit 2
+            );
+        """, r"""
+            type User {
+                required property name -> str;
+            };
+
+            global TwoUsers := (User);
         """])
 
     def test_schema_migrations_equivalence_compound_01(self):


### PR DESCRIPTION
In some situations we create view types as part of aliases that
*don't* actually appear directly in the result type. Currently we fail
to clean up those types when the alias is delted or altered.

For now, fix this by searching for all such types (... by name
prefix) and deleting them.

For 3.x, we will want to fix this in a better way, probably one of:
 * Track the child views in the schema explicitly, instead of needing
   to search through the schema for them.
 * Ensure that we don't create include view types that don't actually
   appear in the output. This approach is probably better, but I'm not
   100% sure it works.

Fixes the second issue in #4769.