### PR TITLE
Fix accessing tuple elements on link properties

### DIFF
--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -718,6 +718,8 @@ class PathId:
         result._norm_path = self._norm_path[0:size]
         result._prefix = self._prefix
         result._namespace = self._namespace
+        if rptr := result.rptr():
+            result._is_linkprop = rptr.source_ptr is not None
 
         if size < len(self._path) and self._norm_path[size][2]:  # type: ignore
             # A link property ref has been chopped off.

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1354,3 +1354,23 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                     insert Src { l := assert_single(Tgt { @y := "..." }) };
                 '''
             )
+
+    async def test_edgeql_props_tuples_01(self):
+        await self.con.execute(r'''
+            create type Org;
+            create type Foo {
+                create multi link orgs -> Org {
+                    create property roles -> tuple<role1: bool, role2: bool>;
+                }
+            };
+            insert Org;
+            insert Foo { orgs := (select Org {
+                @roles := (role1 := true, role2 := false) }) };
+        ''')
+
+        await self.assert_query_result(
+            '''
+            select Foo.orgs@roles.role1;
+            ''',
+            [True],
+        )


### PR DESCRIPTION
The iter_prefixes() method in PathId did not properly mark prefixes
as being link properties when they were, leading to an incorrectly
built scope tree that caused compilation to fail.

Fixes #4793.