### PR TITLE
Don't mangle cast error messages when the cast value contains a type name

### DIFF
--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1377,6 +1377,12 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             await self.con.query_single(
                 'SELECT <decimal>"12313.132n"')
 
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r"invalid input syntax for type std::bigint: 'bigint'"):
+            await self.con.query_single(
+                'SELECT <bigint>"bigint"')
+
     async def test_edgeql_casts_collections_01(self):
         await self.assert_query_result(
             r'''SELECT <array<str>>[1, 2, 3];''',


### PR DESCRIPTION
Currently if we do something like `<int64>'bigint'`, we will produce a
message like `invalid input syntax for type std::int64: "std::int64"`.
This is because we do a pretty simple-minded replacement of pg type
names with edgedb type names in this sort of error message.

Make it a bit less simple-minded: only do the replacement before the
first colon. This isn't particularly principled, but I don't think the
data is structured enough for principle.

Fixes #4999.