### PR TITLE
Optimize trivial WITH-bound `group` uses

### DIFF
--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -218,8 +218,9 @@ def try_group_rewrite(
     # immediately used, so that we can apply the other optimizations.
     match node:
         case qlast.SelectQuery(
-            aliases=[*_, qlast.AliasedExpr(
-                alias=alias, expr=qlast.GroupQuery() as grp)
+            aliases=[
+                *_,
+                qlast.AliasedExpr(alias=alias, expr=qlast.GroupQuery() as grp)
             ] as qaliases,
             result=qlast.Shape(
                 expr=qlast.Path(steps=[
@@ -234,8 +235,9 @@ def try_group_rewrite(
             )
 
         case qlast.ForQuery(
-            aliases=[*_, qlast.AliasedExpr(
-                alias=alias, expr=qlast.GroupQuery() as grp)
+            aliases=[
+                *_,
+                qlast.AliasedExpr(alias=alias, expr=qlast.GroupQuery() as grp)
             ] as qaliases,
             iterator=qlast.Path(steps=[
                 qlast.ObjectRef(module=None, name=alias2)

--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from typing import *
 
+from edb.common import ast
 from edb.common import ordered
 from edb.common.compiler import AliasGenerator
 
@@ -165,6 +166,20 @@ def desugar_group(
     )
 
 
+def _count_alias_uses(
+    node: qlast.Expr,
+    alias: str,
+) -> int:
+    uses = 0
+    for child in ast.find_children(node, qlast.Path):
+        match child:
+            case qlast.Path(steps=[
+                qlast.ObjectRef(module=None, name=alias2)
+            ]) if alias == alias2:
+                uses += 1
+    return uses
+
+
 def try_group_rewrite(
     node: qlast.Query,
     aliases: AliasGenerator,
@@ -199,7 +214,38 @@ def try_group_rewrite(
         )
     """
 
-    # TODO: would Python's new pattern matching fit well here???
+    # Inline trivial uses of aliases bound to a group and then
+    # immediately used, so that we can apply the other optimizations.
+    match node:
+        case qlast.SelectQuery(
+            aliases=[*_, qlast.AliasedExpr(
+                alias=alias, expr=qlast.GroupQuery() as grp)
+            ] as qaliases,
+            result=qlast.Shape(
+                expr=qlast.Path(steps=[
+                    qlast.ObjectRef(module=None, name=alias2)
+                ]),
+                elements=elements,
+            ) as result,
+        ) if alias == alias2 and _count_alias_uses(result, alias) == 1:
+            node = node.replace(
+                aliases=qaliases[:-1],
+                result=qlast.Shape(expr=grp, elements=elements),
+            )
+
+        case qlast.ForQuery(
+            aliases=[*_, qlast.AliasedExpr(
+                alias=alias, expr=qlast.GroupQuery() as grp)
+            ] as qaliases,
+            iterator=qlast.Path(steps=[
+                qlast.ObjectRef(module=None, name=alias2)
+            ]),
+            result=result,
+        ) if alias == alias2 and _count_alias_uses(result, alias) == 0:
+            node = node.replace(
+                aliases=qaliases[:-1],
+                iterator=grp,
+            )
 
     # Sink shapes into the GROUP
     if (

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -209,6 +209,20 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             "group has unnecessary uuid_generate",
         )
 
+    def test_codegen_group_binding(self):
+        sql = self._compile('''
+        with g := (group Issue by .status)
+        select g {
+            name := .key.status.name,
+            num := count(.elements),
+        } order by .name
+        ''')
+
+        self.assertNotIn(
+            "array_agg", sql,
+            "group has unnecessary array_agg",
+        )
+
     def test_codegen_in_array_unpack_no_dupe(self):
         sql = self._compile('''
             select 1 in array_unpack(


### PR DESCRIPTION
If the last alias in a WITH block is a GROUP query that is immediately
used in a shape or a for loop, inline it so that our other
optimizations apply.

This probably covers 95% of WITH-bound group use cases, despite being
a "hyper-local hack", as I said in #4243.

Fixes #4243. (Mostly.)