### PR TITLE
Fix references to the enclosing type in schema-defined computeds

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1515,13 +1515,21 @@ def _get_schema_computed_ctx(
     @contextlib.contextmanager
     def newctx() -> Iterator[context.ContextLevel]:
         with ctx.detached() as subctx:
-            source_stype = get_set_type(source, ctx=ctx)
-
             source_scope = pathctx.get_set_scope(rptr.source, ctx=ctx)
             if source_scope and source_scope.namespaces:
                 subctx.path_id_namespace |= source_scope.namespaces
 
-            inner_path_id = pathctx.get_path_id(source_stype, ctx=subctx)
+            # Get the type of the actual location where the computed pointer
+            # was defined in the schema, since that is the type that must
+            # be used in the view map, since that is the type that might
+            # be *referenced in the definition*.
+            ptr = typegen.ptrcls_from_ptrref(rptr.ptrref, ctx=ctx)
+            assert isinstance(ptr, s_pointers.Pointer)
+            ptr = ptr.maybe_get_topmost_concrete_base(ctx.env.schema) or ptr
+
+            inner_path_id = not_none(irast.PathId.from_pointer(
+                ctx.env.schema, ptr, namespace=subctx.path_id_namespace,
+            ).src_path())
 
             remapped_source = new_set_from_set(
                 rptr.source,
@@ -1529,7 +1537,7 @@ def _get_schema_computed_ctx(
                 ctx=ctx,
             )
             key = inner_path_id.strip_namespace(inner_path_id.namespace)
-            subctx.view_map[key] = ((inner_path_id, remapped_source),)
+            update_view_map(inner_path_id, remapped_source, ctx=subctx)
 
             yield subctx
 

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3868,3 +3868,51 @@ class TestEdgeQLScope(tb.QueryTestCase):
                     {"name": "Carol"}, {"name": "Dave"}]}
             ],
         )
+
+    async def test_edgeql_scope_schema_computed_01(self):
+        await self.con.execute('''
+            alter type User
+            create link lcards := (
+                select Card filter Card.name[0] = User.name[0]);
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                with U := User,
+                select U { name } filter exists .lcards;
+            ''',
+            tb.bag([
+                {"name": "Bob"},
+                {"name": "Dave"},
+            ]),
+        )
+
+        await self.assert_query_result(
+            r'''
+                select Bot { lcards: {name} }
+            ''',
+            [
+                {
+                    "lcards": tb.bag([
+                        {"name": "Dragon"},
+                        {"name": "Dwarf"},
+                        {"name": "Djinn"}
+                    ])
+                }
+            ]
+        )
+
+    async def test_edgeql_scope_schema_computed_02(self):
+        await self.con.execute('''
+            alter type Named
+            create property foo := count(User)
+        ''')
+
+        # Make sure that 'User' doesn't get captured when evaluating
+        # the schema computed here.
+        await self.assert_query_result(
+            r'''
+                select User { foo }
+            ''',
+            [{'foo': 4}, {'foo': 4}, {'foo': 4}, {'foo': 4}]
+        )


### PR DESCRIPTION
Currently, a reference to the enclosing type will sometimes fail to
bind correctly to the source, including when the source is a
WITH-bound alias or when the source is a sub type of the original type.

Fixes #4820. Fixes #4142 for computeds.