### PR TITLE
Bump Postgres to 14.7 and fix non-transactional errors

### DIFF
--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1035,11 +1035,13 @@ cdef class PGConnection:
 
         if state is not None:
             self._build_apply_state_req(state, out)
-            if query.tx_id:
-                # This query has START TRANSACTION in it.
+            if query.tx_id or not query.is_transactional:
+                # This query has START TRANSACTION or non-transactional command
+                # like CREATE DATABASE in it.
                 # Restoring state must be performed in a separate
-                # implicit transaction (otherwise START TRANSACTION DEFERRABLE)
-                # would fail. Hence - inject a SYNC after a state restore step.
+                # implicit transaction (otherwise START TRANSACTION DEFERRABLE
+                # or CREATE DATABASE (since PG 14.7) would fail).
+                # Hence - inject a SYNC after a state restore step.
                 state_sync = 1
                 self.write_sync(out)
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1219,6 +1219,28 @@ class TestServerConfig(tb.QueryTestCase):
             ''')
             await con2.aclose()
 
+    async def test_server_proto_non_transactional_pg_14_7(self):
+        con1 = self.con
+        con2 = await self.connect(database=con1.dbname)
+        try:
+            await con2.execute('''
+                CONFIGURE SESSION SET __internal_sess_testvalue := 2;
+            ''')
+            await con1.execute('''
+                CONFIGURE SESSION SET __internal_sess_testvalue := 1;
+            ''')
+            await con2.execute('''
+                CREATE DATABASE pg_14_7;
+            ''')
+        finally:
+            await con2.aclose()
+            await con1.execute('''
+                CONFIGURE SESSION RESET __internal_sess_testvalue;
+            ''')
+            await con1.execute('''
+                DROP DATABASE pg_14_7;
+            ''')
+
 
 class TestSeparateCluster(tb.TestCase):
 


### PR DESCRIPTION
## Background

Postgres 14.7 [fixed a bug](https://github.com/postgres/postgres/commit/f92944137cdec3e80e826879d817a2d3dff68b5f), so that non-transactional commands like `CREATE DATABASE` cannot be executed in an implicit transaction in the extended query mode.

## Issue

When EdgeDB needs to restore state in the backend connection (e.g. reusing the same pgcon with different session settings), non-transactional commands like `CREATE DATABASE` will fail with an error `CREATE DATABASE cannot be executed within a pipeline`.

## Fix

If the command is not transactional, complete the state-syncing implicit transaction with a SYNC.

## Backport

The test won't fail if we just backport the fix without bumping PG to 14.7 in `stable/2.x` branch, it's just that the test would yield a false pass with PG 14.4.