### PR TITLE
Nuke Rust version check from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ import parsing
 import setuptools_rust
 
 
-RUST_VERSION = '1.65.0'  # Also update docs/guides/contributing.rst
-
 EDGEDBCLI_REPO = 'https://github.com/edgedb/edgedb-cli'
 # This can be a branch, tag, or commit
 EDGEDBCLI_COMMIT = 'c6735ef0520d53c5a5e736574b36fd80f976a49c'
@@ -311,27 +309,6 @@ def _compile_libpg_query():
     )
 
 
-def _check_rust():
-    import packaging.version
-
-    try:
-        rustc_ver = (
-            subprocess.check_output(["rustc", '-V'], text=True).split()[1]
-            .rstrip("-nightly")
-        )
-        if (
-            packaging.version.parse(rustc_ver)
-            < packaging.version.parse(RUST_VERSION)
-        ):
-            raise RuntimeError(
-                f'please upgrade Rust to {RUST_VERSION} to compile '
-                f'edgedb from source')
-    except FileNotFoundError:
-        raise RuntimeError(
-            f'please install rustc >= {RUST_VERSION} to compile '
-            f'edgedb from source (see https://rustup.rs/)')
-
-
 def _get_git_rev(repo, ref):
     output = subprocess.check_output(
         ['git', 'ls-remote', repo, ref],
@@ -364,7 +341,6 @@ def _get_pg_source_stamp():
 
 
 def _compile_cli(build_base, build_temp):
-    _check_rust()
     rust_root = build_base / 'cli'
     env = dict(os.environ)
     env['CARGO_TARGET_DIR'] = str(build_temp / 'rust' / 'cli')
@@ -852,7 +828,6 @@ class build_parsers(setuptools.Command):
 
 class build_rust(setuptools_rust.build.build_rust):
     def run(self):
-        _check_rust()
         build_ext = self.get_finalized_command("build_ext")
         if build_ext.build_mode not in {'both', 'rust-only'}:
             distutils.log.info(


### PR DESCRIPTION
Rust version requirements are appropriate for `Cargo.toml`, not here.