### PR TITLE
[2.x] Fix GROUP regression with some query-builder queries

### DIFF
--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -174,7 +174,7 @@ def _count_alias_uses(
     for child in ast.find_children(node, lambda x: isinstance(x, qlast.Path)):
         match child:
             case qlast.Path(steps=[
-                qlast.ObjectRef(module=None, name=alias2)
+                qlast.ObjectRef(module=None, name=alias2), *_,
             ]) if alias == alias2:
                 uses += 1
     return uses

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -1329,3 +1329,19 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                 }
             ]),
         )
+
+    async def test_edgeql_group_uses_name_01(self):
+        # Make sure that our crappy optimizations don't break anything
+        await self.con.query(
+            r'''
+            WITH g := (GROUP cards::Card BY .cost)
+            SELECT g {
+              key: {cost},
+              grouping,
+              elements: {
+                name,
+                multi owners := g.elements.owners { name },
+              }
+            };
+            ''',
+        )


### PR DESCRIPTION
The optimization introduced in #4978 to optimize trivial with-bound queries had a bug in the code where it tried to make sure the alias was only used exactly once: it failed to consider when it appeared at the head of a path. Fix that oversight.

Fixes #5070.