### PR TITLE
Add WatchError

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -127,6 +127,8 @@
 0x_05_03_01_01   TransactionSerializationError
 0x_05_03_01_02   TransactionDeadlockError
 
+0x_05_04_00_00   WatchError
+
 
 ####
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -82,6 +82,7 @@ __all__ = base.__all__ + (  # type: ignore
     'TransactionConflictError',
     'TransactionSerializationError',
     'TransactionDeadlockError',
+    'WatchError',
     'ConfigurationError',
     'AccessError',
     'AuthenticationError',
@@ -384,6 +385,10 @@ class TransactionSerializationError(TransactionConflictError):
 
 class TransactionDeadlockError(TransactionConflictError):
     _code = 0x_05_03_01_02
+
+
+class WatchError(ExecutionError):
+    _code = 0x_05_04_00_00
 
 
 class ConfigurationError(EdgeDBError):


### PR DESCRIPTION
This is raised when `edgedb watch` have schema or migration error to notify applications that schema is out of date.

It's generally bad to set the same error class as the original error received by `edgedb watch` because various errors could be raised during it's operation (i.e. duplicate key error when migration contains some inserts). And all of them mean only one thing for the client: user attention is needed, and client should not react to that error normally.

I'm not sure whether the name and point in hierarchy are perfect, though.