### PR TITLE
Fix broken DROPs of pointers in some multiple-inheritance situations

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -194,7 +194,7 @@ def delta_objects(
             # how the delta in child objects is treated.
             order_x = cast(
                 Iterable[so.Object_T],
-                _sort_by_inheritance(
+                sort_by_inheritance(
                     new_schema,
                     cast(Iterable[so.InheritingObject], comparison_map),
                 ),
@@ -265,7 +265,7 @@ def delta_objects(
     deleted = old - {y for _, y in alter_pairs}
 
     if issubclass(sclass, so.InheritingObject):
-        deleted_order = _sort_by_inheritance(  # type: ignore
+        deleted_order = sort_by_inheritance(  # type: ignore[assignment]
             old_schema,
             cast(Iterable[so.InheritingObject], deleted),
         )
@@ -286,15 +286,15 @@ def delta_objects(
     return delta
 
 
-def _sort_by_inheritance(
+def sort_by_inheritance(
     schema: s_schema.Schema,
     objs: Iterable[so.InheritingObjectT],
-) -> Iterable[so.InheritingObjectT]:
+) -> Tuple[so.InheritingObjectT, ...]:
     graph = {}
     for x in objs:
         graph[x] = topological.DepGraphEntry(
             item=x,
-            deps=ordered.OrderedSet(x.get_bases(schema).objects(schema)),
+            deps=ordered.OrderedSet(x.get_ancestors(schema).objects(schema)),
             extra=False,
         )
 

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -1459,7 +1459,13 @@ class DeleteReferencedInheritingObject(
                     details=f'{vn} is inherited from:\n- {pnames}'
                 )
 
-        for child in referrer.children(schema):
+        # Sort the children by reverse inheritance order amongst them.
+        # So if we are T and have children A and B and A <: B, we want to
+        # process A first, since we need to rebase it away from T, and then
+        # dropping A will also drop B.
+        for child in reversed(
+            sd.sort_by_inheritance(schema, referrer.children(schema))
+        ):
             assert isinstance(child, so.QualifiedObject)
             child_coll = child.get_field_value(schema, refdict.attr)
             fq_refname_in_child = self._classname_from_name(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7489,6 +7489,121 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             """,
         ])
 
+    def test_schema_migrations_half_diamonds_00(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type A;
+
+                abstract type B {
+                    link z -> G {
+                        constraint exclusive;
+                    }
+                }
+
+                abstract type C extending B {
+                    link y -> H {
+                        constraint exclusive;
+                    }
+                }
+
+                abstract type D;
+
+                type E extending D;
+
+                type F extending C, B, D;
+
+                type G extending D, A {
+                    link x := assert_single(.<z[IS B]);
+                }
+
+                type H extending B, D, A {
+                    link w := assert_single(.<y[IS C]);
+                }
+            """,
+            r"""
+            """,
+        ])
+
+    def test_schema_migrations_half_diamonds_01(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type A;
+                abstract type B {
+                    link z -> A;
+                };
+                abstract type C extending B;
+                abstract type D;
+                type F extending C, B;
+            """,
+            r"""
+            """,
+        ])
+
+    def test_schema_migrations_half_diamonds_02(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type A;
+                abstract type B {
+                    link z -> A;
+                };
+                abstract type C extending B;
+                abstract type C2 extending B;
+                abstract type D;
+                type F extending C, C2, B;
+            """,
+            r"""
+            """,
+        ])
+
+    def test_schema_migrations_half_diamonds_03(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type A;
+                abstract type B {
+                    link z -> A;
+                };
+                abstract type C extending B;
+                abstract type C2 extending C;
+                abstract type D;
+                type F extending C, C2, B;
+            """,
+            r"""
+            """,
+        ])
+
+    def test_schema_migrations_half_diamonds_04(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type A;
+                abstract type B {
+                    link z -> A;
+                };
+                abstract type C extending B;
+                abstract type C2 extending C;
+                abstract type D;
+                type F extending C2, B;
+            """,
+            r"""
+            """,
+        ])
+
+    def test_schema_migrations_half_diamonds_05(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type A;
+                abstract type B {
+                    link z -> A;
+                };
+                abstract type C extending B;
+                abstract type C2 extending C;
+                abstract type D;
+                type F extending C, C2, B;
+                type F2 extending C, C2, B, F;
+            """,
+            r"""
+            """,
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
Fix this by more carefully ordering children by inheritance order
when propagating deletes.

Fixes #4804.