### PR TITLE
bugfix: update last_state after rollback

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1054,6 +1054,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             else:
                 assert query_unit.tx_rollback
                 _dbview.abort_tx()
+            if not _dbview.in_tx():
+                conn.last_state = _dbview.serialize_state()
         finally:
             self.maybe_release_pgcon(conn)
 


### PR DESCRIPTION
Cherry-picking #4953 