### PR TITLE
An initial take on EXPLAIN

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -109,6 +109,9 @@ class flags(metaclass=FlagsMeta):
     edgeql_compile_sql_reordered_text = Flag(
         doc="Dump generated SQL-like text that might better reflect scoping.")
 
+    edgeql_explain = Flag(
+        doc="Dump extra debug info when doing EXPLAIN")
+
     edgeql_disable_normalization = Flag(
         doc="Disable EdgeQL normalization (constant extraction etc)")
 

--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -6,6 +6,7 @@ pub const UNRESERVED_KEYWORDS: &[&str] = &[
     "alias",
     "allow",
     "all",
+    "analyze",
     "annotation",
     "applied",
     "as",
@@ -117,7 +118,6 @@ pub const PARTIAL_RESERVED_KEYWORDS: &[&str] = &[
 
 pub const FUTURE_RESERVED_KEYWORDS: &[&str] = &[
     // Keep in sync with `tokenizer::is_keyword`
-    "analyze",
     "anyarray",
     "begin",
     "case",
@@ -126,7 +126,6 @@ pub const FUTURE_RESERVED_KEYWORDS: &[&str] = &[
     "discard",
     "end",
     "execute",
-    "explain",
     "fetch",
     "get",
     "global",
@@ -181,6 +180,7 @@ pub const CURRENT_RESERVED_KEYWORDS: &[&str] = &[
     "drop",
     "else",
     "exists",
+    "explain",
     "extending",
     "false",
     "filter",

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -902,6 +902,7 @@ pub fn is_keyword(s: &str) -> bool {
         | "drop"
         | "else"
         | "exists"
+        | "explain"
         | "extending"
         | "false"
         | "filter"
@@ -932,7 +933,6 @@ pub fn is_keyword(s: &str) -> bool {
           // Keep in sync with keywords::CURRENT_RESERVED_KEYWORDS
         // # Future reserved keywords #
           // Keep in sync with keywords::FUTURE_RESERVED_KEYWORDS
-        | "analyze"
         | "anyarray"
         | "begin"
         | "case"
@@ -941,7 +941,6 @@ pub fn is_keyword(s: &str) -> bool {
         | "discard"
         | "end"
         | "execute"
-        | "explain"
         | "fetch"
         | "get"
         | "global"

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1470,6 +1470,16 @@ class DescribeStmt(Statement):
 
 
 #
+# Explain
+#
+
+class ExplainStmt(Statement):
+
+    query: Query
+    analyze: bool
+
+
+#
 # SDL
 #
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -484,7 +484,8 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
 
             try:
                 path_tip = type_intersection_set(
-                    path_tip, typ, optional=False, ctx=ctx)
+                    path_tip, typ, optional=False, source_context=step.context,
+                    ctx=ctx)
             except errors.SchemaError as e:
                 e.set_source_context(step.type.context)
                 raise
@@ -843,7 +844,8 @@ def extend_path(
             if not stype.issubclass(ctx.env.schema, source):
                 # Polymorphic link reference
                 source_set = type_intersection_set(
-                    source_set, source, optional=True, ctx=ctx)
+                    source_set, source, optional=True, source_context=srcctx,
+                    ctx=ctx)
 
         src_path_id = source_set.path_id
 
@@ -1079,6 +1081,7 @@ def type_intersection_set(
     stype: s_types.Type,
     *,
     optional: bool,
+    source_context: Optional[parsing.ParserContext] = None,
     ctx: context.ContextLevel,
 ) -> irast.Set:
     """Return an interesection of *source_set* with type *stype*."""
@@ -1089,7 +1092,7 @@ def type_intersection_set(
     if result.stype == arg_type:
         return source_set
 
-    poly_set = new_set(stype=result.stype, ctx=ctx)
+    poly_set = new_set(stype=result.stype, context=source_context, ctx=ctx)
     rptr = source_set.rptr
     rptr_specialization = []
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -313,6 +313,10 @@ def _process_view(
                 ptrref=not_none(ptr_set.path_id.rptr()),
                 is_definition=True,
             )
+            # XXX: We would maybe like to *not* do this when it
+            # already has a context, since for explain output that
+            # seems nicer, but this is what we want for producing
+            # actual error messages.
             ptr_set.context = srcctx
 
             _setup_shape_source(ptr_set, ctx=ctx)
@@ -1178,6 +1182,9 @@ def _normalize_view_ptr_expr(
 
         ctx.env.schema = ptrcls.set_field_value(
             ctx.env.schema, 'cardinality', qltypes.SchemaCardinality.Unknown)
+
+    if irexpr and not irexpr.context:
+        irexpr.context = shape_el.context
 
     return ptrcls, irexpr
 

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -41,6 +41,10 @@ class Stmt(Nonterm):
         # DESCRIBE
         self.val = kids[0].val
 
+    def reduce_ExplainStmt(self, *kids):
+        # Explain
+        self.val = kids[0].val
+
     def reduce_ExprStmt(self, *kids):
         self.val = kids[0].val
 
@@ -250,4 +254,21 @@ class DescribeStmt(Nonterm):
 
         self.val = qlast.DescribeCurrentMigration(
             language=lang,
+        )
+
+
+class OptAnalyze(Nonterm):
+    def reduce_ANALYZE(self, *kids):
+        self.val = True
+
+    def reduce_empty(self, *kids):
+        self.val = False
+
+
+class ExplainStmt(Nonterm):
+
+    def reduce_EXPLAIN_OptAnalyze_ExprStmt(self, *kids):
+        self.val = qlast.ExplainStmt(
+            analyze=kids[1].val,
+            query=kids[2].val,
         )

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -1178,6 +1178,14 @@ def trace_DescribeStmt(
 
 
 @trace.register
+def trace_ExplainStmt(
+    node: qlast.ExplainStmt, *,
+    ctx: TracerContext,
+) -> None:
+    pass
+
+
+@trace.register
 def trace_Placeholder(
     node: qlast.Placeholder,
     *,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -101,6 +101,19 @@ class Base(ast.AST):
         )
 
 
+# DEBUG: Probably don't actually keep this forever?
+@markup.serializer.serializer.register(Base)
+def _serialize_to_markup_base(
+        ir: Base, *, ctx: typing.Any) -> typing.Any:
+    node = ast.serialize_to_markup(ir, ctx=ctx)
+    has_context = bool(ir.context)
+    node.add_child(
+        label='has_context', node=markup.serialize(has_context, ctx=ctx))
+    child = node.children.pop()
+    node.children.insert(1, child)
+    return node
+
+
 class ImmutableBase(ast.ImmutableASTMixin, Base):
     __abstract_node__ = True
 

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -124,6 +124,18 @@ class PathId:
 
         self._hash = -1
 
+    def __getstate__(self) -> Any:
+        # We need to omit the cached _hash when we pickle because it won't
+        # be correct in a different process.
+        return tuple([
+            getattr(self, k) if k != '_hash' else -1
+            for k in PathId.__slots__
+        ])
+
+    def __setstate__(self, state: Any) -> None:
+        for k, v in zip(PathId.__slots__, state):
+            setattr(self, k, v)
+
     @classmethod
     def from_type(
         cls,

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -297,7 +297,7 @@ def type_to_typeref(
                 base_typeref = None
             else:
                 assert isinstance(base_type, s_types.Type)
-                base_typeref = _typeref(base_type)
+                base_typeref = _typeref(base_type, include_children=False)
         else:
             base_typeref = None
 

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -536,7 +536,8 @@ def ptrref_from_ptrcls(  # NoQA: F811
     target = ptrcls.get_target(schema)
     if target is not None and not isinstance(target, irast.TypeRef):
         assert isinstance(target, s_types.Type)
-        target_ref = type_to_typeref(schema, target, cache=typeref_cache)
+        target_ref = type_to_typeref(
+            schema, target, include_children=True, cache=typeref_cache)
     else:
         target_ref = target
 

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -194,7 +194,8 @@ class BaseRangeVar(ImmutableBaseExpr):
     This can be though as a specific instance of a table within a query.
     """
 
-    __ast_meta__ = {'schema_object_id', 'tag'}
+    __ast_meta__ = {'schema_object_id', 'tag', 'ir_origins'}
+    __ast_mutable_fields__ = frozenset(['ir_origins'])
 
     # This is a hack, since there is some code that relies on not
     # having an alias on a range var (to refer to a CTE directly, for
@@ -208,6 +209,12 @@ class BaseRangeVar(ImmutableBaseExpr):
 
     #: Optional identification piece to describe what's inside the rvar
     tag: typing.Optional[str] = None
+
+    #: Optional reference to the sets that this refers to
+    #: Only used for helping recover information during explain.
+    #: The type is a list of objects to help prevent any thought
+    #: of using this field computationally during compilation.
+    ir_origins: typing.Optional[list[object]] = None
 
     def __repr__(self) -> str:
         return (

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -132,13 +132,18 @@ class EdgeQLPathInfo(Base):
 
     # Ignore the below fields in AST visitor/transformer.
     __ast_meta__ = {
-        'path_scope', 'path_outputs', 'path_id', 'is_distinct',
+        'path_id', 'path_scope_id',
+        'path_scope', 'path_outputs', 'is_distinct',
         'path_id_mask', 'path_namespace',
         'packed_path_outputs', 'packed_path_namespace',
     }
 
     # The path id represented by the node.
     path_id: typing.Optional[irast.PathId] = None
+
+    # The active path scope tree id for this node. This is purely to help
+    # map back to IR for EXPLAIN.
+    path_scope_id: typing.Optional[int] = None
 
     # Whether the node represents a distinct set.
     is_distinct: bool = True

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -132,18 +132,13 @@ class EdgeQLPathInfo(Base):
 
     # Ignore the below fields in AST visitor/transformer.
     __ast_meta__ = {
-        'path_id', 'path_scope_id',
-        'path_scope', 'path_outputs', 'is_distinct',
+        'path_id', 'path_scope', 'path_outputs', 'is_distinct',
         'path_id_mask', 'path_namespace',
         'packed_path_outputs', 'packed_path_namespace',
     }
 
     # The path id represented by the node.
     path_id: typing.Optional[irast.PathId] = None
-
-    # The active path scope tree id for this node. This is purely to help
-    # map back to IR for EXPLAIN.
-    path_scope_id: typing.Optional[int] = None
 
     # Whether the node represents a distinct set.
     is_distinct: bool = True

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -143,7 +143,7 @@ def compile_ir_to_sql_tree(
     return (qtree, env)
 
 
-def compile_ir_to_sql(
+def compile_ir_to_tree_and_sql(
     ir_expr: irast.Base, *,
     output_format: Optional[OutputFormat]=None,
     ignore_shapes: bool=False,
@@ -154,7 +154,7 @@ def compile_ir_to_sql(
     expand_inhviews: bool = False,
     pretty: bool=True,
     backend_runtime_params: Optional[pgparams.BackendRuntimeParams]=None,
-) -> Tuple[str, Dict[str, pgast.Param]]:
+) -> Tuple[pgast.Base, str, Dict[str, pgast.Param]]:
 
     qtree, _ = compile_ir_to_sql_tree(
         ir_expr,
@@ -195,6 +195,31 @@ def compile_ir_to_sql(
         debug_sql_text = run_codegen(qtree, pretty=True, reordered=True)
         debug.dump_code(debug_sql_text, lexer='sql')
 
+    return qtree, sql_text, argmap
+
+
+def compile_ir_to_sql(
+    ir_expr: irast.Base, *,
+    output_format: Optional[OutputFormat]=None,
+    ignore_shapes: bool=False,
+    explicit_top_cast: Optional[irast.TypeRef]=None,
+    singleton_mode: bool=False,
+    use_named_params: bool=False,
+    expected_cardinality_one: bool=False,
+    pretty: bool=True,
+    backend_runtime_params: Optional[pgparams.BackendRuntimeParams]=None,
+) -> Tuple[str, Dict[str, pgast.Param]]:
+    _, sql_text, argmap = compile_ir_to_tree_and_sql(
+        ir_expr,
+        output_format=output_format,
+        ignore_shapes=ignore_shapes,
+        explicit_top_cast=explicit_top_cast,
+        singleton_mode=singleton_mode,
+        use_named_params=use_named_params,
+        expected_cardinality_one=expected_cardinality_one,
+        backend_runtime_params=backend_runtime_params,
+        pretty=pretty,
+    )
     return sql_text, argmap
 
 

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -165,6 +165,19 @@ def each_query_in_set(qry: pgast.Query) -> Iterator[pgast.Query]:
             yield qry
 
 
+def each_base_rvar(rvar: pgast.BaseRangeVar) -> Iterator[pgast.BaseRangeVar]:
+    # We do this iteratively instead of recursively (with yield from)
+    # to avoid being pointlessly quadratic.
+    stack = [rvar]
+    while stack:
+        rvar = stack.pop()
+        if isinstance(rvar, pgast.JoinExpr):
+            stack.append(rvar.rarg)
+            stack.append(rvar.larg)
+        else:
+            yield rvar
+
+
 def new_binop(
     lexpr: pgast.BaseExpr,
     rexpr: pgast.BaseExpr,

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -294,7 +294,8 @@ class CompilerContextLevel(compiler.ContextLevel):
                 if self.pending_query is not None:
                     self.rel = self.pending_query
                 else:
-                    self.rel = pgast.SelectStmt()
+                    self.rel = pgast.SelectStmt(
+                        path_scope_id=self.scope_tree.unique_id)
                     if prevlevel.parent_rel is not None:
                         parent_rel = prevlevel.parent_rel
                     else:
@@ -306,7 +307,8 @@ class CompilerContextLevel(compiler.ContextLevel):
                 self.parent_rel = None
 
             elif mode is ContextSwitchMode.SUBREL:
-                self.rel = pgast.SelectStmt()
+                self.rel = pgast.SelectStmt(
+                    path_scope_id=self.scope_tree.unique_id)
                 if prevlevel.parent_rel is not None:
                     parent_rel = prevlevel.parent_rel
                 else:

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -294,8 +294,7 @@ class CompilerContextLevel(compiler.ContextLevel):
                 if self.pending_query is not None:
                     self.rel = self.pending_query
                 else:
-                    self.rel = pgast.SelectStmt(
-                        path_scope_id=self.scope_tree.unique_id)
+                    self.rel = pgast.SelectStmt()
                     if prevlevel.parent_rel is not None:
                         parent_rel = prevlevel.parent_rel
                     else:
@@ -307,8 +306,7 @@ class CompilerContextLevel(compiler.ContextLevel):
                 self.parent_rel = None
 
             elif mode is ContextSwitchMode.SUBREL:
-                self.rel = pgast.SelectStmt(
-                    path_scope_id=self.scope_tree.unique_id)
+                self.rel = pgast.SelectStmt()
                 if prevlevel.parent_rel is not None:
                     parent_rel = prevlevel.parent_rel
                 else:

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1435,7 +1435,11 @@ def range_for_material_objtype(
         and typeref.name_hint.module not in {'cfg', 'sys'}
     ):
         ops = []
-        for subref in [typeref, *irtyputils.get_typeref_descendants(typeref)]:
+        typerefs = [typeref, *irtyputils.get_typeref_descendants(typeref)]
+        all_abstract = all(subref.is_abstract for subref in typerefs)
+        for subref in typerefs:
+            if subref.is_abstract and not all_abstract:
+                continue
             rvar = range_for_material_objtype(
                 subref, path_id, lateral=lateral,
                 include_descendants=False,
@@ -1851,6 +1855,13 @@ def range_for_ptrref(
         for ref in list(refs):
             lrefs.extend(ref.descendants())
             lrefs.append(ref)
+        concrete_lrefs = [
+            ref for ref in lrefs if not ref.out_source.is_abstract
+        ]
+        # If there aren't any concrete types, we still need to
+        # generate *something*, so just do all the abstract ones.
+        if concrete_lrefs:
+            lrefs = concrete_lrefs
     else:
         lrefs = list(refs)
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1481,6 +1481,7 @@ def range_for_material_objtype(
             name=table_name,
             path_id=path_id,
             typeref=typeref,
+            path_scope_id=ctx.scope_tree.unique_id,
         )
 
         rvar = pgast.RelRangeVar(
@@ -1772,7 +1773,11 @@ def table_from_ptrref(
 
     typeref = ptrref.out_source if ptrref else None
     relation = pgast.Relation(
-        schemaname=table_schema_name, name=table_name, typeref=typeref)
+        schemaname=table_schema_name,
+        name=table_name,
+        path_scope_id=ctx.scope_tree.unique_id,
+        typeref=typeref,
+    )
 
     # Pseudo pointers (tuple and type intersection) have no schema id.
     sobj_id = ptrref.id if isinstance(ptrref, irast.PointerRef) else None

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1895,6 +1895,7 @@ def range_for_ptrref(
             for_mutation=for_mutation,
             ctx=ctx,
         )
+        table.query.path_id = path_id
 
         qry = pgast.SelectStmt()
         qry.from_clause.append(table)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1485,7 +1485,6 @@ def range_for_material_objtype(
             name=table_name,
             path_id=path_id,
             typeref=typeref,
-            path_scope_id=ctx.scope_tree.unique_id,
         )
 
         rvar = pgast.RelRangeVar(
@@ -1779,7 +1778,6 @@ def table_from_ptrref(
     relation = pgast.Relation(
         schemaname=table_schema_name,
         name=table_name,
-        path_scope_id=ctx.scope_tree.unique_id,
         typeref=typeref,
     )
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -222,6 +222,12 @@ def get_set_rvar(
         # Actually compile the set
         rvars = _get_set_rvar(ir_set, ctx=subctx)
 
+        if ctx.env.expand_inhviews:
+            for srvar in rvars.new:
+                if not srvar.rvar.ir_origins:
+                    srvar.rvar.ir_origins = []
+                srvar.rvar.ir_origins.append(ir_set)
+
         if optional_wrapping:
             rvars = finalize_optional_rel(ir_set, optrel=optrel,
                                           rvars=rvars, ctx=subctx)

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -28,7 +28,7 @@ from .compiler import compile, compile_schema_storage_in_delta
 from .dbstate import QueryUnit, QueryUnitGroup
 from .enums import Capability, Cardinality
 from .enums import InputFormat, OutputFormat
-
+from .explain import analyze_explain_output
 
 __all__ = (
     'Cardinality',
@@ -40,6 +40,7 @@ __all__ = (
     'Capability',
     'InputFormat',
     'OutputFormat',
+    'analyze_explain_output',
     'compile_edgeql_script',
     'load_std_schema',
     'new_compiler',

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1272,18 +1272,18 @@ def _get_compile_options(
 
     return qlcompiler.CompilerOptions(
         modaliases=ctx.state.current_tx().get_modaliases(),
-        implicit_tid_in_shapes=(
-            can_have_implicit_fields and ctx.inline_typeids
-        ),
         # XXX: All this is_explain checks need to be removed once we
         # have a real solution to this problem
+        implicit_tid_in_shapes=(
+            can_have_implicit_fields and ctx.inline_typeids
+            and not is_explain
+        ),
         implicit_tname_in_shapes=(
             can_have_implicit_fields and ctx.inline_typenames
             and not is_explain
         ),
         implicit_id_in_shapes=(
             can_have_implicit_fields and ctx.inline_objectids
-            and not is_explain
         ),
         constant_folding=not disable_constant_folding,
         json_parameters=ctx.json_parameters,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1338,6 +1338,7 @@ def _compile_ql_explain(
         cacheable=False,
         sql=(sql_bytes,),
         sql_hash=sql_hash,
+        cardinality=enums.Cardinality.ONE,
         # XXX: This is not right really
         out_type_data=out_type_data,
         out_type_id=out_type_id.bytes,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1275,15 +1275,19 @@ def _get_compile_options(
         implicit_tid_in_shapes=(
             can_have_implicit_fields and ctx.inline_typeids
         ),
+        # XXX: All this is_explain checks need to be removed once we
+        # have a real solution to this problem
         implicit_tname_in_shapes=(
             can_have_implicit_fields and ctx.inline_typenames
+            and not is_explain
         ),
         implicit_id_in_shapes=(
             can_have_implicit_fields and ctx.inline_objectids
+            and not is_explain
         ),
         constant_folding=not disable_constant_folding,
         json_parameters=ctx.json_parameters,
-        implicit_limit=ctx.implicit_limit,
+        implicit_limit=ctx.implicit_limit if not is_explain else 0,
         bootstrap_mode=ctx.bootstrap_mode,
         apply_query_rewrites=(
             not ctx.bootstrap_mode

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1313,7 +1313,6 @@ def _compile_ql_explain(
     *,
     script_info: Optional[irast.ScriptInfo] = None,
 ) -> dbstate.BaseQuery:
-    # TODO: more arguments for EXPLAIN
     analyze = 'ANALYZE true, ' if ql.analyze else ''
     exp_command = f'EXPLAIN ({analyze}FORMAT JSON, VERBOSE true)'
 
@@ -1339,7 +1338,6 @@ def _compile_ql_explain(
         sql=(sql_bytes,),
         sql_hash=sql_hash,
         cardinality=enums.Cardinality.ONE,
-        # XXX: This is not right really
         out_type_data=out_type_data,
         out_type_id=out_type_id.bytes,
     )

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -97,6 +97,8 @@ class Query(BaseQuery):
     has_dml: bool = False
     single_unit: bool = False
     cacheable: bool = True
+    is_explain: bool = False
+    query_asts: Any = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -302,6 +304,9 @@ class QueryUnit:
     # If present, represents the future global schema state
     # after the command is run. The schema is pickled.
     global_schema: Optional[bytes] = None
+
+    is_explain: bool = False
+    query_asts: Any = None
 
     @property
     def has_ddl(self) -> bool:

--- a/edb/server/compiler/explain.py
+++ b/edb/server/compiler/explain.py
@@ -1,0 +1,295 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *
+
+import dataclasses
+import json
+import re
+import uuid
+import struct
+
+from edb.common import ast
+from edb.common import context as pctx
+from edb.common import debug
+
+from edb.edgeql import ast as qlast
+
+from edb.ir import ast as irast
+from edb.ir import utils as irutils
+
+from edb.schema import constraints as s_constr
+from edb.schema import indexes as s_indexes
+from edb.schema import pointers as s_pointers
+from edb.schema import schema as s_schema
+
+from edb.pgsql import ast as pgast
+from edb.pgsql.compiler import pathctx
+
+from edb.server.compiler import dbstate
+
+uuid_core = '[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12}'
+uuid_re = re.compile(
+    rf'(\.?"?({uuid_core})"?)',
+    re.I
+)
+
+
+ContextDesc = dict[str, int]
+
+
+@dataclasses.dataclass
+class AnalysisInfo:
+    aliases: dict[str, pgast.PathRangeVar]
+    alias_to_path_id: dict[str, tuple[irast.PathId, Optional[int]]]
+    alias_contexts: dict[str, list[list[ContextDesc]]]
+    sets: dict[irast.PathId, set[irast.Set]]
+    buffers: list[tuple[str, str]]
+
+
+# Do a bunch of analysis of the queries. Currently we produce more
+# info than we actually consume, since we are still in a somewhat
+# exploratory phase.
+def analyze_queries(
+    ql: qlast.Base, ir: irast.Statement, pg: pgast.Base,
+    *, schema: s_schema.Schema,
+    debug_spew: bool=False,
+) -> AnalysisInfo:
+    assert ql.context
+    contexts = {(ql.context.buffer, ql.context.name): 0}
+
+    def get_context(context: pctx.ParserContext) -> ContextDesc:
+        key = context.buffer, context.name
+        if (idx := contexts.get(key)) is None:
+            idx = len(contexts)
+            contexts[key] = idx
+        text = context.buffer[context.start:context.end]
+        return dict(
+            start=context.start, end=context.end, buffer_idx=idx, text=text
+        )
+
+    rvars = ast.find_children(pg, pgast.PathRangeVar)
+    queries = ast.find_children(pg, pgast.Query)
+
+    # Map subqueries back to their rvars
+    subq_to_rvar: dict[pgast.Query, pgast.RangeSubselect] = {}
+    for rvar in rvars:
+        if isinstance(rvar, pgast.RangeSubselect):
+            assert rvar.subquery not in subq_to_rvar
+            subq_to_rvar[rvar.subquery] = rvar
+
+    # Find all *references* to an rvar in path_rvar_maps
+    reverse_path_rvar_map: dict[
+        pgast.PathRangeVar,
+        list[tuple[tuple[irast.PathId, str], pgast.Query]]
+    ] = {}
+    for qry in queries:
+        for key, rvar in qry.path_rvar_map.items():
+            reverse_path_rvar_map.setdefault(rvar, []).append((key, qry))
+
+    # Map aliases to rvars and then to path ids
+    aliases = {
+        rvar.alias.aliasname: rvar for rvar in rvars if rvar.alias.aliasname
+    }
+    path_ids = {
+        alias: (rvar.relation.path_id, rvar.relation.path_scope_id)
+        for alias, rvar in aliases.items()
+        if isinstance(rvar, pgast.RelRangeVar)
+        and isinstance(rvar.relation, pgast.BaseRelation)
+        and rvar.relation.path_id
+    }
+
+    # Find all the sets
+    sets: dict[irast.PathId, set[irast.Set]] = {}
+    for s in ast.find_children(ir, irast.Set, extra_skips={'target'}):
+        if s.context:
+            sets.setdefault(s.path_id, set()).add(s)
+
+    scopes = irutils.find_path_scopes(ir)
+
+    alias_contexts: dict[str, list[list[ContextDesc]]] = {}
+
+    # Try to produce good contexts
+    # KEY FACT: We often duplicate code for with bindings. This means
+    # we want to expose that through the contexts we include.
+    for alias, (path_id, scope_id) in path_ids.items():
+        # print("!!!", alias, path_id, scope_id)
+        if scope_id is None:  # ???
+            continue
+        # Strip the ptr path part off if it exists (which it will on
+        # links), since that won't appear in the sets
+        path_id = path_id.tgt_path()
+        # print("???", sets.get(path_id, ()))
+        for s in sets.get(path_id, ()):
+            if scopes.get(s) == scope_id and s.context:
+                asets = [s]
+
+                # Loop back through...
+                cpath = path_id
+                rvar = aliases[alias]
+                while True:
+                    sources = [
+                        s for k, s in
+                        reverse_path_rvar_map.get(rvar, ())
+                        if k == (cpath, 'source')
+                    ]
+                    if debug_spew:
+                        print(sources, cpath)
+                    if sources:
+                        source = sources[0]
+                        cpath = pathctx.reverse_map_path_id(
+                            cpath, source.view_path_id_map)
+
+                        ns = tuple(sets.get(cpath, ()))
+                        if len(ns) > 1:
+                            ns = tuple(
+                                n for n in ns
+                                if scopes.get(n) == source.path_scope_id)
+                        if len(ns) == 1 and ns[0].context:
+                            if ns[0] not in asets:
+                                asets.append(ns[0])
+
+                        if source not in subq_to_rvar:
+                            break
+                        rvar = subq_to_rvar[source]
+                    else:
+                        break
+
+                sctxs = [get_context(x.context) for x in asets if x.context]
+                if debug_spew:
+                    # print(alias, sctxs)
+                    # print(asets)
+                    for x in asets:
+                        debug.dump(x.context)
+                alias_contexts.setdefault(alias, []).append(sctxs)
+
+    return AnalysisInfo(
+        aliases=aliases,
+        alias_to_path_id=path_ids,
+        alias_contexts=alias_contexts,
+        sets=sets,
+        buffers=list(contexts.keys()),
+    )
+
+
+# Except for injecting contexts based on aliases, this is still mostly pretty
+# basic schema driven string replacement stuff on the pg plan...
+# We need to think about whether we can do better and how we can
+# represent it.
+def json_fixup(
+    obj: Any, info: AnalysisInfo,
+    schema: s_schema.Schema, idx: int | str | None = None
+) -> Any:
+    if isinstance(obj, list):
+        return [json_fixup(x, info, schema) for x in obj]
+    elif isinstance(obj, dict):
+        obj = {
+            k: json_fixup(v, info, schema, k) for k, v in obj.items()
+            if k not in ('Schema',)
+        }
+        if 'Alias' in obj and obj['Alias'] in info.alias_contexts:
+            obj['Contexts'] = info.alias_contexts[obj['Alias']]
+        return obj
+    elif isinstance(obj, str):
+        if idx == 'Index Name':
+            obj = obj.replace('_source_target_key', ' forward link index')
+            obj = obj.replace(';schemaconstr', ' exclusive constraint index')
+            obj = obj.replace('_target_key', ' backward link index')
+            obj = obj.replace('_index', ' index')
+
+        # Try to replace all ids with textual names
+        for (full, m) in uuid_re.findall(obj):
+            uid = uuid.UUID(m)
+            sobj = schema.get_by_id(uid, default=None)
+            if sobj:
+                dotted = full[0] == '.'
+                if isinstance(sobj, s_pointers.Pointer):
+                    # If a pointer is on the RHS of a dot, just use
+                    # the short name. But otherwise, grab the source
+                    # and link it up
+                    s = str(sobj.get_shortname(schema).name)
+                    if sobj.is_link_property(schema):
+                        s = f'@{s}'
+                    if not dotted:
+                        src_name = sobj.get_source(schema).get_name(schema)
+                        s = f'{src_name}.{s}'
+                elif isinstance(sobj, (s_constr.Constraint, s_indexes.Index)):
+                    # XXX: Do we really want verbose names here, they are
+                    # kind of awful.
+                    s = sobj.get_verbosename(schema, with_parent=True)
+                else:
+                    s = str(sobj.get_name(schema))
+
+                if dotted:
+                    s = '.' + s
+                obj = uuid_re.sub(s, obj, count=1)
+
+        return obj
+    else:
+        return obj
+
+
+def analyze_explain_output(
+    query_unit: dbstate.QueryUnit,
+    data: list[list[bytes]],
+) -> bytes:
+    if debug.flags.edgeql_explain:
+        debug.header('Explain')
+
+    ql: qlast.Base
+    ir: irast.Statement
+    pg: pgast.Base
+    ql, ir, pg = query_unit.query_asts
+    schema = ir.schema
+    assert len(data) == 1 and len(data[0]) == 1
+    # print('DATA', data)
+    plan = json.loads(data[0][0])
+    assert len(plan) == 1
+    plan = plan[0]['Plan']
+
+    info = analyze_queries(ql, ir, pg, schema=schema)
+    plan = json_fixup(plan, info, schema)
+
+    output = {
+        'Buffers': info.buffers,
+        'Plan': plan,
+    }
+    if debug.flags.edgeql_explain:
+        debug.dump(output)
+
+    # Repeat the analysis if we are doing debug dumping for the silly reason
+    # of having it appear last in the debug spew.
+    if debug.flags.edgeql_explain:
+        analyze_queries(ql, ir, pg, schema=schema, debug_spew=True)
+        # debug.dump(info, _ast_include_meta=False)
+
+    return make_message([output])
+
+
+def make_message(obj: Any) -> bytes:
+    omsg = json.dumps(obj).encode('utf-8')
+    msg = struct.pack(
+        "!hic",
+        1,
+        len(omsg) + 1,
+        # XXX: why isn't it b'\x01'??
+        b' ',
+    ) + omsg
+    return msg

--- a/edb/server/compiler/explain.py
+++ b/edb/server/compiler/explain.py
@@ -239,8 +239,10 @@ def json_fixup(
         if alias and alias in info.alias_to_path_id:
             path_id, _ = info.alias_to_path_id[alias]
             obj['DEBUG PATH ID'] = str(path_id)
-            if ptr := path_id.rptr():
-                assert isinstance(ptr.real_material_ptr, irast.PointerRef)
+            if (
+                (ptr := path_id.rptr())
+                and isinstance(ptr.real_material_ptr, irast.PointerRef)
+            ):
                 ptr_name = _obj_to_name(
                     schema.get_by_id(ptr.real_material_ptr.id), schema)
                 obj['Pointer Name'] = ptr_name

--- a/edb/server/compiler/explain.py
+++ b/edb/server/compiler/explain.py
@@ -56,7 +56,7 @@ ContextDesc = dict[str, int]
 @dataclasses.dataclass
 class AnalysisInfo:
     aliases: dict[str, pgast.BaseRangeVar]
-    alias_to_path_id: dict[str, tuple[irast.PathId, Optional[int]]]
+    alias_to_path_id: dict[str, irast.PathId]
     alias_contexts: dict[str, list[list[ContextDesc]]]
     sets: dict[irast.PathId, set[irast.Set]]
     buffers: list[tuple[str, str]]
@@ -117,7 +117,7 @@ def analyze_queries(
         rvar.alias.aliasname: rvar for rvar in rvars if rvar.alias.aliasname
     }
     path_ids = {
-        alias: (rvar.relation.path_id, rvar.relation.path_scope_id)
+        alias: rvar.relation.path_id
         for alias, rvar in aliases.items()
         if isinstance(rvar, pgast.RelRangeVar)
         and isinstance(rvar.relation, pgast.BaseRelation)
@@ -223,7 +223,7 @@ def json_fixup(
         # indicate what the original type was (since this is probably
         # the result of expansion.)
         if alias and alias in info.alias_to_path_id:
-            path_id, _ = info.alias_to_path_id[alias]
+            path_id = info.alias_to_path_id[alias]
             obj['DEBUG PATH ID'] = str(path_id)
             if (
                 (ptr := path_id.rptr())

--- a/edb/server/compiler/explain.py
+++ b/edb/server/compiler/explain.py
@@ -284,9 +284,9 @@ def json_fixup(
 # - Plan nodes in 'CollapsedPlans' replaced with their 1-based index in the
 #   'CollapsedPlans' list.
 def collapse_plan(
-    plan,
+    plan: Any,
     find_nearest_ctx: bool = False
-):
+) -> Any:
     subplans = []
     found_nearest = None
 
@@ -308,7 +308,8 @@ def collapse_plan(
                 if nearest_plan:
                     subplan['NearestContextPlan'] = nearest_plan
                     subplans.append(subplan)
-                    parent['Plans'][parent['Plans'].index(subplan)] = len(subplans)
+                    parent['Plans'][parent['Plans'].index(subplan)] = (
+                        len(subplans))
             else:
                 unvisited += [
                     (subsubplan, subplan) for subsubplan
@@ -335,7 +336,7 @@ def collapse_plan(
         # plan node does not share with sibling or parent nodes, to suggest
         # for display in UI
         parent_ctxs = (found_nearest['Contexts'] if
-            found_nearest else plan.get('Contexts'))
+                       found_nearest else plan.get('Contexts'))
         ctx_subplans = [
             subplan.get('NearestContextPlan') or subplan
             for subplan in subplans
@@ -349,18 +350,20 @@ def collapse_plan(
             if sibling_ctxs:
                 for ctx in reversed(plan_ctxs):
                     if not ctx_in_ctxs(ctx, sibling_ctxs):
-                        subplan['SuggestedDisplayCtxIdx'] = plan_ctxs.index(ctx)
+                        subplan['SuggestedDisplayCtxIdx'] = (
+                            plan_ctxs.index(ctx))
                         break
             else:
                 subplan['SuggestedDisplayCtxIdx'] = len(plan_ctxs) - 1
 
     return found_nearest
 
-def ctx_in_ctxs(ctx, ctxs):
+
+def ctx_in_ctxs(ctx: Any, ctxs: Any) -> bool:
     for c in ctxs:
         if (c['buffer_idx'] == ctx['buffer_idx']
-          and c['start'] == ctx['start']
-          and c['end'] == ctx['end']):
+                and c['start'] == ctx['start']
+                and c['end'] == ctx['end']):
             return True
     return False
 

--- a/edb/server/compiler/explain.py
+++ b/edb/server/compiler/explain.py
@@ -238,7 +238,17 @@ def json_fixup(
                 obj['Original Relation Name'] = path_name
 
         if alias and alias in info.alias_contexts:
-            obj['Contexts'] = info.alias_contexts[alias]
+            obj['Contexts'] = info.alias_contexts[alias][0]
+
+        if 'Actual Total Time' in obj:
+            obj['FullTotalTime'] = (
+                obj["Actual Total Time"] * obj.get("Actual Loops", 1))
+            obj['SelfTime'] = obj['FullTotalTime'] - (
+                sum([subplan['FullTotalTime'] for subplan in obj['Plans']])
+                if 'Plans' in obj else 0)
+        obj['SelfCost'] = obj['Total Cost'] - (
+            sum([subplan['Total Cost'] for subplan in obj['Plans']])
+            if 'Plans' in obj else 0)
 
         return obj
     elif isinstance(obj, str):
@@ -260,6 +270,99 @@ def json_fixup(
         return obj
     else:
         return obj
+
+
+# Finds all the direct descendents of the given plan node that have been
+# annotated with 'Contexts', and creates a new collapsed tree of those under
+# the 'CollapsedPlans' key.
+# Also for 'Aggregate' type plan nodes, that do not already have 'Contexts',
+# try to find the nearest descendent plan node with 'Contexts' and
+# attach that as 'NearestContextPlan'.
+# The original plan tree remains under the 'Plans' key, but plan nodes
+# de-duplicated as so:
+# - Plan node in 'NearestContextPlan' replaced with 0
+# - Plan nodes in 'CollapsedPlans' replaced with their 1-based index in the
+#   'CollapsedPlans' list.
+def collapse_plan(
+    plan,
+    find_nearest_ctx: bool = False
+):
+    subplans = []
+    found_nearest = None
+
+    unvisited = [(subplan, plan) for subplan in plan.get('Plans', [])]
+    while unvisited:
+        subplan, parent = unvisited.pop(0)
+        if 'Contexts' in subplan:
+            if find_nearest_ctx and found_nearest is None:
+                found_nearest = subplan
+                parent['Plans'][parent['Plans'].index(subplan)] = 0
+            else:
+                subplans.append(subplan)
+                parent['Plans'][parent['Plans'].index(subplan)] = len(subplans)
+
+            collapse_plan(subplan)
+        else:
+            if subplan['Node Type'] == "Aggregate":
+                nearest_plan = collapse_plan(subplan, True)
+                if nearest_plan:
+                    subplan['NearestContextPlan'] = nearest_plan
+                    subplans.append(subplan)
+                    parent['Plans'][parent['Plans'].index(subplan)] = len(subplans)
+            else:
+                unvisited += [
+                    (subsubplan, subplan) for subsubplan
+                    in subplan.get('Plans', [])
+                ]
+
+    if subplans or found_nearest:
+        all_subplans = (
+            (list(subplans) if subplans else []) +
+            (found_nearest.get('CollapsedPlans', []) if found_nearest else [])
+        )
+        if 'FullTotalTime' in plan:
+            plan['CollapsedSelfTime'] = plan['FullTotalTime'] - (
+                sum([subplan['FullTotalTime'] for subplan in all_subplans])
+            )
+        plan['CollapsedSelfCost'] = plan['Total Cost'] - (
+            sum([subplan['Total Cost'] for subplan in all_subplans])
+        )
+
+    if subplans:
+        plan['CollapsedPlans'] = subplans
+
+        # For each plan with contexts, try to pick the widest context that the
+        # plan node does not share with sibling or parent nodes, to suggest
+        # for display in UI
+        parent_ctxs = (found_nearest['Contexts'] if
+            found_nearest else plan.get('Contexts'))
+        ctx_subplans = [
+            subplan.get('NearestContextPlan') or subplan
+            for subplan in subplans
+        ]
+        for subplan in ctx_subplans:
+            plan_ctxs = subplan['Contexts']
+            sibling_ctxs = list(parent_ctxs) if parent_ctxs else []
+            for sib_plan in ctx_subplans:
+                if sib_plan != subplan:
+                    sibling_ctxs += sib_plan['Contexts']
+            if sibling_ctxs:
+                for ctx in reversed(plan_ctxs):
+                    if not ctx_in_ctxs(ctx, sibling_ctxs):
+                        subplan['SuggestedDisplayCtxIdx'] = plan_ctxs.index(ctx)
+                        break
+            else:
+                subplan['SuggestedDisplayCtxIdx'] = len(plan_ctxs) - 1
+
+    return found_nearest
+
+def ctx_in_ctxs(ctx, ctxs):
+    for c in ctxs:
+        if (c['buffer_idx'] == ctx['buffer_idx']
+          and c['start'] == ctx['start']
+          and c['end'] == ctx['end']):
+            return True
+    return False
 
 
 def analyze_explain_output(
@@ -291,6 +394,8 @@ def analyze_explain_output(
 
     info = analyze_queries(ql, ir, pg, schema=schema)
     plan = json_fixup(plan, info, schema)
+
+    collapse_plan(plan)
 
     output = {
         'Buffers': info.buffers,

--- a/edb/server/compiler/explain.py
+++ b/edb/server/compiler/explain.py
@@ -25,7 +25,6 @@ import json
 import re
 import pickle
 import uuid
-import struct
 
 from edb.common import ast
 from edb.common import context as pctx
@@ -414,14 +413,4 @@ def analyze_explain_output(
     if debug.flags.edgeql_explain:
         debug.dump(output)
 
-    return make_message([output])
-
-
-def make_message(obj: Any) -> bytes:
-    omsg = json.dumps(obj).encode('utf-8')
-    msg = struct.pack(
-        "!hi",
-        1,  # jsonb format version
-        len(omsg),  # string length
-    ) + omsg
-    return msg
+    return json.dumps([output]).encode('utf-8')

--- a/edb/server/compiler/status.py
+++ b/edb/server/compiler/status.py
@@ -194,3 +194,8 @@ def _describe(ql):
 @get_status.register(qlast.Rename)
 def _rename(ql):
     return f'RENAME'.encode()
+
+
+@get_status.register(qlast.ExplainStmt)
+def _explain(ql):
+    return b'EXPLAIN'

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -598,6 +598,22 @@ class AbstractPool:
         finally:
             self._release_worker(worker)
 
+    async def analyze_explain_output(
+        self,
+        *args,
+        **kwargs
+    ):
+        worker = await self._acquire_worker()
+        try:
+            return await worker.call(
+                'analyze_explain_output',
+                *args,
+                **kwargs
+            )
+
+        finally:
+            self._release_worker(worker)
+
 
 class BaseLocalPool(
     AbstractPool, amsg.ServerProtocol, asyncio.SubprocessProtocol

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -120,12 +120,11 @@ async def execute(
                         ]
 
                     if query_unit.is_explain:
-                        # Do it in a thread so that it doesn't *block*
-                        # the IO server, even if it does steal cycles
-                        # from it.
-                        r = await asyncio.to_thread(
-                            compiler.analyze_explain_output,
-                            query_unit, data,
+                        # Go back to the compiler pool to analyze
+                        # the explain output.
+                        compiler_pool = server.get_compiler_pool()
+                        r = await compiler_pool.analyze_explain_output(
+                            query_unit.query_asts, data
                         )
                         buf = WriteBuffer.new_message(b'D')
                         buf.write_bytes(r)

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -22,6 +22,7 @@ from typing import (
     Optional,
 )
 
+import asyncio
 import decimal
 import json
 
@@ -53,7 +54,7 @@ async def execute(
     compiled: dbview.CompiledQuery,
     bind_args: bytes,
     *,
-    fe_conn: Optional[frontend.AbstractFrontendConnection] = None,
+    fe_conn: frontend.AbstractFrontendConnection = None,
     use_prep_stmt: bint = False,
     # HACK: A hook from the notebook ext, telling us to skip dbview.start
     # so that it can handle things differently.
@@ -101,9 +102,11 @@ async def execute(
                     bound_args_buf = args_ser.recode_bind_args(
                         dbv, compiled, bind_args)
 
+                    read_data = query_unit.set_global or query_unit.is_explain
+
                     data = await be_conn.parse_execute(
                         query=query_unit,
-                        fe_conn=fe_conn if not query_unit.set_global else None,
+                        fe_conn=fe_conn if not read_data else None,
                         bind_data=bound_args_buf,
                         use_prep_stmt=use_prep_stmt,
                         state=state,
@@ -115,6 +118,18 @@ async def execute(
                             config.Operation.from_json(r[0][1:])
                             for r in data
                         ]
+
+                    if query_unit.is_explain:
+                        # Do it in a thread so that it doesn't *block*
+                        # the IO server, even if it does steal cycles
+                        # from it.
+                        r = await asyncio.to_thread(
+                            compiler.analyze_explain_output,
+                            query_unit, data,
+                        )
+                        buf = WriteBuffer.new_message(b'D')
+                        buf.write_bytes(r)
+                        fe_conn.write(buf.end_message())
 
                 if state is not None:
                     # state is restored, clear orig_state so that we can
@@ -211,6 +226,8 @@ async def execute_script(
             for idx, query_unit in enumerate(unit_group):
                 if fe_conn is not None and fe_conn.cancelled:
                     raise ConnectionAbortedError
+
+                assert not query_unit.is_explain
 
                 # XXX: pull out?
                 # We want to minimize the round trips we need to make, so

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -127,7 +127,8 @@ async def execute(
                             query_unit.query_asts, data
                         )
                         buf = WriteBuffer.new_message(b'D')
-                        buf.write_bytes(r)
+                        buf.write_int16(1)  # 1 column
+                        buf.write_len_prefixed_bytes(r)
                         fe_conn.write(buf.end_message())
 
                 if state is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ module = [
     "edb.server.connpool.*",
     "edb.server.pgcluster",
     "edb.server.pgconnparams",
+    "edb.server.compiler.explain",
 ]
 # Equivalent of --strict on the command line,
 # but without disallow_untyped_calls:

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -368,3 +368,89 @@ class TestEdgeQLExplain(tb.QueryTestCase):
 
         self.assertEqual(len(res['Buffers']), 2)
         self.assertEqual(res['Buffers'][1][0], ".<owner[is default::Issue]")
+
+    async def test_edgeql_explain_inheritance_01(self):
+        res = await self.explain('''
+            WITH X := Text, select X;
+        ''')
+
+        # TODO: Something tying the things together to default::Text
+        shape = {
+            "Node Type": "Result",
+            "Plans": [
+                {
+                    "Node Type": "Append",
+                    "Parent Relationship": "Outer",
+                    "Plans": tb.bag([
+                        {
+                            "Node Type": "Seq Scan",
+                            "Parent Relationship": "Member",
+                            "Relation Name": "default::Issue",
+                            "Original Relation Name": "default::Text",
+                            "Contexts": [
+                                [
+                                    {
+                                        "start": 31,
+                                        "end": 35,
+                                        "buffer_idx": 0,
+                                        "text": "Text"
+                                    },
+                                    {
+                                        "start": 44,
+                                        "end": 45,
+                                        "buffer_idx": 0,
+                                        "text": "X"
+                                    }
+                                ]
+                            ]
+                        },
+                        {
+                            "Node Type": "Seq Scan",
+                            "Parent Relationship": "Member",
+                            "Relation Name": "default::Comment",
+                            "Original Relation Name": "default::Text",
+                            "Contexts": [
+                                [
+                                    {
+                                        "start": 31,
+                                        "end": 35,
+                                        "buffer_idx": 0,
+                                        "text": "Text"
+                                    },
+                                    {
+                                        "start": 44,
+                                        "end": 45,
+                                        "buffer_idx": 0,
+                                        "text": "X"
+                                    }
+                                ]
+                            ]
+                        },
+                        {
+                            "Node Type": "Seq Scan",
+                            "Parent Relationship": "Member",
+                            "Relation Name": "default::LogEntry",
+                            "Original Relation Name": "default::Text",
+                            "Contexts": [
+                                [
+                                    {
+                                        "start": 31,
+                                        "end": 35,
+                                        "buffer_idx": 0,
+                                        "text": "Text"
+                                    },
+                                    {
+                                        "start": 44,
+                                        "end": 45,
+                                        "buffer_idx": 0,
+                                        "text": "X"
+                                    }
+                                ]
+                            ]
+                        }
+                    ])
+                }
+            ]
+        }
+
+        self.assert_plan(res['Plan'], shape)

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -1,0 +1,370 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2017-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import json
+import os.path
+import unittest
+
+from edb.testbase import server as tb
+from edb.server import pgconnparams
+from edb.common import assert_data_shape
+
+
+class TestEdgeQLExplain(tb.QueryTestCase):
+    '''Tests for EXPLAIN'''
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'issues.esdl')
+
+    SETUP = [
+        os.path.join(os.path.dirname(__file__), 'schemas',
+                     'issues_setup.edgeql'),
+        '''
+            alter type User {
+                create link owned_issues := .<owner[is Issue]
+            };
+            # Make the database more populated so that it uses
+            # indexes...
+            for i in range_unpack(range(1, 1000)) union (
+              with u := (insert User { name := <str>i }),
+              for j in range_unpack(range(0, 5)) union (
+                insert Issue {
+                  owner := u,
+                  number := <str>(i*100 + j),
+                  name := "issue " ++ <str>i ++ "/" ++ <str>j,
+                  status := (select Status filter .name = 'Open'),
+                  body := "BUG",
+                }
+            ));
+            update User set {
+              todo += (select .owned_issues filter <int64>.number % 3 = 0)
+            };
+        '''
+    ]
+
+    @classmethod
+    async def _get_raw_sql_connection(cls):
+        """Get a raw connection to the underlying SQL server, if possible
+
+        We have to do this miserable hack in order to get access to ANALYZE
+        """
+        try:
+            import asyncpg
+        except ImportError:
+            raise unittest.SkipTest(
+                'explain tests skipped: asyncpg not installed')
+
+        settings = cls.con.get_settings()
+        pgaddr = settings.get('pgaddr')
+        if pgaddr is None:
+            raise unittest.SkipTest('explain tests skipped: not in devmode')
+        pgaddr = json.loads(pgaddr)
+
+        # Try to grab a password from the specified DSN, if one is
+        # present, since the pgaddr won't have a real one. (The non
+        # specified DSN test suite setup doesn't have one, so it is
+        # fine.)
+        password = None
+        spec_dsn = os.environ.get('EDGEDB_TEST_BACKEND_DSN')
+        if spec_dsn:
+            _, params = pgconnparams.parse_dsn(spec_dsn)
+            password = params.password
+
+        pgdsn = (
+            f'postgres:///{pgaddr["database"]}?user={pgaddr["user"]}'
+            f'&port={pgaddr["port"]}&host={pgaddr["host"]}'
+        )
+        if password is not None:
+            pgdsn += f'&password={password}'
+
+        return await asyncpg.connect(pgdsn)
+
+    @classmethod
+    async def _analyze_db(cls):
+        # HACK: Run ANALYZE so that test results are more deterministic
+        scon = await cls._get_raw_sql_connection()
+        try:
+            await scon.execute('ANALYZE')
+        finally:
+            await scon.close()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loop.run_until_complete(cls._analyze_db())
+
+    def assert_plan(self, data, shape, message=None):
+        assert_data_shape.assert_data_shape(
+            data, shape, fail=self.fail, message=message)
+
+    async def explain(self, query, *, analyze=False):
+        return json.loads(await self.con.query_single(
+            f'explain {"analyze " if analyze else ""}{query}'
+        ))[0]
+
+    async def test_edgeql_explain_simple_01(self):
+        res = await self.explain('''
+            select User { id, name } filter .name = 'Elvis'
+        ''')
+        self.assert_plan(res['Plan'], {
+            'Node Type': 'Index Scan',
+            'Relation Name': 'default::User',
+            'Contexts': [[{'start': 28, 'end': 32, 'buffer_idx': 0}]],
+        })
+
+    async def test_edgeql_explain_with_bound_01(self):
+        res = await self.explain('''
+            with U := User,
+            select {
+                elvis := (select U filter .name like 'E%'),
+                yury := (select U filter .name[0] = 'Y'),
+            };
+        ''')
+
+        shape = {
+            "Node Type": "Subquery Scan",
+            "Plans": tb.bag([
+                {
+                    "Node Type": "Aggregate",
+                    "Plans": [
+                        {
+                            # XXX: If we don't run ANALYZE in the test setup,
+                            # we sometimes get this plan using bitmap scans
+                            # instead of just the index scan?
+                            # "Node Type": "Bitmap Heap Scan",
+                            # "Plans": [
+                            #     {
+                            #         "Node Type": "Bitmap Index Scan",
+                            #         "Parent Relationship": "Outer",
+                            #         "Index Name": str,
+                            #     }
+                            # ],
+
+                            "Node Type": "Index Scan",
+                            "Parent Relationship": "Outer",
+                            "Relation Name": "default::User",
+                            "Contexts": [
+                                [
+                                    {
+                                        "start": 31,
+                                        "end": 35,
+                                        "buffer_idx": 0
+                                    },
+                                    {
+                                        "start": 91,
+                                        "end": 92,
+                                        "buffer_idx": 0
+                                    },
+                                    {
+                                        "start": 74,
+                                        "end": 116,
+                                        "buffer_idx": 0
+                                    }
+                                ]
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Node Type": "Aggregate",
+                    "Plans": [
+                        {
+                            "Node Type": "Seq Scan",
+                            "Relation Name": "default::User",
+                            "Contexts": [
+                                [
+                                    {
+                                        "start": 31,
+                                        "end": 35,
+                                        "buffer_idx": 0
+                                    },
+                                    {
+                                        "start": 150,
+                                        "end": 151,
+                                        "buffer_idx": 0
+                                    },
+                                    {
+                                        "start": 134,
+                                        "end": 174,
+                                        "buffer_idx": 0
+                                    }
+                                ]
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Node Type": "Result",
+                    "Output": [
+                        "edgedbext.uuid_generate_v4()"
+                    ]
+                }
+            ])
+        }
+        self.assert_plan(res['Plan'], shape)
+
+    async def test_edgeql_explain_multi_link_01(self):
+        res = await self.explain('''
+            select User { name, todo: {name, number} }
+            filter .name = 'Elvis';
+        ''')
+        shape = {
+            "Node Type": "Index Scan",
+            "Index Name": (
+                "index 'name_9d90cf37' of object type 'default::User' index"),
+            "Relation Name": "default::User",
+            "Plans": [
+                {
+                    "Node Type": "Aggregate",
+                    "Strategy": "Plain",
+                    "Parent Relationship": "SubPlan",
+                    "Subplan Name": "SubPlan 1",
+                    "Plans": [
+                        {
+                            "Node Type": "Nested Loop",
+                            "Parent Relationship": "Outer",
+                            "Join Type": "Inner",
+                            "Inner Unique": True,
+                            "Plans": [
+                                {
+                                    "Node Type": "Index Only Scan",
+                                    "Parent Relationship": "Outer",
+                                    "Index Name": (
+                                        "default::User.todo forward link index"
+                                    ),
+                                    "Relation Name": "default::User.todo",
+                                    "Contexts": [
+                                        [
+                                            {
+                                                "start": 41,
+                                                "end": 45,
+                                                "buffer_idx": 0
+                                            }
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Node Type": "Index Scan",
+                                    "Parent Relationship": "Inner",
+                                    "Index Name": (
+                                        "constraint 'std::exclusive' of "
+                                        "property 'id' of object type '"
+                                        "default::Issue' exclusive constraint "
+                                        "index"
+                                    ),
+                                    "Relation Name": "default::Issue",
+                                    "Contexts": [
+                                        [
+                                            {
+                                                "start": 41,
+                                                "end": 45,
+                                                "buffer_idx": 0
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Contexts": [
+                [
+                    {
+                        "start": 28,
+                        "end": 32,
+                        "buffer_idx": 0
+                    }
+                ]
+            ]
+        }
+        self.assert_plan(res['Plan'], shape)
+
+    async def test_edgeql_explain_computed_backlink_01(self):
+        res = await self.explain('''
+            select User { name, owned_issues: {name, number} }
+            filter .name = 'Elvis';
+        ''')
+
+        shape = {
+            "Node Type": "Index Scan",
+            "Index Name": (
+                "index 'name_9d90cf37' of object type 'default::User' index"),
+            "Relation Name": "default::User",
+            "Plans": [
+                {
+                    "Node Type": "Aggregate",
+                    "Parent Relationship": "SubPlan",
+                    "Plans": [
+                        {
+                            "Node Type": "Result",
+                            "Parent Relationship": "Outer",
+                            "Plans": [
+                                {
+                                    "Node Type": "Bitmap Heap Scan",
+                                    "Parent Relationship": "Outer",
+                                    "Relation Name": "default::Issue",
+                                    "Plans": [
+                                        {
+                                            "Node Type": "Bitmap Index Scan",
+                                            "Parent Relationship": "Outer",
+                                            "Index Name": (
+                                                "default::Issue.owner index"),
+                                        }
+                                    ],
+                                    # We get a stack of contexts back
+                                    "Contexts": [
+                                        [
+                                            {
+                                                "start": 0,
+                                                "end": 7,
+                                                "buffer_idx": 1
+                                            },
+                                            {
+                                                "start": 0,
+                                                "end": 26,
+                                                "buffer_idx": 1
+                                            },
+                                            {
+                                                "start": 41,
+                                                "end": 53,
+                                                "buffer_idx": 0
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Contexts": [
+                [
+                    {
+                        "start": 28,
+                        "end": 32,
+                        "buffer_idx": 0
+                    }
+                ]
+            ]
+        }
+        self.assert_plan(res['Plan'], shape)
+
+        self.assertEqual(len(res['Buffers']), 2)
+        self.assertEqual(res['Buffers'][1][0], ".<owner[is default::Issue]")

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -227,7 +227,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
         shape = {
             "Node Type": "Index Scan",
             "Index Name": (
-                "index 'name_9d90cf37' of object type 'default::User' index"),
+                "index of object type 'default::User' on (__subject__.name)"),
             "Relation Name": "default::User",
             "Plans": [1],
             "CollapsedPlans": [
@@ -252,8 +252,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "Index Name": (
                                 "constraint 'std::exclusive' of "
                                 "property 'id' of object type '"
-                                "default::Issue' exclusive constraint "
-                                "index"
+                                "default::Issue'"
                             ),
                             "Relation Name": "default::Issue",
                             "Contexts": [
@@ -301,7 +300,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
         shape = {
             "Node Type": "Index Scan",
             "Index Name": (
-                "index 'name_9d90cf37' of object type 'default::User' index"),
+                "index of object type 'default::User' on (__subject__.name)"),
             "Relation Name": "default::User",
             "Plans": [1],
             "CollapsedPlans": [


### PR DESCRIPTION
Here is an initial take on EXPLAIN that hopefully is in a place that it can be played around with for frontend tooling.

Mostly it returns postgres's JSON output for EXPLAIN, but rewrites references to internal names into useful human readable names.

It also annotates subplans that actually touch tables with a list of "Contexts" indicating corresponding edgeql source positions. It is a list of contexts so that in queries like
`with U := User, U { name }`, we can indicate that the scan of `User` originates from the reference to `User` most specifically and then from the reference to `U` more generally. We also do this with computed pointers, including computed pointers defined in the schema.

In order to support computed pointers defined in the schema, the result also contains a 'Buffers' field that is a list of all the source strings referenced in a context, starting with the actual query text and including any expression from the schema used. When a schema expression is referenced, we also return the object's id and the name of the field.