### PR TITLE
Fix optional tuple query arguments

### DIFF
--- a/edb/edgeql/compiler/tuple_args.py
+++ b/edb/edgeql/compiler/tuple_args.py
@@ -236,6 +236,10 @@ def make_decoder(
         qlast.TypeCast(
             expr=qlast.Parameter(name=param.name),
             type=_ref_to_ast(param.ir_type, ctx=ctx),
+            cardinality_mod=(
+                qlast.CardinalityModifier.Optional if not param.required
+                else None
+            ),
         )
         for param in qparams
     ]

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2767,6 +2767,23 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             variables=(('a', True),)
         )
 
+    async def test_edgeql_casts_tuple_params_08(self):
+        await self.assert_query_result(
+            '''
+            select { x := <optional tuple<str, str>>$0, y := <str>$1 };
+            ''',
+            [{'x': None, 'y': "test"}],
+            variables=(None, 'test'),
+        )
+
+        await self.assert_query_result(
+            '''
+            select { x := <optional tuple<str, str>>$0, y := <int64>$1 };
+            ''',
+            [{'x': None, 'y': 11111}],
+            variables=(None, 11111),
+        )
+
     async def test_edgeql_cast_empty_set_to_array_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
There were two issues I found:

1. The argument re-parsing code in the server mishandled the NULL case
   for arguments containing tuples and failed to consume the -1 that
   indicated a NULL, causing it to be picked up as the *next*
   argument. Fix this, and add another validity check that would have
   turned this bug into an error (as it was in some other cases) and will
   reject various malformed data.
2. The code we compiled to reassemble the tuples inside the query
   didn't understand that the parameters were optional and so would
   produce cursed tuples like `({}, {})` instead of the correct `{}`.

Fixes #5068.