### PR TITLE
pg-ext: bug fixes

### DIFF
--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -103,6 +103,7 @@ cdef dict POSTGRES_SHUTDOWN_ERR_CODES = {
 }
 
 cdef bytes INIT_CON_SCRIPT = None
+cdef object EMPTY_SQL_STATE = json.dumps({}).encode('utf-8')
 
 cdef object logger = logging.getLogger('edb.server')
 
@@ -747,7 +748,7 @@ cdef class PGConnection:
             buf.write_int32(0)  # limit: 0 - return all rows
             out.write_buffer(buf.end_message())
 
-    def _build_apply_sql_state_req(self, settings, WriteBuffer out):
+    def _build_apply_sql_state_req(self, bytes state, WriteBuffer out):
         cdef:
             WriteBuffer buf
 
@@ -764,17 +765,16 @@ cdef class PGConnection:
         buf.write_int32(0)  # limit: 0 - return all rows
         out.write_buffer(buf.end_message())
 
-        if settings:
-            serstate = json.dumps(dict(settings)).encode("utf-8")
+        if state != EMPTY_SQL_STATE:
             buf = WriteBuffer.new_message(b'B')
             buf.write_bytestring(b'')  # portal name
             buf.write_bytestring(b'_apply_sql_state')  # statement name
             buf.write_int16(1)  # number of format codes
             buf.write_int16(1)  # binary
             buf.write_int16(1)  # number of parameters
-            buf.write_int32(len(serstate) + 1)
+            buf.write_int32(len(state) + 1)
             buf.write_byte(1)  # jsonb format version
-            buf.write_bytes(serstate)
+            buf.write_bytes(state)
             buf.write_int16(0)  # number of result columns
             out.write_buffer(buf.end_message())
 
@@ -1386,17 +1386,21 @@ cdef class PGConnection:
             char mtype, field_type
             WriteBuffer buf, msg_buf
             bytes stmt_name, query
-            bint sync_received = 0
+            bint sync_received = 0, state_synced = 0
 
-        settings = None if dbv.in_tx() else dbv.current_settings()
-        if self.debug:
-            self.debug_print("pg_ext settings:", settings)
+        state = None
+        if not dbv.in_tx():
+            state = dbv.serialize_state()
+            if self.last_state == state:
+                state = None
         dbv.start_implicit()
         self.before_command()
         try:
             buf = WriteBuffer.new()
-            if settings is not None:
-                self._build_apply_sql_state_req(settings, buf)
+            if state is not None:
+                if self.debug:
+                    self.debug_print("pg_ext state:", state)
+                self._build_apply_sql_state_req(state, buf)
                 # We need to close the implicit transaction with a SYNC here
                 # because the next command may be "BEGIN DEFERRABLE".
                 self.write_sync(buf)
@@ -1440,9 +1444,13 @@ cdef class PGConnection:
             self.write_sync(buf)
             self.write(buf)
 
-            if settings is not None:
-                await self._parse_apply_state_resp(2 if settings else 1)
+            if state is not None:
+                await self._parse_apply_state_resp(
+                    2 if state != EMPTY_SQL_STATE else 1
+                )
                 await self.wait_for_sync()
+                self.last_state = state
+            state_synced = 1
 
             buf = WriteBuffer.new()
             for unit in query_units:
@@ -1561,6 +1569,10 @@ cdef class PGConnection:
         finally:
             await self.after_command()
             dbv.end_implicit()
+            # There could be multiple transactions in the same simple query, so
+            # last_state should be always updated after the initial state sync
+            if state_synced and not dbv.in_tx():
+                self.last_state = dbv.serialize_state()
 
     async def sql_extended_query(
         self,
@@ -1571,10 +1583,20 @@ cdef class PGConnection:
     ):
         self.before_command()
         try:
-            self._write_sql_extended_query(actions, dbver, dbv)
-            return await self._parse_sql_extended_query(
-                actions, fe_conn, dbver, dbv
-            )
+            state = self._write_sql_extended_query(actions, dbver, dbv)
+            if state is not None:
+                await self._parse_apply_state_resp(
+                    2 if state != EMPTY_SQL_STATE else 1
+                )
+                await self.wait_for_sync()
+                self.last_state = state
+            try:
+                return await self._parse_sql_extended_query(
+                    actions, fe_conn, dbver, dbv
+                )
+            finally:
+                if not dbv.in_tx():
+                    self.last_state = dbv.serialize_state()
         finally:
             await self.after_command()
 
@@ -1584,8 +1606,10 @@ cdef class PGConnection:
             PGMessage action
 
         buf = WriteBuffer.new()
+        state = None
         if not dbv.in_tx():
-            self._build_apply_sql_state_req(dbv.current_settings(), buf)
+            state = dbv.serialize_state()
+            self._build_apply_sql_state_req(state, buf)
             # We need to close the implicit transaction with a SYNC here
             # because the next command may be e.g. "BEGIN DEFERRABLE".
             self.write_sync(buf)
@@ -1660,6 +1684,7 @@ cdef class PGConnection:
             buf.write_buffer(msg_buf.end_message())
 
         self.write(buf)
+        return state
 
     async def _parse_sql_extended_query(
         self,
@@ -1672,12 +1697,6 @@ cdef class PGConnection:
             WriteBuffer buf, msg_buf
             PGMessage action
             bint ignore_till_sync = False
-
-        if not dbv.in_tx():
-            await self._parse_apply_state_resp(
-                2 if dbv.current_settings() else 1
-            )
-            await self.wait_for_sync()
 
         buf = WriteBuffer.new()
         rv = True

--- a/edb/server/protocol/pg_ext.pxd
+++ b/edb/server/protocol/pg_ext.pxd
@@ -53,7 +53,6 @@ cdef class PgConnection(frontend.FrontendConnection):
         ConnectionView _dbview
 
         bytes secret
-        str client_encoding
         dict prepared_stmts
         bint ignore_till_sync
 

--- a/edb/server/protocol/pg_ext.pxd
+++ b/edb/server/protocol/pg_ext.pxd
@@ -37,6 +37,8 @@ cdef class ConnectionView:
         object _in_tx_savepoints
         bint _tx_error
 
+        tuple _session_state_db_cache
+
     cpdef inline current_fe_settings(self)
     cdef inline fe_transaction_state(self)
     cpdef inline bint in_tx(self)

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1264,6 +1264,12 @@ class SQLQueryTestCase(BaseQueryTestCase):
         finally:
             super().tearDownClass()
 
+    def tearDown(self):
+        try:
+            self.loop.run_until_complete(self.scon.execute('RESET ALL'))
+        finally:
+            super().tearDown()
+
     async def squery_values(self, query):
         res = await self.scon.fetch(query)
         return [list(r.values()) for r in res]

--- a/tests/schemas/movies_setup.edgeql
+++ b/tests/schemas/movies_setup.edgeql
@@ -18,6 +18,7 @@
 
 insert Genre { name:= 'Fiction' };
 insert Genre { name:= 'Drama' };
+insert Genre { name:= '武侠' };
 
 insert Person { first_name:= 'Tom', last_name:= 'Hanks' };
 insert Person { first_name:= 'Robin' };


### PR DESCRIPTION
* Don't capture fatal errors in pg-ext protocol
* Support SQL_ASCII client encoding and error out on invalid encodings
* Handle client_encoding correctly
* Remember the last_state of pg-ext
* Forward ParameterStatus in simple query