### PR TITLE
Fix test failure issues in test_sql_query.py

### DIFF
--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -19,7 +19,6 @@
 import os.path
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 try:
     import asyncpg
@@ -645,6 +644,9 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT set_config('search_path', '', FALSE);
             '''
         )
+
+        # HACK: Set search_path back to public
+        await self.scon.execute('SET search_path TO public;')
 
     async def test_sql_query_static_eval(self):
         res = await self.squery_values('select current_schema;')


### PR DESCRIPTION
The lint failure probably snuck through in a merge, and the test
failure is nondeterministic (depends on how the tests are run.)

@aljazerzen, I aiming to merge this before you are online again but
please take a look when you're available.