### PR TITLE
More stmtctx.fini_expression fixes

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -374,7 +374,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write(ident_to_str(node.subject_alias), ' := ')
         self.visit(node.subject)
         self._block_ws(-1)
-        if node.using is not None:
+        if node.using:
             self._write_keywords('USING')
             self._block_ws(1)
             self.visit_list(node.using, newlines=False)

--- a/edb/edgeql/compiler/group.py
+++ b/edb/edgeql/compiler/group.py
@@ -220,11 +220,11 @@ class FindAggregatingUses(ast_visitor.NodeVisitor):
 
 
 def infer_group_aggregates(
-    ir: irast.Base,
+    irs: Sequence[irast.Base],
     *,
     ctx: context.ContextLevel,
 ) -> None:
-    groups = ast_visitor.find_children(ir, irast.GroupStmt)
+    groups = ast_visitor.find_children(irs, irast.GroupStmt)
     for stmt in groups:
         visitor = FindAggregatingUses(
             stmt.group_binding.path_id,

--- a/edb/edgeql/compiler/normalization.py
+++ b/edb/edgeql/compiler/normalization.py
@@ -184,7 +184,7 @@ def _normalize_with_block(
             newaliases.append(alias)
             localnames = {alias.alias} | localnames
 
-    node.aliases = newaliases
+    setattr(node, field, newaliases)
 
     return modaliases, localnames
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -182,8 +182,7 @@ def fini_expression(
             extra, scope_tree=ctx.path_scope, ctx=inf_ctx)
 
     # Fix up weak namespaces
-    for expr in all_exprs:
-        _rewrite_weak_namespaces(expr, ctx)
+    _rewrite_weak_namespaces(all_exprs, ctx)
 
     ctx.path_scope.validate_unique_ids()
 
@@ -225,7 +224,7 @@ def fini_expression(
         ir_set.expr = None
 
     # Analyze GROUP statements to find aggregates that can be optimized
-    group.infer_group_aggregates(ir, ctx=ctx)
+    group.infer_group_aggregates(all_exprs, ctx=ctx)
 
     # If we are producing a schema view, clean up the result types
     if ctx.env.options.schema_view_mode:
@@ -399,7 +398,7 @@ def _try_namespace_fix(
 
 
 def _rewrite_weak_namespaces(
-    ir: irast.Base, ctx: context.ContextLevel
+    irs: Sequence[irast.Base], ctx: context.ContextLevel
 ) -> None:
     """Rewrite weak namespaces in path ids to be usable by the backend.
 
@@ -420,7 +419,7 @@ def _rewrite_weak_namespaces(
     for node in tree.strict_descendants:
         _try_namespace_fix(node, node)
 
-    scopes = irutils.find_path_scopes(ir)
+    scopes = irutils.find_path_scopes(irs)
 
     for ir_set in ctx.env.set_types:
         path_scope_id: Optional[int] = scopes.get(ir_set)

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -350,7 +350,9 @@ class FindPathScopes(ast.NodeVisitor):
         return None
 
 
-def find_path_scopes(stmt: irast.Base) -> Dict[irast.Set, Optional[int]]:
+def find_path_scopes(
+    stmt: irast.Base | Sequence[irast.Base]
+) -> Dict[irast.Set, Optional[int]]:
     visitor = FindPathScopes()
     visitor.visit(stmt)
     return visitor.scopes


### PR DESCRIPTION
More follow up from #4994

 * We didn't call `infer_group_aggregates` on the policy expressions.
 * _rewrite_weak_namespaces actually *already* used a different method
   to iterate over "all sets" (looking at the map of sets to types),
   and only used the passed in set to produce its binding map.
   Avoid redoing the main pass repeatedly.

While trying to test the `infer_group_aggregates` thing, I discovered:
 * Query normalization was busted and would copy a GROUP statement's
   `using` clause to be a `with` binding in front of the GROUP!