### PR TITLE
Implement nested modules

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1426,7 +1426,7 @@ class ModuleDeclaration(SDL):
     # The 'name' is treated same as in CreateModule, for consistency,
     # since this declaration also implies creating a module.
     name: ObjectRef
-    declarations: typing.List[DDL]
+    declarations: typing.List[typing.Union[NamedDDL, ModuleDeclaration]]
 
 
 class Schema(SDL):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -74,7 +74,9 @@ def param_to_str(ident: str) -> str:
 
 
 def module_to_str(module: str) -> str:
-    return '.'.join([ident_to_str(part) for part in module.split('.')])
+    return '::'.join([
+        any_ident_to_str(part) for part in module.split('::')
+    ])
 
 
 class EdgeQLSourceGeneratorError(errors.InternalServerError):
@@ -368,7 +370,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._write_keywords('GROUP')
         self._block_ws(1)
         if node.subject_alias:
-            self.write(any_ident_to_str(node.subject_alias), ' := ')
+            self.write(ident_to_str(node.subject_alias), ' := ')
         self.visit(node.subject)
         self._block_ws(-1)
         if node.using is not None:
@@ -418,7 +420,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write(ident_to_str(node.alias))
             self._write_keywords(' AS ')
         self._write_keywords('MODULE ')
-        self.write(any_ident_to_str(node.module))
+        self.write(module_to_str(node.module))
 
     def visit_SortExpr(self, node: qlast.SortExpr) -> None:
         self.visit(node.path)

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -99,7 +99,7 @@ class TraceContextBase:
         self,
         ref: qlast.ObjectRef,
     ) -> s_name.QualName:
-        return qltracer.get_name(
+        return qltracer.resolve_name(
             ref,
             current_module=self.module,
             schema=self.schema,

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2229,7 +2229,7 @@ class CreateModuleStmt(Nonterm):
     def reduce_CREATE_MODULE_ModuleName_OptIfNotExists_OptCreateCommandsBlock(
             self, *kids):
         self.val = qlast.CreateModule(
-            name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val)),
+            name=qlast.ObjectRef(module=None, name='::'.join(kids[2].val)),
             create_if_not_exists=kids[3].val,
             commands=kids[4].val
         )
@@ -2242,7 +2242,7 @@ class AlterModuleStmt(Nonterm):
     def reduce_ALTER_MODULE_ModuleName_AlterCommandsBlock(
             self, *kids):
         self.val = qlast.AlterModule(
-            name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val)),
+            name=qlast.ObjectRef(module=None, name='::'.join(kids[2].val)),
             commands=kids[3].val
         )
 
@@ -2253,7 +2253,7 @@ class AlterModuleStmt(Nonterm):
 class DropModuleStmt(Nonterm):
     def reduce_DROP_MODULE_ModuleName(self, *kids):
         self.val = qlast.DropModule(
-            name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val))
+            name=qlast.ObjectRef(module=None, name='::'.join(kids[2].val))
         )
 
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -330,12 +330,12 @@ class WithBlock(Nonterm):
 class AliasDecl(Nonterm):
     def reduce_MODULE_ModuleName(self, *kids):
         self.val = qlast.ModuleAliasDecl(
-            module='.'.join(kids[1].val))
+            module='::'.join(kids[1].val))
 
     def reduce_Identifier_AS_MODULE_ModuleName(self, *kids):
         self.val = qlast.ModuleAliasDecl(
             alias=kids[0].val,
-            module='.'.join(kids[3].val))
+            module='::'.join(kids[3].val))
 
     def reduce_AliasedExpr(self, *kids):
         self.val = kids[0].val
@@ -1625,7 +1625,23 @@ class AnyIdentifier(Nonterm):
         self.val = name
 
 
-class ModuleName(ListNonterm, element=AnyIdentifier, separator=tokens.T_DOT):
+class DottedIdents(
+        ListNonterm, element=AnyIdentifier, separator=tokens.T_DOT):
+    pass
+
+
+class DotName(Nonterm):
+    def reduce_DottedIdents(self, *kids):
+        self.val = '.'.join(part for part in kids[0].val)
+
+
+class ModuleName(
+        ListNonterm, element=DotName, separator=tokens.T_DOUBLECOLON):
+    pass
+
+
+class ColonedIdents(
+        ListNonterm, element=AnyIdentifier, separator=tokens.T_DOUBLECOLON):
     pass
 
 
@@ -1634,11 +1650,11 @@ class BaseName(Nonterm):
     def reduce_Identifier(self, *kids):
         self.val = [kids[0].val]
 
-    def reduce_Identifier_DOUBLECOLON_AnyIdentifier(self, *kids):
-        self.val = [kids[0].val, kids[2].val]
+    def reduce_Identifier_DOUBLECOLON_ColonedIdents(self, *kids):
+        self.val = [kids[0].val, *kids[2].val]
 
-    def reduce_DUNDERSTD_DOUBLECOLON_AnyIdentifier(self, *kids):
-        self.val = ['__std__', kids[2].val]
+    def reduce_DUNDERSTD_DOUBLECOLON_ColonedIdents(self, *kids):
+        self.val = ['__std__', *kids[2].val]
 
 
 # this can appear in link/property definitions
@@ -1646,11 +1662,11 @@ class PtrName(Nonterm):
     def reduce_PtrIdentifier(self, *kids):
         self.val = [kids[0].val]
 
-    def reduce_Identifier_DOUBLECOLON_AnyIdentifier(self, *kids):
-        self.val = [kids[0].val, kids[2].val]
+    def reduce_Identifier_DOUBLECOLON_ColonedIdents(self, *kids):
+        self.val = [kids[0].val, *kids[2].val]
 
-    def reduce_DUNDERSTD_DOUBLECOLON_AnyIdentifier(self, *kids):
-        self.val = ['__std__', kids[2].val]
+    def reduce_DUNDERSTD_DOUBLECOLON_ColonedIdents(self, *kids):
+        self.val = ['__std__', *kids[2].val]
 
 
 # Non-collection type.
@@ -1802,7 +1818,7 @@ class NodeName(Nonterm):
 
     def reduce_BaseName(self, *kids):
         self.val = qlast.ObjectRef(
-            module='.'.join(kids[0].val[:-1]) or None,
+            module='::'.join(kids[0].val[:-1]) or None,
             name=kids[0].val[-1])
 
 
@@ -1817,7 +1833,7 @@ class PtrNodeName(Nonterm):
 
     def reduce_PtrName(self, *kids):
         self.val = qlast.ObjectRef(
-            module='.'.join(kids[0].val[:-1]) or None,
+            module='::'.join(kids[0].val[:-1]) or None,
             name=kids[0].val[-1])
 
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -169,11 +169,6 @@ class SDLCommandBlock(Nonterm):
         self.val = stmts.val
 
 
-class DotName(Nonterm):
-    def reduce_ModuleName(self, *kids):
-        self.val = '.'.join(part for part in kids[0].val)
-
-
 class SDLProductionHelper:
     def _passthrough(self, *cmds):
         self.val = cmds[0].val
@@ -322,11 +317,7 @@ class ModuleDeclaration(Nonterm):
         # names and aren't nested module blocks.
         declarations = block.val
         for decl in declarations:
-            if isinstance(decl, qlast.ModuleDeclaration):
-                raise errors.EdgeQLSyntaxError(
-                    "nested module declaration is not allowed",
-                    context=decl.context)
-            elif isinstance(decl, qlast.ExtensionCommand):
+            if isinstance(decl, qlast.ExtensionCommand):
                 raise errors.EdgeQLSyntaxError(
                     "'using extension' cannot be used inside a module block",
                     context=decl.context)
@@ -342,7 +333,7 @@ class ModuleDeclaration(Nonterm):
 
         self.val = qlast.ModuleDeclaration(
             # mirror what we do in CREATE MODULE
-            name=qlast.ObjectRef(module=None, name=".".join(module_name.val)),
+            name=qlast.ObjectRef(module=None, name='::'.join(module_name.val)),
             declarations=declarations,
         )
 

--- a/edb/edgeql/parser/grammar/session.py
+++ b/edb/edgeql/parser/grammar/session.py
@@ -36,12 +36,12 @@ class SessionStmt(Nonterm):
 class SetStmt(Nonterm):
     def reduce_SET_ALIAS_Identifier_AS_MODULE_ModuleName(self, *kids):
         self.val = qlast.SessionSetAliasDecl(
-            module='.'.join(kids[5].val),
+            module='::'.join(kids[5].val),
             alias=kids[2].val)
 
     def reduce_SET_MODULE_ModuleName(self, *kids):
         self.val = qlast.SessionSetAliasDecl(
-            module='.'.join(kids[2].val))
+            module='::'.join(kids[2].val))
 
 
 class ResetStmt(Nonterm):

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -306,10 +306,15 @@ def get_name(
     elif not module:
         module = current_module
     elif modaliases:
-        fq_module = modaliases.get(module)
+        if module:
+            first, sep, rest = module.partition('::')
+        else:
+            first, sep, rest = module, '', ''
+
+        fq_module = modaliases.get(first)
         if fq_module is not None:
             no_std = True
-            module = fq_module
+            module = fq_module + sep + rest
 
     qname = sn.QualName(module=module, name=ref.name)
     if type is None:

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -289,7 +289,7 @@ def trace_refs(
     return frozenset(ctx.refs)
 
 
-def get_name(
+def resolve_name(
     ref: qlast.ObjectRef, *,
     current_module: str,
     schema: s_schema.Schema,
@@ -297,6 +297,10 @@ def get_name(
     modaliases: Optional[Dict[Optional[str], str]],
     local_modules: AbstractSet[str],
 ) -> sn.QualName:
+    """Resolve a name into a fully-qualified one.
+
+    This takes into account the current module and modaliases.
+    """
     module = ref.module
 
     no_std = False
@@ -371,7 +375,7 @@ class TracerContext:
         if not ref.module and ref.name in self.params:
             return self.params[ref.name]
 
-        return get_name(
+        return resolve_name(
             ref,
             current_module=self.module,
             schema=self.schema,

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -272,3 +272,13 @@ std::_datetime_range_buckets(
         hi IS NOT NULL
     $$;
 };
+
+CREATE MODULE std::_test;
+
+
+CREATE FUNCTION
+std::_test::abs(x: std::anyreal) -> std::anyreal
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'abs';
+};

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -355,7 +355,9 @@ def delta_schemas(
             result.add(cmd)
 
     if include_module_diff:
-        for dropped_module in sorted(dropped_modules):
+        # Process dropped modules in *reverse* sorted order, so that
+        # `foo::bar` gets dropped before `foo`.
+        for dropped_module in reversed(sorted(dropped_modules)):
             if (
                 guidance is None
                 or (

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -54,6 +54,11 @@ class ModuleCommand(
         context: sd.CommandContext,
     ) -> None:
         super()._validate_legal_command(schema, context)
+        if '::' in str(self.classname):
+            enclosing = str(self.classname).rpartition('::')[0]
+            if not schema.has_module(enclosing):
+                raise errors.UnknownModuleError(
+                    f'module {enclosing!r} is not in this schema')
 
         if (
             not context.stdmode and not context.testmode

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -30,6 +30,11 @@ from . import annos as s_anno
 from . import delta as sd
 from . import schema as s_schema
 
+RESERVED_MODULE_NAMES = {
+    'ext',
+    'super',
+}
+
 
 class Module(
     s_anno.AnnotationSubject,
@@ -54,11 +59,17 @@ class ModuleCommand(
         context: sd.CommandContext,
     ) -> None:
         super()._validate_legal_command(schema, context)
+
+        last = str(self.classname)
         if '::' in str(self.classname):
-            enclosing = str(self.classname).rpartition('::')[0]
+            enclosing, _, last = str(self.classname).rpartition('::')
             if not schema.has_module(enclosing):
                 raise errors.UnknownModuleError(
                     f'module {enclosing!r} is not in this schema')
+
+        if last in RESERVED_MODULE_NAMES:
+            raise errors.SchemaDefinitionError(
+                f"module {last!r} is a reserved module name")
 
         if (
             not context.stdmode and not context.testmode

--- a/edb/schema/reflection/reader.py
+++ b/edb/schema/reflection/reader.py
@@ -110,6 +110,7 @@ def parse_into(
         if isinstance(obj, s_obj.QualifiedObject):
             name_to_id[name] = objid
         else:
+            name = s_name.UnqualName(str(name))
             globalname_to_id[mcls, name] = objid
 
         if isinstance(obj, (s_func.Function, s_oper.Operator)):

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1061,10 +1061,16 @@ class FlatSchema(Schema):
             cur_module = module_aliases[None]
             module = f'{cur_module}::{module.removeprefix("__current__::")}'
         elif module_aliases is not None:
-            fq_module = module_aliases.get(module)
+            first: Optional[str]
+            if module:
+                first, sep, rest = module.partition('::')
+            else:
+                first, sep, rest = module, '', ''
+
+            fq_module = module_aliases.get(first)
             if fq_module is not None:
                 alias_hit = True
-                module = fq_module
+                module = fq_module + sep + rest
 
         if module is not None:
             fqname = sn.QualName(module, shortname)

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -46,6 +46,7 @@ from edb.server import compiler as edbcompiler
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as sd
 from edb.schema import migrations as s_migrations  # noqa
+from edb.schema import name as sn
 from edb.schema import reflection as s_refl
 from edb.schema import schema as s_schema
 from edb.schema import std as s_std
@@ -278,7 +279,7 @@ def _load_std_schema():
 
         if schema is None:
             schema = s_schema.FlatSchema()
-            for modname in s_schema.STD_SOURCES:
+            for modname in [*s_schema.STD_SOURCES, sn.UnqualName('_testmode')]:
                 schema = s_std.load_std_module(schema, modname)
             schema, _ = s_std.make_schema_version(schema)
             schema, _ = s_std.make_global_schema_version(schema)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8769,7 +8769,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
 
         await self.assert_query_result(
             'SELECT (SELECT schema::Module FILTER .name LIKE "%test").name;',
-            ['newtest']
+            {'newtest', 'std::_test'},
         )
 
     async def test_edgeql_migration_inherited_optionality_01(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3339,6 +3339,60 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema, multi_module=True)
 
+    def test_schema_get_migration_nested_module_01(self):
+        schema = r'''
+        type foo::bar::Y;
+        module foo {
+          module bar {
+            type X {
+                link y -> Y;
+            }
+          }
+        }
+        '''
+
+        self._assert_migration_consistency(schema, multi_module=True)
+
+    def test_schema_get_migration_nested_module_02(self):
+        schema = r'''
+        module foo {
+          type Z;
+          type Y {
+              link x1 -> foo::bar::X;
+              link x2 := foo::bar::X;
+              link z1 -> Z;
+              link z2 := Z;
+          };
+          module bar {
+            type X;
+          }
+        }
+        '''
+
+        self._assert_migration_consistency(schema, multi_module=True)
+
+    def test_schema_get_migration_nested_module_03(self):
+        schema = r'''
+        module default {
+            alias x := _test::abs(-1);
+        };
+        '''
+
+        self._assert_migration_consistency(schema, multi_module=True)
+
+    def test_schema_get_migration_nested_module_04(self):
+        schema = r'''
+        module _test { };
+        module default {
+            alias x := _test::abs(-1);
+        };
+        '''
+        with self.assertRaisesRegex(
+            errors.InvalidReferenceError,
+            "function '_test::abs' does not exist"
+        ):
+            self._assert_migration_consistency(schema, multi_module=True)
+
     def test_schema_get_migration_default_ptrs_01(self):
         schema = r'''
         type Foo {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -746,6 +746,28 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
         """
 
+    @tb.must_fail(
+        errors.SchemaDefinitionError,
+        "module 'super' is a reserved module name"
+    )
+    def test_schema_module_reserved_01(self):
+        """
+            module foo {
+                module super {}
+            }
+        """
+
+    @tb.must_fail(
+        errors.SchemaDefinitionError,
+        "module 'ext' is a reserved module name"
+    )
+    def test_schema_module_reserved_02(self):
+        """
+            module foo {
+                module ext {}
+            }
+        """
+
     def test_schema_refs_01(self):
         schema = self.load_schema("""
             type Object1;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3415,6 +3415,20 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         ):
             self._assert_migration_consistency(schema, multi_module=True)
 
+    def test_schema_get_migration_nested_module_02(self):
+        schema = r'''
+        module foo {
+          module bar {
+            type X;
+          }
+        };
+        module default {
+          alias x := (with m as module foo select m::bar::X);
+        }
+        '''
+
+        self._assert_migration_consistency(schema, multi_module=True)
+
     def test_schema_get_migration_default_ptrs_01(self):
         schema = r'''
         type Foo {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3415,7 +3415,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         ):
             self._assert_migration_consistency(schema, multi_module=True)
 
-    def test_schema_get_migration_nested_module_02(self):
+    def test_schema_get_migration_nested_module_05(self):
         schema = r'''
         module foo {
           module bar {
@@ -7731,6 +7731,13 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             r"""
             """,
         ])
+
+    def test_schema_migrations_equivalence_nested_module_01(self):
+        self._assert_migration_equivalence([r"""
+            module foo { module bar {} }
+        """, r"""
+            module foo { module bar { module baz {} } }
+        """])
 
 
 class TestDescribe(tb.BaseSchemaLoadTest):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8321,9 +8321,9 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             abstract constraint test::my_constr1(val: std::int64) {
-                using (WITH m AS MODULE math
+                using (
                     SELECT
-                        (m::abs((__subject__ + val)) > 2)
+                        (math::abs((__subject__ + val)) > 2)
                 );
             };
             ''',


### PR DESCRIPTION
This implements the ABS proposal, discussed in #4883, but without use of
the `module` keyword.

It also doesn't reserve module names, which I'll do in a follow up.

Also postponed to a follow up: possibly moving a number of the existing
modules into the std:: namespace.

Also postponed to a follow up (that I will probably try to pawn off
onto @raddevon): documentation.