### PR TITLE
docs: Remove `--server-install-method`

### DIFF
--- a/docs/cli/edgedb_project/edgedb_project_init.rst
+++ b/docs/cli/edgedb_project/edgedb_project_init.rst
@@ -48,11 +48,6 @@ Options
     The project directory can be specified explicitly. Defaults to the
     current directory.
 
-:cli:synopsis:`--server-install-method=<server-install-method>`
-    Specifies which server should be used for this project: server
-    installed via the local package system (``package``) or as a docker
-    image (``docker``).
-
 :cli:synopsis:`--server-instance=<server-instance>`
     Specifies the EdgeDB server instance to be associated with the
     project.


### PR DESCRIPTION
Fixes edgedb/edgedb-cli#927

This is an old option that has not been there for a while.