### PR TITLE
Fix flaky test_server_adjacent_database_propagation

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1458,9 +1458,12 @@ class Server(ha_base.ClusterProtocol):
                     if not self._dbindex.has_db(dbname):
                         g.create_task(self._early_introspect_db(dbname))
 
+            dropped = []
             for db in self._dbindex.iter_dbs():
                 if db.name not in dbnames:
-                    self._on_after_drop_db(db.name)
+                    dropped.append(db.name)
+            for dbname in dropped:
+                self._on_after_drop_db(dbname)
 
         self.create_task(task(), interruptable=True)
 


### PR DESCRIPTION
`test_server_adjacent_database_propagation` is flaky because of #5081, which needs a better fix. This PR adds an additional check in the test to avoid the racing condition so that we can see less flakiness before #5081 is properly fixed.

Also fixed a RuntimeError "dictionary changed size during iteration", interestingly this error didn't break anything - because Python only raises this error before the 2nd iteration, after the 1st iteration is already done, while the remaining iterations will be taken care of in the next events.