### PR TITLE
Properly execute function calls in UPDATE once per object

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1359,6 +1359,9 @@ def process_update_body(
         subctx.expr_exposed = False
         subctx.enclosing_cte_iterator = iterator
 
+        clauses.setup_iterator_volatility(
+            iterator, is_cte=True, ctx=subctx)
+
         for shape_el, shape_op in ir_stmt.subject.shape:
             if shape_op == qlast.ShapeOp.MATERIALIZE:
                 continue

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -3671,3 +3671,29 @@ class TestUpdate(tb.QueryTestCase):
             """,
             [],
         )
+
+    async def test_edgeql_update_volatility_01(self):
+        # random should be executed once for each object
+        await self.con.execute(r"""
+            update UpdateTest set { comment := <str>random() };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                select count(distinct UpdateTest.comment) = count(UpdateTest)
+            """,
+            [True],
+        )
+
+    async def test_edgeql_update_volatility_02(self):
+        # random should be executed once for each object
+        await self.con.execute(r"""
+            update UpdateTest set { str_tags := <str>random() };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                select count(distinct UpdateTest.str_tags) = count(UpdateTest)
+            """,
+            [True],
+        )


### PR DESCRIPTION
Currently we aren't properly setting a volatility_ref, which means we
might not force functions like random() to be called enough.

Fixes #4799.