### PR TITLE
Fix SQL typecast to "char"

### DIFF
--- a/edb/pgsql/keywords.py
+++ b/edb/pgsql/keywords.py
@@ -68,7 +68,7 @@ pg_keywords = {
     "cast": ("CAST", RESERVED_KEYWORD),
     "catalog": ("CATALOG_P", UNRESERVED_KEYWORD),
     "chain": ("CHAIN", UNRESERVED_KEYWORD),
-    "char": ("CHAR_P", TYPE_FUNC_NAME_KEYWORD),
+    "char": ("CHAR_P", COL_NAME_KEYWORD),
     "character": ("CHARACTER", COL_NAME_KEYWORD),
     "characteristics": ("CHARACTERISTICS", UNRESERVED_KEYWORD),
     "check": ("CHECK", RESERVED_KEYWORD),

--- a/edb/pgsql/keywords.py
+++ b/edb/pgsql/keywords.py
@@ -68,7 +68,7 @@ pg_keywords = {
     "cast": ("CAST", RESERVED_KEYWORD),
     "catalog": ("CATALOG_P", UNRESERVED_KEYWORD),
     "chain": ("CHAIN", UNRESERVED_KEYWORD),
-    "char": ("CHAR_P", COL_NAME_KEYWORD),
+    "char": ("CHAR_P", TYPE_FUNC_NAME_KEYWORD),
     "character": ("CHARACTER", COL_NAME_KEYWORD),
     "characteristics": ("CHARACTERISTICS", UNRESERVED_KEYWORD),
     "check": ("CHECK", RESERVED_KEYWORD),

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -683,8 +683,14 @@ def _build_type_name(n: Node, c: Context) -> pgast.TypeName:
     def unwrap_int(n: Node, _c: Context):
         return _unwrap(_unwrap(n, 'Integer'), 'ival')
 
+    name: Tuple[str, ...] = tuple(_list(n, c, "names", _build_str))
+
+    # we don't escape char properly, so let's just resolve it during parsing
+    if name == ("char",):
+        name = ("pg_catalog", "char")
+
     return pgast.TypeName(
-        name=tuple(_list(n, c, "names", _build_str)),
+        name=name,
         setof=_bool_or_false(n, "setof"),
         typmods=None,
         array_bounds=_maybe_list(n, c, "arrayBounds", unwrap_int),

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -1074,6 +1074,13 @@ class TestEdgeQLSelect(tb.BaseDocTest):
         SELECT nullif(a, 3) FROM b
         """
 
+    def test_sql_parse_query_50(self):
+        """
+        SELECT 'a'::char, 'a'::"char"
+% OK %
+        SELECT ('a')::pg_catalog.bpchar, ('a')::pg_catalog.char
+        """
+
     # The transaction_* settings are always on transaction level
 
     def test_sql_parse_transaction_29(self):


### PR DESCRIPTION
The problem is that this query:
```
SELECT 'a'::"char"
```
... get compiled to ...
```
SELECT 'a'::char
```

... which apparently is not the same.

The former is an ident that should resolve to pg_catalog.char, and the latter is a keyword (that is equivalent to pg_catalog.bpchar).

