### PR TITLE
Get rid of the __std__derived__ hack

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -31,7 +31,6 @@ from edb.ir import typeutils as irtyputils
 
 from edb.schema import name as s_name
 from edb.schema import pointers as s_pointers
-from edb.schema import schema as s_schema
 from edb.schema import types as s_types
 
 from . import context
@@ -77,17 +76,7 @@ def get_expression_path_id(
         ctx: context.ContextLevel) -> irast.PathId:
     if alias is None:
         alias = ctx.aliases.get('expr')
-    name = stype.get_name(ctx.env.schema)
-    # If the type comes from one of our standard modules, we need to
-    # make our derived typename also be from a standard module, so that
-    # if we need to generate a cast on the backend we can detect that
-    # it is a stdlib type and not a user one.
-    in_std_module = (
-        isinstance(name, s_name.QualName)
-        and s_name.UnqualName(name.module) in s_schema.STD_MODULES
-    )
-    modname = '__std_derived__' if in_std_module else '__derived__'
-    typename = s_name.QualName(module=modname, name=alias)
+    typename = s_name.QualName(module='__derived__', name=alias)
     return get_path_id(stype, typename=typename, ctx=ctx)
 
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -120,6 +120,9 @@ class TypeRef(ImmutableBase):
     # Full name of the type, not necessarily schema-addressable,
     # used for annotations only.
     name_hint: sn.Name
+    # Name hint of the real underlying type, if the type ref was created
+    # with an explicitly specified typename.
+    orig_name_hint: typing.Optional[sn.Name] = None
     # The ref of the underlying material type, if this is a view type,
     # else None.
     material_type: typing.Optional[TypeRef] = None

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -231,15 +231,20 @@ def type_to_typeref(
             if cached_result.name_hint == t.get_name(schema):
                 return cached_result
 
+    name_hint = typename or t.get_name(schema)
+    orig_name_hint = None if not typename else t.get_name(schema)
+
     if t.is_anytuple(schema):
         result = irast.AnyTupleRef(
             id=t.id,
-            name_hint=typename or t.get_name(schema),
+            name_hint=name_hint,
+            orig_name_hint=orig_name_hint,
         )
     elif t.is_any(schema):
         result = irast.AnyTypeRef(
             id=t.id,
-            name_hint=typename or t.get_name(schema),
+            name_hint=name_hint,
+            orig_name_hint=orig_name_hint,
         )
     elif not isinstance(t, s_types.Collection):
         assert isinstance(t, s_types.InheritingType)
@@ -296,12 +301,6 @@ def type_to_typeref(
         else:
             base_typeref = None
 
-        tname = t.get_name(schema)
-        if typename is not None:
-            name = typename
-        else:
-            name = tname
-
         children: Optional[FrozenSet[irast.TypeRef]]
 
         if material_typeref is None and include_children:
@@ -325,7 +324,8 @@ def type_to_typeref(
 
         result = irast.TypeRef(
             id=t.id,
-            name_hint=name,
+            name_hint=name_hint,
+            orig_name_hint=orig_name_hint,
             material_type=material_typeref,
             base_type=base_typeref,
             children=children,
@@ -349,7 +349,8 @@ def type_to_typeref(
 
         result = irast.TypeRef(
             id=t.id,
-            name_hint=typename or t.get_name(schema),
+            name_hint=name_hint,
+            orig_name_hint=orig_name_hint,
             material_type=material_typeref,
             element_name=_name,
             collection=t.get_schema_name(),
@@ -371,7 +372,8 @@ def type_to_typeref(
 
         result = irast.TypeRef(
             id=t.id,
-            name_hint=typename or t.get_name(schema),
+            name_hint=name_hint,
+            orig_name_hint=orig_name_hint,
             material_type=material_typeref,
             element_name=_name,
             collection=t.get_schema_name(),

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -299,9 +299,10 @@ def pg_type_from_ir_typeref(
         else:
             pg_type = base_type_name_map.get(material.id)
             if pg_type is None:
+                real_name_hint = material.orig_name_hint or material.name_hint
                 # User-defined scalar type
                 pg_type = common.get_scalar_backend_name(
-                    material.id, material.name_hint.module, catenate=False)
+                    material.id, real_name_hint.module, catenate=False)
 
             return pg_type
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -54,7 +54,6 @@ if TYPE_CHECKING:
     ]
 
 STD_MODULES = (
-    sn.UnqualName('__std_derived__'),
     sn.UnqualName('std'),
     sn.UnqualName('schema'),
     sn.UnqualName('math'),


### PR DESCRIPTION
In #4530 I introduced a new __std_derived__ fake module for
distinguishing whether a pathid with a made up type name came from a
standard module or not, since that information is needed to generate
correct type names in the backend in some places (notably when dealing
with emptysets of standard library enum types).

This was a hack, and it made all our debug output uglier.  Instead,
track the original name of types in typerefs, even when the name has
been overridden.