### PR TITLE
Note volatile ops prohibited in schema computables

### DIFF
--- a/docs/datamodel/computeds.rst
+++ b/docs/datamodel/computeds.rst
@@ -33,6 +33,14 @@ field is referenced in a query.
   For more information, see the :ref:`EdgeQL > Select > Computeds
   <ref_eql_select_computeds>`.
 
+.. warning::
+
+  Volatile functions are not allowed in computed properties defined in schema.
+  This means that, for example, your schema-defined computed property cannot
+  call :eql:func:`datetime_current`, but it *can* call
+  :eql:func:`datetime_of_transaction` or :eql:func:`datetime_of_statement`.
+  This does *not* apply to computed properties outside of schema.
+
 .. _ref_dot_notation:
 
 Leading dot notation
@@ -121,6 +129,28 @@ The ``User.blog_posts`` expression above uses the *backlink operator* ``.<`` in
 conjunction with a *type filter* ``[is BlogPost]`` to fetch all the
 ``BlogPosts`` associated with a given ``User``. For details on this syntax, see
 the EdgeQL docs for :ref:`Backlinks <ref_eql_paths_backlinks>`.
+
+Created Timestamp
+^^^^^^^^^^^^^^^^^
+
+Using a computed property, you can timestamp when an object was created in your
+database.
+
+.. code-block:: sdl
+
+  type BlogPost {
+    property title -> str;
+    link author -> User;
+    required property created_at -> datetime {
+      readonly := true;
+      default := datetime_of_statement();
+    }
+  }
+
+When a ``BlogPost`` is created, :eql:func:`datetime_of_statement` will be
+called to supply it with a timestamp as the ``created_at`` property. You might
+also consider :eql:func:`datetime_of_transaction` if that's better suited to
+your use case.
 
 
 .. list-table::

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -668,8 +668,8 @@ EdgeDB stores and outputs timezone-aware values in UTC.
 
     This function is non-volatile since it returns the current time when the
     transaction is started, not when the function is called. As a result, it
-    can be used in :ref:`computed properties <ref_datamodel_computed>`, even
-    when they are defined in schema.
+    can be used in :ref:`computed properties <ref_datamodel_computed>` defined
+    in schema.
 
 ----------
 
@@ -682,8 +682,8 @@ EdgeDB stores and outputs timezone-aware values in UTC.
 
     This function is non-volatile since it returns the current time when the
     statement is started, not when the function is called. As a result, it
-    can be used in :ref:`computed properties <ref_datamodel_computed>`, even
-    when they are defined in schema.
+    can be used in :ref:`computed properties <ref_datamodel_computed>` defined
+    in schema.
 
 ----------
 

--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -652,6 +652,10 @@ EdgeDB stores and outputs timezone-aware values in UTC.
         db> select datetime_current();
         {<datetime>'2018-05-14T20:07:11.755827Z'}
 
+    This function is volatile since it always returns the current time when it
+    is called. As a result, it cannot be used in :ref:`computed properties
+    defined in schema <ref_datamodel_computed>`. This does *not* apply to
+    computed properties outside of schema.
 
 ----------
 
@@ -662,6 +666,10 @@ EdgeDB stores and outputs timezone-aware values in UTC.
 
     Return the date and time of the start of the current transaction.
 
+    This function is non-volatile since it returns the current time when the
+    transaction is started, not when the function is called. As a result, it
+    can be used in :ref:`computed properties <ref_datamodel_computed>`, even
+    when they are defined in schema.
 
 ----------
 
@@ -672,6 +680,10 @@ EdgeDB stores and outputs timezone-aware values in UTC.
 
     Return the date and time of the start of the current statement.
 
+    This function is non-volatile since it returns the current time when the
+    statement is started, not when the function is called. As a result, it
+    can be used in :ref:`computed properties <ref_datamodel_computed>`, even
+    when they are defined in schema.
 
 ----------
 


### PR DESCRIPTION
This is a common area of user confusion, particularly when trying to created timestamp properties. Hoping to better expose https://github.com/edgedb/edgedb/issues/2467 to users.