### PR TITLE
Avoid infinite recursion in some do-nothing intersection cases

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -557,6 +557,7 @@ def _infer_set_inner(
     if rptr is not None:
         rptrref = rptr.ptrref
 
+        assert ir is not rptr.source, "self-referential pointer"
         source_card = infer_cardinality(
             rptr.source, scope_tree=scope_tree, ctx=ctx,
         )

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -277,8 +277,8 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                 'could not resolve partial path ',
                 context=expr.context)
 
-    computables = []
-    path_sets = []
+    computables: list[irast.Set] = []
+    path_sets: list[irast.Set] = []
 
     for i, step in enumerate(expr.steps):
         is_computable = False
@@ -542,7 +542,10 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         if pathctx.path_is_inserting(path_tip.path_id, ctx=ctx):
             raise_self_insert_error(stype, step.context, ctx=ctx)
 
-        path_sets.append(path_tip)
+        # Don't track this step of the path if it didn't change the set
+        # (probably because of do-nothing intersection)
+        if not path_sets or path_sets[-1] != path_tip:
+            path_sets.append(path_tip)
 
     path_tip.context = expr.context
     pathctx.register_set_in_scope(path_tip, ctx=ctx)

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1684,6 +1684,19 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_select_polymorphic_14(self):
+        # This one isn't *really* polymorphic, and that caused some trouble
+        await self.assert_query_result(
+            r'''
+            select Issue { number, related_to }
+            filter exists .related_to;
+            ''',
+            tb.bag([
+                {'number': "3", 'related_to': [{}]},
+                {'number': "4", 'related_to': [{}]},
+            ]),
+        )
+
     async def test_edgeql_select_id_01(self):
         # allow assigning id to a computed (#4781)
         await self.con.query('SELECT schema::Type { XYZ := .id};')


### PR DESCRIPTION
If a computed (or just appearing in a shape) link is referred to in a
clause with a type intersection that doesn't change the type, we
include it multiple times in our list of sets along the path, which
causes us to patch it up in an invalidly self referential way when we
handle computeds. Avoid doing that.

Fixes #4996.