### PR TITLE
Add a few more retries on serialization errors

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -152,7 +152,7 @@ class TestCaseMeta(type(unittest.TestCase)):
                 except (edgedb.TransactionSerializationError,
                         edgedb.TransactionDeadlockError):
                     if (
-                        try_no == 6
+                        try_no == 10
                         # Only do a retry loop when we have a transaction
                         or not getattr(self, 'TRANSACTION_ISOLATION', False)
                     ):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -160,7 +160,8 @@ class TestCaseMeta(type(unittest.TestCase)):
                     else:
                         self.loop.run_until_complete(self.xact.rollback())
                         self.loop.run_until_complete(asyncio.sleep(
-                            (2 ** try_no) * 0.1 + random.randrange(100) * 0.001
+                            min((2 ** try_no) * 0.1, 10)
+                            + random.randrange(100) * 0.001
                         ))
                         self.xact = self.con.transaction()
                         self.loop.run_until_complete(self.xact.start())


### PR DESCRIPTION
We had a serialization deadlock flake in the release build and I want
to feel like I'm doing *something* about it. This shouldn't hurt and
might help.