### PR TITLE
Fix assert_exists() not firing on some tuple values

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2008,10 +2008,6 @@ def process_set_as_tuple_indirection(
                     break
         rvar = get_set_rvar(tuple_set, ctx=subctx)
 
-        # Check if unpack_rvar has found our answer for us.
-        if ret_rvar := _lookup_set_rvar(ir_set, ctx=ctx):
-            return new_simple_set_rvar(ir_set, ret_rvar, aspects=('value',))
-
         source_rvar = relctx.maybe_get_path_rvar(
             stmt, tuple_set.path_id, aspect='source', ctx=subctx)
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -8001,6 +8001,16 @@ aa \
                 ).name;
             """)
 
+        async with self.assertRaisesRegexTx(
+            edgedb.CardinalityViolationError,
+            "assert_exists violation",
+        ):
+            await self.con.query("""
+                with x := assert_exists(
+                    (select {(1, 2), (3, 4)} filter false)),
+                select x.0;
+            """)
+
     async def test_edgeql_assert_exists_02(self):
         await self.con.execute('''
             insert BooleanTest { name := "" }


### PR DESCRIPTION
The _lookup_set_rvar we did in process_set_as_tuple_indirection was
finding the values of the tuple components when it shouldn't have
been.

It was always a hack, and fortunately it seems that we fixed whatever
it was hacking around, so just remove the call.