### PR TITLE
Implement manual error override configuration

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_01_31_00_00
+EDGEDB_CATALOG_VERSION = 2022_02_01_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -186,6 +186,14 @@ CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject {
         CREATE ANNOTATION std::description :=
             'The default data statistics target for the planner.';
     };
+
+    CREATE PROPERTY force_database_error -> std::str {
+        SET default := 'false';
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION std::description :=
+            'A hook to force all queries to produce an error.';
+    };
+
 };
 
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -35,6 +35,7 @@ import edgedb
 from edb import buildmeta
 from edb import errors
 from edb.edgeql import qltypes
+from edb.edgeql import quote as qlquote
 
 from edb.testbase import server as tb
 from edb.schema import objects as s_obj
@@ -1172,6 +1173,50 @@ class TestServerConfig(tb.QueryTestCase):
                 1,
             )
         finally:
+            await con2.aclose()
+
+    async def test_server_proto_configure_error(self):
+        con1 = self.con
+        con2 = await self.connect(database=con1.dbname)
+        try:
+            await con2.execute('''
+                select 1;
+            ''')
+
+            err = {
+                'type': 'SchemaError',
+                'message': 'danger',
+                'context': {'start': 42},
+            }
+            await con1.execute(f'''
+                configure current database set force_database_error :=
+                  {qlquote.quote_literal(json.dumps(err))};
+            ''')
+
+            with self.assertRaisesRegex(edgedb.SchemaError, 'danger'):
+                async for tx in con1.retrying_transaction():
+                    async with tx:
+                        await tx.query('select schema::Object')
+
+            # It might take a bit before con2 sees the error config
+            async for tr in self.try_until_succeeds(
+                    ignore=AssertionError):
+                async with tr:
+                    with self.assertRaisesRegex(edgedb.SchemaError, 'danger',
+                                                _position=42):
+                        async for tx in con2.retrying_transaction():
+                            async with tx:
+                                await tx.query('select schema::Object')
+
+            await con2.execute(f'''
+                configure session set force_database_error := "false";
+            ''')
+            await con2.query('select schema::Object')
+
+        finally:
+            await con1.execute(f'''
+                configure current database reset force_database_error;
+            ''')
             await con2.aclose()
 
 


### PR DESCRIPTION
Implement a configuration field that causes the server to return an
error for all non-configuration commands.
See #4625 for details and motivation. Closes #4625.

The details here are a little different than proposed there.
There is one config property, `force_database_error`, that
accepts a json encoded string with the following format:
`false` means no error, and an object means to raise an error:
```
{
  "type": <name of exception class>,
  "message": <exception message>,
  "hint": <exception hint>,
  "details": <exception details>,
  "context": {
    "line": <line number>,
    "col": <column number>,
    "start": <start position>,
    "end": <end position>,
    "filename": <file name for error>
  }
}
```
All fields except for `type` are optional.