### PR TITLE
Implement compilation of triggers

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -324,6 +324,7 @@ def compile_ast_fragment_to_ir(
         scope_tree=ctx.path_scope,
         type_rewrites={},
         singletons=[],
+        triggers=(),
     )
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -207,9 +207,7 @@ class Environment:
     """
 
     dml_stmts: Set[irast.MutatingStmt]
-    """A list of DML expressions (statements and DML-containing
-    functions) that appear in a function body.
-    """
+    """A list of DML statements in the query"""
 
     #: A list of bindings that should be assumed to be singletons.
     singletons: List[irast.PathId]

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1412,6 +1412,16 @@ def __infer_tuple(
     )
 
 
+@_infer_cardinality.register
+def __infer_trigger_anchor(
+    ir: irast.TriggerAnchor,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Cardinality:
+    return MANY
+
+
 def infer_cardinality(
     ir: irast.Base,
     *,

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -846,6 +846,16 @@ def __infer_tuple(
     )
 
 
+@_infer_multiplicity.register
+def __infer_trigger_anchor(
+    ir: irast.TriggerAnchor,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    return UNIQUE
+
+
 def infer_multiplicity(
     ir: irast.Base,
     *,

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -542,6 +542,15 @@ def __infer_tuple(
     return tup
 
 
+@_infer_type.register
+def __infer_trigger_anchor(
+    ir: irast.TriggerAnchor,
+    env: context.Environment,
+) -> s_types.Type:
+    env.schema, t = irtyputils.ir_typeref_to_type(env.schema, ir.typeref)
+    return t
+
+
 def infer_type(ir: irast.Base, env: context.Environment) -> s_types.Type:
     result = env.inferred_types.get(ir)
     if result is not None:

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -290,6 +290,14 @@ def __infer_group_stmt(
 
 
 @_infer_volatility_inner.register
+def __infer_trigger_anchor(
+    ir: irast.TriggerAnchor,
+    env: context.Environment,
+) -> InferredVolatility:
+    return STABLE, STABLE
+
+
+@_infer_volatility_inner.register
 def __infer_dml_stmt(
     ir: irast.MutatingStmt,
     env: context.Environment,

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -471,7 +471,7 @@ def concretify(
     t = get_material_type(t, ctx=ctx)
     if els := t.get_union_of(ctx.env.schema):
         ts = [concretify(e, ctx=ctx) for e in els.objects(ctx.env.schema)]
-        return get_union_type(ts , ctx=ctx)
+        return get_union_type(ts, ctx=ctx)
     if els := t.get_intersection_of(ctx.env.schema):
         ts = [concretify(e, ctx=ctx) for e in els.objects(ctx.env.schema)]
         return get_intersection_type(ts , ctx=ctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -485,8 +485,6 @@ def compile_InsertQuery(
         stmt.conflict_checks = conflicts.compile_inheritance_conflict_checks(
             stmt, stmt_subject_stype, ctx=ictx)
 
-        ctx.env.dml_stmts.add(stmt)
-
         if expr.unless_conflict is not None:
             constraint_spec, else_branch = expr.unless_conflict
 
@@ -562,7 +560,7 @@ def compile_UpdateQuery(
             context=expr.context,
         )
 
-    # Record this node in the list of potential DML expressions.
+    # Record this node in the list of DML statements.
     ctx.env.dml_exprs.append(expr)
 
     with ctx.subquery() as ictx:
@@ -616,8 +614,6 @@ def compile_UpdateQuery(
                 compile_views=True,
                 exprtype=s_types.ExprType.Update,
                 ctx=bodyctx)
-
-        ctx.env.dml_stmts.add(stmt)
 
         result = setgen.class_set(
             mat_stype, path_id=stmt.subject.path_id, ctx=ctx,
@@ -1138,6 +1134,9 @@ def fini_stmt(
 
     view: Optional[s_types.Type]
     path_id: Optional[irast.PathId]
+
+    if isinstance(irstmt, irast.MutatingStmt):
+        ctx.env.dml_stmts.add(irstmt)
 
     if (isinstance(t, s_pseudo.PseudoType)
             and t.is_any(ctx.env.schema)):

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -141,8 +141,7 @@ def fini_expression(
         ir = setgen.scoped_set(ir, ctx=ctx)
 
     # Compile any triggers that were triggered by the query
-    ir_triggers = triggers.compile_triggers(
-        ast_visitor.find_children(ir, irast.MutatingStmt), ctx=ctx)
+    ir_triggers = triggers.compile_triggers(ctx.env.dml_stmts, ctx=ctx)
 
     # Collect all of the expressions stored in various side sets
     # that can make it into the output, so that we can make sure

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -56,6 +56,7 @@ from . import pathctx
 from . import setgen
 from . import viewgen
 from . import schemactx
+from . import triggers
 from . import tuple_args
 from . import typegen
 
@@ -139,6 +140,10 @@ def fini_expression(
     ):
         ir = setgen.scoped_set(ir, ctx=ctx)
 
+    # Compile any triggers that were triggered by the query
+    ir_triggers = triggers.compile_triggers(
+        ast_visitor.find_children(ir, irast.MutatingStmt), ctx=ctx)
+
     # Collect all of the expressions stored in various side sets
     # that can make it into the output, so that we can make sure
     # to catch them all in our fixups and analyses.
@@ -153,6 +158,7 @@ def fini_expression(
         p.sub_params.decoder_ir for p in ctx.env.query_parameters.values()
         if p.sub_params and p.sub_params.decoder_ir
     ]
+    extra_exprs += [trigger.expr for trigger in ir_triggers]
 
     all_exprs = [ir] + extra_exprs
 
@@ -268,6 +274,7 @@ def fini_expression(
             if isinstance(s, irast.Set)},
         dml_exprs=ctx.env.dml_exprs,
         singletons=ctx.env.singletons,
+        triggers=ir_triggers,
     )
     return result
 

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -1,0 +1,155 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""EdgeQL trigger compilation."""
+
+
+from __future__ import annotations
+
+from typing import *
+
+from edb.ir import ast as irast
+
+from edb.schema import name as sn
+from edb.schema import objtypes as s_objtypes
+from edb.schema import triggers as s_triggers
+
+from edb.edgeql import qltypes
+
+from . import context
+from . import dispatch
+from . import schemactx
+from . import setgen
+from . import typegen
+
+
+TRIGGER_KINDS = {
+    irast.UpdateStmt: qltypes.TriggerKind.Update,
+    irast.DeleteStmt: qltypes.TriggerKind.Delete,
+    irast.InsertStmt: qltypes.TriggerKind.Insert,
+}
+
+
+def compile_trigger(
+    trigger: s_triggers.Trigger,
+    affected: set[tuple[s_objtypes.ObjectType, irast.MutatingStmt]],
+    *,
+    ctx: context.ContextLevel,
+) -> irast.Trigger:
+    schema = ctx.env.schema
+
+    scope = trigger.get_scope(schema)
+    kinds = set(trigger.get_kinds(schema))
+    source = trigger.get_subject(schema)
+
+    with ctx.detached() as _, ctx.newscope(fenced=True) as sctx:
+        sctx.anchors = sctx.anchors.copy()
+
+        anchors = {}
+        new_path = irast.PathId.from_type(
+            schema, source, typename=sn.QualName(
+                module='__derived__', name='__new__')
+        )
+        new_set = setgen.class_set(
+            source, path_id=new_path, ignore_rewrites=True, ctx=sctx)
+
+        old_set = None
+        if qltypes.TriggerKind.Insert not in kinds:
+            old_path = irast.PathId.from_type(
+                schema, source, typename=sn.QualName(
+                    module='__derived__', name='__old__')
+            )
+            old_set = setgen.class_set(
+                source, path_id=old_path, ignore_rewrites=True, ctx=sctx)
+            old_set.expr = irast.TriggerAnchor(typeref=old_set.typeref)
+            anchors['__old__'] = old_set
+        if qltypes.TriggerKind.Delete not in kinds:
+            anchors['__new__'] = new_set
+
+        for name, ir in anchors.items():
+            if scope == qltypes.TriggerScope.Each:
+                sctx.path_scope.attach_path(ir.path_id, context=None)
+                sctx.iterator_path_ids |= {ir.path_id}
+            sctx.anchors[name] = ir
+
+        trigger_set = dispatch.compile(
+            trigger.get_expr(schema).qlast, ctx=sctx)
+
+    typeref = typegen.type_to_typeref(source, env=ctx.env)
+    taffected = {
+        (typegen.type_to_typeref(t, env=ctx.env), ir) for t, ir in affected
+    }
+
+    return irast.Trigger(
+        expr=trigger_set,
+        kinds=kinds,
+        scope=scope,
+        source_type=typeref,
+        affected=taffected,
+        new_set=new_set,
+        old_set=old_set,
+    )
+
+
+def compile_triggers(
+    dml_stmts: Collection[irast.MutatingStmt],
+    *,
+    ctx: context.ContextLevel,
+) -> tuple[irast.Trigger, ...]:
+    schema = ctx.env.schema
+
+    trigger_map: dict[
+        s_triggers.Trigger,
+        set[tuple[s_objtypes.ObjectType, irast.MutatingStmt]],
+    ] = {}
+    for stmt in dml_stmts:
+        kind = TRIGGER_KINDS[type(stmt)]
+
+        stype = schemactx.concretify(
+            setgen.get_set_type(stmt.result, ctx=ctx), ctx=ctx)
+        assert isinstance(stype, s_objtypes.ObjectType)
+        # For updates and deletes, we need to look to see if any
+        # descendant types have triggers.
+        if isinstance(stmt, irast.InsertStmt):
+            stypes = {stype}
+        else:
+            stypes = schemactx.get_all_concrete(stype, ctx=ctx)
+
+        # Process all the types, starting with the base type
+        for subtype in sorted(stypes, key=lambda t: t != stype):
+            for trigger in subtype.get_relevant_triggers(kind, schema):
+                mro = (trigger, *trigger.get_ancestors(schema).objects(schema))
+                base = mro[-1]
+                tmap = trigger_map.setdefault(base, set())
+                # N.B: If the *base type* of the DML appears, that
+                # suffices, because it covers everything, and we don't
+                # need to duplicate.  This is a specific interaction
+                # with how dml.compile_trigger is implemented, where
+                # processing the base type of a DML naturally covers
+                # all subtypes, but processing a child does not cover
+                # a grandchild.
+                if (stype, stmt) not in tmap:
+                    tmap.add((subtype, stmt))
+
+    # sort these by name just to avoid weird nondeterminism
+    return tuple(
+        compile_trigger(trigger, affected, ctx=ctx)
+        for trigger, affected
+        in sorted(trigger_map.items(), key=lambda t: t[0].get_name(schema))
+    )

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -248,14 +248,23 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
             return cur_set.expr
         elif isinstance(cur_set.expr, irast.SelectStmt):
             cur_set = cur_set.expr.result
-        # FIXME: This is a very narrow hack around issue #3030 designed
-        # to make the most common case work: assert_exists inserted by
-        # access policies.
+        # FIXME: This is a very narrow hack around issue #3030
+        # designed to make simple cases work. The critical one is
+        # assert_exists inserted by access policies.
         elif (
-            isinstance(cur_set.expr, irast.FunctionCall)
-            and str(cur_set.expr.func_shortname) == 'std::assert_exists'
+            isinstance(cur_set.expr, irast.Call)
+            and str(cur_set.expr.func_shortname) in {
+                'std::assert_exists',
+                'std::assert_single',
+                'std::assert_distinct',
+                'std::enumerate',
+                'std::min',
+                'std::max',
+                'std::DISTINCT',
+            }
+
         ):
-            cur_set = cur_set.expr.args[1].expr
+            cur_set = cur_set.expr.args[-1].expr
         elif cur_set.rptr is not None:
             cur_set = cur_set.rptr.source
         else:

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -238,13 +238,15 @@ def collapse_type_intersection(
     return source, result
 
 
-def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
+def get_nearest_dml_stmt(
+    ir_set: irast.Set
+) -> Optional[irast.MutatingLikeStmt]:
     """For a given *ir_set* representing a Path, return the nearest path
        step that is a DML expression.
     """
     cur_set: Optional[irast.Set] = ir_set
     while cur_set is not None:
-        if isinstance(cur_set.expr, irast.MutatingStmt):
+        if isinstance(cur_set.expr, irast.MutatingLikeStmt):
             return cur_set.expr
         elif isinstance(cur_set.expr, irast.SelectStmt):
             cur_set = cur_set.expr.result

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -1032,6 +1032,10 @@ class IteratorCTE(ImmutableBase):
     cte: CommonTableExpr
     parent: typing.Optional[IteratorCTE]
 
+    # A list of other paths to *also* register the iterator rvar as
+    # providing when it is merged into a statement.
+    other_paths: tuple[tuple[irast.PathId, str], ...] = ()
+
 
 class Statement(Base):
     """A statement that does not return a relation"""

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -58,7 +58,10 @@ def compile_ir_to_sql_tree(
         Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
     ] = None,
     external_rels: Optional[
-        Mapping[irast.PathId, pgast.BaseRelation]
+        Mapping[
+            irast.PathId,
+            Tuple[pgast.BaseRelation | pgast.CommonTableExpr, Tuple[str, ...]],
+        ]
     ] = None,
     backend_runtime_params: Optional[pgparams.BackendRuntimeParams]=None,
 ) -> Tuple[pgast.Base, context.Environment]:
@@ -104,7 +107,6 @@ def compile_ir_to_sql_tree(
             singleton_mode=singleton_mode,
             scope_tree_nodes=scope_tree_nodes,
             external_rvars=external_rvars,
-            external_rels=external_rels,
             backend_runtime_params=backend_runtime_params,
         )
 
@@ -122,6 +124,8 @@ def compile_ir_to_sql_tree(
         ctx.expr_exposed = True
         for sing in singletons:
             ctx.path_scope[sing] = ctx.rel
+        if external_rels:
+            ctx.external_rels = external_rels
         clauses.populate_argmap(query_params, query_globals, ctx=ctx)
 
         qtree = dispatch.compile(ir_expr, ctx=ctx)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1357,7 +1357,7 @@ def range_for_material_objtype(
     include_overlays: bool=True,
     include_descendants: bool=True,
     ignore_rewrites: bool=False,
-    dml_source: Optional[irast.MutatingStmt]=None,
+    dml_source: Optional[irast.MutatingLikeStmt]=None,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
 
@@ -1377,6 +1377,12 @@ def range_for_material_objtype(
         and key not in ctx.pending_type_ctes
         and not for_mutation
     ):
+        # Don't include overlays in the normal way in trigger mode
+        # when a type cte is used, because we bake the overlays into
+        # the cte instead (and so including them normally could union
+        # back in things that we have filtered out)
+        if ctx.trigger_mode:
+            include_overlays = False
 
         type_rel: pgast.BaseRelation | pgast.CommonTableExpr
         if (type_cte := ctx.type_ctes.get(key)) is None:
@@ -1384,10 +1390,16 @@ def range_for_material_objtype(
                 sctx.pending_type_ctes.add(key)
                 sctx.pending_query = sctx.rel
                 sctx.volatility_ref = ()
-                sctx.type_rel_overlays = collections.defaultdict(
-                    lambda: collections.defaultdict(list))
-                sctx.ptr_rel_overlays = collections.defaultdict(
-                    lambda: collections.defaultdict(list))
+                # Normally we want to compile type rewrites without
+                # polluting them with any sort of overlays, but when
+                # compiling triggers, we recompile all of the type
+                # rewrites *to include* overlays, so that we can't peek
+                # at all newly created objects that we can't see
+                if not ctx.trigger_mode:
+                    sctx.type_rel_overlays = collections.defaultdict(
+                        lambda: collections.defaultdict(list))
+                    sctx.ptr_rel_overlays = collections.defaultdict(
+                        lambda: collections.defaultdict(list))
                 dispatch.visit(rewrite, ctx=sctx)
                 # If we are expanding inhviews, we also expand type
                 # rewrites, so don't populate type_ctes. The normal
@@ -1568,7 +1580,7 @@ def range_for_typeref(
     for_mutation: bool=False,
     include_descendants: bool=True,
     ignore_rewrites: bool=False,
-    dml_source: Optional[irast.MutatingStmt]=None,
+    dml_source: Optional[irast.MutatingLikeStmt]=None,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
 
@@ -1797,7 +1809,7 @@ def table_from_ptrref(
 
 def range_for_ptrref(
     ptrref: irast.BasePointerRef, *,
-    dml_source: Optional[irast.MutatingStmt]=None,
+    dml_source: Optional[irast.MutatingLikeStmt]=None,
     for_mutation: bool=False,
     only_self: bool=False,
     path_id: Optional[irast.PathId]=None,
@@ -1966,7 +1978,7 @@ def range_for_ptrref(
 def range_for_pointer(
     pointer: irast.Pointer,
     *,
-    dml_source: Optional[irast.MutatingStmt] = None,
+    dml_source: Optional[irast.MutatingLikeStmt] = None,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
 
@@ -2023,7 +2035,7 @@ def _add_type_rel_overlay(
         typeid: uuid.UUID,
         op: str,
         rel: Union[pgast.BaseRelation, pgast.CommonTableExpr], *,
-        dml_stmts: Iterable[irast.MutatingStmt] = (),
+        dml_stmts: Iterable[irast.MutatingLikeStmt] = (),
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> None:
     entry = (op, rel, path_id)
@@ -2043,7 +2055,7 @@ def add_type_rel_overlay(
         op: str,
         rel: Union[pgast.BaseRelation, pgast.CommonTableExpr], *,
         stop_ref: Optional[irast.TypeRef]=None,
-        dml_stmts: Iterable[irast.MutatingStmt] = (),
+        dml_stmts: Iterable[irast.MutatingLikeStmt] = (),
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> None:
     typeref = typeref.real_material_type
@@ -2065,7 +2077,7 @@ def add_type_rel_overlay(
 def get_type_rel_overlays(
     typeref: irast.TypeRef,
     *,
-    dml_source: Optional[irast.MutatingStmt]=None,
+    dml_source: Optional[irast.MutatingLikeStmt]=None,
     ctx: context.CompilerContextLevel,
 ) -> List[
     Tuple[
@@ -2082,8 +2094,8 @@ def get_type_rel_overlays(
 
 def reuse_type_rel_overlays(
     *,
-    dml_stmts: Iterable[irast.MutatingStmt] = (),
-    dml_source: irast.MutatingStmt,
+    dml_stmts: Iterable[irast.MutatingLikeStmt] = (),
+    dml_source: irast.MutatingLikeStmt,
     ctx: context.CompilerContextLevel,
 ) -> None:
     """Update type rel overlays when a DML statement is reused.
@@ -2112,7 +2124,7 @@ def _add_ptr_rel_overlay(
         ptrref_name: str,
         op: str,
         rel: Union[pgast.BaseRelation, pgast.CommonTableExpr], *,
-        dml_stmts: Iterable[irast.MutatingStmt] = (),
+        dml_stmts: Iterable[irast.MutatingLikeStmt] = (),
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> None:
 
@@ -2132,7 +2144,7 @@ def add_ptr_rel_overlay(
         ptrref: irast.PointerRef,
         op: str,
         rel: Union[pgast.BaseRelation, pgast.CommonTableExpr], *,
-        dml_stmts: Iterable[irast.MutatingStmt] = (),
+        dml_stmts: Iterable[irast.MutatingLikeStmt] = (),
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> None:
 
@@ -2150,7 +2162,7 @@ def add_ptr_rel_overlay(
 
 def get_ptr_rel_overlays(
     ptrref: irast.PointerRef, *,
-    dml_source: Optional[irast.MutatingStmt]=None,
+    dml_source: Optional[irast.MutatingLikeStmt]=None,
     ctx: context.CompilerContextLevel,
 ) -> List[
     Tuple[
@@ -2161,6 +2173,17 @@ def get_ptr_rel_overlays(
 ]:
     typeref = ptrref.out_source.real_material_type
     return ctx.ptr_rel_overlays[dml_source][typeref.id, ptrref.shortname.name]
+
+
+def clone_type_rel_overlays(
+    *,
+    ctx: context.CompilerContextLevel,
+) -> None:
+    ctx.type_rel_overlays = ctx.type_rel_overlays.copy()
+    for k, v in ctx.type_rel_overlays.items():
+        ctx.type_rel_overlays[k] = v.copy()
+        for k2, v2 in v.items():
+            v[k2] = list(v2)
 
 
 def clone_ptr_rel_overlays(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -391,6 +391,9 @@ def _get_set_rvar(
             # {<const>[, <const> ...]}
             return process_set_as_const_set(ir_set, ctx=ctx)
 
+        if isinstance(expr, irast.TriggerAnchor):
+            return process_set_as_trigger_anchor(ir_set, ctx=ctx)
+
         # All other expressions.
         return process_set_as_expr(ir_set, ctx=ctx)
 
@@ -2190,6 +2193,16 @@ def process_set_as_oper_expr(
     )
 
     return new_stmt_set_rvar(ir_set, ctx.rel, ctx=ctx)
+
+
+def process_set_as_trigger_anchor(
+    ir_set: irast.Set, *, ctx: context.CompilerContextLevel
+) -> SetRVars:
+    # XXX: This will need to grow more things
+    if ir_set.path_id in ctx.external_rels:
+        return process_external_rel(ir_set, ctx=ctx)
+
+    return process_set_as_root(ir_set, ctx=ctx)
 
 
 def process_set_as_expr(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -406,7 +406,7 @@ def _get_set_rvar(
         # {}
         return process_set_as_empty(ir_set, ctx=ctx)
 
-    if ir_set.path_id in ctx.env.external_rels:
+    if ir_set.path_id in ctx.external_rels:
         return process_external_rel(ir_set, ctx=ctx)
 
     # Regular non-computable path start.
@@ -740,10 +740,10 @@ def process_set_as_empty(
 def process_external_rel(
     ir_set: irast.Set, *, ctx: context.CompilerContextLevel
 ) -> SetRVars:
-    rel = ctx.env.external_rels[ir_set.path_id]
+    rel, aspects = ctx.external_rels[ir_set.path_id]
 
     rvar = relctx.rvar_for_rel(rel, ctx=ctx)
-    return new_source_set_rvar(ir_set, rvar)
+    return new_simple_set_rvar(ir_set, rvar, aspects)
 
 
 def process_set_as_link_property_ref(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4417,7 +4417,7 @@ class PointerMetaCommand(
             external_rels[src_path_id] = compiler.new_external_rel(
                 rel_name=(source_alias,),
                 path_id=src_path_id,
-            )
+            ), ('value', 'source')
         else:
             if ptr_table:
                 rvar = compiler.new_external_rvar(

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -98,10 +98,15 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         inherited_fields_update = {}
         deferred_complex_ops = []
 
-        for field_name in field_names:
+        # Iterate over mcls.get_schema_fields() instead of field_names for
+        # determinism reasons, and so earlier declared fields get
+        # processed first.
+        for field_name, field in mcls.get_schema_fields().items():
+            if field_name not in field_names:
+                continue
+
             was_inherited = field_name in inherited_fields
             ignore_local_field = ignore_local or was_inherited
-            field = mcls.get_field(field_name)
 
             try:
                 result = field.merge_fn(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -219,6 +219,14 @@ class ObjectType(
 
         return ptrs
 
+    def get_relevant_triggers(
+        self, kind: qltypes.TriggerKind, schema: s_schema.Schema
+    ) -> list[triggers.Trigger]:
+        return [
+            t for t in self.get_triggers(schema).objects(schema)
+            if kind in t.get_kinds(schema)
+        ]
+
     def implicitly_castable_to(
         self,
         other: s_types.Type,

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -71,7 +71,6 @@ class Trigger(
 
     expr = so.SchemaField(
         s_expr.Expression,
-        default=None,
         compcoef=0.909,
         special_ddl_syntax=True,
     )

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -19,6 +19,7 @@
 
 type Subordinate {
     required property name -> str;
+    property val -> int64;
 }
 
 type InsertTest {

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -1,0 +1,905 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+import edgedb
+
+from edb.testbase import server as tb
+from edb.tools import test
+
+
+class TestTriggers(tb.QueryTestCase):
+    '''The scope of the tests is testing various modes of Object creation.'''
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'insert.esdl')
+
+    SETUP = [
+        '''
+            alter type InsertTest {
+                alter property name set required;
+                alter property l2 set optional;
+            };
+            alter type Note {
+                create multi property notes -> str;
+            };
+        ''',
+    ]
+
+    # TODO: Possible additional tests:
+    # * more multi?
+    # * more access policies?
+    # * more use of __old__?
+    # * the interaction of __old__ and access policies!!
+    # * update on union
+
+    async def do_basic_work(self):
+        """Do a standardized set of DML operations.
+
+        We'll run this with different triggers and observe the results
+        """
+        await self.con.execute('''
+            insert InsertTest { name := "a" };
+
+            select {
+              (insert InsertTest { name := "b" }),
+              (update InsertTest filter .name = 'a'
+               set { name := 'a!' }),
+            };
+
+            select {
+              (insert InsertTest { name := "c" }),
+              (insert DerivedTest { name := "d" }),
+              (update InsertTest filter .name = 'b'
+               set { name := 'b!' }),
+              (delete InsertTest filter .name = "a!"),
+            };
+
+            select {
+              (for x in {'e', 'f'} union (insert DerivedTest { name := x })),
+              (delete InsertTest filter .name = "b!"),
+             };
+
+            update InsertTest filter .name = 'd'
+            set { name := .name ++ '!' };
+
+            for x in {'c', 'e'} union (
+                update InsertTest filter .name = x
+                set { name := x ++ '!' }
+            );
+
+            select {
+              (update DerivedTest filter .name = 'f'
+               set { name := 'f!' }),
+              (delete DerivedTest filter .name = 'd!'),
+            };
+
+            delete InsertTest;
+        ''')
+
+    async def assert_notes(self, data):
+        q = r"""
+            select (group Note by .name)
+            { name := .key.name, notes := .elements.note }
+            order by .name;
+        """
+        # print(await self.con.query(q))
+        await self.assert_query_result(q, data)
+
+    # Actual tests now
+
+    async def test_edgeql_triggers_insert_01(self):
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log after insert for each do (
+                insert Note { name := "insert", note := __new__.name }
+              );
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "insert", 'notes': set("abcdef")},
+        ])
+
+    async def test_edgeql_triggers_update_01(self):
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log_upd after update for each do (
+                insert Note {
+                  name := "update",
+                  note := (__old__.name ?? "") ++ " -> " ++ (__new__.name??"")
+                }
+              )
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "update", 'notes': set(f'{x} -> {x}!' for x in "abcdef")},
+        ])
+
+    async def test_edgeql_triggers_update_02(self):
+        # This is the same as update_01 except the trigger is on DerivedTest
+        await self.con.execute('''
+            alter type DerivedTest {
+              create trigger log_upd after update for each do (
+                insert Note {
+                  name := "update",
+                  note := (__old__.name ?? "") ++ " -> " ++ (__new__.name??"")
+                }
+              )
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "update", 'notes': set(f'{x} -> {x}!' for x in "def")},
+        ])
+
+    async def test_edgeql_triggers_delete_01(self):
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log_del after delete for each do (
+                insert Note { name := "delete", note := __old__.name }
+              )
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "delete", 'notes': set(f'{x}!' for x in "abcdef")},
+        ])
+
+    async def test_edgeql_triggers_delete_02(self):
+        # This is the same as delete_01 except the trigger is on DerivedTest
+        await self.con.execute('''
+            alter type DerivedTest {
+              create trigger log_del after delete for each do (
+                insert Note { name := "delete", note := __old__.name }
+              )
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "delete", 'notes': set(f'{x}!' for x in "def")},
+        ])
+
+    async def test_edgeql_triggers_mixed_01(self):
+        # Install triggers for everything
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log_del after delete for each do (
+                insert Note { name := "delete", note := __old__.name }
+              );
+              create trigger log after insert for each do (
+                insert Note { name := "insert", note := __new__.name }
+              );
+              create trigger log_upd after update for each do (
+                insert Note {
+                  name := "update",
+                  note := (__old__.name ?? "") ++ " -> " ++ (__new__.name??"")
+                }
+              )
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "delete", 'notes': set(f'{x}!' for x in "abcdef")},
+            {'name': "insert", 'notes': set("abcdef")},
+            {'name': "update", 'notes': set(f'{x} -> {x}!' for x in "abcdef")},
+        ])
+
+    async def test_edgeql_triggers_mixed_02(self):
+        # Install double and triple triggers
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log after insert, update for each do (
+                insert Note { name := "new", note := __new__.name }
+              );
+              create trigger log_old after delete, update for each do (
+                insert Note { name := "old", note := __old__.name }
+              );
+              create trigger log_all after delete, update, insert for each do (
+                insert Note { name := "all", note := "." }
+              );
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {
+                'name': "all",
+                'notes': ["."] * 18,
+            },
+            {
+                'name': "new",
+                'notes': set("abcdef") | {f'{x}!' for x in "abcdef"}
+            },
+            {
+                'name': "old",
+                'notes': set("abcdef") | {f'{x}!' for x in "abcdef"}
+            },
+        ])
+
+    # MULTI!
+
+    async def test_edgeql_triggers_multi_insert_01(self):
+        await self.con.execute('''
+            alter type InsertTest {
+              alter property name set multi;
+
+              create trigger log after insert for each do (
+                insert Note {
+                    name := "insert", note := assert_single(__new__.name) }
+              );
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "insert", 'notes': set("abcdef")},
+        ])
+
+    async def test_edgeql_triggers_multi_mixed_01(self):
+        # Install triggers for everything
+        await self.con.execute('''
+            alter type InsertTest {
+              alter property name set multi;
+
+              create trigger log_del after delete for each do (
+                insert Note {
+                  name := "delete",
+                  note := assert_single(__old__.name)
+                }
+              );
+              create trigger log after insert for each do (
+                insert Note {
+                  name := "insert",
+                  note := assert_single(__new__.name)
+                }
+              );
+              create trigger log_upd after update for each do (
+                insert Note {
+                  name := "update",
+                  note := assert_single(
+                    (__old__.name ?? "") ++ " -> " ++ (__new__.name??""))
+                }
+              )
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {'name': "delete", 'notes': set(f'{x}!' for x in "abcdef")},
+            {'name': "insert", 'notes': set("abcdef")},
+            {'name': "update", 'notes': set(f'{x} -> {x}!' for x in "abcdef")},
+        ])
+
+    async def test_edgeql_triggers_multi_mixed_02(self):
+        # Install double and triple triggers
+        await self.con.execute('''
+            alter type InsertTest {
+              alter property name set multi;
+
+              create trigger log after insert, update for each do (
+                insert Note {
+                  name := "new",
+                  note := assert_single(__new__.name)
+                }
+              );
+              create trigger log_old after delete, update for each do (
+                insert Note {
+                  name := "old",
+                  note := assert_single(__old__.name)
+                }
+              );
+              create trigger log_all after delete, update, insert for each do (
+                insert Note { name := "all", note := "." }
+              );
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        await self.assert_notes([
+            {
+                'name': "all",
+                'notes': ["."] * 18,
+            },
+            {
+                'name': "new",
+                'notes': set("abcdef") | {f'{x}!' for x in "abcdef"}
+            },
+            {
+                'name': "old",
+                'notes': set("abcdef") | {f'{x}!' for x in "abcdef"}
+            },
+        ])
+
+    async def test_edgeql_triggers_mixed_all_01(self):
+        # Install FOR ALL triggers for everything
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log_del after delete for all do (
+                insert Note { name := "delete", notes := __old__.name }
+              );
+              create trigger log_ins after insert for all do (
+                insert Note { name := "insert", notes := __new__.name }
+              );
+              create trigger log_upd after update for all do (
+                insert Note {
+                  name := "update",
+                  notes := __old__.name,
+                  subject := (insert DerivedNote {
+                    name := "", notes := __new__.name
+                  })
+                }
+              )
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        res = tb.bag([
+            {"name": "insert", "notes": ["a"], "subject": None},
+            {"name": "insert", "notes": ["b"], "subject": None},
+            {"name": "insert", "notes": {"c", "d"}, "subject": None},
+            {"name": "insert", "notes": {"e", "f"}, "subject": None},
+
+            {"name": "update", "notes": ["a"], "subject": {"notes": ["a!"]}},
+            {"name": "update", "notes": ["b"], "subject": {"notes": ["b!"]}},
+            {"name": "update", "notes": ["d"], "subject": {"notes": ["d!"]}},
+            {
+                "name": "update",
+                "notes": {"c", "e"},
+                "subject": {"notes": {"c!", "e!"}}
+            },
+            {"name": "update", "notes": ["f"], "subject": {"notes": ["f!"]}},
+
+            {"name": "delete", "notes": ["b!"], "subject": None},
+            {"name": "delete", "notes": ["d!"], "subject": None},
+            {"name": "delete", "notes": ["a!"], "subject": None},
+            {"name": "delete", "notes": {"c!", "e!", "f!"}, "subject": None},
+        ])
+
+        await self.assert_query_result(
+            '''
+            select Note { name, notes, subject[is Note]: {notes} }
+            filter .name != "";
+            ''',
+            res,
+        )
+
+    async def test_edgeql_triggers_mixed_all_02(self):
+        # Install FOR ALL triggers for everything
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log_new after insert, update for all do (
+                insert Note { name := "new", notes := __new__.name }
+              );
+              create trigger log_old after delete, update for all do (
+                insert Note { name := "old", notes := __old__.name }
+              );
+              create trigger log_all after delete, update, insert for all do (
+                insert Note { name := "all", notes := "." }
+              );
+            };
+        ''')
+
+        await self.do_basic_work()
+
+        res = tb.bag([
+            {"name": "all", "notes": {"."}},
+            {"name": "all", "notes": {"."}},
+            {"name": "all", "notes": {"."}},
+            {"name": "all", "notes": {"."}},
+            {"name": "all", "notes": {"."}},
+            {"name": "all", "notes": {"."}},
+            {"name": "all", "notes": {"."}},
+            {"name": "all", "notes": {"."}},
+            {"name": "new", "notes": {"a"}},
+            {"name": "new", "notes": {"c!", "e!"}},
+            {"name": "new", "notes": {"d!"}},
+            {"name": "new", "notes": {"e", "f"}},
+            {"name": "new", "notes": {"f!"}},
+            {"name": "new", "notes": {"b", "a!"}},
+            {"name": "new", "notes": {"b!", "d", "c"}},
+            {"name": "old", "notes": {"f", "d!"}},
+            {"name": "old", "notes": {"a"}},
+            {"name": "old", "notes": {"b", "a!"}},
+            {"name": "old", "notes": {"b!"}},
+            {"name": "old", "notes": {"d"}},
+            {"name": "old", "notes": {"c", "e"}},
+            {"name": "old", "notes": ["c!", "e!", "f!"]},
+        ])
+
+        await self.assert_query_result(
+            '''
+            select Note { name, notes } order by .name
+            ''',
+            res,
+        )
+
+    async def test_edgeql_triggers_enforce_errors_01(self):
+        # Simulate a global constraint that we can't do with constraints:
+        # ensure the *count* of subordinates in each InsertTest is unique
+        # This is woefully inefficient though.
+        # (A better approach would be to enforce that a _count field
+        # matches the count (using policies, triggers, or best of all
+        # rewrite rules), and then having an exclusive constraint on that.)
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger check_distinct after insert, update for all do (
+                assert_distinct(
+                  (InsertTest { cnt := count(.subordinates) }.cnt),
+                  message := "subordinate counts collide",
+                )
+              );
+            };
+        ''')
+
+        await self.con.execute('''
+            insert InsertTest { name := "0" };
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                insert InsertTest { name := "1" };
+            ''')
+
+        await self.con.query('''
+            insert InsertTest {
+                name := "1",
+                subordinates := (insert Subordinate { name := "a" }),
+            };
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                insert InsertTest {
+                    name := "2",
+                    subordinates := (insert Subordinate { name := "b" }),
+                };
+            ''')
+
+        await self.con.query('''
+            insert InsertTest {
+                name := "2",
+                subordinates := {
+                  (insert Subordinate { name := "b" }),
+                  (insert Subordinate { name := "c" }),
+                }
+            }
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name = "0"
+                set { subordinates := (insert Subordinate { name := "d" }) }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name = "0"
+                set { subordinates += (insert Subordinate { name := "d" }) }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name = "1"
+                set { subordinates += (insert Subordinate { name := "d" }) }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name = "1"
+                set { subordinates -= .subordinates }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name = "1"
+                set { subordinates -= .subordinates }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name = "2"
+                set { subordinates -= (select Subordinate filter .name = "b") }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name = "2"
+                set { subordinates := (select Subordinate filter .name = "b") }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                r"subordinate counts collide"):
+            await self.con.query('''
+                update InsertTest filter .name in {"1", "2"}
+                set { subordinates := Subordinate }
+            ''')
+
+        await self.con.query('''
+            with c := (select Subordinate filter .name = "c"),
+            select {
+                (update InsertTest filter .name = "1"
+                set { subordinates += c }),
+                (update InsertTest filter .name = "2"
+                set { subordinates -= c }),
+            };
+        ''')
+
+    async def test_edgeql_triggers_enforce_errors_02(self):
+        # Simulate a multi-table constraint that we can't do with constraints:
+        # ensure the *sum* of the val fields in subordinates is zero
+        # To do this we put triggers on both InsertTest for inserts and updates
+        # and Subordinate for updates.
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger check_subs after insert, update for each do (
+                select assert(
+                  sum(__new__.subordinates.val) = 0,
+                  message := "subordinate sum is not zero for "++__new__.name,
+                )
+              );
+            };
+            alter type Subordinate {
+              # use for all so that we semi-join deduplicate the InsertTests
+              # before checking
+              # Use a shape to drive the error check for fun (testing).
+              create trigger check_subs after update for all do (
+                (__new__.<subordinates[is InsertTest]) {
+                  fail := assert(
+                    sum(.subordinates.val) = 0,
+                    message := "subordinate sum is not zero for " ++ .name,
+                  )
+                }
+              );
+            };
+            create function sub(i: str) -> set of Subordinate using (
+              select Subordinate filter .name = i
+            );
+        ''')
+
+        await self.con.query('''
+            for x in range_unpack(range(-10, 10)) union (
+                insert Subordinate { name := <str>x, val := x }
+            );
+        ''')
+
+        await self.con.query('''
+            insert InsertTest { name := "a" }
+        ''')
+
+        err = lambda name: self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            f"subordinate sum is not zero for {name}"
+        )
+
+        await self.con.query('''
+            insert InsertTest {
+                name := "b",
+                subordinates := assert_distinct(sub({"1", "2", "-3"}))
+            }
+        ''')
+
+        async with err("c"):
+            await self.con.query('''
+                insert InsertTest {
+                    name := "c", subordinates := assert_distinct(sub("1"))
+                }
+            ''')
+
+        async with err("c"):
+            await self.con.query('''
+                insert InsertTest {
+                    name := "c",
+                    subordinates := assert_distinct(sub({"1", "-2"})),
+                }
+            ''')
+
+        # Try some updates
+        async with err("b"):
+            await self.con.query('''
+                update InsertTest filter .name = "b" set {
+                    subordinates := assert_distinct(sub({"1", "2", "3"}))
+                }
+            ''')
+
+        async with err("b"):
+            await self.con.query('''
+                update InsertTest filter .name = "b" set {
+                    subordinates += assert_distinct(sub({"4", "-2"}))
+                }
+            ''')
+
+        async with err("b"):
+            await self.con.query('''
+                update InsertTest filter .name = "b" set {
+                    subordinates -= assert_distinct(sub({"2"}))
+                }
+            ''')
+
+        await self.con.query('''
+            update InsertTest filter .name = "b" set {
+                subordinates += assert_distinct(sub({"-4", "-2", "6", "2"}))
+            }
+        ''')
+
+        await self.con.query('''
+            update InsertTest filter .name = "b" set {
+                subordinates -= assert_distinct(
+                  sub({"1", "6", "-4", "-3", "5"}))
+            }
+        ''')
+
+        await self.con.query('''
+            update InsertTest filter .name = "b" set {
+                subordinates := assert_distinct(sub({"-1", "-2", "3"}))
+            };
+        ''')
+
+        # Now try updating Subordinate
+        async with err("b"):
+            await self.con.query('''
+                update Subordinate filter .name = "3"
+                set { val := -3 };
+            ''')
+
+        await self.con.query('''
+            insert InsertTest {
+                name := "b2",
+                subordinates := assert_distinct(sub({"-1", "-2", "3"}))
+            }
+        ''')
+
+        async with err("b"):
+            await self.con.query('''
+                update Subordinate filter .name = "3"
+                set { val := -3 };
+            ''')
+
+        # This one *should* work, though, since the sums still work out
+        await self.con.query('''
+            update Subordinate filter .name in {"-1", "-2", "3"}
+            set { val := - .val };
+        ''')
+        # ... and set it back
+        await self.con.query('''
+            update Subordinate filter .name in {"-1", "-2", "3"}
+            set { val := - .val };
+        ''')
+
+        # Now create a new InsertTest that uses one of those vals
+        await self.con.query('''
+            insert InsertTest {
+                name := "d",
+                subordinates := assert_distinct(sub({"3", "-3"}))
+            }
+        ''')
+
+        # And now it *shouldn't* work
+        async with err("d"):
+            await self.con.query('''
+                update Subordinate filter .name in {"-1", "-2", "3"}
+                set { val := - .val };
+            ''')
+
+        # Make sure they fire with typename injection on
+        async with err("a"):
+            await self.con._fetchall('''
+                update InsertTest filter .name = "a"
+                set { subordinates := assert_distinct(sub("1")) };
+            ''', __typenames__=True)
+
+        async with err("c"):
+            await self.con._fetchall('''
+                insert InsertTest {
+                    name := "c", subordinates := assert_distinct(sub("1"))
+                }
+            ''', __typenames__=True)
+
+    async def test_edgeql_triggers_policies_01(self):
+        # It is OK to see the newly created object during a trigger,
+        # even if you shouldn't otherwise. (Much like with overlays
+        # normally.)
+        await self.con.execute('''
+            alter type InsertTest {
+              create access policy ins_ok allow insert;
+              create trigger log after insert for each do (
+                insert Note { name := "insert", note := __new__.name }
+              );
+            };
+        ''')
+
+        await self.con.query('''
+            insert InsertTest {
+                name := "x",
+            }
+        ''')
+
+        await self.assert_query_result(
+            '''
+            select Note { note }
+            ''',
+            [{'note': "x"}],
+        )
+
+    async def test_edgeql_triggers_policies_02(self):
+        # But you *can't* see things by accessing them through the
+        # "normal channels"
+        await self.con.execute('''
+            alter type InsertTest {
+              create access policy ins_ok allow insert;
+              create trigger log after insert for each do (
+                insert Note {
+                  name := "insert", note := <str>count(InsertTest)
+                }
+              );
+            };
+        ''')
+
+        await self.con.query('''
+            insert InsertTest {name := "x"};
+            insert InsertTest {name := "y"};
+        ''')
+
+        await self.assert_query_result(
+            '''
+            select Note { note }
+            ''',
+            tb.bag([
+                {'note': "0"},
+                {'note': "0"},
+            ]),
+        )
+
+    async def test_edgeql_triggers_policies_03(self):
+        await self.con.execute('''
+            alter type Note {
+              create access policy ok allow all;
+              create access policy no_x deny insert using (
+                (.note like 'x%') ?? false);
+            };
+            alter type InsertTest {
+              create trigger log after insert for each do (
+                insert Note { name := "insert", note := __new__.name }
+              );
+            };
+        ''')
+
+        await self.con.query('''
+            insert InsertTest {name := "y"};
+        ''')
+
+        async with self.assertRaisesRegexTx(edgedb.AccessPolicyError, ''):
+            await self.con.query('''
+                insert InsertTest {name := "x"};
+            ''')
+
+    async def test_edgeql_triggers_policies_04(self):
+        await self.con.execute('''
+            alter type InsertTest {
+              create access policy ok allow all;
+              create access policy no_x deny select
+                using (.name = 'xx');
+
+              create trigger log after update for all do (
+                insert Note {
+                  name := "update",
+                  note := <str>count(__old__)++"/"++<str>count(__new__)++"/"
+                          ++<str>count(InsertTest),
+                }
+              );
+            };
+        ''')
+
+        await self.con.query('''
+            insert InsertTest {name := "x"};
+            insert InsertTest {name := "y"};
+        ''')
+
+        await self.con.query('''
+            update InsertTest set {name := .name ++ "x"};
+        ''')
+
+        await self.assert_query_result(
+            '''
+            select Note { note }
+            ''',
+            tb.bag([
+                {'note': "2/2/1"},
+            ]),
+        )
+
+    @test.xfail('''
+        We return 0/0/0
+    ''')
+    async def test_edgeql_triggers_policies_05(self):
+        await self.con.execute('''
+            alter type Subordinate {
+              create access policy ok allow all;
+              create access policy no deny select using (
+                any(.<subordinates[is InsertTest].l2 < 0)
+              );
+            };
+            insert Subordinate { name := "foo" };
+            insert Subordinate { name := "bar" };
+            alter type InsertTest {
+              create trigger log after update for each do (
+                insert Note {
+                  name := "update",
+                  note := <str>count(__old__.subordinates)++
+                          "/"++<str>count(__new__.subordinates)++
+                          "/"++<str>count(InsertTest.subordinates),
+                }
+              );
+            };
+        ''')
+
+        await self.con.execute('''
+            update InsertTest set { l2 := -1 };
+        ''')
+
+        # __old__ *definitely* should be 2
+        # __new__ I /think/ should be 2, though you could sensibly define
+        # it in either direction
+        # InsertTest is correctly zero
+        await self.assert_query_result(
+            '''
+            select Note { note }
+            ''',
+            tb.bag([
+                {'note': "2/2/0"},
+            ]),
+        )


### PR DESCRIPTION
Closes #4936.

The interesting part of the compilation runs at the end of IR->SQL and 
injects the triggers into CTEs. The overlay system is (somewhat hackily)
used to drive what objects are triggered on and (slightly less hackily) to
provide a view of the new database state.

I have one known bug at the moment, which is approximately that we apply
access policies *too much* in one case. I have a plan for fixing it that
doesn't change that much of the big picture, and I wanted to get something
up for review.