### PR TITLE
Document `allow_bare_ddl`, `apply_access_policies`

### DIFF
--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -322,6 +322,19 @@ making the current user able to see their own ``User`` record.
   following to the schema: ``using future nonrecursive_access_policies;``
 
 
+Disabling policies
+^^^^^^^^^^^^^^^^^^
+
+You may disable all access policies by setting the ``apply_access_policies``
+:ref:`configuration parameter <ref_std_cfg>` to ``false``.
+
+You may also toggle access policies using the "Disable Access Policies"
+checkbox in the "Config" dropdown in the EdgeDB UI (accessible by running
+the CLI command ``edgedb ui`` from inside your project). This is the most
+convenient way to temporarily disable access policies since it applies only to
+your UI session.
+
+
 Examples
 ^^^^^^^^
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -90,7 +90,7 @@ Query behavior
 
 :eql:synopsis:`apply_access_policies -> bool`
   Determines whether access policies should be applied when running queries.
-  Setting this to ``false`` effctively puts you into super-user mode, ignoring
+  Setting this to ``false`` effectively puts you into super-user mode, ignoring
   any access policies that might otherwise limit you on the instance.
 
   .. note::

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -75,6 +75,33 @@ Query planning
   An estimate of the effective size of the disk
   cache available to a single query.
 
+
+Query behavior
+--------------
+
+:eql:synopsis:`allow_bare_ddl -> cfg::AllowBareDDL`
+  Allows for running bare DDL outside a migration. Possible values are
+  ``cfg::AllowBareDDL.AlwaysAllow`` and ``cfg::AllowBareDDL.NeverAllow``.
+
+  When you create an instance, this is set to ``cfg::AllowBareDDL.AlwaysAllow``
+  until you run a migration. At that point it is set to
+  ``cfg::AllowBareDDL.NeverAllow`` because it's generally a bad idea to mix
+  migrations with bare DDL.
+
+:eql:synopsis:`apply_access_policies -> bool`
+  Determines whether access policies should be applied when running queries.
+  Setting this to ``false`` effctively puts you into super-user mode, ignoring
+  any access policies that might otherwise limit you on the instance.
+
+  .. note::
+
+      This setting can also be conveniently accessed via the "Config" dropdown
+      menu at the top of the EdgeDB UI (accessible by running the CLI command
+      ``edgedb ui`` from within a project). The setting will apply only to your
+      UI session, so you won't have to remember to re-enable it when you're
+      done.
+
+
 Client connections
 ------------------
 

--- a/docs/stdlib/cfg.rst
+++ b/docs/stdlib/cfg.rst
@@ -82,6 +82,34 @@ Query planning
   PostgreSQL configuration parameter of the same name.
 
 
+Query behavior
+--------------
+
+:eql:synopsis:`allow_bare_ddl -> cfg::AllowBareDDL`
+  Allows for running bare DDL outside a migration. Possible values are
+  ``cfg::AllowBareDDL.AlwaysAllow`` and ``cfg::AllowBareDDL.NeverAllow``.
+
+  When you create an instance, this is set to ``cfg::AllowBareDDL.AlwaysAllow``
+  until you run a migration. At that point it is set to
+  ``cfg::AllowBareDDL.NeverAllow`` because it's generally a bad idea to mix
+  migrations with bare DDL.
+
+.. _ref_std_cfg_apply_access_policies:
+
+:eql:synopsis:`apply_access_policies -> bool`
+  Determines whether access policies should be applied when running queries.
+  Setting this to ``false`` effctively puts you into super-user mode, ignoring
+  any access policies that might otherwise limit you on the instance.
+
+  .. note::
+
+      This setting can also be conveniently accessed via the "Config" dropdown
+      menu at the top of the EdgeDB UI (accessible by running the CLI command
+      ``edgedb ui`` from within a project). The setting will apply only to your
+      UI session, so you won't have to remember to re-enable it when you're
+      done.
+
+
 Client connections
 ------------------
 

--- a/docs/stdlib/cfg.rst
+++ b/docs/stdlib/cfg.rst
@@ -98,7 +98,7 @@ Query behavior
 
 :eql:synopsis:`apply_access_policies -> bool`
   Determines whether access policies should be applied when running queries.
-  Setting this to ``false`` effctively puts you into super-user mode, ignoring
+  Setting this to ``false`` effectively puts you into super-user mode, ignoring
   any access policies that might otherwise limit you on the instance.
 
   .. note::


### PR DESCRIPTION
I have a technical issue here. The `` :ref:`configuration parameter <ref_std_cfg>` `` link anchors to nearly the end of the config page rather than the top where that anchor is. I've asked about this issue on Slack. I will fix it once I get that figured out.

The content should be ready for review though.

Addresses #4787 