### PR TITLE
Fix bug that dropping non-existing db leaves with unaccessible state

### DIFF
--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -1250,8 +1250,12 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
                             # see the same comments in _legacy_execute()
                             conn.last_state = state
                 finally:
+                    if query_unit.drop_db:
+                        self.server._allow_database_connections(
+                            query_unit.drop_db,
+                        )
                     if query_unit.create_db_template:
-                        await self.server._allow_database_connections(
+                        self.server._allow_database_connections(
                             query_unit.create_db_template,
                         )
         finally:

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -158,6 +158,13 @@ async def execute(
                 #   2. The state is synced with dbview (orig_state is None)
                 #   3. We came out from a transaction (orig_state is None)
                 be_conn.last_state = state
+    finally:
+        if query_unit.drop_db:
+            server._allow_database_connections(query_unit.drop_db)
+        if query_unit.create_db_template:
+            server._allow_database_connections(
+                query_unit.create_db_template,
+            )
 
     return data
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1169,9 +1169,10 @@ class Server(ha_base.ClusterProtocol):
         if current_dbname == dbname:
             raise errors.ExecutionError(
                 f'cannot drop the currently open database {dbname!r}')
+        assert self._dbindex is not None
         if not self._dbindex.has_db(dbname):
             raise errors.UnknownDatabaseError(
-                f'database {dbname!r} does not exist')
+                f'database "{dbname}" does not exist')
 
         await self._ensure_database_not_connected(dbname)
 
@@ -1184,9 +1185,10 @@ class Server(ha_base.ClusterProtocol):
             raise errors.ExecutionError(
                 f'cannot create database using currently open database '
                 f'{dbname!r} as a template database')
+        assert self._dbindex is not None
         if not self._dbindex.has_db(dbname):
             raise errors.UnknownDatabaseError(
-                f'database {dbname!r} does not exist')
+                f'database "{dbname}" does not exist')
 
         await self._ensure_database_not_connected(dbname)
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1169,6 +1169,9 @@ class Server(ha_base.ClusterProtocol):
         if current_dbname == dbname:
             raise errors.ExecutionError(
                 f'cannot drop the currently open database {dbname!r}')
+        if not self._dbindex.has_db(dbname):
+            raise errors.UnknownDatabaseError(
+                f'database {dbname!r} does not exist')
 
         await self._ensure_database_not_connected(dbname)
 
@@ -1181,6 +1184,9 @@ class Server(ha_base.ClusterProtocol):
             raise errors.ExecutionError(
                 f'cannot create database using currently open database '
                 f'{dbname!r} as a template database')
+        if not self._dbindex.has_db(dbname):
+            raise errors.UnknownDatabaseError(
+                f'database {dbname!r} does not exist')
 
         await self._ensure_database_not_connected(dbname)
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1169,10 +1169,6 @@ class Server(ha_base.ClusterProtocol):
         if current_dbname == dbname:
             raise errors.ExecutionError(
                 f'cannot drop the currently open database {dbname!r}')
-        assert self._dbindex is not None
-        if not self._dbindex.has_db(dbname):
-            raise errors.UnknownDatabaseError(
-                f'database "{dbname}" does not exist')
 
         await self._ensure_database_not_connected(dbname)
 
@@ -1185,10 +1181,6 @@ class Server(ha_base.ClusterProtocol):
             raise errors.ExecutionError(
                 f'cannot create database using currently open database '
                 f'{dbname!r} as a template database')
-        assert self._dbindex is not None
-        if not self._dbindex.has_db(dbname):
-            raise errors.UnknownDatabaseError(
-                f'database "{dbname}" does not exist')
 
         await self._ensure_database_not_connected(dbname)
 
@@ -1466,9 +1458,9 @@ class Server(ha_base.ClusterProtocol):
                     if not self._dbindex.has_db(dbname):
                         g.create_task(self._early_introspect_db(dbname))
 
-            for dbname in self._dbindex.iter_dbs():
-                if dbname not in dbnames:
-                    self._on_after_drop_db(dbname)
+            for db in self._dbindex.iter_dbs():
+                if db.name not in dbnames:
+                    self._on_after_drop_db(db.name)
 
         self.create_task(task(), interruptable=True)
 


### PR DESCRIPTION
Refs #4422, when dropping a database that doesn't exist, the database name is remembered as unaccessible by mistake, making the database unaccessible when actually created with that name. Fixed in a way that the existance of the database to be dropped (or used as a template) is checked before actually proceeding on.

Found in edgedb/edgedb-examples#105