### PR TITLE
Fix GROUP on the result of enumerate

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2592,7 +2592,7 @@ def process_set_as_simple_enumerate(
             newctx.rel, ir_set.path_id, set_expr, aspect='value', env=ctx.env)
 
     aspects = pathctx.list_path_aspects(
-        newctx.rel, ir_arg.path_id, env=ctx.env)
+        newctx.rel, ir_arg.path_id, env=ctx.env) | {'source'}
 
     pathctx.put_path_id_map(newctx.rel, expr.tuple_path_ids[1], ir_arg.path_id)
 

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -1254,3 +1254,45 @@ class TestEdgeQLGroup(tb.QueryTestCase):
           ''',
             tb.bag([{"sum": -7}, {"sum": 5}, {"sum": -23}]),
         )
+
+    async def test_edgeql_group_enumerate_01(self):
+        await self.assert_query_result(
+            '''
+                group enumerate({'a', 'b', 'c', 'd'})
+                using groupIndex := .0 // 2
+                by groupIndex;
+            ''',
+            tb.bag([
+                {
+                    "elements": tb.bag([[0, "a"], [1, "b"]]),
+                    "grouping": ["groupIndex"],
+                    "key": {"groupIndex": 0}
+                },
+                {
+                    "elements": tb.bag([[2, "c"], [3, "d"]]),
+                    "grouping": ["groupIndex"],
+                    "key": {"groupIndex": 1}
+                }
+            ]),
+        )
+
+    async def test_edgeql_group_enumerate_02(self):
+        await self.assert_query_result(
+            '''
+                group enumerate(array_unpack(['a', 'b', 'c', 'd']))
+                using groupIndex := .0 // 2
+                by groupIndex;
+            ''',
+            tb.bag([
+                {
+                    "elements": tb.bag([[0, "a"], [1, "b"]]),
+                    "grouping": ["groupIndex"],
+                    "key": {"groupIndex": 0}
+                },
+                {
+                    "elements": tb.bag([[2, "c"], [3, "d"]]),
+                    "grouping": ["groupIndex"],
+                    "key": {"groupIndex": 1}
+                }
+            ]),
+        )


### PR DESCRIPTION
The problem was that we weren't populating the 'source' aspect when
compiling enumerate.

Fixes #4770.