### PR TITLE
Fix two issues with DML in free objects

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1075,8 +1075,17 @@ def init_stmt(
             (dv := ctx.defining_view) is not None
             and dv.get_expr_type(ctx.env.schema) is s_types.ExprType.Select
             and not (
+                # We allow DML in trivial *top-level* free objects
                 ctx.partial_path_prefix
                 and irutils.is_trivial_free_object(ctx.partial_path_prefix)
+                # Find the enclosing context at the point the free object
+                # was defined.
+                and (outer_ctx := next((
+                    x for x in reversed(ctx._stack.stack)
+                    if isinstance(x, context.ContextLevel)
+                    and x.partial_path_prefix != ctx.partial_path_prefix
+                ), None))
+                and outer_ctx.expr_exposed
             )
         ):
             # This is some shape in a regular query. Although

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1270,7 +1270,10 @@ def process_set_as_subquery(
         semi_join = False
 
         if ir_source is not None:
-            if ir_source.path_id != ctx.current_insert_path_id:
+            if (
+                ir_source.path_id != ctx.current_insert_path_id
+                and not irutils.is_trivial_free_object(ir_source)
+            ):
                 # This is a computable pointer.  In order to ensure that
                 # the volatile functions in the pointer expression are called
                 # the necessary number of times, we must inject a
@@ -1280,6 +1283,17 @@ def process_set_as_subquery(
                 # If the source is an insert that we are in the middle
                 # of doing, we don't have a volatility ref to add, so
                 # skip it based on the current_insert_path_id check.
+
+                # Note also that we skip this when the source is a
+                # trivial free object reference. A trivial free object
+                # reference is always executed exactly once (if there
+                # is an outer iterator of some kind, we'll pick up
+                # *that* volatility ref) and, unlike other shapes, may
+                # contain DML. We disable the volatility ref for
+                # trival free objects then both as a minor
+                # optimization and to avoid it interfering with DML in
+                # the object (since the volatility ref would not be
+                # visible in DML CTEs).
                 path_id = ir_source.path_id
                 newctx.volatility_ref += (
                     lambda _stmt, xctx: relctx.maybe_get_path_var(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5786,6 +5786,21 @@ class TestInsert(tb.QueryTestCase):
             [{"obj": {'name': "insert simple 02", 'l2': 0}}],
         )
 
+        await self.assert_query_result(
+            r"""
+                select {
+                    objs := (
+                        for name in {'one', 'two'} union (
+                            INSERT InsertTest {
+                                name := name, l2 := 0,
+                            }
+                        )
+                    )
+                }
+            """,
+            [{"objs": [{"id": str}, {"id": str}]}],
+        )
+
     async def test_edgeql_insert_in_free_object_02(self):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
@@ -5812,6 +5827,20 @@ class TestInsert(tb.QueryTestCase):
                         }
                      )
                 };
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                "mutations are invalid in a shape's computed expression"):
+            await self.con.query('''
+                with X := {
+                    obj := (
+                        INSERT InsertTest {
+                            name := 'insert simple 01',
+                            l2 := 0,
+                        }
+                     )
+                }, select X;
             ''')
 
     async def test_edgeql_insert_rebind_with_typenames_01(self):


### PR DESCRIPTION
Fix an ISE where the volatility ref from the free object will
get referenced in the CTE for a for loop that contains DML
inside the free object. Fix this by not inserting volatility
refs for free objects, where they shouldn't be needed.
Fixes #4875.

Also fix an issue where DML in a non-exposed free object would not be
executed. Fix this by only allowing free object DML in exposed
positions.