### PR TITLE
Link tutorial from appropriate doc pages

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -221,4 +221,4 @@ using arbitrary EdgeQL expressions. The example below uses the built-in
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
   * - :ref:`Standard Library > Constraints <ref_std_constraints>`
   * - `Tutorial > Advanced EdgeQL > Constraints
-      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_
+      </tutorial/advanced-edgeql/constraints>`_

--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -220,3 +220,5 @@ using arbitrary EdgeQL expressions. The example below uses the built-in
   * - :ref:`DDL > Constraints <ref_eql_ddl_constraints>`
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
   * - :ref:`Standard Library > Constraints <ref_std_constraints>`
+  * - `Tutorial > Advanced EdgeQL > Constraints
+      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_

--- a/docs/datamodel/functions.rst
+++ b/docs/datamodel/functions.rst
@@ -42,4 +42,6 @@ This function accepts a :eql:type:`str` as an argument and produces a
   * - :ref:`Reference > Function calls <ref_reference_function_call>`
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
+  * - `Tutorial > Advanced EdgeQL > User-Defined Functions
+      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/datamodel/functions.rst
+++ b/docs/datamodel/functions.rst
@@ -43,5 +43,5 @@ This function accepts a :eql:type:`str` as an argument and produces a
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
   * - `Tutorial > Advanced EdgeQL > User-Defined Functions
-      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
+      </tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/edgeql/delete.rst
+++ b/docs/edgeql/delete.rst
@@ -102,4 +102,4 @@ permanently deleted.
   * - :ref:`Reference > Commands > Delete <ref_eql_statements_delete>`
   * - :ref:`Cheatsheets > Deleting data <ref_cheatsheet_delete>`
   * - `Tutorial > Data Mutations > Delete
-      <https://www.edgedb.com/tutorial/data-mutations/delete>`_
+      </tutorial/data-mutations/delete>`_

--- a/docs/edgeql/delete.rst
+++ b/docs/edgeql/delete.rst
@@ -101,3 +101,5 @@ permanently deleted.
   * - **See also**
   * - :ref:`Reference > Commands > Delete <ref_eql_statements_delete>`
   * - :ref:`Cheatsheets > Deleting data <ref_cheatsheet_delete>`
+  * - `Tutorial > Data Mutations > Delete
+      <https://www.edgedb.com/tutorial/data-mutations/delete>`_

--- a/docs/edgeql/insert.rst
+++ b/docs/edgeql/insert.rst
@@ -283,6 +283,9 @@ When a conflict occurs during the initial ``insert``, the statement falls back
 to the ``update`` statement in the ``else`` clause. This updates the
 ``release_year`` of the conflicting object.
 
+To learn to use upserts by trying them yourself, see `our interactive upserts
+tutorial <https://www.edgedb.com/tutorial/data-mutations/upsert>`_.
+
 
 Suppressing failures
 ^^^^^^^^^^^^^^^^^^^^
@@ -331,3 +334,7 @@ using a :ref:`for loop <ref_eql_for>` to insert the objects.
   * - **See also**
   * - :ref:`Reference > Commands > Insert <ref_eql_statements_insert>`
   * - :ref:`Cheatsheets > Inserting data <ref_cheatsheet_insert>`
+  * - `Tutorial > Data Mutations > Insert
+      <https://www.edgedb.com/tutorial/data-mutations/insert>`_
+  * - `Tutorial > Data Mutations > Upsert
+      <https://www.edgedb.com/tutorial/data-mutations/upsert>`_

--- a/docs/edgeql/insert.rst
+++ b/docs/edgeql/insert.rst
@@ -284,7 +284,7 @@ to the ``update`` statement in the ``else`` clause. This updates the
 ``release_year`` of the conflicting object.
 
 To learn to use upserts by trying them yourself, see `our interactive upserts
-tutorial <https://www.edgedb.com/tutorial/data-mutations/upsert>`_.
+tutorial </tutorial/data-mutations/upsert>`_.
 
 
 Suppressing failures
@@ -335,6 +335,6 @@ using a :ref:`for loop <ref_eql_for>` to insert the objects.
   * - :ref:`Reference > Commands > Insert <ref_eql_statements_insert>`
   * - :ref:`Cheatsheets > Inserting data <ref_cheatsheet_insert>`
   * - `Tutorial > Data Mutations > Insert
-      <https://www.edgedb.com/tutorial/data-mutations/insert>`_
+      </tutorial/data-mutations/insert>`_
   * - `Tutorial > Data Mutations > Upsert
-      <https://www.edgedb.com/tutorial/data-mutations/upsert>`_
+      </tutorial/data-mutations/upsert>`_

--- a/docs/edgeql/select.rst
+++ b/docs/edgeql/select.rst
@@ -103,7 +103,7 @@ this result would look like this:
   ]
 
 Learn to select objects by trying it in `our interactive object query
-tutorial <https://www.edgedb.com/tutorial/basic-queries/objects>`_.
+tutorial </tutorial/basic-queries/objects>`_.
 
 
 .. _ref_eql_shapes:
@@ -124,7 +124,7 @@ shape can be attached to any object type expression in EdgeQL.
   }
 
 To learn to use shapes by trying them yourself, see `our interactive shapes
-tutorial <https://www.edgedb.com/tutorial/nested-structures/shapes>`_.
+tutorial </tutorial/nested-structures/shapes>`_.
 
 Nested shapes
 ^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ of the ``Villain`` type. In other words, we are in the **scope** of the
   {default::Villain {name: 'Doc Ock'}}
 
 Learn to filter your queries by trying it in `our interactive filters
-tutorial <https://www.edgedb.com/tutorial/basic-queries/config>`_.
+tutorial </tutorial/basic-queries/config>`_.
 
 Filtering by ID
 ^^^^^^^^^^^^^^^
@@ -525,7 +525,7 @@ from which they inherit the ``name`` property.
 
 To learn how to leverage polymorphism in your queries, see `our interactive
 polymorphism tutorial
-<https://www.edgedb.com/tutorial/nested-structures/polymorphism>`_.
+</tutorial/nested-structures/polymorphism>`_.
 
 Polymorphic sets
 ^^^^^^^^^^^^^^^^
@@ -727,12 +727,12 @@ For full documentation on ``with``, see :ref:`EdgeQL > With <ref_eql_with>`.
   * - :ref:`Reference > Commands > Select <ref_eql_statements_select>`
   * - :ref:`Cheatsheets > Selecting data <ref_cheatsheet_select>`
   * - `Tutorial > Basic Queries > Objects
-      <https://www.edgedb.com/tutorial/basic-queries/objects>`_
+      </tutorial/basic-queries/objects>`_
   * - `Tutorial > Basic Queries > Filters
-      <https://www.edgedb.com/tutorial/basic-queries/config>`_
+      </tutorial/basic-queries/config>`_
   * - `Tutorial > Basic Queries > Aggregates
-      <https://www.edgedb.com/tutorial/basic-queries/aggregate-functions>`_
+      </tutorial/basic-queries/aggregate-functions>`_
   * - `Tutorial > Nested Structures > Shapes
-      <https://www.edgedb.com/tutorial/nested-structures/shapes>`_
+      </tutorial/nested-structures/shapes>`_
   * - `Tutorial > Nested Structures > Polymorphism
-      <https://www.edgedb.com/tutorial/nested-structures/polymorphism>`_
+      </tutorial/nested-structures/polymorphism>`_

--- a/docs/edgeql/select.rst
+++ b/docs/edgeql/select.rst
@@ -102,6 +102,9 @@ this result would look like this:
     {"id": "b233ca98-3c23-11ec-b81f-6ba8c4f0084e"},
   ]
 
+Learn to select objects by trying it in `our interactive object query
+tutorial <https://www.edgedb.com/tutorial/basic-queries/objects>`_.
+
 
 .. _ref_eql_shapes:
 
@@ -119,6 +122,9 @@ shape can be attached to any object type expression in EdgeQL.
     default::Villain { id: 6ddbb04a..., name: 'Green Goblin', },
     default::Villain { id: b233ca98..., name: 'Doc Ock' },
   }
+
+To learn to use shapes by trying them yourself, see `our interactive shapes
+tutorial <https://www.edgedb.com/tutorial/nested-structures/shapes>`_.
 
 Nested shapes
 ^^^^^^^^^^^^^
@@ -197,6 +203,9 @@ of the ``Villain`` type. In other words, we are in the **scope** of the
   db> select Villain {name}
   ... filter .name = "Doc Ock";
   {default::Villain {name: 'Doc Ock'}}
+
+Learn to filter your queries by trying it in `our interactive filters
+tutorial <https://www.edgedb.com/tutorial/basic-queries/config>`_.
 
 Filtering by ID
 ^^^^^^^^^^^^^^^
@@ -514,6 +523,10 @@ All queries thus far have referenced concrete object types: ``Hero`` and
 ``Villain``. However, both of these types extend the abstract type ``Person``,
 from which they inherit the ``name`` property.
 
+To learn how to leverage polymorphism in your queries, see `our interactive
+polymorphism tutorial
+<https://www.edgedb.com/tutorial/nested-structures/polymorphism>`_.
+
 Polymorphic sets
 ^^^^^^^^^^^^^^^^
 
@@ -713,3 +726,13 @@ For full documentation on ``with``, see :ref:`EdgeQL > With <ref_eql_with>`.
   * - **See also**
   * - :ref:`Reference > Commands > Select <ref_eql_statements_select>`
   * - :ref:`Cheatsheets > Selecting data <ref_cheatsheet_select>`
+  * - `Tutorial > Basic Queries > Objects
+      <https://www.edgedb.com/tutorial/basic-queries/objects>`_
+  * - `Tutorial > Basic Queries > Filters
+      <https://www.edgedb.com/tutorial/basic-queries/config>`_
+  * - `Tutorial > Basic Queries > Aggregates
+      <https://www.edgedb.com/tutorial/basic-queries/aggregate-functions>`_
+  * - `Tutorial > Nested Structures > Shapes
+      <https://www.edgedb.com/tutorial/nested-structures/shapes>`_
+  * - `Tutorial > Nested Structures > Polymorphism
+      <https://www.edgedb.com/tutorial/nested-structures/polymorphism>`_

--- a/docs/edgeql/sets.rst
+++ b/docs/edgeql/sets.rst
@@ -449,3 +449,10 @@ Reference
   * - Cardinality assertion
     - :eql:func:`assert_distinct` :eql:func:`assert_single`
       :eql:func:`assert_exists`
+
+.. list-table::
+  :class: seealso
+
+  * - **See also**
+  * - `Tutorial > Building Blocks > Sets
+      <https://www.edgedb.com/tutorial/building-blocks/working-with-sets>`_

--- a/docs/edgeql/sets.rst
+++ b/docs/edgeql/sets.rst
@@ -455,4 +455,4 @@ Reference
 
   * - **See also**
   * - `Tutorial > Building Blocks > Sets
-      <https://www.edgedb.com/tutorial/building-blocks/working-with-sets>`_
+      </tutorial/building-blocks/working-with-sets>`_

--- a/docs/edgeql/types.rst
+++ b/docs/edgeql/types.rst
@@ -171,4 +171,4 @@ introspectable as instances of the ``schema::Type`` type. For a set of
 introspection examples, see :ref:`Guides > Introspection
 <ref_eql_introspection>`. To try introspection for yourself, see `our
 interactive introspection tutorial
-<https://www.edgedb.com/tutorial/advanced-edgeql/introspection>`_.
+</tutorial/advanced-edgeql/introspection>`_.

--- a/docs/edgeql/types.rst
+++ b/docs/edgeql/types.rst
@@ -169,4 +169,6 @@ Introspection
 The entire type system of EdgeDB is *stored inside EdgeDB*. All types are
 introspectable as instances of the ``schema::Type`` type. For a set of
 introspection examples, see :ref:`Guides > Introspection
-<ref_eql_introspection>`.
+<ref_eql_introspection>`. To try introspection for yourself, see `our
+interactive introspection tutorial
+<https://www.edgedb.com/tutorial/advanced-edgeql/introspection>`_.

--- a/docs/edgeql/update.rst
+++ b/docs/edgeql/update.rst
@@ -121,4 +121,4 @@ For documentation on performing *upsert* operations, see :ref:`EdgeQL > Insert
   * - :ref:`Reference > Commands > Update <ref_eql_statements_update>`
   * - :ref:`Cheatsheets > Updating data <ref_cheatsheet_update>`
   * - `Tutorial > Data Mutations > Update
-      <https://www.edgedb.com/tutorial/data-mutations/update>`_
+      </tutorial/data-mutations/update>`_

--- a/docs/edgeql/update.rst
+++ b/docs/edgeql/update.rst
@@ -120,3 +120,5 @@ For documentation on performing *upsert* operations, see :ref:`EdgeQL > Insert
 
   * - :ref:`Reference > Commands > Update <ref_eql_statements_update>`
   * - :ref:`Cheatsheets > Updating data <ref_cheatsheet_update>`
+  * - `Tutorial > Data Mutations > Update
+      <https://www.edgedb.com/tutorial/data-mutations/update>`_

--- a/docs/guides/cheatsheet/delete.rst
+++ b/docs/guides/cheatsheet/delete.rst
@@ -40,4 +40,4 @@ Alternative way to delete all reviews from a specific user:
   * - :ref:`EdgeQL > Delete <ref_eql_delete>`
   * - :ref:`Reference > Commands > Delete <ref_eql_statements_delete>`
   * - `Tutorial > Data Mutations > Delete
-      <https://www.edgedb.com/tutorial/data-mutations/delete>`_
+      </tutorial/data-mutations/delete>`_

--- a/docs/guides/cheatsheet/delete.rst
+++ b/docs/guides/cheatsheet/delete.rst
@@ -39,3 +39,5 @@ Alternative way to delete all reviews from a specific user:
   * - **See also**
   * - :ref:`EdgeQL > Delete <ref_eql_delete>`
   * - :ref:`Reference > Commands > Delete <ref_eql_statements_delete>`
+  * - `Tutorial > Data Mutations > Delete
+      <https://www.edgedb.com/tutorial/data-mutations/delete>`_

--- a/docs/guides/cheatsheet/functions.rst
+++ b/docs/guides/cheatsheet/functions.rst
@@ -57,5 +57,5 @@ Define and use polymorphic function:
   * - :ref:`Reference > Function calls <ref_reference_function_call>`
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - `Tutorial > Advanced EdgeQL > User-Defined Functions
-      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
+      </tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/guides/cheatsheet/functions.rst
+++ b/docs/guides/cheatsheet/functions.rst
@@ -56,4 +56,6 @@ Define and use polymorphic function:
   * - :ref:`DDL > Functions <ref_eql_ddl_functions>`
   * - :ref:`Reference > Function calls <ref_reference_function_call>`
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
+  * - `Tutorial > Advanced EdgeQL > User-Defined Functions
+      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/guides/cheatsheet/index.rst
+++ b/docs/guides/cheatsheet/index.rst
@@ -9,7 +9,7 @@ Cheatsheets
 Just getting started? Keep an eye on this collection of cheatsheets with
 handy examples for what you'll need to get started with EdgeDB.
 After familiarizing yourself with them, feel free to dive into more EdgeDB
-via our longer `interactive tutorial <https://www.edgedb.com/tutorial>`_ and
+via our longer `interactive tutorial </tutorial>`_ and
 **much** longer `Easy EdgeDB textbook </easy-edgedb>`_.
 
 EdgeQL:

--- a/docs/guides/cheatsheet/insert.rst
+++ b/docs/guides/cheatsheet/insert.rst
@@ -206,3 +206,7 @@ inserting nested structures:
   * - **See also**
   * - :ref:`EdgeQL > Insert <ref_eql_insert>`
   * - :ref:`Reference > Commands > Insert <ref_eql_statements_insert>`
+  * - `Tutorial > Data Mutations > Insert
+      <https://www.edgedb.com/tutorial/data-mutations/insert>`_
+  * - `Tutorial > Data Mutations > Upsert
+      <https://www.edgedb.com/tutorial/data-mutations/upsert>`_

--- a/docs/guides/cheatsheet/insert.rst
+++ b/docs/guides/cheatsheet/insert.rst
@@ -207,6 +207,6 @@ inserting nested structures:
   * - :ref:`EdgeQL > Insert <ref_eql_insert>`
   * - :ref:`Reference > Commands > Insert <ref_eql_statements_insert>`
   * - `Tutorial > Data Mutations > Insert
-      <https://www.edgedb.com/tutorial/data-mutations/insert>`_
+      </tutorial/data-mutations/insert>`_
   * - `Tutorial > Data Mutations > Upsert
-      <https://www.edgedb.com/tutorial/data-mutations/upsert>`_
+      </tutorial/data-mutations/upsert>`_

--- a/docs/guides/cheatsheet/select.rst
+++ b/docs/guides/cheatsheet/select.rst
@@ -225,3 +225,13 @@ instead of the named tuple if no ``matches`` are found.
   * - **See also**
   * - :ref:`EdgeQL > Select <ref_eql_select>`
   * - :ref:`Reference > Commands > Select <ref_eql_statements_select>`
+  * - `Tutorial > Basic Queries > Objects
+      <https://www.edgedb.com/tutorial/basic-queries/objects>`_
+  * - `Tutorial > Basic Queries > Filters
+      <https://www.edgedb.com/tutorial/basic-queries/config>`_
+  * - `Tutorial > Basic Queries > Aggregates
+      <https://www.edgedb.com/tutorial/basic-queries/aggregate-functions>`_
+  * - `Tutorial > Nested Structures > Shapes
+      <https://www.edgedb.com/tutorial/nested-structures/shapes>`_
+  * - `Tutorial > Nested Structures > Polymorphism
+      <https://www.edgedb.com/tutorial/nested-structures/polymorphism>`_

--- a/docs/guides/cheatsheet/select.rst
+++ b/docs/guides/cheatsheet/select.rst
@@ -226,12 +226,12 @@ instead of the named tuple if no ``matches`` are found.
   * - :ref:`EdgeQL > Select <ref_eql_select>`
   * - :ref:`Reference > Commands > Select <ref_eql_statements_select>`
   * - `Tutorial > Basic Queries > Objects
-      <https://www.edgedb.com/tutorial/basic-queries/objects>`_
+      </tutorial/basic-queries/objects>`_
   * - `Tutorial > Basic Queries > Filters
-      <https://www.edgedb.com/tutorial/basic-queries/config>`_
+      </tutorial/basic-queries/config>`_
   * - `Tutorial > Basic Queries > Aggregates
-      <https://www.edgedb.com/tutorial/basic-queries/aggregate-functions>`_
+      </tutorial/basic-queries/aggregate-functions>`_
   * - `Tutorial > Nested Structures > Shapes
-      <https://www.edgedb.com/tutorial/nested-structures/shapes>`_
+      </tutorial/nested-structures/shapes>`_
   * - `Tutorial > Nested Structures > Polymorphism
-      <https://www.edgedb.com/tutorial/nested-structures/polymorphism>`_
+      </tutorial/nested-structures/polymorphism>`_

--- a/docs/guides/cheatsheet/update.rst
+++ b/docs/guides/cheatsheet/update.rst
@@ -154,4 +154,4 @@ Update the ``list_order`` link property for a specific link:
   * - :ref:`EdgeQL > Update <ref_eql_update>`
   * - :ref:`Reference > Commands > Update <ref_eql_statements_update>`
   * - `Tutorial > Data Mutations > Update
-      <https://www.edgedb.com/tutorial/data-mutations/update>`_
+      </tutorial/data-mutations/update>`_

--- a/docs/guides/cheatsheet/update.rst
+++ b/docs/guides/cheatsheet/update.rst
@@ -153,3 +153,5 @@ Update the ``list_order`` link property for a specific link:
   * - **See also**
   * - :ref:`EdgeQL > Update <ref_eql_update>`
   * - :ref:`Reference > Commands > Update <ref_eql_statements_update>`
+  * - `Tutorial > Data Mutations > Update
+      <https://www.edgedb.com/tutorial/data-mutations/update>`_

--- a/docs/reference/ddl/constraints.rst
+++ b/docs/reference/ddl/constraints.rst
@@ -472,4 +472,4 @@ Remove constraint "min_value" from the property "score" of the
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
   * - :ref:`Standard Library > Constraints <ref_std_constraints>`
   * - `Tutorial > Advanced EdgeQL > Constraints
-      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_
+      </tutorial/advanced-edgeql/constraints>`_

--- a/docs/reference/ddl/constraints.rst
+++ b/docs/reference/ddl/constraints.rst
@@ -471,3 +471,5 @@ Remove constraint "min_value" from the property "score" of the
   * - :ref:`SDL > Constraints <ref_eql_sdl_constraints>`
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
   * - :ref:`Standard Library > Constraints <ref_std_constraints>`
+  * - `Tutorial > Advanced EdgeQL > Constraints
+      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_

--- a/docs/reference/ddl/functions.rst
+++ b/docs/reference/ddl/functions.rst
@@ -273,4 +273,5 @@ Remove the ``mysum`` function:
   * - :ref:`Reference > Function calls <ref_reference_function_call>`
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
-
+  * - `Tutorial > Advanced EdgeQL > User-Defined Functions
+      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_

--- a/docs/reference/ddl/functions.rst
+++ b/docs/reference/ddl/functions.rst
@@ -274,4 +274,4 @@ Remove the ``mysum`` function:
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
   * - `Tutorial > Advanced EdgeQL > User-Defined Functions
-      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
+      </tutorial/advanced-edgeql/user-def-functions>`_

--- a/docs/reference/edgeql/functions.rst
+++ b/docs/reference/edgeql/functions.rst
@@ -53,4 +53,6 @@ default value:
   * - :ref:`DDL > Functions <ref_eql_ddl_functions>`
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
+  * - `Tutorial > Advanced EdgeQL > User-Defined Functions
+      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/reference/edgeql/functions.rst
+++ b/docs/reference/edgeql/functions.rst
@@ -54,5 +54,5 @@ default value:
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
   * - `Tutorial > Advanced EdgeQL > User-Defined Functions
-      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
+      </tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/reference/sdl/constraints.rst
+++ b/docs/reference/sdl/constraints.rst
@@ -153,4 +153,4 @@ The valid SDL sub-declarations are listed below:
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
   * - :ref:`Standard Library > Constraints <ref_std_constraints>`
   * - `Tutorial > Advanced EdgeQL > Constraints
-      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_
+      </tutorial/advanced-edgeql/constraints>`_

--- a/docs/reference/sdl/constraints.rst
+++ b/docs/reference/sdl/constraints.rst
@@ -152,3 +152,5 @@ The valid SDL sub-declarations are listed below:
   * - :ref:`DDL > Constraints <ref_eql_ddl_constraints>`
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
   * - :ref:`Standard Library > Constraints <ref_std_constraints>`
+  * - `Tutorial > Advanced EdgeQL > Constraints
+      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_

--- a/docs/reference/sdl/functions.rst
+++ b/docs/reference/sdl/functions.rst
@@ -181,5 +181,5 @@ are called *overloaded functions*.
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
   * - `Tutorial > Advanced EdgeQL > User-Defined Functions
-      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
+      </tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/reference/sdl/functions.rst
+++ b/docs/reference/sdl/functions.rst
@@ -180,4 +180,6 @@ are called *overloaded functions*.
   * - :ref:`Reference > Function calls <ref_reference_function_call>`
   * - :ref:`Introspection > Functions <ref_eql_introspection_functions>`
   * - :ref:`Cheatsheets > Functions <ref_cheatsheet_functions>`
+  * - `Tutorial > Advanced EdgeQL > User-Defined Functions
+      <https://www.edgedb.com/tutorial/advanced-edgeql/user-def-functions>`_
 

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -205,4 +205,4 @@ Constraints
   * - :ref:`DDL > Constraints <ref_eql_ddl_constraints>`
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
   * - `Tutorial > Advanced EdgeQL > Constraints
-      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_
+      </tutorial/advanced-edgeql/constraints>`_

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -204,3 +204,5 @@ Constraints
   * - :ref:`SDL > Constraints <ref_eql_sdl_constraints>`
   * - :ref:`DDL > Constraints <ref_eql_ddl_constraints>`
   * - :ref:`Introspection > Constraints <ref_eql_introspection_constraints>`
+  * - `Tutorial > Advanced EdgeQL > Constraints
+      <https://www.edgedb.com/tutorial/advanced-edgeql/constraints>`_


### PR DESCRIPTION
This was inspired by a Discord member who suggested we link to the [upsert tutorial](https://www.edgedb.com/tutorial/data-mutations/upsert) from the appropriate page and section in the documentation. I took the opportunity to liberally add links from documentation pages to related tutorials.