### PR TITLE
fix: alter abstract pointer set default

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -333,12 +333,6 @@ class CreateLink(
         if isinstance(astnode, qlast.CreateConcreteLink):
             assert isinstance(cmd, pointers.PointerCommand)
             cmd._process_create_or_alter_ast(schema, astnode, context)
-        else:
-            # this is an abstract property then
-            if cmd.get_attribute_value('default') is not None:
-                raise errors.SchemaDefinitionError(
-                    f"'default' is not a valid field for an abstract link",
-                    context=astnode.context)
         assert isinstance(cmd, sd.Command)
         return cmd
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1404,14 +1404,16 @@ class PointerCommandOrFragment(
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
     ) -> s_expr.CompiledExpression:
+
         if field.name in {'default', 'expr'}:
-            parent_ctx = self.get_referrer_context_or_die(context)
-            source = parent_ctx.op.get_object(schema, context)
-            parent_vname = source.get_verbosename(schema)
-            ptr_name = self.get_verbosename(parent=parent_vname)
-            in_ddl_context_name = None
             if field.name == 'expr':
+                parent_ctx = self.get_referrer_context_or_die(context)
+                source = parent_ctx.op.get_object(schema, context)
+                parent_vname = source.get_verbosename(schema)
+                ptr_name = self.get_verbosename(parent=parent_vname)
                 in_ddl_context_name = f'computed {ptr_name}'
+            else:
+                in_ddl_context_name = None
 
             return self._compile_expr(
                 schema,
@@ -1717,10 +1719,19 @@ class PointerCommand(
         context: sd.CommandContext,
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        assert isinstance(cmd, PointerCommand)
+
         referrer_ctx = cls.get_referrer_context(context)
         if referrer_ctx is not None:
             if getattr(astnode, 'declared_overloaded', False):
                 cmd.set_attribute_value('declared_overloaded', True)
+        else:
+            # This is an abstract propery/link
+            if cmd.get_attribute_value('default') is not None:
+                typ = cls.get_schema_metaclass().get_schema_class_displayname()
+                raise errors.SchemaDefinitionError(
+                    f"'default' is not a valid field for an abstract {typ}",
+                    context=astnode.context)
         return cmd
 
     def _process_create_or_alter_ast(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1726,7 +1726,7 @@ class PointerCommand(
             if getattr(astnode, 'declared_overloaded', False):
                 cmd.set_attribute_value('declared_overloaded', True)
         else:
-            # This is an abstract propery/link
+            # This is an abstract property/link
             if cmd.get_attribute_value('default') is not None:
                 typ = cls.get_schema_metaclass().get_schema_class_displayname()
                 raise errors.SchemaDefinitionError(

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -292,12 +292,6 @@ class CreateProperty(
         if isinstance(astnode, qlast.CreateConcreteProperty):
             assert isinstance(cmd, pointers.PointerCommand)
             cmd._process_create_or_alter_ast(schema, astnode, context)
-        else:
-            # this is an abstract property then
-            if cmd.get_attribute_value('default') is not None:
-                raise errors.SchemaDefinitionError(
-                    f"'default' is not a valid field for an abstract property",
-                    context=astnode.context)
 
         return cmd
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3495,6 +3495,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     };
                 """)
 
+    async def test_edgeql_ddl_link_bad_04(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                f"'default' is not a valid field for an abstract link"):
+            async with self.con.transaction():
+                await self.migrate("""
+                    abstract link bar {
+                        default := Object;
+                    };
+                """)
+
     async def test_edgeql_ddl_property_long_01(self):
         prop_name = (
             'f123456789_123456789_123456789_123456789'
@@ -3531,6 +3542,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 await self.con.execute("""
                     CREATE ABSTRACT PROPERTY bar {
                         SET default := 'bad';
+                    };
+                """)
+
+    async def test_edgeql_ddl_property_bad_04(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                f"'default' is not a valid field for an abstract property"):
+            async with self.con.transaction():
+                await self.migrate("""
+                    abstract property currency_fallback {
+                        default := 'EUR';
                     };
                 """)
 


### PR DESCRIPTION
Closes #4837

The problem was in that when creating a property with an enum default, CreateProperty command is split into two: CreateProperty & AlterProperty set default. Because the check for default on abstract pointers was implemented on CreateProperty, it was not throwing when default was added via AlterProperty.

This commit moves the check to PointerCommand - unifies Property & Link and Create & Alter.