### PR TITLE
bugfix: update last_state after rollback

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -712,6 +712,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             else:
                 assert query_unit.tx_rollback
                 _dbview.abort_tx()
+            if not _dbview.in_tx():
+                conn.last_state = _dbview.serialize_state()
         finally:
             self.maybe_release_pgcon(conn)
 


### PR DESCRIPTION
As demonstrated in the unit test, a recovered failing transaction will leave a wrong mark of the last-used state in the backend connection (because actually the state is permanently restored with a SYNC added in #3755, but rollback is keeping the `last_state` mark untouched), possibly causing a fake state-match in the next frontend connection call.

Fixed by setting the `pgcon.last_state` after ROLLBACK.

This does not affect EdgeQL scripts because we don't allow explicit transactions in scripts, and migration transactions are done in plpgsql scripts that run in the same transaction of the whole script.