### PR TITLE
Fix quote_string function to quote backslash

### DIFF
--- a/edb/edgeql-parser/src/helpers.rs
+++ b/edb/edgeql-parser/src/helpers.rs
@@ -44,6 +44,10 @@ pub fn quote_string(s: &str) -> String {
                 buf.push('\\');
                 buf.push('"');
             }
+            '\\' => {
+                buf.push('\\');
+                buf.push('\\');
+            }
             '\x00'..='\x08' | '\x0B' | '\x0C' | '\x0E'..='\x1F' |
             '\u{007F}' | '\u{0080}'..='\u{009F}'
             => {
@@ -183,6 +187,12 @@ aa \
         aa").unwrap(), "bbaa");
     assert_eq!(_unquote_string("bb\\\r   aa").unwrap(), "bbaa");
     assert_eq!(_unquote_string("bb\\\r\n   aa").unwrap(), "bbaa");
+}
+
+#[test]
+fn test_quote_string() {
+    assert_eq!(quote_string(r"\n"), r#""\\n""#);
+    assert_eq!(unquote_string(&quote_string(r"\n")).unwrap(), r"\n");
 }
 
 #[test]


### PR DESCRIPTION
This function is mostly used in the CLI for quoting configuration values. We haven't seen too many complex configuration values so far, so this was unnoticed.