### PR TITLE
Fix: computed from id

### DIFF
--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1684,6 +1684,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_select_id_01(self):
+        # allow assigning id to a computed (#4781)
+        await self.con.query('SELECT schema::Type { XYZ := .id};')
+
     async def test_edgeql_select_reverse_link_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
Fixes #4781

The problem was that `XYZ` was a derived property which is extending `Object#id`. Because of that, `is_id_pointer` evaluates to True.

This commit basically moves the two checks for id modification and updates of readonly to an earlier place, where the properties have not yet been derived and `ptrcls` is simply None.