### PR TITLE
Fix some migrations with tricky constraint/computed interactions

### DIFF
--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -915,10 +915,13 @@ def _get_referrers(
         if not ref.is_blocking_ref(schema, obj):
             continue
 
+        referrer: so.Object | None = None
+
         parent_ref = strongrefs.get(ref.get_name(schema))
         if parent_ref is not None:
-            referrer: so.Object = schema.get(parent_ref)
-        else:
+            referrer = schema.get(parent_ref, default=None)
+
+        if not referrer or obj == referrer:
             referrer = ref
 
         result.add(referrer)

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -189,7 +189,7 @@ class Property(
             **kwargs,
         )
         assert isinstance(delta, referencing.ReferencedObjectCommandBase)
-        delta.is_strong_ref = self.is_endpoint_pointer(schema)
+        delta.is_strong_ref = self.is_special_pointer(schema)
         return delta  # type: ignore
 
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -5922,6 +5922,8 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         await self.interact([
             "did you create object type 'test::HasContent'?",
             "did you alter object type 'test::Post'?",
+            "did you alter constraint 'std::max_len_value' of property "
+            "'content'?",
             "did you create object type 'test::Reply'?",
             "did you alter property 'content' of object type 'test::Post'?",
         ])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4726,6 +4726,26 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             global TwoUsers := (User);
         """])
 
+    def test_schema_migrations_equivalence_58(self):
+        self._assert_migration_equivalence([r"""
+            abstract type C {
+                link x -> E {
+                    constraint exclusive;
+                }
+            }
+
+            abstract type A;
+
+            type B extending A;
+
+            type D extending C, A;
+
+            type E extending A {
+                link y := assert_single(.<`x`[IS C]);
+            }
+        """, r"""
+        """])
+
     def test_schema_migrations_equivalence_compound_01(self):
         # Check that union types can be referenced in computables
         # Bug #2002.


### PR DESCRIPTION
The issue here is that the deletion of `id` and the deletion of a type
might get separated in the generated delta. While processing the delta
to produce an AST, expressions that reference the type might get
recompiled, and nasty things can happen since the id is missing.

Fix this by treating `id` as a "strong ref", which shouldn't ever have
its operations hoisted outside of the main operation on the enclosing
object.

Tweak some bits in ordering to not cause knock-on problems.

Fixes #4789