### PR TITLE
Fix `cal::local_time` parsing from `str`.

### DIFF
--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -212,7 +212,23 @@ cal::to_local_time(hour: std::int64, min: std::int64, sec: std::float64)
     CREATE ANNOTATION std::description := 'Create a `cal::local_time` value.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT make_time("hour"::int, "min"::int, "sec")
+    SELECT
+        CASE WHEN date_part('hour', x.t) = 24
+        THEN
+            edgedb.raise(
+                NULL::time,
+                'invalid_datetime_format',
+                msg => (
+                    'cal::local_time field value out of range: '
+                    || quote_literal(x.t::text)
+                )
+            )
+        ELSE
+            x.t
+        END
+    FROM (
+        SELECT make_time("hour"::int, "min"::int, "sec") as t
+    ) as x
     $$;
 };
 

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -2565,6 +2565,54 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                         cal::to_local_datetime('00:00:00 0715');
                 ''')
 
+    async def test_edgeql_functions_to_local_time_05(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            'cal::local_time field value out of range'
+        ):
+            async with self.con.transaction():
+                # including time zone
+                await self.con.query(r'''
+                    SELECT
+                        cal::to_local_time('24:00:00');
+                ''')
+
+    async def test_edgeql_functions_to_local_time_06(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            'cal::local_time field value out of range'
+        ):
+            async with self.con.transaction():
+                # including time zone
+                await self.con.query(r'''
+                    SELECT
+                        cal::to_local_time(23, 59, 60);
+                ''')
+
+    async def test_edgeql_functions_to_local_time_07(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            'cal::local_time field value out of range'
+        ):
+            async with self.con.transaction():
+                # including time zone
+                await self.con.query(r'''
+                    SELECT
+                        <cal::local_time>'23:59:59.999999999999';
+                ''')
+
+    async def test_edgeql_functions_to_local_time_08(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            'cal::local_time field value out of range'
+        ):
+            async with self.con.transaction():
+                # including time zone
+                await self.con.query(r'''
+                    SELECT
+                        <cal::local_time><json>'24:00:00';
+                ''')
+
     async def test_edgeql_functions_to_duration_01(self):
         await self.assert_query_result(
             r'''SELECT <str>to_duration(hours:=20);''',


### PR DESCRIPTION
Change casts from `str` and `json` to `cal::local_time` to disallow creating "24:00:00" value.
Change `cal::to_local_time` to disallow creating "24:00:00" value.

Fixes #4884