### PR TITLE
Add type introspection to Parse and Execute

### DIFF
--- a/edb/protocol/messages.py
+++ b/edb/protocol/messages.py
@@ -521,9 +521,10 @@ class Capability(enum.IntFlag):
 
 class CompilationFlag(enum.IntFlag):
 
-    INJECT_OUTPUT_TYPE_IDS   = 1 << 0    # noqa
-    INJECT_OUTPUT_TYPE_NAMES = 1 << 1    # noqa
-    INJECT_OUTPUT_OBJECT_IDS = 1 << 2    # noqa
+    INJECT_OUTPUT_TYPE_IDS       = 1 << 0    # noqa
+    INJECT_OUTPUT_TYPE_NAMES     = 1 << 1    # noqa
+    INJECT_OUTPUT_OBJECT_IDS     = 1 << 2    # noqa
+    INTROSPECT_TYPE_INFORMATION  = 1 << 3    # noqa
 
 
 class ErrorSeverity(enum.Enum):

--- a/edb/protocol/messages.py
+++ b/edb/protocol/messages.py
@@ -521,10 +521,12 @@ class Capability(enum.IntFlag):
 
 class CompilationFlag(enum.IntFlag):
 
-    INJECT_OUTPUT_TYPE_IDS       = 1 << 0    # noqa
-    INJECT_OUTPUT_TYPE_NAMES     = 1 << 1    # noqa
-    INJECT_OUTPUT_OBJECT_IDS     = 1 << 2    # noqa
-    INTROSPECT_TYPE_INFORMATION  = 1 << 3    # noqa
+    INJECT_OUTPUT_TYPE_IDS      = 1 << 0    # noqa
+    INJECT_OUTPUT_TYPE_NAMES    = 1 << 1    # noqa
+    INJECT_OUTPUT_OBJECT_IDS    = 1 << 2    # noqa
+    INTROSPECT_TYPE_INFORMATION = 1 << 3    # noqa
+    DETAILED_TYPE_INFORMATION   = 1 << 4    # noqa
+    DETAILED_SCALAR_INFORMATION = 1 << 5    # noqa
 
 
 class ErrorSeverity(enum.Enum):

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -109,6 +109,8 @@ class CompileContext:
     inline_typenames: bool = False
     inline_objectids: bool = True
     introspect_type_information: bool = False
+    detailed_type_information: bool = False
+    detailed_scalar_information: bool = False
     schema_object_ids: Optional[Mapping[s_name.Name, uuid.UUID]] = None
     source: Optional[edgeql.Source] = None
     backend_runtime_params: pg_params.BackendRuntimeParams = (
@@ -468,6 +470,8 @@ class Compiler:
                     inline_typeids=False,
                     inline_typenames=True,
                     introspect_type_information=False,
+                    introspect_detailed_type_information=False,
+                    introspect_detailed_scalar_information=False,
                     json_parameters=False,
                     source=source,
                     protocol_version=protocol_version,
@@ -509,6 +513,8 @@ class Compiler:
         inline_objectids: bool = True,
         json_parameters: bool = False,
         introspect_type_information: bool = False,
+        detailed_type_information: bool = False,
+        detailed_scalar_information: bool = False,
     ) -> Tuple[dbstate.QueryUnitGroup,
                Optional[dbstate.CompilerConnectionState]]:
 
@@ -547,6 +553,8 @@ class Compiler:
             inline_typenames=inline_typenames,
             inline_objectids=inline_objectids,
             introspect_type_information=introspect_type_information,
+            detailed_type_information=detailed_type_information,
+            detailed_scalar_information=detailed_scalar_information,
             skip_first=skip_first,
             json_parameters=json_parameters,
             source=source,
@@ -580,6 +588,8 @@ class Compiler:
         inline_objectids: bool = True,
         json_parameters: bool = False,
         introspect_type_information: bool = False,
+        detailed_type_information: bool = False,
+        detailed_scalar_information: bool = False,
         expect_rollback: bool = False,
     ) -> Tuple[dbstate.QueryUnitGroup, dbstate.CompilerConnectionState]:
         if (
@@ -605,6 +615,8 @@ class Compiler:
             inline_typenames=inline_typenames,
             inline_objectids=inline_objectids,
             introspect_type_information=introspect_type_information,
+            detailed_type_information=detailed_type_information,
+            detailed_scalar_information=detailed_scalar_information,
             skip_first=skip_first,
             source=source,
             protocol_version=protocol_version,
@@ -1226,6 +1238,8 @@ def _compile_ql_query(
             ir.view_shapes, ir.view_shapes_metadata,
             inline_typenames=ctx.inline_typenames,
             introspect_type_information=ctx.introspect_type_information,
+            detailed_type_information=ctx.detailed_type_information,
+            detailed_scalar_information=ctx.detailed_scalar_information,
             protocol_version=ctx.protocol_version)
     else:
         out_type_data, out_type_id = \

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -108,6 +108,7 @@ class CompileContext:
     inline_typeids: bool = False
     inline_typenames: bool = False
     inline_objectids: bool = True
+    introspect_type_information: bool = False
     schema_object_ids: Optional[Mapping[s_name.Name, uuid.UUID]] = None
     source: Optional[edgeql.Source] = None
     backend_runtime_params: pg_params.BackendRuntimeParams = (
@@ -466,6 +467,7 @@ class Compiler:
                     implicit_limit=implicit_limit,
                     inline_typeids=False,
                     inline_typenames=True,
+                    introspect_type_information=False,
                     json_parameters=False,
                     source=source,
                     protocol_version=protocol_version,
@@ -506,6 +508,7 @@ class Compiler:
         protocol_version: Tuple[int, int],
         inline_objectids: bool = True,
         json_parameters: bool = False,
+        introspect_type_information: bool = False,
     ) -> Tuple[dbstate.QueryUnitGroup,
                Optional[dbstate.CompilerConnectionState]]:
 
@@ -543,6 +546,7 @@ class Compiler:
             inline_typeids=inline_typeids,
             inline_typenames=inline_typenames,
             inline_objectids=inline_objectids,
+            introspect_type_information=introspect_type_information,
             skip_first=skip_first,
             json_parameters=json_parameters,
             source=source,
@@ -575,6 +579,7 @@ class Compiler:
         protocol_version: Tuple[int, int],
         inline_objectids: bool = True,
         json_parameters: bool = False,
+        introspect_type_information: bool = False,
         expect_rollback: bool = False,
     ) -> Tuple[dbstate.QueryUnitGroup, dbstate.CompilerConnectionState]:
         if (
@@ -599,6 +604,7 @@ class Compiler:
             inline_typeids=inline_typeids,
             inline_typenames=inline_typenames,
             inline_objectids=inline_objectids,
+            introspect_type_information=introspect_type_information,
             skip_first=skip_first,
             source=source,
             protocol_version=protocol_version,
@@ -1219,6 +1225,7 @@ def _compile_ql_query(
             ir.schema, ir.stype,
             ir.view_shapes, ir.view_shapes_metadata,
             inline_typenames=ctx.inline_typenames,
+            introspect_type_information=ctx.introspect_type_information,
             protocol_version=ctx.protocol_version)
     else:
         out_type_data, out_type_id = \

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -516,7 +516,7 @@ class TypeSerializer:
         self.anno_buffer.append(tn_bytes)
 
     def _add_type_annotation(
-        self, id: uuid.UUID, t: s_types.InheritingType, 
+        self, id: uuid.UUID, t: s_types.InheritingType,
         schema: s_schema.Schema
     ):
         self.anno_buffer.append(CTYPE_ANNO_INTROSPECTION)
@@ -524,10 +524,10 @@ class TypeSerializer:
         # append the descriptor id
         self.anno_buffer.append(id.bytes)
 
-        # get all ancestors of the type, excluding 'BaseObject' 
+        # get all ancestors of the type, excluding 'BaseObject'
         # and 'Object', and make distinct by 'id'
         ancestors = {
-            x.id: x for x in t.get_ancestors(schema).objects(schema) 
+            x.id: x for x in t.get_ancestors(schema).objects(schema)
             if x.get_displayname(schema) not in [
                 'std::BaseObject', 'std::Object'
             ]
@@ -536,7 +536,7 @@ class TypeSerializer:
         # encode the information for the current type
         type_buf = b''.join(
             self._encode_type_annotation_ancestors(
-                t, 
+                t,
                 ancestors, schema
             )
         )
@@ -549,8 +549,8 @@ class TypeSerializer:
         for x in ancestors:
             anc_buf = b''.join(
                 self._encode_type_annotation_ancestors(
-                    x, 
-                    ancestors, 
+                    x,
+                    ancestors,
                     schema
                 )
             )
@@ -558,7 +558,7 @@ class TypeSerializer:
             self.anno_buffer.append(anc_buf)
 
     def _encode_type_annotation_ancestors(
-        self, t: s_types.InheritingType, 
+        self, t: s_types.InheritingType,
         ancestors: typing.Tuple[s_types.InheritingType, ...],
         schema: s_schema.Schema
     ):
@@ -571,18 +571,18 @@ class TypeSerializer:
         buf.append(_uint32_packer(len(tn_bytes)))
         buf.append(tn_bytes)
 
-         # append the type id
+        # append the type id
         buf.append(t.get_id(schema).bytes)
 
         # get direct parents of this type and grab their indexes
         direct_ancestors = [
             ancestors.index(x)
             for x in t.get_ancestors(schema).objects(schema)
-            if x not in x.get_ancestors(schema).objects(schema) and 
-                x.get_displayname(schema) not in [
-                    'std::BaseObject', 
-                    'std::Object'
-                ]
+            if x not in x.get_ancestors(schema).objects(schema) and
+            x.get_displayname(schema) not in [
+                'std::BaseObject',
+                'std::Object'
+            ]
         ]
 
         buf.append(_uint16_packer(len(direct_ancestors)))
@@ -591,7 +591,7 @@ class TypeSerializer:
             buf.append(_uint16_packer(index))
 
         return buf
-        
+
     @classmethod
     def describe_params(
         cls,

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -45,6 +45,7 @@ cdef class QueryRequestInfo:
     cdef public bint inline_typeids
     cdef public bint inline_typenames
     cdef public bint inline_objectids
+    cdef public bint introspect_type_information
     cdef public uint64_t allow_capabilities
 
     cdef int cached_hash

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -46,6 +46,8 @@ cdef class QueryRequestInfo:
     cdef public bint inline_typenames
     cdef public bint inline_objectids
     cdef public bint introspect_type_information
+    cdef public bint detailed_type_information
+    cdef public bint detailed_scalar_information
     cdef public uint64_t allow_capabilities
 
     cdef int cached_hash

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -78,6 +78,7 @@ cdef class QueryRequestInfo:
         inline_typeids: bint = False,
         inline_typenames: bint = False,
         inline_objectids: bint = True,
+        introspect_type_information: bint = False,
         allow_capabilities: uint64_t = <uint64_t>compiler.Capability.ALL,
     ):
         self.source = source
@@ -89,6 +90,7 @@ cdef class QueryRequestInfo:
         self.inline_typeids = inline_typeids
         self.inline_typenames = inline_typenames
         self.inline_objectids = inline_objectids
+        self.introspect_type_information = introspect_type_information
         self.allow_capabilities = allow_capabilities
 
         self.cached_hash = hash((
@@ -956,6 +958,7 @@ cdef class DatabaseConnectionView:
         query_req: QueryRequestInfo,
     ) -> CompiledQuery:
         source = query_req.source
+        # TODO: introspect compilation flag should be omitted for cached queries
         query_unit_group = self.lookup_compiled_query(query_req)
         cached = True
         if query_unit_group is None:
@@ -1038,6 +1041,7 @@ cdef class DatabaseConnectionView:
                     self._protocol_version,
                     query_req.inline_objectids,
                     query_req.input_format is compiler.InputFormat.JSON,
+                    query_req.introspect_type_information,
                     self.in_tx_error(),
                 )
             else:
@@ -1060,6 +1064,7 @@ cdef class DatabaseConnectionView:
                     self._protocol_version,
                     query_req.inline_objectids,
                     query_req.input_format is compiler.InputFormat.JSON,
+                    query_req.introspect_type_information,
                 )
         finally:
             metrics.edgeql_query_compilation_duration.observe(

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -79,6 +79,8 @@ cdef class QueryRequestInfo:
         inline_typenames: bint = False,
         inline_objectids: bint = True,
         introspect_type_information: bint = False,
+        detailed_type_information: bint = False,
+        detailed_scalar_information: bint = False,
         allow_capabilities: uint64_t = <uint64_t>compiler.Capability.ALL,
     ):
         self.source = source
@@ -91,6 +93,8 @@ cdef class QueryRequestInfo:
         self.inline_typenames = inline_typenames
         self.inline_objectids = inline_objectids
         self.introspect_type_information = introspect_type_information
+        self.detailed_type_information = detailed_type_information
+        self.detailed_scalar_information = detailed_scalar_information
         self.allow_capabilities = allow_capabilities
 
         self.cached_hash = hash((
@@ -1042,6 +1046,8 @@ cdef class DatabaseConnectionView:
                     query_req.inline_objectids,
                     query_req.input_format is compiler.InputFormat.JSON,
                     query_req.introspect_type_information,
+                    query_req.detailed_type_information,
+                    query_req.detailed_scalar_information,
                     self.in_tx_error(),
                 )
             else:
@@ -1065,6 +1071,8 @@ cdef class DatabaseConnectionView:
                     query_req.inline_objectids,
                     query_req.input_format is compiler.InputFormat.JSON,
                     query_req.introspect_type_information,
+                    query_req.detailed_type_information,
+                    query_req.detailed_scalar_information,
                 )
         finally:
             metrics.edgeql_query_compilation_duration.observe(

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1093,6 +1093,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             bint inline_typenames = False
             bint inline_typeids = False
             bint inline_objectids = False
+            bint introspect_type_information = False
             object output_format
             bint expect_one = False
             bytes query
@@ -1117,6 +1118,10 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         inline_objectids = (
             compilation_flags
             & messages.CompilationFlag.INJECT_OUTPUT_OBJECT_IDS
+        )
+        introspect_type_information = (
+            compilation_flags
+            & messages.CompilationFlag.INTROSPECT_TYPE_INFORMATION
         )
 
         output_format = self.parse_output_format(self.buffer.read_byte())
@@ -1145,6 +1150,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             inline_typeids=inline_typeids,
             inline_typenames=inline_typenames,
             inline_objectids=inline_objectids,
+            introspect_type_information=introspect_type_information,
             allow_capabilities=allow_capabilities,
         )
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1123,6 +1123,14 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             compilation_flags
             & messages.CompilationFlag.INTROSPECT_TYPE_INFORMATION
         )
+        detailed_type_information = (
+            compilation_flags
+            & messages.CompilationFlag.DETAILED_TYPE_INFORMATION
+        )
+        detailed_scalar_information = (
+            compilation_flags
+            & messages.CompilationFlag.DETAILED_SCALAR_INFORMATION
+        )
 
         output_format = self.parse_output_format(self.buffer.read_byte())
         expect_one = (
@@ -1151,6 +1159,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             inline_typenames=inline_typenames,
             inline_objectids=inline_objectids,
             introspect_type_information=introspect_type_information,
+            detailed_type_information=detailed_type_information,
+            detailed_scalar_information=detailed_scalar_information,
             allow_capabilities=allow_capabilities,
         )
 


### PR DESCRIPTION
## Summary
This PR adds the ability to introspect type information when sending `Parse` and `Execute`.

### Overview
A new compilation flag `INTROSPECT_TYPE_INFORMATION = 1 << 3` has been added, when this flag is set, a type annotation descriptor is returned with the result descriptors:
```c
struct TypeIntrospectionDescriptor {
    // Indicates that this is an
    // Type introspection descriptor.
    uint8        type = 0xf0

    // ID of the descriptor the
    // annotation is for.
    uuid         id;

    // Annotation text.
    string       annotation;
};
```
with the annotation text being a binary encoded struct with the following format:
```c
struct TypeInformation {
  // The name of the type.
  string            name;

  // The id of the type in EdgeDB.
  uuid              id;

  // Ancestors of the type.
  uint16            ancestors_length;
  TypeInformation[] ancestors;
}
```

**Remarks**
The type information is encoded as a string to maintain backwards compatibility with the [TypeAnnotationDescriptor](https://www.edgedb.com/docs/reference/protocol/typedesc#type-annotation-descriptor), although, since this data is gatekept by a new flag, maybe we could change the format of the `TypeIntrospectionDescriptor` to not be encoded as a string?



