### PR TITLE
Pin the CLI to the last working version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ RUST_VERSION = '1.59.0'  # Also update docs/internal/dev.rst
 
 EDGEDBCLI_REPO = 'https://github.com/edgedb/edgedb-cli'
 # This can be a branch, tag, or commit
-EDGEDBCLI_COMMIT = 'master'
+EDGEDBCLI_COMMIT = '96af7430373f817603e7531672a1b597a61fd087'
 
 EDGEDBGUI_REPO = 'https://github.com/edgedb/edgedb-studio.git'
 # This can be a branch, tag, or commit


### PR DESCRIPTION
It looks like https://github.com/edgedb/edgedb-cli/pull/905 broke
CI somehow.

Pin it back for now