### PR TITLE
Annotate migration required_user_input with type information

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -491,14 +491,16 @@ class Command(
     def is_data_safe(self) -> bool:
         return False
 
-    def get_required_user_input(self) -> Dict[str, str]:
-        return {}
+    def get_required_user_input(self) -> list[dict[str, str]]:
+        return []
 
     def record_diff_annotations(
-        self,
+        self, *,
         schema: s_schema.Schema,
         orig_schema: Optional[s_schema.Schema],
         context: so.ComparisonContext,
+        orig_object: Optional[so.Object],
+        object: Optional[so.Object],
     ) -> None:
         """Record extra information on a delta obtained by diffing schemas.
 
@@ -1776,14 +1778,12 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                 for subcmd in self.get_subcommands()
             )
 
-    def get_required_user_input(self) -> Dict[str, str]:
-        result: Dict[str, str] = self.get_annotation('required_input')
-        if result is None:
-            result = {}
+    def get_required_user_input(self) -> list[dict[str, str]]:
+        result: list[dict[str, str]] = []
+        if ann := self.get_annotation('required_input'):
+            result.append(ann)
         for cmd in self.get_subcommands():
-            subresult = cmd.get_required_user_input()
-            if subresult:
-                result.update(subresult)
+            result.extend(cmd.get_required_user_input())
         return result
 
     def get_friendly_description(

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -595,15 +595,19 @@ class SetGlobalType(
             )
 
     def record_diff_annotations(
-        self,
+        self, *,
         schema: s_schema.Schema,
         orig_schema: Optional[s_schema.Schema],
         context: so.ComparisonContext,
+        object: Optional[so.Object],
+        orig_object: Optional[so.Object],
     ) -> None:
         super().record_diff_annotations(
             schema=schema,
             orig_schema=orig_schema,
             context=context,
+            orig_object=orig_object,
+            object=object,
         )
 
         if orig_schema is None:

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1869,6 +1869,8 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
             schema=schema,
             orig_schema=orig_schema,
             context=context,
+            object=self,
+            orig_object=orig_object,
         )
         context.parent_ops.pop()
 
@@ -3173,6 +3175,8 @@ class InheritingObject(SubclassableObject):
             schema=schema,
             orig_schema=orig_schema,
             context=context,
+            object=self,
+            orig_object=orig_object,
         )
         context.parent_ops.pop()
 

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -481,26 +481,19 @@ class ProposedMigrationStep(NamedTuple):
     prompt: str
     prompt_id: str
     data_safe: bool
-    required_user_input: Tuple[Tuple[str, str], ...]
+    required_user_input: tuple[dict[str, str], ...]
     # This isn't part of the output data, but is used to figure out
     # what to prohibit when something is rejected.
     operation_key: s_delta.CommandKey
 
     def to_json(self) -> Dict[str, Any]:
-        user_input_list = []
-        for var_name, var_desc in self.required_user_input:
-            user_input_list.append({
-                'placeholder': var_name,
-                'prompt': var_desc,
-            })
-
         return {
             'statements': [{'text': stmt} for stmt in self.statements],
             'confidence': self.confidence,
             'prompt': self.prompt,
             'prompt_id': self.prompt_id,
             'data_safe': self.data_safe,
-            'required_user_input': user_input_list,
+            'required_user_input': list(self.required_user_input)
         }
 
 

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -646,9 +646,9 @@ def _describe_current_migration(
                         for p in ast.find_children(ddl_ast, qlast.Placeholder)
                     }
                     required_user_input = tuple(
-                        (k, v)
-                        for k, v in (top_op.get_required_user_input().items())
-                        if k in used_placeholders
+                        inp
+                        for inp in top_op.get_required_user_input()
+                        if inp['placeholder'] in used_placeholders
                     )
 
                     # The prompt_id still needs to come from

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -9882,6 +9882,8 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                         "Please specify a conversion expression"
                         " to alter the type of property 'foo'"
                     ),
+                    'old_type': 'std::str',
+                    'new_type': 'std::int64',
                 }],
             },
         })
@@ -9913,6 +9915,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                         " property 'foo' of object type 'test::Bar' to"
                         " 'single' cardinality"
                     ),
+                    'type': 'std::str',
                 }],
             },
         })
@@ -9954,6 +9957,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                         "objects in order to make property 'bar' of object "
                         "type 'test::Bar' required"
                     ),
+                    'type': 'std::str',
                 }],
             },
         })
@@ -10052,6 +10056,57 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 )
             except Exception as e:
                 raise e.__cause__
+
+    async def test_edgeql_migration_user_input_06(self):
+        await self.migrate('''
+            type Bar {
+                property foo -> int64;
+            };
+        ''')
+        await self.con.execute('''
+            SET MODULE test;
+            INSERT Bar { foo := 42 };
+            INSERT Bar;
+        ''')
+
+        await self.start_migration('''
+            type Bar {
+                required property foo -> str;
+            };
+        ''')
+
+        await self.assert_describe_migration({
+            'proposed': {
+                'required_user_input': [
+                    {
+                        'placeholder': 'fill_expr',
+                        'type': 'std::int64',
+                    },
+                    {
+                        'placeholder': 'cast_expr',
+                        'old_type': 'std::int64',
+                        'new_type': 'std::str',
+                    },
+                ],
+            },
+        })
+
+        await self.fast_forward_describe_migration(
+            user_input=[
+                "0",
+                "<str>.foo",
+            ]
+        )
+
+        await self.assert_query_result(
+            '''
+                SELECT Bar {foo} ORDER BY .foo
+            ''',
+            [
+                {'foo': "0"},
+                {'foo': "42"},
+            ],
+        )
 
     async def test_edgeql_migration_union_01(self):
         async with self.assertRaisesRegexTx(


### PR DESCRIPTION
This should enable various bits of potential cleverness on the
migration client side.