### PR TITLE
[DRAFT] An initial take on an fts::test that hits indexes

### DIFF
--- a/edb/lib/fts.edgeql
+++ b/edb/lib/fts.edgeql
@@ -28,6 +28,18 @@ CREATE ABSTRACT INDEX fts::textsearch(named only language: std::str) {
 ## ---------
 
 CREATE FUNCTION
+fts::make_doc(
+    variadic doc: optional std::str,
+) -> optional std::str
+{
+    CREATE ANNOTATION std::description :=
+        'Combine multiple arguments to make a document to index';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE FUNCTION
 fts::test(
     query: std::str,
     variadic doc: optional std::str,


### PR DESCRIPTION
Implement an inlined version of fts::test that succefully hits
indexes. (I tested using imdbench extended with some fts::textsearch
indexes.)

Per some discussions with @vpetrovykh, I introduced an fts::make_doc
function that is a variadic optional function that produces a string
that can be reasonable passed to an fts::textsearch index and that
works well will fts::test. (fts::test does the same operations.)

make_doc essentially does `array_to_string("docs", ' ')`, but inlined.

The most unpleasant bit about all of this, though, in handling the
language argument to postgres's `to_tsvector`, and how it interacts
with our constant extraction preprocessing. Because we extract string
literals during preprocessing, the `language` argument to `fts::test`
and similar will typically be a parameter.

The language argument is of type `regconfig` (which is an int id);
there is a cast from `text` to `regconfig`, but if the argument to
language is a text query parameter cast to `regconfig`, the index will
not match and the query will be slow.

The index *will* match if the argument is of type `regconfig` (which
is to say, an int32), but that doesn't help us any.

What *does* work is if it the argument is a string literal that is
cast directly to `regconfig`.

The only way I could come up with of accomplishing this is that the
normalization pass no longer extracts string literals that appear
directly after the token sequence `language :=`.
If anybody has a better idea I'd love to know it.