### PR TITLE
Resolve SQL ColumnRef to relation vars

### DIFF
--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -119,6 +119,15 @@ def _lookup_column(
             for table in ctx.scope.tables:
                 matched_columns.extend(_lookup_in_table(col_name, table))
 
+        if not matched_columns:
+            # is it a reference to a rel var?
+            try:
+                tab = _lookup_table(col_name, ctx)
+                col = context.Column(reference_as=tab.reference_as)
+                return [(context.Table(), col)]
+            except:
+                pass
+
     elif len(name) >= 2:
         # look for the column in the specific table
         tab_name, col_name = name[-2:]

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -125,7 +125,7 @@ def _lookup_column(
                 tab = _lookup_table(col_name, ctx)
                 col = context.Column(reference_as=tab.reference_as)
                 return [(context.Table(), col)]
-            except:
+            except errors.QueryError:
                 pass
 
     elif len(name) >= 2:

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -546,6 +546,16 @@ class TestSQL(tb.SQLQueryTestCase):
             ['Saving Private Ryan', 1]
         ])
 
+    async def test_sql_query_36(self):
+        # ColumnRef to relation
+
+        res = await self.squery_values(
+            """
+            select rel from (select 1 as a, 2 as b) rel
+            """
+        )
+        self.assertEqual(res, [[(1, 2)]])
+
     async def test_sql_query_introspection_00(self):
         res = await self.squery_values(
             '''


### PR DESCRIPTION
Support for this:

```
chinook=# select rel from (select 1 as a, 2 as b) rel;
  rel
-------
 (1,2)
(1 row)

chinook=#
```

If you ask me, this feature should not exist. But pg_dump disagrees, apparently :D