### PR TITLE
Properly cast to containers of enums when loading from the schema

### DIFF
--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -254,9 +254,7 @@ class AccessPolicyCommand(
                     and obj.is_link_property(schema)
                     and obj.get_default(schema)
                     and any(
-                        # XXX: apparently we don't do this coercion
-                        # automatically!
-                        qltypes.AccessKind(kind).is_data_check()
+                        kind.is_data_check()
                         for kind in self.scls.get_access_kinds(schema)
                     )
                 ):

--- a/edb/schema/reflection/reader.py
+++ b/edb/schema/reflection/reader.py
@@ -26,6 +26,7 @@ import uuid
 
 import immutables
 
+from edb.common import checked
 from edb.common import verutils
 from edb.common import uuidgen
 
@@ -196,6 +197,17 @@ def parse_into(
                     if type(v) is not ftype:
                         if issubclass(ftype, verutils.Version):
                             objdata[findex] = _parse_version(v)
+                        elif (
+                            issubclass(ftype, checked.ParametricContainer)
+                            and ftype.types
+                            and len(ftype.types) == 1
+                        ):
+                            # Coerce the elements in a parametric container
+                            # type.
+                            # XXX: Or should we do it in the container?
+                            subtyp = ftype.types[0]
+                            objdata[findex] = ftype(
+                                subtyp(x) for x in v)  # type: ignore
                         else:
                             objdata[findex] = ftype(v)
                     else:


### PR DESCRIPTION
Currently when reflecting container types from the database to
our schema objects, we don't cast the elements of the container.
This causes issues with containers of enums, which end up as just
strings. We have at least one hack around this in the code base.