### PR TITLE
Fix a number of nested module issues

### DIFF
--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -41,6 +41,9 @@ class Module(
     qlkind=qltypes.SchemaObjectClass.MODULE,
     data_safe=False,
 ):
+    # N.B: Modules are not "qualified" objects, even though they can
+    # be nested (because they might *not* be nested) and we arrange
+    # for their names to always be represented with an UnqualName.
     pass
 
 

--- a/edb/schema/reflection/reader.py
+++ b/edb/schema/reflection/reader.py
@@ -194,7 +194,10 @@ def parse_into(
                         elif issubclass(ftype, s_obj.Object):
                             val = val.id
                         elif issubclass(ftype, s_name.Name):
-                            val = s_name.name_from_string(val)
+                            if isinstance(obj, s_obj.QualifiedObject):
+                                val = s_name.name_from_string(val)
+                            else:
+                                val = s_name.UnqualName(val)
                         else:
                             val = ftype(val)
 

--- a/tests/schemas/dump_v3_default.esdl
+++ b/tests/schemas/dump_v3_default.esdl
@@ -15,3 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+module nested { type T }
+module `back``ticked` { type T }

--- a/tests/test_dump_v3.py
+++ b/tests/test_dump_v3.py
@@ -33,8 +33,17 @@ class DumpTestCaseMixin:
             await tx.rollback()
 
     async def _ensure_schema_data_integrity(self):
-        # Nothing yet
-        pass
+        await self.assert_query_result(
+            r'''
+            SELECT _ := schema::Module.name
+            FILTER _ LIKE 'default%'
+            ''',
+            {'default', 'default::nested', 'default::back`ticked'},
+        )
+
+        # We don't bother to validate these but we need them to work
+        await self.con.query('describe schema as sdl')
+        await self.con.query('describe schema as ddl')
 
 
 class TestDumpV3(tb.StableDumpTestCase, DumpTestCaseMixin):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11315,6 +11315,16 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             type Bar extending Foo;
         """)
 
+    async def test_edgeql_migration_nested_backticks_01(self):
+        await self.migrate(r"""
+            module nested { type Test };
+        """)
+
+        await self.migrate(r"""
+            module nested { type Test };
+            module `back``ticked` { type Test };
+        """)
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2466,6 +2466,17 @@ aa';
             spam,
             ham := baz
         } FILTER (foo = 'special');
+
+% OK %
+
+        WITH
+            extra AS MODULE `lib.extra`,
+            foo := Bar.foo,
+            baz := (SELECT extra::Foo.baz)
+        SELECT Bar {
+            spam,
+            ham := baz
+        } FILTER (foo = 'special');
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, line=5, col=9)
@@ -2496,15 +2507,17 @@ aa';
         WITH MODULE abstract SELECT Foo;
         WITH MODULE all SELECT Foo;
         WITH MODULE all.abstract.bar SELECT Foo;
+
+% OK %
+
+        WITH MODULE abstract SELECT Foo;
+        WITH MODULE all SELECT Foo;
+        WITH MODULE `all.abstract.bar` SELECT Foo;
         """
 
     def test_edgeql_syntax_with_07(self):
         """
         WITH MODULE `all.abstract.bar` SELECT Foo;
-
-% OK %
-
-        WITH MODULE all.abstract.bar SELECT Foo;
         """
 
     def test_edgeql_syntax_with_08(self):


### PR DESCRIPTION
1. Properly escape modules in codegen. As a side effect of how this is
   implemented, we now *always* backtick escape module names with dots
   in them, despite allowing them without dots in some places in the
   schema. Previously we would escape some but not all such locations.
   An earlier take caused them to never be escaped, but if I'm are going
   to change the behavior for such a silly misfeature, I want to do it
   in a way the removes annoying code, not a way that adds a bunch more.
2. When reading from the schema, make sure to always load module names
   (and the names of other unqualified objects) as UnqualNames, not as
   QualNames.

This made me realize that the reflection reading system is
surprisingly under-tested, with the main testing happening via the
dump tests.

Fixes #5004.