### PR TITLE
Parse and ignore SQL LOCK TABLE

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -1147,6 +1147,7 @@ class MinMaxExpr(BaseExpr):
     op: str
     args: typing.List[BaseExpr]
 
+
 class LockStmt(Statement):
     relations: typing.List[BaseRangeVar]
     mode: str

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -1146,3 +1146,8 @@ class MinMaxExpr(BaseExpr):
 
     op: str
     args: typing.List[BaseExpr]
+
+class LockStmt(Statement):
+    relations: typing.List[BaseRangeVar]
+    mode: str
+    no_wait: bool = False

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -1066,5 +1066,14 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         self.visit_list(node.args)
         self.write(')')
 
+    def visit_LockStmt(self, node: pgast.LockStmt) -> None:
+        self.write('LOCK TABLE ')
+        self.visit_list(node.relations)
+        self.write(' IN ')
+        self.write(node.mode)
+        self.write(' MODE')
+        if node.no_wait:
+            self.write(' NOWAIT')
+
 
 generate_source = SQLSourceGenerator.to_source

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -632,7 +632,7 @@ class Compiler:
                         "exclusive lock is not supported"
                     )
                 # just ignore
-                unit = dbstate.SQLQueryUnit(query="")
+                unit = dbstate.SQLQueryUnit(query="DO $$ BEGIN END $$;")
             else:
                 args = {}
                 try:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -626,6 +626,13 @@ class Compiler:
                 raise NotImplementedError
             elif isinstance(stmt, pgast.ExecuteStmt):
                 raise NotImplementedError
+            elif isinstance(stmt, pgast.LockStmt):
+                if stmt.mode not in ('ACCESS SHARE', 'ROW SHARE', 'SHARE'):
+                    raise NotImplementedError(
+                        "exclusive lock is not supported"
+                    )
+                # just ignore
+                unit = dbstate.SQLQueryUnit(query="")
             else:
                 args = {}
                 try:

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -1105,57 +1105,57 @@ class TestEdgeQLSelect(tb.BaseDocTest):
         """
         SELECT (x IS NOT DISTINCT FROM y) FROM b
         """
-    
+
     def test_sql_parse_lock_01(self):
         '''
         LOCK TABLE films IN ACCESS SHARE MODE
         '''
-    
+
     def test_sql_parse_lock_02(self):
         '''
         LOCK TABLE films IN ACCESS SHARE MODE NOWAIT
         '''
-    
+
     def test_sql_parse_lock_03(self):
         '''
         LOCK TABLE ONLY (films) IN ACCESS SHARE MODE
         '''
-    
+
     def test_sql_parse_lock_04(self):
         '''
         LOCK TABLE ONLY (films) IN ACCESS SHARE MODE NOWAIT
         '''
-    
+
     def test_sql_parse_lock_05(self):
         '''
         LOCK TABLE films IN ROW SHARE MODE
         '''
-    
+
     def test_sql_parse_lock_06(self):
         '''
         LOCK TABLE films IN ROW EXCLUSIVE MODE
         '''
-    
+
     def test_sql_parse_lock_07(self):
         '''
         LOCK TABLE films IN SHARE UPDATE EXCLUSIVE MODE
         '''
-    
+
     def test_sql_parse_lock_08(self):
         '''
         LOCK TABLE films IN SHARE MODE
         '''
-    
+
     def test_sql_parse_lock_09(self):
         '''
         LOCK TABLE films IN SHARE ROW EXCLUSIVE MODE
         '''
-    
+
     def test_sql_parse_lock_10(self):
         '''
         LOCK TABLE films IN EXCLUSIVE MODE
         '''
-    
+
     def test_sql_parse_lock_11(self):
         '''
         LOCK TABLE films IN ACCESS EXCLUSIVE MODE

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -3,7 +3,7 @@
 #
 # Copyright 2012-present MagicStack Inc. and the EdgeDB authors.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -1105,6 +1105,61 @@ class TestEdgeQLSelect(tb.BaseDocTest):
         """
         SELECT (x IS NOT DISTINCT FROM y) FROM b
         """
+    
+    def test_sql_parse_lock_01(self):
+        '''
+        LOCK TABLE films IN ACCESS SHARE MODE
+        '''
+    
+    def test_sql_parse_lock_02(self):
+        '''
+        LOCK TABLE films IN ACCESS SHARE MODE NOWAIT
+        '''
+    
+    def test_sql_parse_lock_03(self):
+        '''
+        LOCK TABLE ONLY (films) IN ACCESS SHARE MODE
+        '''
+    
+    def test_sql_parse_lock_04(self):
+        '''
+        LOCK TABLE ONLY (films) IN ACCESS SHARE MODE NOWAIT
+        '''
+    
+    def test_sql_parse_lock_05(self):
+        '''
+        LOCK TABLE films IN ROW SHARE MODE
+        '''
+    
+    def test_sql_parse_lock_06(self):
+        '''
+        LOCK TABLE films IN ROW EXCLUSIVE MODE
+        '''
+    
+    def test_sql_parse_lock_07(self):
+        '''
+        LOCK TABLE films IN SHARE UPDATE EXCLUSIVE MODE
+        '''
+    
+    def test_sql_parse_lock_08(self):
+        '''
+        LOCK TABLE films IN SHARE MODE
+        '''
+    
+    def test_sql_parse_lock_09(self):
+        '''
+        LOCK TABLE films IN SHARE ROW EXCLUSIVE MODE
+        '''
+    
+    def test_sql_parse_lock_10(self):
+        '''
+        LOCK TABLE films IN EXCLUSIVE MODE
+        '''
+    
+    def test_sql_parse_lock_11(self):
+        '''
+        LOCK TABLE films IN ACCESS EXCLUSIVE MODE
+        '''
 
     # The transaction_* settings are always on transaction level
 


### PR DESCRIPTION
Ignores only ACCESS SHARE, ROW SHARE, SHARE lock modes.

For any other mode (ROW EXCLUSIVE, SHARE UPDATE EXCLUSIVE, SHARE ROW EXCLUSIVE, EXCLUSIVE, ACCESS EXCLUSIVE) an error is thrown.