### PR TITLE
Add system columns to inhviews

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2890,10 +2890,21 @@ class CompositeMetaCommand(MetaCommand):
         ptrnames: Dict[sn.UnqualName, Tuple[str, Tuple[str, ...]]],
         pg_schema: Optional[str] = None,
     ) -> Optional[str]:
+
+        cols = []
+
+        if pg_schema not in ('edgedbss',):
+            cols.extend([
+                ('tableoid', 'tableoid', True),
+                ('xmin', 'xmin', True),
+                ('cmin', 'cmin', True),
+                ('xmax', 'xmax', True),
+                ('cmax', 'cmax', True),
+                ('ctid', 'ctid', True),
+            ])
+
         if isinstance(obj, s_sources.Source):
             ptrs = dict(obj.get_pointers(schema).items(schema))
-
-            cols = []
 
             for ptrname, (alias, pgtype) in ptrnames.items():
                 ptr = ptrs.get(ptrname)
@@ -2912,10 +2923,10 @@ class CompositeMetaCommand(MetaCommand):
                 else:
                     return None
         else:
-            cols = [
+            cols.extend(
                 (str(ptrname), alias, True)
                 for ptrname, (alias, _) in ptrnames.items()
-            ]
+            )
 
         tabname = common.get_backend_name(
             schema,

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -292,11 +292,9 @@ def resolve_relation(
     columns.sort(key=lambda c: () if c.name == 'id' else (c.name or '',))
     table.columns.extend(columns)
 
-    if ctx.include_inherited:
-        aspect = 'inhview'
-    else:
-        table.columns.extend(_construct_system_columns())
-        aspect = 'table'
+    aspect = 'inhview' if ctx.include_inherited else 'table'
+
+    table.columns.extend(_construct_system_columns())
 
     schemaname, dbname = pgcommon.get_backend_name(
         ctx.schema, obj, aspect=aspect, catenate=False

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -505,6 +505,20 @@ class TestSQL(tb.SQLQueryTestCase):
         # this numbers change, so let's just check that there are 6 of them
         self.assertEqual(len(res[0]), 6)
 
+        res = await self.squery_values(
+            '''
+            SELECT tableoid, xmin, cmin, xmax, cmax, ctid FROM "Content"
+            '''
+        )
+        self.assertEqual(len(res[0]), 6)
+
+        res = await self.squery_values(
+            '''
+            SELECT tableoid, xmin, cmin, xmax, cmax, ctid FROM "Movie.actors"
+            '''
+        )
+        self.assertEqual(len(res[0]), 6)
+
     async def test_sql_query_34(self):
         # GROUP and ORDER BY aliased column
 


### PR DESCRIPTION
Add [system columns](https://www.postgresql.org/docs/9.1/ddl-system-columns.html) to our inhviews.

Required for pg_dump and DataGrip.

As discussed with @msullivan, this should not have any performance implications as the views are not materialized and we never produce SQL statements that would select *.