### PR TITLE
Fix `grouping` field when grouping by one key or nothing

### DIFF
--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -83,12 +83,13 @@ def _compile_grouping_value(
     assert stmt.grouping_binding
     grouprel = ctx.rel
 
-    # If there is only one thing grouped on, just output the hardcoded
-    if len(used_args) == 1:
+    # If there is only one grouping set, hardcode the output
+    if all(isinstance(b, qlast.GroupingSimple) for b in stmt.by):
         return pgast.ArrayExpr(
             elements=[
-                pgast.StringConstant(
-                    val=desugar_group.key_name(list(used_args)[0]))]
+                pgast.StringConstant(val=desugar_group.key_name(arg))
+                for arg in used_args
+            ],
         )
 
     using = {k: stmt.using[k] for k in used_args}

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -988,6 +988,17 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             [{"grouping": ["awd_size", "element"]}] * 6,
         )
 
+    async def test_edgeql_trivial_grouping_01(self):
+        await self.assert_query_result(
+            '''
+            group 0 using x := 0 by cube(x)
+            ''',
+            tb.bag([
+                {"elements": [0], "grouping": [], "key": {"x": None}},
+                {"elements": [0], "grouping": ["x"], "key": {"x": 0}}
+            ]),
+        )
+
     async def test_edgeql_group_binding_01(self):
         await self.assert_query_result(
             '''


### PR DESCRIPTION
The computation of the grouping field has an optimization where if
there is only one argument being grouped on, just hardcode the result
to be that argument instead of computing it. This is incorrect:
something like `by cube(foo)` will group by both `foo` and by nothing,
but the nothing group will have an incorrect `grouping` field

Fix the optimization to trigger when there is only one grouping *set*,
rather than when there is just one grouping key. This also lets the
optimization fire in more cases, since previously something like `by
(foo, bar)` wouldn't get optimized, even though it is trivial.