### PR TITLE
Cleanups and refactors of Expression

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -532,8 +532,7 @@ class ConstraintCommand(
                 return value  # type: ignore
 
             elif field.name in {'subjectexpr', 'finalexpr', 'except_expr'}:
-                return s_expr.Expression.compiled(
-                    value,
+                return value.compiled(
                     schema=schema,
                     options=qlcompiler.CompilerOptions(
                         modaliases=context.modaliases,
@@ -561,8 +560,7 @@ class ConstraintCommand(
                 inlined_defaults=False,
             )
 
-            return s_expr.Expression.compiled(
-                value,
+            return value.compiled(
                 schema=schema,
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,
@@ -809,8 +807,7 @@ class ConstraintCommand(
             singletons = frozenset()
 
         assert subject is not None
-        final_expr = s_expr.Expression.compiled(
-            s_expr.Expression.from_ast(expr_ql, schema, {}),
+        final_expr = s_expr.Expression.from_ast(expr_ql, schema, {}).compiled(
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 anchors={qlast.Subject().name: subject},
@@ -850,16 +847,16 @@ class ConstraintCommand(
                 schema_object_context=self.get_schema_metaclass(),
             )
 
-            final_subjectexpr = s_expr.Expression.compiled(
-                subjectexpr, schema=schema, options=options
+            final_subjectexpr = subjectexpr.compiled(
+                schema=schema, options=options
             )
 
             refs = ir_utils.get_longest_paths(final_expr.irast)
 
             final_except_expr = None
             if except_expr:
-                final_except_expr = s_expr.Expression.compiled(
-                    except_expr, schema=schema, options=options
+                final_except_expr = except_expr.compiled(
+                    schema=schema, options=options
                 )
                 refs |= ir_utils.get_longest_paths(final_except_expr.irast)
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1605,7 +1605,6 @@ class Query(Command):
         schema = super().apply(schema, context)
         if not self.expr.is_compiled():
             self.expr = self.expr.compiled(
-                self.expr,
                 schema,
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -68,7 +68,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         self,
         *args: Any,
         _qlast: Optional[qlast_.Expr] = None,
-        _irast: Optional[irast_.Command] = None,
+        _irast: Optional[irast_.Statement] = None,
         **kwargs: Any
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -91,7 +91,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         return self._qlast
 
     @property
-    def irast(self) -> Optional[irast_.Command]:
+    def irast(self) -> Optional[irast_.Statement]:
         return self._irast
 
     def set_origin(self, id: uuid.UUID, field: str) -> None:
@@ -162,7 +162,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
 
         norm_text = qlcodegen.generate_source(qltree, pretty=False)
 
-        return cls(
+        return Expression(
             text=norm_text,
             _qlast=qltree,
         )
@@ -179,7 +179,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         *,
         options: Optional[qlcompiler.CompilerOptions] = None,
         as_fragment: bool = False,
-    ) -> Expression:
+    ) -> CompiledExpression:
 
         from edb.ir import ast as irast_
 
@@ -201,7 +201,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         # XXX: ref stuff - why doesn't it go into the delta tree? - temporary??
         srefs = {ref for ref in ir.schema_refs if schema.has_object(ref.id)}
 
-        return cls(
+        return CompiledExpression(
             text=expr.text,
             refs=so.ObjectSet.create(schema, srefs),
             _qlast=expr.qlast,
@@ -209,31 +209,29 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             origin=expr.origin,
         )
 
+    def ensure_compiled(
+        self,
+        schema: s_schema.Schema,
+        *,
+        options: Optional[qlcompiler.CompilerOptions] = None,
+        as_fragment: bool = False,
+    ) -> CompiledExpression:
+        if self._irast:
+            return self  # type: ignore
+        else:
+            return self.compiled(
+                self, schema, options=options, as_fragment=as_fragment)
+
     @classmethod
     def from_ir(cls: Type[Expression],
                 expr: Expression,
                 ir: irast_.Statement,
-                schema: s_schema.Schema) -> Expression:
-        return cls(
+                schema: s_schema.Schema) -> CompiledExpression:
+        return CompiledExpression(
             text=expr.text,
             refs=so.ObjectSet.create(schema, ir.schema_refs),
             _qlast=expr.qlast,
             _irast=ir,
-            origin=expr.origin,
-        )
-
-    @classmethod
-    def from_expr(cls: Type[Expression],
-                  expr: Expression,
-                  schema: s_schema.Schema) -> Expression:
-        return cls(
-            text=expr.text,
-            refs=(
-                so.ObjectSet.create(schema, expr.refs.objects(schema))
-                if expr.refs is not None else None
-            ),
-            _qlast=expr._qlast,
-            _irast=expr._irast,
             origin=expr.origin,
         )
 
@@ -327,6 +325,22 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         return self.ir_statement.schema
 
 
+class CompiledExpression(Expression):
+    def __init__(
+        self,
+        *args: Any,
+        _qlast: Optional[qlast_.Expr] = None,
+        _irast: irast_.Statement,
+        **kwargs: Any
+    ) -> None:
+        super().__init__(*args, _qlast=_qlast, _irast=_irast, **kwargs)
+
+    @property
+    def irast(self) -> irast_.Statement:
+        assert self._irast
+        return self._irast
+
+
 class ExpressionShell(so.Shell):
 
     def __init__(
@@ -335,7 +349,7 @@ class ExpressionShell(so.Shell):
         text: str,
         refs: Optional[Iterable[so.ObjectShell[so.Object]]],
         _qlast: Optional[qlast_.Expr] = None,
-        _irast: Optional[irast_.Command] = None,
+        _irast: Optional[irast_.Statement] = None,
     ) -> None:
         self.text = text
         self.refs = tuple(refs) if refs is not None else None
@@ -343,14 +357,15 @@ class ExpressionShell(so.Shell):
         self._irast = _irast
 
     def resolve(self, schema: s_schema.Schema) -> Expression:
-        return Expression(
+        cls = CompiledExpression if self._irast else Expression
+        return cls(
             text=self.text,
             refs=so.ObjectSet.create(
                 schema,
                 (s.resolve(schema) for s in self.refs),
             ) if self.refs is not None else None,
             _qlast=self._qlast,
-            _irast=self._irast,
+            _irast=self._irast,  # type: ignore[arg-type]
         )
 
     @property

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -167,14 +167,11 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             _qlast=qltree,
         )
 
-    @classmethod
-    def not_compiled(cls: Type[Expression], expr: Expression) -> Expression:
-        return Expression(text=expr.text, origin=expr.origin)
+    def not_compiled(self) -> Expression:
+        return Expression(text=self.text, origin=self.origin)
 
-    @classmethod
     def compiled(
-        cls: Type[Expression],
-        expr: Expression,
+        self,
         schema: s_schema.Schema,
         *,
         options: Optional[qlcompiler.CompilerOptions] = None,
@@ -185,13 +182,13 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
 
         if as_fragment:
             ir: irast_.Command = qlcompiler.compile_ast_fragment_to_ir(
-                expr.qlast,
+                self.qlast,
                 schema=schema,
                 options=options,
             )
         else:
             ir = qlcompiler.compile_ast_to_ir(
-                expr.qlast,
+                self.qlast,
                 schema=schema,
                 options=options,
             )
@@ -202,11 +199,11 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         srefs = {ref for ref in ir.schema_refs if schema.has_object(ref.id)}
 
         return CompiledExpression(
-            text=expr.text,
+            text=self.text,
             refs=so.ObjectSet.create(schema, srefs),
-            _qlast=expr.qlast,
+            _qlast=self.qlast,
             _irast=ir,
-            origin=expr.origin,
+            origin=self.origin,
         )
 
     def ensure_compiled(
@@ -220,7 +217,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             return self  # type: ignore
         else:
             return self.compiled(
-                self, schema, options=options, as_fragment=as_fragment)
+                schema, options=options, as_fragment=as_fragment)
 
     @classmethod
     def from_ir(cls: Type[Expression],

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -173,17 +173,17 @@ class AliasLikeCommand(
             prev_expr = None
         else:
             prev = schema.get(classname, type=s_types.Type)
-            prev_expr = prev.get_expr(schema)
-            assert prev_expr is not None
+            prev_expr_ = prev.get_expr(schema)
+            assert prev_expr_ is not None
             prev_ir = compile_alias_expr(
-                prev_expr.qlast,
+                prev_expr_.qlast,
                 classname,
                 schema,
                 context,
                 parser_context=parser_context,
             )
             prev_expr = s_expr.Expression.from_ir(
-                prev_expr, prev_ir, schema=schema)
+                prev_expr_, prev_ir, schema=schema)
 
         is_global = (self.get_schema_metaclass().
                      get_schema_class_displayname() == 'global')
@@ -231,7 +231,7 @@ class AliasCommand(
         field: so.Field[Any],
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> s_expr.Expression:
+    ) -> s_expr.CompiledExpression:
         assert field.name == 'expr'
         classname = sn.shortname_from_fullname(self.classname)
         assert isinstance(classname, sn.QualName), \
@@ -431,8 +431,8 @@ def compile_alias_expr(
 
 def define_alias(
     *,
-    expr: s_expr.Expression,
-    prev_expr: Optional[s_expr.Expression] = None,
+    expr: s_expr.CompiledExpression,
+    prev_expr: Optional[s_expr.CompiledExpression] = None,
     classname: sn.QualName,
     schema: s_schema.Schema,
     is_global: bool,
@@ -441,7 +441,6 @@ def define_alias(
     from edb.ir import ast as irast
     from . import ordering as s_ordering
 
-    assert isinstance(expr.irast, irast.Statement)
     ir = expr.irast
     new_schema = ir.schema
 
@@ -464,7 +463,6 @@ def define_alias(
             expr_aliases.append(vt)
 
     if prev_expr is not None:
-        assert isinstance(prev_expr.irast, irast.Statement)
         prev_ir = prev_expr.irast
         old_schema = prev_ir.schema
         for vt in prev_ir.views.values():

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -236,8 +236,7 @@ class AliasCommand(
         classname = sn.shortname_from_fullname(self.classname)
         assert isinstance(classname, sn.QualName), \
             "expected qualified name"
-        return type(value).compiled(
-            value,
+        return value.compiled(
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 derived_target_module=classname.module,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -197,8 +197,7 @@ class ParameterDesc(ParameterLike):
         if astnode.default is not None:
             defexpr = s_expr.Expression.from_ast(
                 astnode.default, schema, modaliases, as_fragment=True)
-            paramd = s_expr.Expression.compiled(
-                defexpr,
+            paramd = defexpr.compiled(
                 schema,
                 as_fragment=True,
                 options=qlcompiler.CompilerOptions(
@@ -424,8 +423,8 @@ class Parameter(
 
         defexpr = self.get_default(schema)
         assert defexpr is not None
-        defexpr = s_expr.Expression.compiled(
-            defexpr, as_fragment=True, schema=schema)
+        defexpr = defexpr.compiled(
+            as_fragment=True, schema=schema)
         ir = defexpr.irast
         if not irutils.is_const(ir.expr):
             raise ValueError('expression not constant')
@@ -1459,8 +1458,7 @@ class FunctionCommand(
         track_schema_ref_exprs: bool=False,
     ) -> s_expr.CompiledExpression:
         if field.name == 'initial_value':
-            return type(value).compiled(
-                value,
+            return value.compiled(
                 schema=schema,
                 options=qlcompiler.CompilerOptions(
                     allow_generic_type_output=True,
@@ -1534,7 +1532,7 @@ class FunctionCommand(
         ):
             self.set_attribute_value(
                 'nativecode',
-                s_expr.Expression.not_compiled(nativecode)
+                nativecode.not_compiled()
             )
 
         # Resolving 'nativecode' has side effects on has_dml and
@@ -2302,8 +2300,7 @@ def compile_function(
         inlined_defaults=has_inlined_defaults,
     )
 
-    compiled = type(body).compiled(
-        body,
+    compiled = body.compiled(
         schema,
         options=qlcompiler.CompilerOptions(
             anchors=param_anchors,

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -127,15 +127,12 @@ class GlobalCommand(
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        from edb.ir import ast as irast
-
         expression = self.get_attribute_value('expr')
         assert isinstance(expression, s_expr.Expression)
         # If it's not compiled, don't worry about it. This should just
         # be a dummy expression.
         if not expression.irast:
             return schema
-        assert isinstance(expression.irast, irast.Statement)
 
         required, card = expression.irast.cardinality.to_schema_value()
 
@@ -225,11 +222,7 @@ class GlobalCommand(
         default_expr = scls.get_default(schema)
 
         if default_expr is not None:
-            from edb.ir import ast as irast
-            if default_expr.irast is None:
-                default_expr = default_expr.compiled(default_expr, schema)
-
-            assert isinstance(default_expr.irast, irast.Statement)
+            default_expr = default_expr.ensure_compiled(schema)
 
             default_schema = default_expr.irast.schema
             default_type = default_expr.irast.stype
@@ -303,7 +296,7 @@ class GlobalCommand(
         field: so.Field[Any],
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> s_expr.Expression:
+    ) -> s_expr.CompiledExpression:
         if field.name in {'default', 'expr'}:
             ptr_name = self.get_verbosename()
             in_ddl_context_name = None

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -303,8 +303,7 @@ class GlobalCommand(
             if field.name == 'expr':
                 in_ddl_context_name = f'computed {ptr_name}'
 
-            return type(value).compiled(
-                value,
+            return value.compiled(
                 schema=schema,
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -291,7 +291,7 @@ class IndexCommand(
         field: so.Field[Any],
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> s_expr.Expression:
+    ) -> s_expr.CompiledExpression:
         singletons: List[s_types.Type]
         if field.name in {'expr', 'except_expr'}:
             # type ignore below, for the class is used as mixin
@@ -318,8 +318,6 @@ class IndexCommand(
             )
 
             # Check that the inferred cardinality is no more than 1
-            from edb.ir import ast as ir_ast
-            assert isinstance(expr.irast, ir_ast.Statement)
             if expr.irast.cardinality.is_multi():
                 raise errors.ResultCardinalityMismatchError(
                     f'possibly more than one element returned by '

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -303,8 +303,7 @@ class IndexCommand(
             assert isinstance(parent_ctx.op, sd.ObjectCommand)
             subject = parent_ctx.op.get_object(schema, context)
 
-            expr = type(value).compiled(
-                value,
+            expr = value.compiled(
                 schema=schema,
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1365,8 +1365,7 @@ class PointerCommandOrFragment(
             else:
                 singletons.append(self.scls)
 
-        compiled = type(expr).compiled(
-            expr,
+        compiled = expr.compiled(
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,
@@ -2028,8 +2027,7 @@ class AlterPointer(
         assert isinstance(expr, s_expr.Expression)
         pointer = schema.get(self.classname, type=Pointer)
         source = cast(s_types.Type, pointer.get_source(schema))
-        expression = s_expr.Expression.compiled(
-            expr,
+        expression = expr.compiled(
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1156,7 +1156,6 @@ class PointerCommandOrFragment(
             value=s_expr.Expression.from_ast(expr, schema, context.modaliases),
         )
 
-        assert isinstance(expression.irast, irast.Statement)
         base = None
         target = expression.irast.stype
         target_shell = target.as_shell(expression.irast.schema)
@@ -1321,7 +1320,7 @@ class PointerCommandOrFragment(
         target_as_singleton: bool = False,
         expr_description: Optional[str] = None,
         no_query_rewrites: bool = False,
-    ) -> s_expr.Expression:
+    ) -> s_expr.CompiledExpression:
         singletons: List[Union[s_types.Type, Pointer]] = []
 
         parent_ctx = self.get_referrer_context_or_die(context)
@@ -1402,7 +1401,7 @@ class PointerCommandOrFragment(
         field: so.Field[Any],
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> s_expr.Expression:
+    ) -> s_expr.CompiledExpression:
         if field.name in {'default', 'expr'}:
             parent_ctx = self.get_referrer_context_or_die(context)
             source = parent_ctx.op.get_object(schema, context)
@@ -1581,8 +1580,6 @@ class PointerCommand(
         context: sd.CommandContext,
     ) -> None:
         """Check that pointer definition is sound."""
-        from edb.ir import ast as irast
-
         referrer_ctx = self.get_referrer_context(context)
         if referrer_ctx is None:
             return
@@ -1599,14 +1596,11 @@ class PointerCommand(
 
             source_context = self.get_attribute_source_context('default')
 
-            if default_expr.irast is None:
-                try:
-                    default_expr = default_expr.compiled(default_expr, schema)
-                except errors.QueryError as e:
-                    e.set_source_context(source_context)
-                    raise
-
-            assert isinstance(default_expr.irast, irast.Statement)
+            try:
+                default_expr = default_expr.ensure_compiled(schema)
+            except errors.QueryError as e:
+                e.set_source_context(source_context)
+                raise
 
             if scls.is_id_pointer(schema):
                 self._check_id_default(
@@ -2025,8 +2019,6 @@ class AlterPointer(
         # expression, then we also need to change the type to the
         # new expression type
 
-        from edb.ir import ast as irast
-
         expr = self.get_attribute_value('expr')
         if expr is None:
             # This shouldn't happen, but asserting here doesn't seem quite
@@ -2048,7 +2040,6 @@ class AlterPointer(
             ),
         )
 
-        assert isinstance(expression.irast, irast.Statement)
         target = expression.irast.stype
         self.set_attribute_value(
             'target',

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -149,8 +149,6 @@ class AccessPolicyCommand(
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        from edb.ir import ast as irast
-
         schema = super().canonicalize_attributes(schema, context)
 
         parent_ctx = self.get_referrer_context_or_die(context)
@@ -168,7 +166,6 @@ class AccessPolicyCommand(
                 field=AccessPolicy.get_field(field),
                 value=expr,
             )
-            assert isinstance(expression.irast, irast.Statement)
 
             srcctx = self.get_attribute_source_context(field)
 
@@ -213,7 +210,7 @@ class AccessPolicyCommand(
         field: so.Field[Any],
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> s_expr.Expression:
+    ) -> s_expr.CompiledExpression:
         if field.name in {'expr', 'condition'}:
             parent_ctx = self.get_referrer_context_or_die(context)
             source = parent_ctx.op.get_object(schema, context)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2522,7 +2522,7 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
         field: so.Field[Any],
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> s_expr.Expression:
+    ) -> s_expr.CompiledExpression:
         assert field.name == 'expr'
         return type(value).compiled(
             value,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2524,8 +2524,7 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
         track_schema_ref_exprs: bool=False,
     ) -> s_expr.CompiledExpression:
         assert field.name == 'expr'
-        return type(value).compiled(
-            value,
+        return value.compiled(
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,


### PR DESCRIPTION
Two big typing changes:
* Make irast officially return irast.Statement. Basically every call
  site asserts this.
* Try to track whether an Expression has an irast in the type system.

These clean up a decent amount of crud and reduce the amount of crud I will
need to *add* to make pgsql/delta typecheck cleanly.

Also make a bunch of the classmethods into regular methods. Many of
the call sites were doing `type(expr).compiled(expr, ...)`, which is
just silly. I split that out if people don't like it, though.