### PR TITLE
Document aliveness/readiness endpoints

### DIFF
--- a/docs/clients/http/health-checks.rst
+++ b/docs/clients/http/health-checks.rst
@@ -4,10 +4,9 @@
 Health Checks
 =============
 
-Through the HTTP client, EdgeDB exposes endpoints to check for aliveness and
-readiness of your database instance. Once the client is enabled (see
-:ref:`ref_edgeql_http`), you can make requests to the endpoints to check the
-instance status.
+EdgeDB exposes endpoints to check for aliveness and readiness of your database
+instance. You can make requests to these endpoints to check the instance
+status.
 
 Aliveness
 ---------

--- a/docs/clients/http/health-checks.rst
+++ b/docs/clients/http/health-checks.rst
@@ -4,9 +4,9 @@
 Health Checks
 =============
 
-EdgeDB exposes endpoints to check for aliveness and readiness of your database
-instance. You can make requests to these endpoints to check the instance
-status.
+EdgeDB exposes HTTP endpoints to check for aliveness and readiness of your
+database instance. You can make GET requests to these endpoints to check the
+instance status.
 
 Aliveness
 ---------

--- a/docs/clients/http/health-checks.rst
+++ b/docs/clients/http/health-checks.rst
@@ -1,8 +1,8 @@
-.. _ref_edgeql_http_liveness_readiness:
+.. _ref_edgeql_http_health_checks:
 
-===============
-Instance Status
-===============
+=============
+Health Checks
+=============
 
 Through the HTTP client, EdgeDB exposes endpoints to check for aliveness and
 readiness of your database instance. Once the client is enabled (see
@@ -10,15 +10,17 @@ readiness of your database instance. Once the client is enabled (see
 instance status.
 
 Aliveness
-^^^^^^^^^
+---------
 
 Check that your instance is alive by making a request to
 ``http://<hostname>:<port>/server/status/alive``. If your instance is alive, it
-will respond with a ``200`` status code and ``"OK"`` as the payload.
+will respond with a ``200`` status code and ``"OK"`` as the payload. Otherwise,
+it will respond with a ``50x`` or a network error.
 
 Readiness
-^^^^^^^^^
+---------
 
 Check that your instance is ready by making a request to
 ``http://<hostname>:<port>/server/status/ready``. If your instance is ready, it
-will respond with a ``200`` status code and ``"OK"`` as the payload.
+will respond with a ``200`` status code and ``"OK"`` as the payload. Otherwise,
+it will respond with a ``50x`` or a network error.

--- a/docs/clients/http/index.rst
+++ b/docs/clients/http/index.rst
@@ -40,3 +40,4 @@ In development:
     :hidden:
 
     protocol
+    liveness-readiness

--- a/docs/clients/http/index.rst
+++ b/docs/clients/http/index.rst
@@ -40,4 +40,4 @@ In development:
     :hidden:
 
     protocol
-    liveness-readiness
+    health-checks

--- a/docs/clients/http/liveness-readiness.rst
+++ b/docs/clients/http/liveness-readiness.rst
@@ -1,0 +1,24 @@
+.. _ref_edgeql_http_liveness_readiness:
+
+===============
+Instance Status
+===============
+
+Through the HTTP client, EdgeDB exposes endpoints to check for aliveness and
+readiness of your database instance. Once the client is enabled (see
+:ref:`ref_edgeql_http`), you can make requests to the endpoints to check the
+instance status.
+
+Aliveness
+^^^^^^^^^
+
+Check that your instance is alive by making a request to
+``http://<hostname>:<port>/server/status/alive``. If your instance is alive, it
+will respond with a ``200`` status code and ``"OK"`` as the payload.
+
+Readiness
+^^^^^^^^^
+
+Check that your instance is ready by making a request to
+``http://<hostname>:<port>/server/status/ready``. If your instance is ready, it
+will respond with a ``200`` status code and ``"OK"`` as the payload.

--- a/docs/guides/deployment/aws_aurora_ecs.rst
+++ b/docs/guides/deployment/aws_aurora_ecs.rst
@@ -844,3 +844,10 @@ link``:
    intended to manage production instances.
 
 You can now open a REPL to this instance
+
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/aws_aurora_ecs.rst
+++ b/docs/guides/deployment/aws_aurora_ecs.rst
@@ -848,6 +848,6 @@ You can now open a REPL to this instance
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/azure_flexibleserver.rst
+++ b/docs/guides/deployment/azure_flexibleserver.rst
@@ -183,3 +183,10 @@ You can now connect to your instance.
 .. code-block:: bash
 
    $ edgedb -I azure
+
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/azure_flexibleserver.rst
+++ b/docs/guides/deployment/azure_flexibleserver.rst
@@ -187,6 +187,6 @@ You can now connect to your instance.
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/bare_metal.rst
+++ b/docs/guides/deployment/bare_metal.rst
@@ -195,6 +195,6 @@ CentOS/RHEL 7/8
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/bare_metal.rst
+++ b/docs/guides/deployment/bare_metal.rst
@@ -191,3 +191,10 @@ CentOS/RHEL 7/8
 
    $ sudo yum update edgedb-2
    $ sudo systemctl restart edgedb-server-2
+
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/digitalocean.rst
+++ b/docs/guides/deployment/digitalocean.rst
@@ -221,3 +221,10 @@ instance.
 
    The command groups ``edgedb instance`` and ``edgedb project`` are not
    intended to manage production instances.
+
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/digitalocean.rst
+++ b/docs/guides/deployment/digitalocean.rst
@@ -225,6 +225,6 @@ instance.
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -263,6 +263,6 @@ been applied.
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -259,3 +259,10 @@ To perform additional initialization, a derived image may include one or more
 executed *before* any schema migrations are applied, and parts in
 ``/edgedb-bootstrap-late.d`` are executed *after* the schema migration have
 been applied.
+
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/fly_io.rst
+++ b/docs/guides/deployment/fly_io.rst
@@ -327,3 +327,10 @@ with ``-I fly``; for example, to apply migrations:
    $ edgedb -I fly migrate
 
 .. _vpn: https://fly.io/docs/reference/private-networking/#private-network-vpn
+
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/fly_io.rst
+++ b/docs/guides/deployment/fly_io.rst
@@ -331,6 +331,6 @@ with ``-I fly``; for example, to apply migrations:
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/gcp.rst
+++ b/docs/guides/deployment/gcp.rst
@@ -275,3 +275,9 @@ variable wherever you deploy your application server; EdgeDB's client
 libraries read the value of this variable to know how to connect to your
 instance.
 
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/gcp.rst
+++ b/docs/guides/deployment/gcp.rst
@@ -278,6 +278,6 @@ instance.
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/health_checks.rst
+++ b/docs/guides/deployment/health_checks.rst
@@ -6,38 +6,8 @@ Health Checks
 
 You may want to monitor the status of your EdgeDB instance. Is it up? Is it
 ready to take queries? This guide will show you to perform health checks using
-our HTTP client and the ``alive`` and ``ready`` endpoints.
+HTTP and the ``alive`` and ``ready`` endpoints.
 
-Enable the HTTP Client
-======================
-
-Add this line to your schema, outside the ``module`` block:
-
-.. code-block:: sdl
-
-    using extension edgeql_http;
-
-Then use the CLI to create a migration:
-
-.. code-block:: bash
-
-    $ edgedb migration create
-    did you create extension 'edgeql_http'? [y,n,l,c,b,s,q,?]
-    > y
-    Created dbschema/migrations/00003.edgeql, id: <your-migration-id>
-
-Your migration's filename and ID may be different.
-
-Apply the new migration:
-
-.. code-block:: bash
-
-    $ edgedb migrate
-    Applied <your-migration-id> (00003.edgeql)
-
-EdgeDB will now expose HTTP endpoints you can use to interact with the
-database.
-    
 
 Check Instance Aliveness
 ========================

--- a/docs/guides/deployment/health_checks.rst
+++ b/docs/guides/deployment/health_checks.rst
@@ -1,0 +1,73 @@
+.. _ref_guide_deployment_health_checks:
+
+=============
+Health Checks
+=============
+
+You may want to monitor the status of your EdgeDB instance. Is it up? Is it
+ready to take queries? This guide will show you to perform health checks using
+our HTTP client and the ``alive`` and ``ready`` endpoints.
+
+Enable the HTTP Client
+======================
+
+Add this line to your schema, outside the ``module`` block:
+
+.. code-block:: sdl
+
+    using extension edgeql_http;
+
+Then use the CLI to create a migration:
+
+.. code-block:: bash
+
+    $ edgedb migration create
+    did you create extension 'edgeql_http'? [y,n,l,c,b,s,q,?]
+    > y
+    Created dbschema/migrations/00003.edgeql, id: <your-migration-id>
+
+Your migration's filename and ID may be different.
+
+Apply the new migration:
+
+.. code-block:: bash
+
+    $ edgedb migrate
+    Applied <your-migration-id> (00003.edgeql)
+
+EdgeDB will now expose HTTP endpoints you can use to interact with the
+database.
+    
+
+Check Instance Aliveness
+========================
+
+To check if the instance is alive, make a request to this endpoint:
+
+.. code-block::
+
+    http://<hostname>:<port>/server/status/alive
+
+To find your ``<port>``, you can run ``edgedb instance list`` to see a table of
+all your instances along with their port numbers.
+
+The endpoint will respond with a ``200`` status code and ``"OK"`` as the
+payload if the server is alive. If not, you will receive a ``50x`` code or a
+network error.
+
+Check Instance Readiness
+========================
+
+To check if the instance is ready, make a request to this endpoint:
+
+.. code-block::
+
+    http://<hostname>:<port>/server/status/ready
+
+As with the ``alive`` endpoint, you can find your ``<port>`` by running
+``edgedb instance list`` to see a table of all your instances along with their
+port numbers.
+
+The endpoint will respond with a ``200`` status code and ``"OK"`` as the
+payload if the server is ready. If not, you will receive a ``50x`` code or a
+network error.

--- a/docs/guides/deployment/heroku.rst
+++ b/docs/guides/deployment/heroku.rst
@@ -130,6 +130,6 @@ Commit the changes and push to Heroku to deploy the app.
 Health Checks
 =============
 
-Using the EdgeDB HTTP client, you can perform health checks to monitor the
-status of your EdgeDB instance. Learn how to use them with our :ref:`health
-checks guide <ref_guide_deployment_health_checks>`.
+Using an HTTP client, you can perform health checks to monitor the status of
+your EdgeDB instance. Learn how to use them with our :ref:`health checks guide
+<ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/heroku.rst
+++ b/docs/guides/deployment/heroku.rst
@@ -126,3 +126,10 @@ Commit the changes and push to Heroku to deploy the app.
    $ git add .
    $ git commit -m "first commit"
    $ git push heroku main
+
+Health Checks
+=============
+
+Using the EdgeDB HTTP client, you can perform health checks to monitor the
+status of your EdgeDB instance. Learn how to use them with our :ref:`health
+checks guide <ref_guide_deployment_health_checks>`.

--- a/docs/guides/deployment/index.rst
+++ b/docs/guides/deployment/index.rst
@@ -25,3 +25,4 @@ running EdgeDB `in Docker <https://github.com/edgedb/edgedb-docker>`_.
     heroku
     docker
     bare_metal
+    health_checks


### PR DESCRIPTION
to address #4854

A couple of questions to help me get this ready:

1. What do the endpoints return if the states are _not_ OK? (Is there any way to create or simulate these scenarios so that I can find out?)
2. Where else should this be documented? I believe this needs to be documented where I have it in the HTTP client documentation since it's tied to that, but I feel it's unlikely someone looking for this functionality will know to look there. I don't see an obvious place within the current docs' structure that this should go. I was thinking of adding a cheatsheet (at Guides > Cheatsheets) and then maybe adding a new top-level document under "Reference". Do those locations make sense? Anywhere else I'm missing?