### PR TITLE
[parser] Adjust associativity to make PtrQuals nonterminal more useful

### DIFF
--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -235,7 +235,7 @@ class PrecedenceMeta(type):
             doc = '%%%s' % assoc
 
             last = mcls.last.get((mcls, prec_group))
-            if last:
+            if last and rel_to_last:
                 doc += ' %s%s' % (rel_to_last, last.__name__)
 
             result.__doc__ = doc

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -588,86 +588,15 @@ class OptPtrQuals(Nonterm):
         self.val = kids[0].val
 
 
-# We have to inline the OptPtrQuals here because the parser generator
-# fails to cope with a shift/reduce on a REQUIRED token, since PtrQuals
-# are followed by an ident in this case (unlike in DDL, where it is followed
-# by a keyword).
 class ComputableShapePointer(Nonterm):
-
-    def reduce_OPTIONAL_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_PtrQuals_SimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[1].val
+        self.val.required = kids[0].val.required
+        self.val.cardinality = kids[0].val.cardinality
         self.val.compexpr = kids[3].val
-        self.val.required = False
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
             context=kids[2].context,
-        )
-
-    def reduce_REQUIRED_SimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[1].val
-        self.val.compexpr = kids[3].val
-        self.val.required = True
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
-        )
-
-    def reduce_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[1].val
-        self.val.compexpr = kids[3].val
-        self.val.cardinality = qltypes.SchemaCardinality.Many
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
-        )
-
-    def reduce_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[1].val
-        self.val.compexpr = kids[3].val
-        self.val.cardinality = qltypes.SchemaCardinality.One
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
-        )
-
-    def reduce_OPTIONAL_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = False
-        self.val.cardinality = qltypes.SchemaCardinality.Many
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
-        )
-
-    def reduce_OPTIONAL_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = False
-        self.val.cardinality = qltypes.SchemaCardinality.One
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
-        )
-
-    def reduce_REQUIRED_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = True
-        self.val.cardinality = qltypes.SchemaCardinality.Many
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
-        )
-
-    def reduce_REQUIRED_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = True
-        self.val.cardinality = qltypes.SchemaCardinality.One
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
         )
 
     def reduce_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -698,80 +627,14 @@ class ComputableShapePointer(Nonterm):
 # This is the same as the above ComputableShapePointer, except using
 # FreeSimpleShapePointer and not allowing +=/-=.
 class FreeComputableShapePointer(Nonterm):
-    def reduce_OPTIONAL_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_PtrQuals_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[1].val
+        self.val.required = kids[0].val.required
+        self.val.cardinality = kids[0].val.cardinality
         self.val.compexpr = kids[3].val
-        self.val.required = False
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
             context=kids[2].context,
-        )
-
-    def reduce_REQUIRED_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[1].val
-        self.val.compexpr = kids[3].val
-        self.val.required = True
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
-        )
-
-    def reduce_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[1].val
-        self.val.compexpr = kids[3].val
-        self.val.cardinality = qltypes.SchemaCardinality.Many
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
-        )
-
-    def reduce_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[1].val
-        self.val.compexpr = kids[3].val
-        self.val.cardinality = qltypes.SchemaCardinality.One
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
-        )
-
-    def reduce_OPTIONAL_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = False
-        self.val.cardinality = qltypes.SchemaCardinality.Many
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
-        )
-
-    def reduce_OPTIONAL_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = False
-        self.val.cardinality = qltypes.SchemaCardinality.One
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
-        )
-
-    def reduce_REQUIRED_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = True
-        self.val.cardinality = qltypes.SchemaCardinality.Many
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
-        )
-
-    def reduce_REQUIRED_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
-        self.val = kids[2].val
-        self.val.compexpr = kids[4].val
-        self.val.required = True
-        self.val.cardinality = qltypes.SchemaCardinality.One
-        self.val.operation = qlast.ShapeOperation(
-            op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
         )
 
     def reduce_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):

--- a/edb/edgeql/parser/grammar/precedence.py
+++ b/edb/edgeql/parser/grammar/precedence.py
@@ -165,3 +165,15 @@ class P_DOUBLECOLON(Precedence, assoc='left', tokens=('DOUBLECOLON',)):
 
 class P_AT(Precedence, assoc='left', tokens=('AT',)):
     pass
+
+
+# Make all the cardinality qualifiers right associative,
+# so that we can parse `required multi <ident>` and similar
+# without needing to inline PtrQuals.
+class P_QUALS(
+    Precedence,
+    assoc='right',
+    tokens=('MULTI', 'REQUIRED', 'OPTIONAL', 'SINGLE'),
+    rel_to_last=None,
+):
+    pass


### PR DESCRIPTION
By making MULTI/REQUIRED/OPTIONAL/SINGLE right associative, we can get
rid of an unfortunate bit in our parser where we need to inline the
body of PtrQuals.

The downside here is that this breaks some stuff: currently
`{required multi := 1}` works, with `multi` being the name of
the property, but this change breaks that.