### PR TITLE
Fix custom function calls on the HTTP interface

### DIFF
--- a/edb/server/protocol/edgeql_ext.pyx
+++ b/edb/server/protocol/edgeql_ext.pyx
@@ -125,7 +125,7 @@ async def handle_request(
             db,
             query,
             variables=variables or {},
-            globals_=globals_ or {},
+            globals_=globals_,
         )
     except Exception as ex:
         if debug.flags.server:

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -400,7 +400,7 @@ async def parse_execute_json(
     query: str,
     *,
     variables: Mapping[str, Any] = immutables.Map(),
-    globals_: Mapping[str, Any] = immutables.Map(),
+    globals_: Optional[Mapping[str, Any]] = None,
     output_format: compiler.OutputFormat = compiler.OutputFormat.JSON,
     query_cache_enabled: Optional[bool] = None,
 ) -> bytes:
@@ -443,20 +443,19 @@ async def execute_json(
     dbv: dbview.DatabaseConnectionView,
     compiled: dbview.CompiledQuery,
     variables: Mapping[str, Any] = immutables.Map(),
-    globals_: Mapping[str, Any] = immutables.Map(),
+    globals_: Optional[Mapping[str, Any]] = None,
     *,
     fe_conn: Optional[frontend.AbstractFrontendConnection] = None,
     use_prep_stmt: bint = False,
 ) -> bytes:
-    if globals_:
-        dbv.set_globals(immutables.Map({
-            "__::__edb_json_globals__": config.SettingValue(
-                name="__::__edb_json_globals__",
-                value=_encode_json_value(globals_),
-                source='global',
-                scope=qltypes.ConfigScope.GLOBAL,
-            )
-        }))
+    dbv.set_globals(immutables.Map({
+        "__::__edb_json_globals__": config.SettingValue(
+            name="__::__edb_json_globals__",
+            value=_encode_json_value(globals_),
+            source='global',
+            scope=qltypes.ConfigScope.GLOBAL,
+        )
+    }))
 
     qug = compiled.query_unit_group
 

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -162,8 +162,14 @@ function get_glob() -> optional str using (global test_global_str);
 
 alias GlobalTest := {
     gstr := global test_global_str,
-	garray := global test_global_array,
-	gid := global test_global_id,
-	gdef := global test_global_def,
-	gdef2 := global test_global_def2,
+    garray := global test_global_array,
+    gid := global test_global_id,
+    gdef := global test_global_def,
+    gdef2 := global test_global_def2,
+};
+
+function id_func(s: str) -> str using (s);
+
+alias FuncTest := {
+    fstr := id_func('test'),
 };

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -327,3 +327,23 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
                 globals={'default::test_global_str': 'foo'},
                 use_http_post=use_http_post,
             )
+
+    def test_http_edgeql_query_globals_04(self):
+        Q = r'''select get_glob()'''
+
+        for use_http_post in [True, False]:
+            self.assert_edgeql_query_result(
+                Q,
+                [],
+                use_http_post=use_http_post,
+            )
+
+    def test_http_edgeql_query_func_01(self):
+        Q = r'''select id_func('foo')'''
+
+        for use_http_post in [True, False]:
+            self.assert_edgeql_query_result(
+                Q,
+                ['foo'],
+                use_http_post=use_http_post,
+            )

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -4136,6 +4136,20 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 use_http_post=use_http_post,
             )
 
+    def test_graphql_func_01(self):
+        Q = r'''query { FuncTest { fstr } }'''
+
+        for use_http_post in [True, False]:
+            self.assert_graphql_query_result(
+                Q,
+                {
+                    "FuncTest": [{
+                        'fstr': 'test',
+                    }]
+                },
+                use_http_post=use_http_post,
+            )
+
 
 class TestGraphQLInit(tb.GraphQLTestCase):
     """Test GraphQL initialization on an empty database."""


### PR DESCRIPTION
The problem was that, if no global variables were passed,
we were passing in NULL for the global variable JSON object,
which causes strict functions to spuriously return NULL.

Fixes #4989