### PR TITLE
Instruct readers to install generator

### DIFF
--- a/docs/guides/tutorials/nextjs.rst
+++ b/docs/guides/tutorials/nextjs.rst
@@ -365,7 +365,13 @@ typed EdgeQL queries easy and painless. The result type of our queries will be
 automatically inferred, so we won't need to manually type something like
 ``type Post = { id: string; ... }``.
 
-Generate the query builder with the following command.
+First, install the generator to your project.
+
+.. code-block:: bash
+
+  $ yarn add @edgedb/generate
+
+Then generate the query builder with the following command.
 
 .. code-block:: bash
 

--- a/docs/guides/tutorials/nextjs.rst
+++ b/docs/guides/tutorials/nextjs.rst
@@ -369,7 +369,7 @@ First, install the generator to your project.
 
 .. code-block:: bash
 
-  $ yarn add @edgedb/generate
+  $ yarn add --dev @edgedb/generate
 
 Then generate the query builder with the following command.
 


### PR DESCRIPTION
`npx` running a remote package will continue to run the cached version, presumably until the cached version is deleted or until a version is specified. We want the user to manage the generator version alongside their other dependencies instead.

See Slack discussion: https://edgedb.slack.com/archives/CNECHA9EW/p1671488065449729