### PR TITLE
Fix creation of a new link property with a default value

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5253,6 +5253,11 @@ class PropertyMetaCommand(PointerMetaCommand[s_props.Property]):
                 (default := prop.get_default(schema))
                 and not prop.is_pure_computable(schema)
                 and not fills_required
+                # link properties use SQL defaults and shouldn't need
+                # us to do it explicitly (which is good, since
+                # _alter_pointer_optionality doesn't currently work on
+                # linkprops)
+                and not prop.is_link_property(schema)
             ):
                 self._alter_pointer_optionality(
                     schema, schema, context, fill_expr=default)


### PR DESCRIPTION
This was a regression from 2.9 to 2.10, introduced by #4873.
`_alter_pointer_optionality` is also (ab)used to populate newly
created pointers with their default values, and #4873 broke that flow
for link properties (which don't have an `id` field).

Link properties *shouldn't* be running the
`_alter_pointer_optionality` explicit flow for explicitly populating a
field, though! Defaults on link properties are (unlike defaults on
object properties) currently represented using SQL defaults. (Though I
want to change this eventually since it places more limitations on
what can be done.)

Fixes #5060.