### PR TITLE
Fill in some missing parts of index DDL/SDL

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1117,6 +1117,7 @@ def _register_item(
             if isinstance(decl, qlast.CreateConcreteIndex):
                 assert isinstance(alter_cmd, qlast.ConcreteIndexCommand)
                 alter_cmd.expr = decl.expr
+                alter_cmd.kwargs = decl.kwargs
 
             # constraints need to preserve their "on" expression
             if isinstance(decl, qlast.CreateConcreteConstraint):

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1374,7 +1374,7 @@ class CreateConcreteIndexStmt(Nonterm, commondl.ProcessIndexMixin):
 #
 # ALTER CONCRETE INDEX
 #
-class AlterConcreteIndexStmt(Nonterm):
+class AlterConcreteIndexStmt(Nonterm, commondl.ProcessIndexMixin):
     def reduce_AlterConcreteIndex(self, *kids):
         r"""%reduce ALTER INDEX OnExpr OptExceptExpr \
                     AlterConcreteIndexCommandsBlock \
@@ -1384,6 +1384,20 @@ class AlterConcreteIndexStmt(Nonterm):
             expr=kids[2].val,
             except_expr=kids[3].val,
             commands=kids[4].val,
+        )
+
+    def reduce_AlterConcreteNamedIndex(self, *kids):
+        r"""%reduce ALTER INDEX NodeName OptIndexExtArgList OnExpr \
+                    OptExceptExpr \
+                    AlterConcreteIndexCommandsBlock \
+        """
+        kwargs = self._process_arguments(kids[3].val)
+        self.val = qlast.AlterConcreteIndex(
+            name=kids[2].val,
+            kwargs=kwargs,
+            expr=kids[4].val,
+            except_expr=kids[5].val,
+            commands=kids[6].val,
         )
 
 
@@ -1397,7 +1411,7 @@ commands_block(
 #
 # DROP CONCRETE INDEX
 #
-class DropConcreteIndexStmt(Nonterm):
+class DropConcreteIndexStmt(Nonterm, commondl.ProcessIndexMixin):
     def reduce_DropConcreteIndex(self, *kids):
         r"""%reduce DROP INDEX OnExpr OptExceptExpr \
                     OptDropConcreteIndexCommandsBlock \
@@ -1407,6 +1421,20 @@ class DropConcreteIndexStmt(Nonterm):
             expr=kids[2].val,
             except_expr=kids[3].val,
             commands=kids[4].val,
+        )
+
+    def reduce_DropConcreteNamedIndex(self, *kids):
+        r"""%reduce DROP INDEX NodeName OptIndexExtArgList OnExpr \
+                    OptExceptExpr \
+                    OptDropConcreteIndexCommandsBlock \
+        """
+        kwargs = self._process_arguments(kids[3].val)
+        self.val = qlast.DropConcreteIndex(
+            name=kids[2].val,
+            kwargs=kwargs,
+            expr=kids[4].val,
+            except_expr=kids[5].val,
+            commands=kids[6].val,
         )
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3432,6 +3432,10 @@ class DeleteIndex(IndexCommand, adapts=s_indexes.DeleteIndex):
         schema = super().apply(schema, context)
         index = self.scls
 
+        if index.get_abstract(orig_schema):
+            # Don't do anything for abstract indexes
+            return schema
+
         source: Optional[
             sd.CommandContextToken[s_sources.SourceCommand[s_sources.Source]]]
         # XXX: I think to make these work, the type vars in the Commands

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11328,6 +11328,63 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             module `back``ticked` { type Test };
         """)
 
+    async def test_edgeql_migration_abstract_index_01(self):
+        await self.migrate(r"""
+            abstract index MyIndex(language := 'english')
+                extending fts::textsearch;
+            type Base {
+                property name -> str;
+                index MyIndex on (.name);
+                index fts::textsearch(language:='english') on (.name);
+            };
+        """)
+
+        await self.migrate(r"""
+            abstract index MyIndex(language := 'english')
+                extending fts::textsearch;
+            type Base {
+                property name -> str;
+                index MyIndex on (.name);
+                index fts::textsearch(language:='english') on (.name);
+            };
+            type Child extending Base;
+        """)
+
+        async with self.assertRaisesRegexTx(
+                edgedb.SchemaError,
+                r"because other objects in the schema depend on it"):
+            await self.con.execute('''
+                drop abstract index test::MyIndex
+            ''')
+
+        await self.migrate(r"""
+            abstract index MyIndex(language := 'german')
+                extending fts::textsearch;
+            type Base {
+                property name -> str;
+                index MyIndex on (.name);
+                index fts::textsearch(language:='english') on (.name);
+            };
+            type Child extending Base;
+        """)
+
+        await self.migrate(r"""
+            abstract index MyIndex(language := 'german')
+                extending fts::textsearch {
+              annotation title := "test";
+            }
+            type Base {
+                property name -> str;
+                index MyIndex on (.name);
+                index fts::textsearch(language:='english') on (.name) {
+                   annotation description := "test";
+                };
+            };
+            type Child extending Base;
+        """)
+
+        await self.migrate("")
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
* Support named indexes in DROP/ALTER syntactically
 * Make DROP/ALTER work for both abstract and concrete
 * Fix inheritance

(One trick that helped solve some problems was moving the validation
from validate_create, which runs before the create, to
validate_object, which runs after.)