### PR TITLE
Fix: forbid aggregation in index expressions

### DIFF
--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -292,6 +292,9 @@ class IndexCommand(
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
     ) -> s_expr.CompiledExpression:
+        from edb.ir import utils as irutils
+        from edb.ir import ast as irast
+
         singletons: List[s_types.Type]
         if field.name in {'expr', 'except_expr'}:
             # type ignore below, for the class is used as mixin
@@ -329,6 +332,34 @@ class IndexCommand(
                 raise errors.SchemaDefinitionError(
                     f'index expressions must be immutable',
                     context=value.qlast.context,
+                )
+
+            refs = irutils.get_longest_paths(expr.irast)
+
+            has_multi = False
+            for ref in refs:
+                assert subject
+                while ref.rptr:
+                    rptr = ref.rptr
+                    if rptr.dir_cardinality.is_multi():
+                        has_multi = True
+
+                    # We don't need to look further than the subject,
+                    # which is always valid. (And which is a singleton
+                    # in an index expression if it is itself a
+                    # singleton, regardless of other parts of the path.)
+                    if (
+                        isinstance(rptr.ptrref, irast.PointerRef)
+                        and rptr.ptrref.id == subject.id
+                    ):
+                        break
+                    ref = rptr.source
+
+            if has_multi and irutils.contains_set_of_op(expr.irast):
+                raise errors.SchemaDefinitionError(
+                    "cannot use aggregate functions or operators "
+                    "in an index expression",
+                    context=self.source_context,
                 )
 
             return expr


### PR DESCRIPTION
Add a check on indexes that prevents aggregation, similar to what's already on the constraint expressions.