### PR TITLE
Fix GROUP regression with some query-builder queries

### DIFF
--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -152,13 +152,16 @@ def find_parameters(
     return v.params
 
 
-class alias_view(view_patterns.ViewPattern[str], targets=(qlast.Base,)):
+class alias_view(
+    view_patterns.ViewPattern[tuple[str, list[qlast.PathElement]]],
+    targets=(qlast.Base,),
+):
     @staticmethod
-    def match(obj: object) -> str:
+    def match(obj: object) -> tuple[str, list[qlast.PathElement]]:
         match obj:
             case qlast.Path(
-                steps=[qlast.ObjectRef(module=None, name=alias)],
+                steps=[qlast.ObjectRef(module=None, name=alias), *rest],
                 partial=False,
             ):
-                return alias
+                return alias, rest
         raise view_patterns.NoMatch

--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -174,7 +174,7 @@ def _count_alias_uses(
     uses = 0
     for child in ast.find_children(node, qlast.Path):
         match child:
-            case astutils.alias_view(alias2) if alias == alias2:
+            case astutils.alias_view((alias2, _)) if alias == alias2:
                 uses += 1
     return uses
 
@@ -222,7 +222,7 @@ def try_group_rewrite(
                 qlast.AliasedExpr(alias=alias, expr=qlast.GroupQuery() as grp)
             ] as qaliases,
             result=qlast.Shape(
-                expr=astutils.alias_view(alias2),
+                expr=astutils.alias_view((alias2, [])),
                 elements=elements,
             ) as result,
         ) if alias == alias2 and _count_alias_uses(result, alias) == 1:
@@ -236,7 +236,7 @@ def try_group_rewrite(
                 *_,
                 qlast.AliasedExpr(alias=alias, expr=qlast.GroupQuery() as grp)
             ] as qaliases,
-            iterator=astutils.alias_view(alias2),
+            iterator=astutils.alias_view((alias2, [])),
             result=result,
         ) if alias == alias2 and _count_alias_uses(result, alias) == 0:
             node = node.replace(

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -1329,3 +1329,19 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                 }
             ]),
         )
+
+    async def test_edgeql_group_uses_name_01(self):
+        # Make sure that our crappy optimizations don't break anything
+        await self.con.query(
+            r'''
+            WITH g := (GROUP cards::Card BY .cost)
+            SELECT g {
+              key: {cost},
+              grouping,
+              elements: {
+                name,
+                multi owners := g.elements.owners { name },
+              }
+            };
+            ''',
+        )


### PR DESCRIPTION
The optimization introduced in #4978 to optimize trivial with-bound
queries had a bug in the code where it tried to make sure the alias
was only used exactly once: it failed to consider when it appeared
at the head of a path. Fix that oversight.

Fixes #5070.