### PR TITLE
docs: a stub for client libraries section

### DIFF
--- a/docs/reference/bindings/datetime.rst
+++ b/docs/reference/bindings/datetime.rst
@@ -1,0 +1,92 @@
+.. _ref_bindings_datetime:
+
+==================
+Date/Time Handling
+==================
+
+EdgeDB has 6 types related to date and time handling:
+
+* :eql:type:`datetime` (:ref:`binary format <ref_protocol_fmt_datetime>`)
+* :eql:type:`duration` (:ref:`binary format <ref_protocol_fmt_duration>`)
+* :eql:type:`cal::local_datetime`
+  (:ref:`binary format <ref_protocol_fmt_local_datetime>`)
+* :eql:type:`cal::local_date`
+  (:ref:`binary format <ref_protocol_fmt_local_date>`)
+* :eql:type:`cal::relative_duration`
+  (:ref:`binary format <ref_protocol_fmt_relative_duration>`)
+* :eql:type:`cal::date_duration`
+  (:ref:`binary format <ref_protocol_fmt_date_duration>`)
+
+Usually we try to map those types to the respective language-native types,
+with the following caveats:
+
+* The type in standard library
+* It has enough range (EdgeDB has timestamps from year 1 to 9999)
+* And it has good enough precision (at least microseconds)
+
+If any of the above is not true we tend to provide a custom type in the client
+library itself that is convertible to whatever type language or any popular
+external dependencies have. Exceptions: JavaScript has millisecond precision on
+their ``Date`` type (which is actually a timestamp) and we decided that it's
+better to use that type by default even though it doesn't have enough
+precision.
+
+
+Precision
+=========
+
+:eql:type:`datetime`, :eql:type:`duration`, :eql:type:`cal::local_datetime` and
+:eql:type:`cal::relative_duration` all have precision of **1 millisecond**.
+
+This means that if language-native type have a bigger precision such as
+nanosecond, client library has to round that timestamp when encoding it for
+EdgeDB.
+
+We use **rouding to the nearest even** for that operation. Here are some
+examples of timetamps with high precision, and how they are stored in the
+database::
+
+    2022-02-24T05:43:03.123456789Z → 2022-02-24T05:43:03.123457Z
+
+    2022-02-24T05:43:03.000002345Z → 2022-02-24T05:43:03.000002Z
+    2022-02-24T05:43:03.000002500Z → 2022-02-24T05:43:03.000002Z
+    2022-02-24T05:43:03.000002501Z → 2022-02-24T05:43:03.000003Z
+    2022-02-24T05:43:03.000002499Z → 2022-02-24T05:43:03.000002Z
+
+    2022-02-24T05:43:03.000001234Z → 2022-02-24T05:43:03.000001Z
+    2022-02-24T05:43:03.000001500Z → 2022-02-24T05:43:03.000002Z
+    2022-02-24T05:43:03.000001501Z → 2022-02-24T05:43:03.000002Z
+    2022-02-24T05:43:03.000001499Z → 2022-02-24T05:43:03.000001Z
+
+.. note::
+
+   A quick refresher on rounding types: If we perform multiple operations of
+   summing while rounding half-up or rounding half-down, the error margin of
+   the resulting value tends to increase. If we round half-to-even instead,
+   the expected value of summing tends to be more accurate.
+
+Note as described in :ref:`datetime protocol documentation
+<ref_protocol_fmt_datetime>` the value is encoded as a *signed* microseconds
+delta since a fixed time. Some care must be taken when rounding negative
+microsecond values. See `tests for Rust implementation`_ for a good set of
+test cases.
+
+Rounding to the nearest even applies to all operations that client libraries
+perform, in particular:
+
+1. Encoding timestamps *and* time deltas (see the :ref:`list of types
+   <ref_bindings_datetime>`) to the binary format if precision of the native
+   type is higher than microseconds.
+2. Decoding timestamps *and* time deltas from the binary format is precision
+   of native type is lower than microseconds (applies for JavaScript for
+   example)
+3. Converting from EdgeDB specific type (if there is one) to native type and
+   back (depending on the difference in precision)
+4. Parsing a string to an EdgeDB specific type (this operation is optional to
+   implement, but if it is implemented, it must obey the rules)
+
+.. lint-off
+
+.. _tests for Rust implementation: https://github.com/edgedb/edgedb-rust/tree/master/edgedb-protocol/tests/datetime_chrono.rs
+
+.. lint-on

--- a/docs/reference/bindings/index.rst
+++ b/docs/reference/bindings/index.rst
@@ -1,0 +1,40 @@
+.. _ref_bindings_overview:
+
+================
+Client Libraries
+================
+
+EdgeDB client libraries are a bit higher level than usual database bindings.
+In particular, they contain:
+
+* Structured data retrieval
+* Connection pooling
+* Retrying of failed transactions and queries
+
+Additionally, client libraries might provide:
+
+* Code generation for type-safe database access
+* Query builder
+
+This is a **work-in-progress** reference for writing client libraries for
+EdgeDB.
+
+External Links:
+
+* :ref:`Official Client Libraries <ref_clients_index>`
+* :ref:`Binary protocol <ref_protocol_overview>`
+* `RFC 1004`_ - Robust Client API
+
+Contents:
+
+.. toctree::
+    :maxdepth: 3
+
+    datetime
+
+
+.. lint-off
+
+.. _RFC 1004: https://github.com/edgedb/rfcs/blob/master/text/1004-transactions-api.rst
+
+.. lint-on

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -23,6 +23,7 @@ Reference
     configuration
     http
     protocol/index
+    bindings/index
     admin/index
 
 

--- a/docs/reference/protocol/dataformats.rst
+++ b/docs/reference/protocol/dataformats.rst
@@ -419,6 +419,9 @@ encoded as:
 
     0x00 0x02 0x2b 0x35 0x9b 0xc4 0x10 0x00
 
+See :ref:`client libraries <ref_bindings_datetime>` section for more info
+about how to handle different precision when encoding data.
+
 
 .. _ref_protocol_fmt_local_datetime:
 
@@ -435,6 +438,9 @@ encoded as:
 .. code-block:: c
 
     0x00 0x02 0x2b 0x35 0x9b 0xc4 0x10 0x00
+
+See :ref:`client libraries <ref_bindings_datetime>` section for more info
+about how to handle different precision when encoding data.
 
 
 .. _ref_protocol_fmt_local_date:
@@ -469,6 +475,9 @@ encoded as:
 .. code-block:: c
 
     0x00 0x00 0x00 0x0a 0x32 0xae 0xf6 0x00
+
+See :ref:`client libraries <ref_bindings_datetime>` section for more info
+about how to handle different precision when encoding data.
 
 
 .. _ref_protocol_fmt_duration:
@@ -505,6 +514,9 @@ encoded as:
     // months
     0x00 0x00 0x00 0x00
 
+See :ref:`client libraries <ref_bindings_datetime>` section for more info
+about how to handle different precision when encoding data.
+
 
 .. _ref_protocol_fmt_relative_duration:
 
@@ -535,6 +547,9 @@ For example, the ``cal::relative_duration`` value
 
     // months
     0x00 0x00 0x00 0x1f
+
+See :ref:`client libraries <ref_bindings_datetime>` section for more info
+about how to handle different precision when encoding data.
 
 
 .. _ref_protocol_fmt_date_duration:


### PR DESCRIPTION
Also includes initial description for the rounding during encoding/decoding datetimes