### PR TITLE
Upgrade our python linters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = B008,B306,E203,E402,E731,D100,D101,D102,D103,D104,D105,W503,W504,E252,F999,F541
+ignore = B008,B306,E203,E402,E731,D100,D101,D102,D103,D104,D105,W503,W504,E252,F999,F541,E741,B019
 max-line-length = 79
 exclude = .git,__pycache__,build,dist,.eggs,postgres
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -402,8 +402,8 @@ def try_bind_call_args(
             break
 
     # Handle yet unprocessed POSITIONAL & VARIADIC arguments.
-    for pi in range(pi, nparams):
-        param = params[pi]
+    for i in range(pi, nparams):
+        param = params[i]
         param_kind = param.get_kind(schema)
 
         if param_kind is _POSITIONAL:

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -39,7 +39,6 @@ from . import utils
 
 if TYPE_CHECKING:
     from edb.schema import schema as s_schema
-    from . import pointers as s_pointers
 
 
 class Global(
@@ -389,8 +388,6 @@ class CreateGlobal(
             )
 
         assert astnode.target is not None
-        target_ref: Union[
-            s_types.TypeShell[s_types.Type], s_pointers.ComputableRef]
 
         if isinstance(astnode.target, qlast.TypeExpr):
             type_ref = utils.ast_to_type_shell(

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -388,7 +388,6 @@ class IndexCommand(
         from edb.ir import utils as irutils
         from edb.ir import ast as irast
 
-        singletons: List[s_types.Type]
         if field.name in {'expr', 'except_expr'}:
             # type ignore below, for the class is used as mixin
             parent_ctx = context.get_ancestor(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ dependencies = [
 test = [
     'black~=21.7b0',
     'coverage~=5.5',
-    'flake8~=3.9.2',
-    'flake8-bugbear~=21.4.3',
-    'pycodestyle~=2.7.0',
-    'pyflakes~=2.3.1',
+    'flake8~=6.0.0',
+    'flake8-bugbear~=23.1.20',
+    'pycodestyle~=2.10.0',
+    'pyflakes~=3.0.1',
     'asyncpg~=0.26.0',
 
     # Needed for test_docs_sphinx_ext

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -143,7 +143,7 @@ class EdgeQLDataMigrationTestCase(tb.DDLTestCase):
                     curddl = stmt['text']
 
                     if interpolations:
-                        def _replace(match):
+                        def _replace(match, interpolations=interpolations):
                             var_name = match.group(1)
                             var_value = interpolations.get(var_name)
                             if var_value is None:


### PR DESCRIPTION
The current versions choked when I tried to add a complex pattern match,
so upgrade them.

I disabled two new warning categories that came up:
E741: ambiguous variable name
B019: don't use lru_cache because it can leak