### PR TITLE
Fix array arguments in HTTP interface

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2082,9 +2082,14 @@ def _extract_params(
         if idx >= user_params:
             continue
 
+        if ctx.json_parameters:
+            schema_type = schema.get('std::json')
+        else:
+            schema_type = param.schema_type
+
         array_tid = None
-        if param.schema_type.is_array():
-            el_type = param.schema_type.get_element_type(schema)
+        if schema_type.is_array():
+            el_type = schema_type.get_element_type(schema)
             array_tid = el_type.id
 
         # NB: We'll need to turn this off for script args
@@ -2099,11 +2104,12 @@ def _extract_params(
 
         oparams[idx] = (
             param.name,
-            param.schema_type,
+            schema_type,
             param.required,
         )
 
         if param.sub_params:
+            assert not ctx.json_parameters
             array_tids = []
             for p in param.sub_params.params:
                 if p.schema_type.is_array():

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -258,6 +258,16 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
                 variables={'x': None},
             )
 
+    def test_http_edgeql_query_13(self):
+        self.assert_edgeql_query_result(
+            r'''select (<array<int64>>$foo, <tuple<int64, str>>$bar)''',
+            [[[1, 2, 3], [1, 'test']]],
+            variables=dict(
+                foo=[1, 2, 3],
+                bar=(1, 'test'),
+            )
+        )
+
     def test_http_edgeql_query_globals_01(self):
         Q = r'''select GlobalTest { gstr, garray, gid, gdef, gdef2 }'''
 


### PR DESCRIPTION
The problem was that the arguments were being reported to the server
as being based on their actual types, when actually they are all json
in the HTTP protocol. This resulted in trying to validate the array
parameters that we received, which failed because they were json!

Fixes #4908.