### PR TITLE
Get rid of the "unused alias definition" error

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -186,16 +186,6 @@ class Environment:
 
     view_shapes_metadata: Dict[s_types.Type, irast.ViewShapeMetadata]
 
-    must_use_views: Dict[
-        s_types.Type,
-        Optional[Tuple[s_name.Name, Optional[parsing.ParserContext]]],
-    ]
-    """A set of views that *must* be used in an expression.
-
-    Once a view is used, we set it to None rather than removing it so
-    that we can avoid adding it again if it is defined inside a
-    computable."""
-
     schema_refs: Set[s_obj.Object]
     """A set of all schema objects referenced by an expression."""
 
@@ -299,7 +289,6 @@ class Environment:
         self.view_shapes = collections.defaultdict(list)
         self.view_shapes_metadata = collections.defaultdict(
             irast.ViewShapeMetadata)
-        self.must_use_views = {}
         self.schema_refs = set()
         self.schema_ref_exprs = {} if options.track_schema_ref_exprs else None
         self.created_schema_objects = set()

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -134,7 +134,6 @@ def _get_type_variant(
 ) -> Optional[s_obj.Object]:
     type_variant = ctx.aliased_views.get(name)
     if type_variant is not None:
-        ctx.env.must_use_views[type_variant] = None
         return type_variant
     else:
         return None

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1200,7 +1200,6 @@ def process_with_block(
                     with_entry.expr,
                     s_name.UnqualName(with_entry.alias),
                     binding_kind=irast.BindingKind.With,
-                    must_be_used=True,
                     ctx=scopectx,
                 )
                 results.append(binding)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -212,14 +212,6 @@ def fini_expression(
                 hint='Consider using an explicit type cast.',
                 context=ctx.env.type_origins.get(anytype))
 
-    must_use_views = [val for val in ctx.env.must_use_views.values() if val]
-    if must_use_views:
-        alias, srcctx = must_use_views[0]
-        raise errors.QueryError(
-            f'unused alias definition: {str(alias)!r}',
-            context=srcctx,
-        )
-
     # Clear out exprs that we decided to omit from the IR
     for ir_set in exprs_to_clear:
         ir_set.expr = None
@@ -631,7 +623,6 @@ def declare_view(
     *,
     factoring_fence: bool=False,
     fully_detached: bool=False,
-    must_be_used: bool=False,
     binding_kind: irast.BindingKind,
     path_id_namespace: Optional[FrozenSet[str]]=None,
     ctx: context.ContextLevel,
@@ -702,9 +693,6 @@ def declare_view(
         view_type = setgen.get_set_type(view_set, ctx=ctx)
         ctx.aliased_views[alias] = view_type
         ctx.env.expr_view_cache[expr, alias] = view_set
-
-        if must_be_used and view_type not in ctx.env.must_use_views:
-            ctx.env.must_use_views[view_type] = (alias, expr.context)
 
     return view_set
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -182,6 +182,32 @@ class TestInsert(tb.QueryTestCase):
             [{'num': 101}, {'num': 102}, {'num': 103}],
         )
 
+    async def test_edgeql_insert_unused_01(self):
+        await self.con.execute(r"""
+            with _ := (
+                INSERT InsertTest {
+                    name := 'insert simple 01',
+                    l2 := 0,
+                }
+            ), select 1;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT
+                    InsertTest {
+                        l2
+                    }
+                FILTER
+                    InsertTest.name = 'insert simple 01'
+            """,
+            [
+                {
+                    'l2': 0,
+                },
+            ]
+        )
+
     async def test_edgeql_insert_nested_01(self):
         await self.con.execute('''
             INSERT Subordinate {

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2773,30 +2773,13 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
     async def test_edgeql_scope_unused_with_def_01(self):
 
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r"unused alias definition: 'foo'",
-                _position=48):
-            await self.con.query("""\
-                WITH
-                    foo := 1
+        await self.assert_query_result(
+            """
+                WITH foo := 1
                 SELECT 1;
-            """)
-
-    async def test_edgeql_scope_unused_with_def_02(self):
-
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r"unused alias definition: 'foo'",
-                _position=48):
-            await self.con.query("""\
-                WITH
-                    foo := 1
-                SELECT (
-                    WITH foo := 2
-                    SELECT foo
-                )
-            """)
+            """,
+            [1]
+        )
 
     async def test_edgeql_scope_nested_computable_01(self):
         # This is a test for a bug where the outside filter would get


### PR DESCRIPTION
It makes incrementally debugging queries more annoying, makes writing
big DML queries where you don't care if you return the data harder,
and doesn't accomplish anything useful semantically.

We should just ditch it.