### PR TITLE
Add documentation for interactive shell commands

### DIFF
--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -143,34 +143,34 @@ many of the commands:
 - ``-s``- Show system objects
 - ``-c``- Case-sensitive pattern matching
 
-:cli:synopsis:`\\d [-v] NAME`
+:cli:synopsis:`\\d object [-v] NAME, \\describe object [-v] NAME`
   Describe schema object specified by *NAME*.
 
-:cli:synopsis:`\\ds, \\describe schema`
+:cli:synopsis:`\\ds, \\d schema, \\describe schema`
   Describe the entire schema.
 
 :cli:synopsis:`\\l, \\list databases`
   List databases.
 
-:cli:synopsis:`\\ls, \\list scalars [-sc] [PATTERN]`
+:cli:synopsis:`\\ls [-sc] [PATTERN], \\list scalars [-sc] [PATTERN]`
   List scalar types.
 
-:cli:synopsis:`\\lt, \\list types [-sc] [PATTERN]`
+:cli:synopsis:`\\lt [-sc] [PATTERN], \\list types [-sc] [PATTERN]`
   List object types.
 
-:cli:synopsis:`\\lr, \\list roles [-c] [PATTERN]`
+:cli:synopsis:`\\lr [-c] [PATTERN], \\list roles [-c] [PATTERN]`
   List roles.
 
-:cli:synopsis:`\\lm, \\list modules [-c] [PATTERN]`
+:cli:synopsis:`\\lm [-c] [PATTERN], \\list modules [-c] [PATTERN]`
   List modules.
 
-:cli:synopsis:`\\la, \\list aliases [-vsc] [PATTERN]`
+:cli:synopsis:`\\la [-vsc] [PATTERN], \\list aliases [-vsc] [PATTERN]`
   List expression aliases.
 
-:cli:synopsis:`\\lc, \\list casts [-c] [PATTERN]`
-  List casts.
+:cli:synopsis:`\\lc [-c] [PATTERN], \\list casts [-c] [PATTERN]`
+  List available conversions between types.
 
-:cli:synopsis:`\\li, \\list indexes [-vsc] [PATTERN]`
+:cli:synopsis:`\\li [-vsc] [PATTERN], \\list indexes [-vsc] [PATTERN]`
   List indexes.
 
 .. rubric:: Operations

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -173,6 +173,11 @@ many of the commands:
 :cli:synopsis:`\\li [-vsc] [PATTERN], \\list indexes [-vsc] [PATTERN]`
   List indexes.
 
+.. rubric:: Database
+
+:cli:synopsis:`\\database create [NAME]`
+  Create a new database.
+
 .. rubric:: Data Operations
 
 :cli:synopsis:`\\dump FILENAME`

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -141,7 +141,7 @@ many of the commands:
 
 - ``-v``- Verbose
 - ``-s``- Show system objects
-- ``-I``- Case-insensitive matching
+- ``-c``- Case-sensitive pattern matching
 
 :cli:synopsis:`\\d [-v] NAME`
   Describe schema object specified by *NAME*.
@@ -152,25 +152,25 @@ many of the commands:
 :cli:synopsis:`\\l, \\list databases`
   List databases.
 
-:cli:synopsis:`\\ls, \\list scalars [-sI] [PATTERN]`
+:cli:synopsis:`\\ls, \\list scalars [-sc] [PATTERN]`
   List scalar types.
 
-:cli:synopsis:`\\lt, \\list types [-sI] [PATTERN]`
+:cli:synopsis:`\\lt, \\list types [-sc] [PATTERN]`
   List object types.
 
-:cli:synopsis:`\\lr, \\list roles [PATTERN]`
+:cli:synopsis:`\\lr, \\list roles [-c] [PATTERN]`
   List roles.
 
-:cli:synopsis:`\\lm, \\list modules [PATTERN]`
+:cli:synopsis:`\\lm, \\list modules [-c] [PATTERN]`
   List modules.
 
-:cli:synopsis:`\\la, \\list aliases [-Isv] [PATTERN]`
+:cli:synopsis:`\\la, \\list aliases [-vsc] [PATTERN]`
   List expression aliases.
 
-:cli:synopsis:`\\lc, \\list casts [-I] [PATTERN]`
+:cli:synopsis:`\\lc, \\list casts [-c] [PATTERN]`
   List casts.
 
-:cli:synopsis:`\\li, \\list indexes [-Isv] [PATTERN]`
+:cli:synopsis:`\\li, \\list indexes [-vsc] [PATTERN]`
   List indexes.
 
 .. rubric:: Operations

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -131,8 +131,8 @@ Options
     value is ``10s``.
 
 
-Shell Commands
-==============
+Backslash Commands
+==================
 
 .. rubric:: Introspection
 

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -195,7 +195,6 @@ many of the commands:
 
   The output of this will then be used as input into the shell.
 
-
 .. rubric:: Settings
 
 :cli:synopsis:`\\set [OPTION [VALUE]]`

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -129,3 +129,85 @@ Options
     :cli:synopsis:`<timeout>` value must be given using time units
     (e.g. ``hr``, ``min``, ``sec``, ``ms``, etc.). The default
     value is ``10s``.
+
+
+Shell Commands
+==============
+
+.. rubric:: Introspection
+
+The introspection commands share a few common options that are available to
+many of the commands:
+
+- ``-v``- Verbose
+- ``-s``- Show system objects
+- ``-I``- Case-insensitive matching
+
+:cli:synopsis:`\\d [-v] NAME`
+  Describe schema object specified by *NAME*.
+
+:cli:synopsis:`\\ds, \\describe-schema`
+  Describe the entire schema.
+
+:cli:synopsis:`\\l, \\list databases`
+  List databases.
+
+:cli:synopsis:`\\ls, \\list scalars [-sI] [PATTERN]`
+  List scalar types.
+
+:cli:synopsis:`\\lt, \\list types [-sI] [PATTERN]`
+  List object types.
+
+:cli:synopsis:`\\lr, \\list roles [-I]`
+  List roles.
+
+:cli:synopsis:`\\lm, \\list modules [-I]`
+  List modules.
+
+:cli:synopsis:`\\la, \\list aliases [-Isv] [PATTERN]`
+  List expression aliases.
+
+:cli:synopsis:`\\lc, \\list casts [-I] [PATTERN]`
+  List casts.
+
+:cli:synopsis:`\\li, \\list indexes [-Isv] [PATTERN]`
+  List indexes.
+
+.. rubric:: Operations
+
+:cli:synopsis:`\\dump FILENAME`
+  Dump current database to a file at *FILENAME*.
+
+:cli:synopsis:`\\restore FILENAME`
+  Restore the database dump at *FILENAME* into the currently connected
+  database.
+
+.. rubric:: Editing
+
+:cli:synopsis:`\\s, \\history`
+  Show a history of commands executed in the shell.
+
+:cli:synopsis:`\\e, \\edit [N]`
+  Spawn ``$EDITOR`` to edit the most recent history entry or history entry *N*.
+  The output of this will then be used as input into the shell.
+
+
+.. rubric:: Settings
+
+:cli:synopsis:`\\set [OPTION [VALUE]]`
+  With *VALUE*, the option named by *OPTION* will be set to the provided value.
+  If *VALUE* is omitted, the command will show the current value of *OPTION*.
+  Use ``\set`` with no arguments for a listing of all available options.
+
+.. rubric:: Connection
+
+:cli:synopsis:`\\c, \\connect [DBNAME]`
+  Connect to database *DBNAME*.
+
+.. rubric:: Help
+
+:cli:synopsis:`\\?, \\h, \\help`
+  Show help on backslash commands.
+
+:cli:synopsis:`\\q, \\quit, \\exit`
+  Quit the REPL. You can also do this by pressing Ctrl+D.

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -208,6 +208,34 @@ many of the commands:
 :cli:synopsis:`\\c, \\connect [DBNAME]`
   Connect to database *DBNAME*.
 
+.. rubric:: Migrations
+
+These migration commands are also accessible directly from the command line
+without first entering the EdgeDB shell. Their counterpart commands are noted
+and linked in their descriptions if you want more detail.
+
+:cli:synopsis:`\\migration create`
+  Create a migration script based on differences between the current database
+  and the schema file, just like running
+  :ref:`ref_cli_edgedb_migration_create`.
+
+:cli:synopsis:`\\migrate, \\migration apply`
+  Apply your migration, just like running the
+  :ref:`ref_cli_edgedb_migrate`.
+
+:cli:synopsis:`\\migration edit`
+  Spawn ``$EDITOR`` on the last migration file and fixes the migration ID after
+  the editor exits, just like :ref:`ref_cli_edgedb_migration_edit`. This is
+  typically used only on migrations that have not yet been applied.
+
+:cli:synopsis:`\\migration log`
+  Show the migration history, just like :ref:`ref_cli_edgedb_migration_log`.
+
+:cli:synopsis:`\\migration status`
+  Show how the state of the schema in the EdgeDB instance compares to the
+  migration stored in the schema directory, just like
+  :ref:`ref_cli_edgedb_migration_status`.
+
 .. rubric:: Help
 
 :cli:synopsis:`\\?, \\h, \\help`

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -189,8 +189,9 @@ many of the commands:
 
 :cli:synopsis:`\\e, \\edit [N]`
   Spawn ``$EDITOR`` to edit the most recent history entry or history entry *N*.
-  History entries are negative indexed with `-1` being the most recent command.
-  Use the `\history` command (above) to see previous command indexes.
+  History entries are negative indexed with ``-1`` being the most recent
+  command. Use the ``\history`` command (above) to see previous command
+  indexes.
 
   The output of this will then be used as input into the shell.
 

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -189,6 +189,9 @@ many of the commands:
 
 :cli:synopsis:`\\e, \\edit [N]`
   Spawn ``$EDITOR`` to edit the most recent history entry or history entry *N*.
+  History entries are negative indexed with `-1` being the most recent command.
+  Use the `\history` command (above) to see previous command indexes.
+
   The output of this will then be used as input into the shell.
 
 

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -173,7 +173,7 @@ many of the commands:
 :cli:synopsis:`\\li [-vsc] [PATTERN], \\list indexes [-vsc] [PATTERN]`
   List indexes.
 
-.. rubric:: Operations
+.. rubric:: Data Operations
 
 :cli:synopsis:`\\dump FILENAME`
   Dump current database to a file at *FILENAME*.

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -158,10 +158,10 @@ many of the commands:
 :cli:synopsis:`\\lt, \\list types [-sI] [PATTERN]`
   List object types.
 
-:cli:synopsis:`\\lr, \\list roles [-I]`
+:cli:synopsis:`\\lr, \\list roles [PATTERN]`
   List roles.
 
-:cli:synopsis:`\\lm, \\list modules [-I]`
+:cli:synopsis:`\\lm, \\list modules [PATTERN]`
   List modules.
 
 :cli:synopsis:`\\la, \\list aliases [-Isv] [PATTERN]`

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -146,7 +146,7 @@ many of the commands:
 :cli:synopsis:`\\d [-v] NAME`
   Describe schema object specified by *NAME*.
 
-:cli:synopsis:`\\ds, \\describe-schema`
+:cli:synopsis:`\\ds, \\describe schema`
   Describe the entire schema.
 
 :cli:synopsis:`\\l, \\list databases`

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -198,8 +198,8 @@ many of the commands:
 .. rubric:: Settings
 
 :cli:synopsis:`\\set [OPTION [VALUE]]`
-  With *VALUE*, the option named by *OPTION* will be set to the provided value.
   If *VALUE* is omitted, the command will show the current value of *OPTION*.
+  With *VALUE*, the option named by *OPTION* will be set to the provided value.
   Use ``\set`` with no arguments for a listing of all available options.
 
 .. rubric:: Connection


### PR DESCRIPTION
A couple of questions I had on this as I was working through it:

1. Is "Shell Commands" the right name for this section? We refer to them in the help at one point as "backslash commands" so maybe that is better? Maybe "REPL commands"?
2. Is `:cli:synopsis:` the right way to render the commands? It leads to some questionable highlighting, but I notice the highlighting of the command options earlier on this page are also a little wonky.

Open to any other feedback as well.