### PR TITLE
Fix zlibg1-dev name

### DIFF
--- a/docs/guides/contributing.rst
+++ b/docs/guides/contributing.rst
@@ -36,7 +36,7 @@ On Ubuntu 22.10, these can be installed by running:
 .. code-block:: bash
 
    $ apt install make gcc rust-all autotools-dev python3.11-dev \
-     python3.11-venv bison flex libreadline-dev perl zlibg1-dev \
+     python3.11-venv bison flex libreadline-dev perl zlib1g-dev \
      uuid-dev nodejs npm
    $ npm i -g corepack
    $ corepack enable && corepack prepare yarn@stable --activate


### PR DESCRIPTION
Looks like there is a mistake in the library name

```shell
wolphin@meow:~$ docker run -it ubuntu:22.10 bash
root@bbeedfbb7589:/# apt update
<...>

root@bbeedfbb7589:/# apt install zlibg1-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package zlibg1-dev

root@bbeedfbb7589:/# apt install zlib1g-dev
<...>
Need to get 14.5 MB of archives.
After this operation, 50.0 MB of additional disk space will be used.
Do you want to continue? [Y/n] 
```
