### PR TITLE
Fix backlinks on derived union types

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -706,8 +706,10 @@ def resolve_ptr_with_intersections(
                     ref.get_target(ctx.env.schema), ctx=ctx)
 
     else:
-        ptrs = near_endpoint.getrptrs(ctx.env.schema, pointer_name,
-                                      sources=far_endpoints)
+        assert isinstance(near_endpoint, s_types.Type)
+        concrete_near_endpoint = schemactx.concretify(near_endpoint, ctx=ctx)
+        ptrs = concrete_near_endpoint.getrptrs(
+            ctx.env.schema, pointer_name, sources=far_endpoints)
         if ptrs:
             # If this reverse pointer access is followed by
             # intersections, we filter out any pointers that

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3854,3 +3854,17 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ''',
             [9],
         )
+
+    async def test_edgeql_scope_union_backlink_01(self):
+        await self.assert_query_result(
+            r'''
+                select {Card {name}, Card{element}} {name, owners: {name}}
+                filter .name = 'Djinn';
+            ''',
+            [
+                {"name": "Djinn", "owners": [
+                    {"name": "Carol"}, {"name": "Dave"}]},
+                {"name": "Djinn", "owners": [
+                    {"name": "Carol"}, {"name": "Dave"}]}
+            ],
+        )


### PR DESCRIPTION
We need to try to find the pointers on the concrete types instead.