### PR TITLE
Eliminate ptr_info arg to get_path_output and similar

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -224,6 +224,11 @@ class BaseRelation(EdgeQLPathInfo, BaseExpr):
 class Relation(BaseRelation):
     """A reference to a table or a view."""
 
+    # The type this represents. For a link relation, the source type.
+    # Should be non-None for any relation arising from a type or
+    # pointer during compilation.
+    typeref: typing.Optional[irast.TypeRef] = None
+
     catalogname: typing.Optional[str] = None
     schemaname: typing.Optional[str] = None
     is_temporary: typing.Optional[bool] = None
@@ -475,6 +480,8 @@ class ReturningQuery(BaseRelation):
 
 class NullRelation(ReturningQuery):
     """Special relation that produces nulls for all its attributes."""
+
+    typeref: typing.Optional[irast.TypeRef] = None
 
     where_clause: typing.Optional[BaseExpr] = None
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -406,7 +406,8 @@ def maybe_get_path_var(
 def new_empty_rvar(
         ir_set: irast.EmptySet, *,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
-    nullrel = pgast.NullRelation(path_id=ir_set.path_id)
+    nullrel = pgast.NullRelation(
+        path_id=ir_set.path_id, typeref=ir_set.typeref)
     rvar = rvar_for_rel(nullrel, ctx=ctx)
     pathctx.put_rvar_path_bond(rvar, ir_set.path_id)
     return rvar
@@ -1479,6 +1480,7 @@ def range_for_material_objtype(
             schemaname=table_schema_name,
             name=table_name,
             path_id=path_id,
+            typeref=typeref,
         )
 
         rvar = pgast.RelRangeVar(
@@ -1768,12 +1770,12 @@ def table_from_ptrref(
         # Redirect all queries to schema tables to edgedbss
         table_schema_name = 'edgedbss'
 
+    typeref = ptrref.out_source if ptrref else None
     relation = pgast.Relation(
-        schemaname=table_schema_name, name=table_name)
+        schemaname=table_schema_name, name=table_name, typeref=typeref)
 
     # Pseudo pointers (tuple and type intersection) have no schema id.
     sobj_id = ptrref.id if isinstance(ptrref, irast.PointerRef) else None
-    typeref = ptrref.out_source if ptrref else None
     rvar = pgast.RelRangeVar(
         schema_object_id=sobj_id,
         typeref=typeref,


### PR DESCRIPTION
Instead of figuring out the column name for the actual pointer
(which could be a subtype of the one in the path id) in get_path_var
/get_rvar_path_var and threading it through, track typeref in Relation
so that we can find the actual ptrref when we get pointer path outputs
from Relations.

This allows us to do the correct column determination at a place that
makes more sense (_get_rel_path_output), and also gives
_get_rel_path_output access to the actual type information, which I'm
going to want in a follow-up PR to remove `__type__` from database
tables (#4637).