### PR TITLE
Prettyprint : instead of -> in links and properties

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1725,7 +1725,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self._ddl_visit_bases(node)
             if node.target is not None:
                 if isinstance(node.target, qlast.TypeExpr):
-                    self.write(' -> ')
+                    self.write(': ')
                     self.visit(node.target)
                 elif pure_computable:
                     # computable

--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -19,8 +19,8 @@
 
 SET MODULE default;
 
-CREATE MIGRATION m14pt32wg7zijus7jmmnvbtf7dftt34xxgbkrtmys46pmrailnkcia
-ONTO m1bzqjsa6r7e3prynbm52zutm3jo42ybgulhsjlnxbd43m4sqdmcoq {
+CREATE MIGRATION m12hdldnmvzj5weaevxsmizppnl2poo6nconx2hcfkklbwcghqsmaq
+ONTO m1vyvlra26tef6oe6yu37m7lfw7i3ef3n62m6om353dvnbm3mynqqa {
     CREATE TYPE default::Migrated;
     create type default::Migrated2 {};
 };

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -986,7 +986,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                     'text': (
                         'CREATE TYPE test::Type01 {\n'
                         '    CREATE PROPERTY field1'
-                        ' -> std::str;\n'
+                        ': std::str;\n'
                         '};'
                     )
                 }],
@@ -1060,7 +1060,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                     'text': (
                         'CREATE TYPE test::Type02 {\n'
                         '    CREATE PROPERTY field02'
-                        ' -> std::str;\n'
+                        ': std::str;\n'
                         '};'
                     )
                 }],
@@ -1133,7 +1133,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                     'text': (
                         'ALTER TYPE test::Type02 {\n'
                         '    CREATE PROPERTY field02'
-                        ' -> std::str;\n'
+                        ': std::str;\n'
                         '};'
                     )
                 }],
@@ -1180,7 +1180,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                     'text': (
                         'CREATE TYPE test::Type01 {\n'
                         '    CREATE LINK foo1'
-                        ' -> test::Foo;\n'
+                        ': test::Foo;\n'
                         '};'
                     )
                 }],
@@ -1266,7 +1266,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                     'text': (
                         'CREATE TYPE test::Type02 {\n'
                         '    CREATE LINK foo02'
-                        ' -> test::Foo;\n'
+                        ': test::Foo;\n'
                         '};'
                     )
                 }],
@@ -1352,7 +1352,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                     'text': (
                         'ALTER TYPE test::Type02 {\n'
                         '    CREATE LINK foo02'
-                        ' -> test::Foo;\n'
+                        ': test::Foo;\n'
                         '};'
                     )
                 }],
@@ -4024,7 +4024,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         await self.assert_describe_migration({
             'confirmed': ["""
                 ALTER TYPE test::Base {
-                    CREATE PROPERTY foo -> std::str;
+                    CREATE PROPERTY foo: std::str;
                 };
             """, """
                 ALTER TYPE test::Derived {
@@ -9145,7 +9145,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                         'CREATE TYPE test::NewObj2 {\n'
                         "    CREATE ANNOTATION std::title := 'Obj2';\n"
                         '    CREATE PROPERTY name'
-                        ' -> std::str;\n'
+                        ': std::str;\n'
                         '};'
                 }],
             },
@@ -9190,7 +9190,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         await self.assert_describe_migration({
             'confirmed': [
                 'SELECT 1;',
-                'CREATE TYPE test::Obj1 { CREATE PROPERTY foo -> std::str; };',
+                'CREATE TYPE test::Obj1 { CREATE PROPERTY foo: std::str; };',
                 "INSERT Obj1 { foo := 'test' };"
             ],
             'complete': True,
@@ -9394,8 +9394,8 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 'statements': [{
                     'text':
                         'CREATE TYPE test::NewObj1 {\n'
-                        '    CREATE PROPERTY bar -> std::str;'
-                        '\n    CREATE PROPERTY foo -> std::str;'
+                        '    CREATE PROPERTY bar: std::str;'
+                        '\n    CREATE PROPERTY foo: std::str;'
                         '\n};'
                 }],
                 'confidence': 1.0,
@@ -9460,7 +9460,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 'statements': [{
                     'text':
                         'ALTER TYPE test::Obj1 {\n    '
-                        'CREATE PROPERTY x -> std::str;\n};'
+                        'CREATE PROPERTY x: std::str;\n};'
                 }],
                 'confidence': 1.0,
             },
@@ -9498,7 +9498,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                     'text':
                         'ALTER TYPE test::Obj1 {\n    '
                         'ALTER LINK link {\n        '
-                        'CREATE PROPERTY x -> std::str;\n    };\n};'
+                        'CREATE PROPERTY x: std::str;\n    };\n};'
                 }],
                 'confidence': 1.0,
             },
@@ -9578,7 +9578,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 'statements': [{
                     'text': """
                         ALTER TYPE test::Obj11 {
-                            CREATE PROPERTY name -> std::str {
+                            CREATE PROPERTY name: std::str {
                                 CREATE CONSTRAINT std::exclusive;
                             };
                         };
@@ -9828,7 +9828,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 'statements': [{
                     'text': """
                         CREATE TYPE test::Spam {
-                            CREATE LINK bar -> test::Bar;
+                            CREATE LINK bar: test::Bar;
                         };
                     """,
                 }],
@@ -9848,7 +9848,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 'statements': [{
                     'text': """
                         ALTER TYPE test::Bar {
-                            CREATE LINK spam -> test::Spam;
+                            CREATE LINK spam: test::Spam;
                         };
                     """,
                 }],
@@ -9946,7 +9946,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 'statements': [{
                     'text': '''
                         ALTER TYPE test::Bar {
-                            CREATE REQUIRED PROPERTY bar -> std::str {
+                            CREATE REQUIRED PROPERTY bar: std::str {
                                 SET REQUIRED USING (\\(fill_expr));
                             };
                         };

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -4108,7 +4108,7 @@ aa';
 
         START MIGRATION TO {
             type test::Foo {
-                property bar -> str;
+                property bar: str;
             };
         };
         """
@@ -4505,7 +4505,7 @@ aa';
 % OK %
 
         CREATE TYPE Foo {
-            CREATE LINK bar -> Bar {
+            CREATE LINK bar: Bar {
                 CREATE CONSTRAINT my_constraint ON (
                     (__source__{
                         baz := (__source__.a + __source__.b)
@@ -5248,14 +5248,14 @@ aa';
     def test_edgeql_syntax_ddl_type_02(self):
         """
         CREATE TYPE schema::TypeElement {
-            CREATE REQUIRED LINK type -> schema::Type;
-            CREATE REQUIRED LINK num -> std::int64;
-            CREATE PROPERTY name EXTENDING foo, bar -> std::str;
-            CREATE LINK lnk EXTENDING l1 -> schema::Type;
-            CREATE LINK lnk1 EXTENDING l1, l2 -> schema::Type;
-            CREATE LINK lnk2 EXTENDING l1, l2 -> schema::Type {
-                CREATE PROPERTY lnk2_prop -> std::str;
-                CREATE PROPERTY lnk2_prop2 EXTENDING foo -> std::str;
+            CREATE REQUIRED LINK type: schema::Type;
+            CREATE REQUIRED LINK num: std::int64;
+            CREATE PROPERTY name EXTENDING foo, bar: std::str;
+            CREATE LINK lnk EXTENDING l1: schema::Type;
+            CREATE LINK lnk1 EXTENDING l1, l2: schema::Type;
+            CREATE LINK lnk2 EXTENDING l1, l2: schema::Type {
+                CREATE PROPERTY lnk2_prop: std::str;
+                CREATE PROPERTY lnk2_prop2 EXTENDING foo: std::str;
             };
         };
         """
@@ -5269,23 +5269,23 @@ aa';
 % OK %
 
         ALTER TYPE schema::Object {
-            CREATE MULTI LINK attributes -> schema::Attribute;
+            CREATE MULTI LINK attributes: schema::Attribute;
         };
         """
 
     def test_edgeql_syntax_ddl_type_04(self):
         """
         CREATE TYPE mymod::Foo {
-            CREATE LINK bar0 -> mymod::Bar {
+            CREATE LINK bar0: mymod::Bar {
                 ON TARGET DELETE RESTRICT;
             };
-            CREATE LINK bar1 -> mymod::Bar {
+            CREATE LINK bar1: mymod::Bar {
                 ON TARGET DELETE DELETE SOURCE;
             };
-            CREATE LINK bar2 -> mymod::Bar {
+            CREATE LINK bar2: mymod::Bar {
                 ON TARGET DELETE ALLOW;
             };
-            CREATE LINK bar3 -> mymod::Bar {
+            CREATE LINK bar3: mymod::Bar {
                 ON TARGET DELETE DEFERRED RESTRICT;
             };
         };
@@ -5294,20 +5294,20 @@ aa';
     def test_edgeql_syntax_ddl_type_05(self):
         """
         CREATE TYPE mymod::Foo {
-            CREATE SINGLE LINK foo -> mymod::Foo;
-            CREATE MULTI LINK bar -> mymod::Bar;
-            CREATE REQUIRED SINGLE LINK baz -> mymod::Baz;
-            CREATE REQUIRED MULTI LINK spam -> mymod::Spam;
+            CREATE SINGLE LINK foo: mymod::Foo;
+            CREATE MULTI LINK bar: mymod::Bar;
+            CREATE REQUIRED SINGLE LINK baz: mymod::Baz;
+            CREATE REQUIRED MULTI LINK spam: mymod::Spam;
         };
         """
 
     def test_edgeql_syntax_ddl_type_06(self):
         """
         CREATE TYPE mymod::Foo {
-            CREATE SINGLE PROPERTY foo -> str;
-            CREATE MULTI PROPERTY bar -> str;
-            CREATE REQUIRED SINGLE PROPERTY baz -> str;
-            CREATE REQUIRED MULTI PROPERTY spam -> str;
+            CREATE SINGLE PROPERTY foo: str;
+            CREATE MULTI PROPERTY bar: str;
+            CREATE REQUIRED SINGLE PROPERTY baz: str;
+            CREATE REQUIRED MULTI PROPERTY spam: str;
         };
         """
 
@@ -5444,7 +5444,7 @@ aa';
     def test_edgeql_syntax_ddl_type_19(self):
         """
         ALTER TYPE Foo {
-            CREATE PROPERTY bar -> str {
+            CREATE PROPERTY bar: str {
                 USING (4);
             };
         };
@@ -5463,7 +5463,7 @@ aa';
     def test_edgeql_syntax_ddl_type_21(self):
         """
         ALTER TYPE Foo {
-            CREATE LINK bar -> Object {
+            CREATE LINK bar: Object {
                 USING (SELECT Object);
             };
         };
@@ -5482,7 +5482,7 @@ aa';
     def test_edgeql_syntax_ddl_type_23(self):
         """
         CREATE TYPE `123` {
-            CREATE PROPERTY `456` -> str;
+            CREATE PROPERTY `456`: str;
         };
         """
 
@@ -5968,7 +5968,7 @@ aa';
     def test_edgeql_syntax_ddl_rewrite_01(self):
         """
         create type Foo {
-            create property foo -> i64 {
+            create property foo: i64 {
                 create rewrite update, insert using (1);
             };
         };
@@ -5977,7 +5977,7 @@ aa';
     def test_edgeql_syntax_ddl_rewrite_02(self):
         """
         alter type Foo {
-            create property name_updated_at -> i64 {
+            create property name_updated_at: i64 {
                 create rewrite update using ((
                     datetime_current()
                     if __specified__.name
@@ -6022,7 +6022,7 @@ aa';
 % OK %
 
         CREATE TYPE Foo {
-            CREATE PROPERTY bar -> str;
+            CREATE PROPERTY bar: str;
         };
         """
 
@@ -6055,7 +6055,7 @@ aa';
 
         START MIGRATION to {
             type default::User {
-                property name -> str;
+                property name: str;
             };
         };
         """
@@ -6082,8 +6082,8 @@ aa';
 % OK %
 
         CREATE TYPE Foo {
-            CREATE PROPERTY bar -> str;
-            CREATE PROPERTY baz -> int64;
+            CREATE PROPERTY bar: str;
+            CREATE PROPERTY baz: int64;
         };
         """
 
@@ -6118,8 +6118,8 @@ aa';
 
         START MIGRATION to {
             type default::User {
-                property bar -> int64;
-                property name -> str;
+                property bar: int64;
+                property name: str;
             };
         };
         """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7891,7 +7891,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             type test::Child extending test::Parent, test::Parent2 {
                 annotation test::anno := 'annotated';
-                overloaded link foo extending test::f -> test::Foo {
+                overloaded link foo extending test::f: test::Foo {
                     annotation test::anno := 'annotated link';
                     constraint std::exclusive {
                         annotation test::anno := 'annotated constraint';
@@ -7906,23 +7906,23 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             type test::Child extending test::Parent, test::Parent2 {
                 annotation test::anno := 'annotated';
                 index on (.foo);
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                overloaded single link foo extending test::f -> test::Foo {
+                overloaded single link foo extending test::f: test::Foo {
                     annotation test::anno := 'annotated link';
                     constraint std::exclusive {
                         annotation test::anno := 'annotated constraint';
                     };
-                    optional single property p -> test::int_t {
+                    optional single property p: test::int_t {
                         constraint std::max_value(10);
                     };
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                     constraint std::exclusive;
                 };
-                optional multi property name -> std::str;
+                optional multi property name: std::str;
             };
             """,
 
@@ -7930,16 +7930,16 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Child extending test::Parent, test::Parent2 {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                overloaded single link foo extending test::f -> test::Foo {
-                    optional single property p -> test::int_t;
+                overloaded single link foo extending test::f: test::Foo {
+                    optional single property p: test::int_t;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                 };
-                optional multi property name -> std::str;
+                optional multi property name: std::str;
             };
             """,
 
@@ -8009,12 +8009,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             [
                 """
                 type test::Spam {
-                    link foobar -> (test::Foo | test::Bar);
+                    link foobar: (test::Foo | test::Bar);
                 };
                 """,
                 """
                 type test::Spam {
-                    link foobar -> (test::Bar | test::Foo);
+                    link foobar: (test::Bar | test::Foo);
                 };
                 """,
             ]
@@ -8071,13 +8071,13 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                 };
-                required single property middle_name -> std::str {
+                required single property middle_name: std::str {
                     default := 'abc';
                     readonly := true;
                 };
@@ -8088,14 +8088,14 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                     constraint std::exclusive;
                 };
-                required single property middle_name -> std::str {
+                required single property middle_name: std::str {
                     default := 'abc';
                     readonly := true;
                 };
@@ -8106,14 +8106,14 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Bar extending test::Foo {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
 
                     readonly := true;
                 };
-                required single property middle_name -> std::str {
+                required single property middle_name: std::str {
                     default := 'abc';
                     readonly := true;
                 };
@@ -8124,7 +8124,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Foo {
-                required single property middle_name -> std::str {
+                required single property middle_name: std::str {
                     default := 'abc';
                     readonly := true;
                 };
@@ -8156,15 +8156,15 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             type test::User extending test::HasImage {
                 index on (__subject__.image);
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                     constraint std::exclusive;
                 };
-                required single property image -> std::str;
-                optional single property name -> std::str;
+                required single property image: std::str;
+                optional single property name: std::str;
             };
             """,
 
@@ -8172,14 +8172,14 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::User extending test::HasImage {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                 };
-                required single property image -> std::str;
-                optional single property name -> std::str;
+                required single property image: std::str;
+                optional single property name: std::str;
             };
             """,
 
@@ -8187,7 +8187,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::User extending test::HasImage {
-                property name -> std::str;
+                property name: std::str;
             };
             ''',
 
@@ -8196,14 +8196,14 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             '''
             abstract type test::HasImage {
                 index on (__subject__.image);
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                     constraint std::exclusive;
                 };
-                required single property image -> std::str;
+                required single property image: std::str;
             };
             ''',
 
@@ -8211,13 +8211,13 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             abstract type test::HasImage {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                 };
-                required single property image -> std::str;
+                required single property image: std::str;
             };
             ''',
 
@@ -8226,7 +8226,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             '''
             abstract type test::HasImage {
                 index on (__subject__.image);
-                required property image -> std::str;
+                required property image: std::str;
             };
             ''',
 
@@ -8234,7 +8234,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             CREATE ABSTRACT TYPE test::HasImage {
-                CREATE REQUIRED PROPERTY image -> std::str;
+                CREATE REQUIRED PROPERTY image: std::str;
                 CREATE INDEX ON (__subject__.image);
             };
             '''
@@ -8296,8 +8296,8 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::UniqueName {
-                link translated_label extending test::translated_label
-                        -> test::Label {
+                link translated_label extending test::translated_label:
+                        test::Label {
                     constraint std::exclusive on (__subject__@prop1);
                     constraint std::exclusive on (
                         (__subject__@source, __subject__@lang)
@@ -8310,17 +8310,17 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::UniqueName {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
                 optional single link translated_label
-                extending test::translated_label
-                    -> test::Label
+                extending test::translated_label:
+                    test::Label
                 {
-                    optional single property lang -> std::str;
-                    optional single property prop1 -> std::str;
+                    optional single property lang: std::str;
+                    optional single property prop1: std::str;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                 };
             };
@@ -8330,20 +8330,20 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::UniqueName {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
                 optional single link translated_label
-                extending test::translated_label
-                    -> test::Label
+                extending test::translated_label:
+                    test::Label
                 {
                     constraint std::exclusive on (__subject__@prop1);
                     constraint std::exclusive on (
                         (__subject__@source, __subject__@lang));
-                    optional single property lang -> std::str;
-                    optional single property prop1 -> std::str;
+                    optional single property lang: std::str;
+                    optional single property prop1: std::str;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                     constraint std::exclusive;
                 };
@@ -8408,7 +8408,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE PROPERTY bar -> std::str {
+                CREATE PROPERTY bar: std::str {
                     SET readonly := false;
                 };
             };
@@ -8417,7 +8417,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                property bar -> std::str {
+                property bar: std::str {
                     readonly := false;
                 };
             };
@@ -8555,7 +8555,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar0 {
-                link insert_foo -> test::Foo {
+                link insert_foo: test::Foo {
                     default := (INSERT
                         test::Foo
                         {
@@ -8568,7 +8568,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar1 {
-                multi link update_foo -> test::Foo {
+                multi link update_foo: test::Foo {
                     default := (UPDATE
                         test::Foo
                     FILTER
@@ -8583,7 +8583,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar2 {
-                multi link for_foo -> test::Foo {
+                multi link for_foo: test::Foo {
                     default := (FOR x IN {2, 3}
                     UNION
                         (SELECT
@@ -8598,7 +8598,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar3 {
-                property delete_foo -> std::int64 {
+                property delete_foo: std::int64 {
                     default := (SELECT
                         ((DELETE
                             test::Foo
@@ -8627,7 +8627,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE PROPERTY name -> std::str;
+                CREATE PROPERTY name: std::str;
             };
             CREATE ALIAS test::Bar := (
                 SELECT test::Foo {
@@ -8655,7 +8655,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE PROPERTY name -> std::str;
+                CREATE PROPERTY name: std::str;
             };
             CREATE ALIAS test::Bar {
                 USING (
@@ -8721,7 +8721,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE PROPERTY name -> std::str;
+                CREATE PROPERTY name: std::str;
             };
             CREATE ALIAS test::Bar := (
                 SELECT test::Foo {
@@ -8821,7 +8821,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE PROPERTY name -> std::str;
+                CREATE PROPERTY name: std::str;
                 CREATE PROPERTY comp := (WITH
                     x :=
                         std::count(std::Object)
@@ -8849,12 +8849,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                       schema::Source
             {
                 CREATE MULTI LINK access_policies
-                  EXTENDING schema::reference -> schema::AccessPolicy {
+                  EXTENDING schema::reference: schema::AccessPolicy {
                     ON TARGET DELETE ALLOW;
                     CREATE CONSTRAINT std::exclusive;
                 };
-                CREATE MULTI LINK intersection_of -> schema::ObjectType;
-                CREATE MULTI LINK union_of -> schema::ObjectType;
+                CREATE MULTI LINK intersection_of: schema::ObjectType;
+                CREATE MULTI LINK union_of: schema::ObjectType;
                 CREATE PROPERTY compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
@@ -8866,7 +8866,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     .pointers[IS schema::Property]
                 );
                 CREATE MULTI LINK triggers
-                  EXTENDING schema::reference -> schema::Trigger {
+                  EXTENDING schema::reference: schema::Trigger {
                     ON TARGET DELETE ALLOW;
                     CREATE CONSTRAINT std::exclusive;
                 };
@@ -8884,21 +8884,21 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     schema::Source
             {
                 multi link access_policies
-                  extending schema::reference -> schema::AccessPolicy {
+                  extending schema::reference: schema::AccessPolicy {
                     on target delete allow;
                     constraint std::exclusive;
                 };
-                multi link intersection_of -> schema::ObjectType;
+                multi link intersection_of: schema::ObjectType;
                 multi link links := (.pointers[IS schema::Link]);
                 multi link properties := (
                     .pointers[IS schema::Property]
                 );
                 multi link triggers
-                  extending schema::reference -> schema::Trigger {
+                  extending schema::reference: schema::Trigger {
                     on target delete allow;
                     constraint std::exclusive;
                 };
-                multi link union_of -> schema::ObjectType;
+                multi link union_of: schema::ObjectType;
                 property compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
@@ -8936,7 +8936,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE LINK bar -> std::Object {
+                CREATE LINK bar: std::Object {
                     ON TARGET DELETE ALLOW;
                 };
             };
@@ -8946,7 +8946,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                link bar -> std::Object {
+                link bar: std::Object {
                     on target delete  allow;
                 };
             };
@@ -8956,13 +8956,13 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                optional single link bar -> std::Object {
+                optional single link bar: std::Object {
                     on target delete  allow;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                 };
             };
@@ -9015,22 +9015,22 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Object {
-                required single link __type__ -> schema::ObjectType {
+                required single link __type__: schema::ObjectType {
                     readonly := true;
                 };
-                required single property id -> std::uuid {
+                required single property id: std::uuid {
                     readonly := true;
                 };
-                optional single property real -> std::bool;
+                optional single property real: std::bool;
             };
 
             # The following builtins are masked by the above:
 
             # abstract type std::Object extending std::BaseObject {
-            #     required single link __type__ -> schema::ObjectType {
+            #     required single link __type__: schema::ObjectType {
             #         readonly := true;
             #     };
-            #     required single property id -> std::uuid {
+            #     required single property id: std::uuid {
             #         readonly := true;
             #     };
             # };
@@ -9057,9 +9057,9 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Tree {
-                CREATE LINK parent -> test::Tree;
+                CREATE LINK parent: test::Tree;
                 CREATE MULTI LINK children := (.<parent[IS test::Tree]);
-                CREATE REQUIRED PROPERTY val -> std::str {
+                CREATE REQUIRED PROPERTY val: std::str {
                     CREATE CONSTRAINT std::exclusive;
                 };
                 CREATE MULTI LINK test_comp := (
@@ -9122,17 +9122,17 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 CREATE CONSTRAINT std::max_value(15);
             };
             CREATE ABSTRACT LINK test::f {
-                CREATE PROPERTY p -> test::int_t {
+                CREATE PROPERTY p: test::int_t {
                     CREATE CONSTRAINT std::max_value(10);
                     CREATE ANNOTATION test::anno := 'annotated link property';
                 };
             };
             CREATE TYPE test::Foo;
             CREATE TYPE test::Parent {
-                CREATE MULTI PROPERTY name -> std::str;
+                CREATE MULTI PROPERTY name: std::str;
             };
             CREATE TYPE test::Parent2 {
-                CREATE LINK foo -> test::Foo;
+                CREATE LINK foo: test::Foo;
                 CREATE INDEX ON (.foo);
             };
             CREATE TYPE test::Child EXTENDING test::Parent, test::Parent2 {
@@ -9156,7 +9156,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             module test {
                 abstract annotation anno;
                 abstract link f {
-                    property p -> test::int_t {
+                    property p: test::int_t {
                         annotation test::anno := 'annotated link property';
                         constraint std::max_value(10);
                     };
@@ -9167,7 +9167,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 };
                 type Child extending test::Parent, test::Parent2 {
                     annotation test::anno := 'annotated';
-                    overloaded link foo extending test::f -> test::Foo {
+                    overloaded link foo extending test::f: test::Foo {
                         annotation test::anno := 'annotated link';
                         constraint std::exclusive {
                             annotation test::anno := 'annotated constraint';
@@ -9176,11 +9176,11 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 };
                 type Foo;
                 type Parent {
-                    multi property name -> std::str;
+                    multi property name: std::str;
                 };
                 type Parent2 {
                     index on (.foo);
-                    link foo -> test::Foo;
+                    link foo: test::Foo;
                 };
             };
             """,
@@ -9210,10 +9210,10 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             CREATE EXTENSION NOTEBOOK VERSION '1.0';
             CREATE TYPE default::Foo;
             CREATE TYPE test::Bar {
-                CREATE LINK foo -> default::Foo;
+                CREATE LINK foo: default::Foo;
             };
             ALTER TYPE default::Foo {
-                CREATE LINK bar -> test::Bar;
+                CREATE LINK bar: test::Bar;
             };
             """,
 
@@ -9223,12 +9223,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             using extension notebook version '1.0';
             module default {
                 type Foo {
-                    link bar -> test::Bar;
+                    link bar: test::Bar;
                 };
             };
             module test {
                 type Bar {
-                    link foo -> default::Foo;
+                    link foo: default::Foo;
                 };
             };
             """,
@@ -9255,7 +9255,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             create type test::ExceptTest {
-                create property e -> std::bool;
+                create property e: std::bool;
                 create constraint std::expression on (true) except (.e);
                 create constraint test::always_ok on (.e) except (.e);
                 create constraint test::always_ok on (.e);

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -62,34 +62,34 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
     def test_eschema_syntax_tabs_01(self):
         """
 \tabstract type test::Foo {
-\t\trequired property foo -> str;
+\t\trequired property foo: str;
 \t};
 
 \tabstract type test::Bar {
-\t\trequired property bar -> str;
+\t\trequired property bar: str;
 \t};
         """
 
     def test_eschema_syntax_tabs_02(self):
         """
 \t  abstract type test::Foo {
-\t      required property foo -> str;
+\t      required property foo: str;
 };
 
 \t  abstract type test::Bar {
-\t      required property bar -> str;
+\t      required property bar: str;
 };
         """
     def test_eschema_syntax_semicolon_01(self):
         """
         abstract type test::OwnedObject {
-            required link owner -> User
+            required link owner: User
         };
 
 % OK %
 
         abstract type test::OwnedObject {
-            required link owner -> User;
+            required link owner: User;
         };
         """
 
@@ -97,7 +97,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             abstract type OwnedObject {
-                required property tag -> str
+                required property tag: str
             }
         }
 
@@ -105,7 +105,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
         module test {
             abstract type OwnedObject {
-                required property tag -> str;
+                required property tag: str;
             };
         };
         """
@@ -113,15 +113,15 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
     def test_eschema_syntax_semicolon_03(self):
         """
         abstract type test::OwnedObject {
-            required link owner -> User;
-            required property tag -> str
+            required link owner: User;
+            required property tag: str
         };
 
 % OK %
 
         abstract type test::OwnedObject {
-            required link owner -> User;
-            required property tag -> str;
+            required link owner: User;
+            required property tag: str;
         };
         """
 
@@ -131,7 +131,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
     def test_eschema_syntax_type_02(self):
         """
         abstract type test::OwnedObject {
-            required link owner -> User;
+            required link owner: User;
         };
         """
 
@@ -139,7 +139,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             abstract type Text {
-                required property body -> str {
+                required property body: str {
                     constraint max_len_value (10000);
                 };
             };
@@ -150,7 +150,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type LogEntry extending OwnedObject, Text {
-                required property spent_time -> int64;
+                required property spent_time: int64;
             };
         };
         """
@@ -168,7 +168,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type LogEntry extending OwnedObject, Text {
-                property start_date -> datetime {
+                property start_date: datetime {
                    default :=
                         (SELECT datetime::datetime_current());
                    title := 'Start Date';
@@ -181,33 +181,33 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Issue extending `foo.bar`::NamedObject, OwnedObject, Text {
-                required link number -> issue_num_t {
+                required link number: issue_num_t {
                     readonly := true;
                 };
 
-                required link status -> Status;
+                required link status: Status;
 
-                link priority -> Priority;
+                link priority: Priority;
 
-                multi link watchers extending orderable -> User {
-                    property foo extending bar -> str;
+                multi link watchers extending orderable: User {
+                    property foo extending bar: str;
                 };
 
-                multi link time_spent_log -> LogEntry;
+                multi link time_spent_log: LogEntry;
 
                 link start_date := (SELECT datetime::datetime_current());
 
-                multi link related_to -> Issue;
+                multi link related_to: Issue;
 
-                property time_estimate -> int64;
+                property time_estimate: int64;
 
-                property start_date -> datetime {
+                property start_date: datetime {
                    default :=
                         (SELECT datetime::datetime_current());
                    title := 'Start Date';
                 };
 
-                property due_date -> datetime;
+                property due_date: datetime;
 
                 property real_time_estimate {
                     using ((.time_estimate * 2));
@@ -227,7 +227,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                property time_estimate -> int64 {
+                property time_estimate: int64 {
                     property unit {
                         default := 'minute';
                     };
@@ -240,7 +240,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type LogEntry extending OwnedObject, Text {
-                required link attachment -> Post | File | User;
+                required link attachment: Post | File | User;
             };
         };
         """
@@ -249,7 +249,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type `Log-Entry` extending `OwnedObject`, `Text` {
-                required link attachment -> `Post` | `File` | `User`;
+                required link attachment: `Post` | `File` | `User`;
             };
         };
 
@@ -257,7 +257,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
         module test {
             type `Log-Entry` extending OwnedObject, Text {
-                required link attachment -> Post | File | User;
+                required link attachment: Post | File | User;
             };
         };
         """
@@ -268,7 +268,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Commit {
-                required property name -> std::str;
+                required property name: std::str;
             };
         };
         """
@@ -278,7 +278,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type __Foo__ {
-                required property name -> std::str;
+                required property name: std::str;
             };
         };
         """
@@ -288,7 +288,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type `__Foo__` {
-                required property name -> std::str;
+                required property name: std::str;
             };
         };
         """
@@ -298,7 +298,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type __Foo {
-                required property __name__ -> std::str;
+                required property __name__: std::str;
             };
         };
         """
@@ -308,7 +308,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type `__Foo` {
-                required property `__name__` -> std::str;
+                required property `__name__`: std::str;
             };
         };
         """
@@ -317,7 +317,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Пример {
-                required property номер -> int16;
+                required property номер: int16;
             };
         };
         """
@@ -326,16 +326,16 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                link bar0 -> Bar {
+                link bar0: Bar {
                     on target delete restrict;
                 };
-                link bar1 -> Bar {
+                link bar1: Bar {
                     on target delete delete source;
                 };
-                link bar2 -> Bar {
+                link bar2: Bar {
                     on target delete allow;
                 };
-                link bar3 -> Bar {
+                link bar3: Bar {
                     on target delete deferred restrict;
                 };
             };
@@ -349,7 +349,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                link bar0 -> Bar {
+                link bar0: Bar {
                     on target delete restrict;
                     on target delete delete source;
                 };
@@ -361,7 +361,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                property foo -> str {
+                property foo: str {
                     default := some_func(
         1, 2, 3);
                 };
@@ -373,18 +373,18 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         r"""
         module test {
             type Foo {
-                property foo -> str {
+                property foo: str {
                     # if it's defined on the same line as :=
                     # the definition must be a one-liner
                     default := some_func(1, 2, 3);
                 };
-                property bar -> str {
+                property bar: str {
                     # multi-line definition with correct indentation
                     default :=
                         some_func('
                         1, 2, 3');
                 };
-                property baz -> str {
+                property baz: str {
                     # multi-line definition with correct indentation
                     default :=
                         $$some_func(
@@ -397,16 +397,16 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
         module test {
             type Foo {
-                property foo -> str {
+                property foo: str {
                     # if it's defined on the same line as :=
                     # the definition must be a one-liner
                     default := some_func(1, 2, 3);
                 };
-                property bar -> str {
+                property bar: str {
                     # multi-line definition with correct indentation
                     default := some_func('\n                        1, 2, 3');
                 };
-                property baz -> str {
+                property baz: str {
                     # multi-line definition with correct indentation
                     default := 'some_func(\n                        1, 2, 3)';
                 };
@@ -418,15 +418,15 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                single link foo -> Foo;
-                multi link bar -> Bar;
-                required single link baz -> Baz;
-                required multi link spam -> Spam;
-                overloaded required single link ham -> Ham;
-                overloaded required multi link eggs -> Egg;
+                single link foo: Foo;
+                multi link bar: Bar;
+                required single link baz: Baz;
+                required multi link spam: Spam;
+                overloaded required single link ham: Ham;
+                overloaded required multi link eggs: Egg;
                 overloaded link knight;
                 overloaded link clinic {
-                    property argument -> int64;
+                    property argument: int64;
                 };
                 overloaded property castle;
                 overloaded property tower {
@@ -442,17 +442,17 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                property -> Foo;
-                single foo -> Foo;
-                multi bar -> Bar {
-                    prop -> int64;
+                property: Foo;
+                single foo: Foo;
+                multi bar: Bar {
+                    prop: int64;
                 };
-                required property multi -> Bar;
-                required single baz -> Baz;
-                required multi spam -> Spam;
-                overloaded required single ham -> Ham;
-                overloaded required multi eggs -> Egg;
-                overloaded ham2 -> Ham;
+                required property multi: Bar;
+                required single baz: Baz;
+                required multi spam: Spam;
+                overloaded required single ham: Ham;
+                overloaded required multi eggs: Egg;
+                overloaded ham2: Ham;
                 constraint exclusive on (.asdf) except (.baz);
                 index on (.asdf) except (.baz);
             };
@@ -463,12 +463,12 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                single property foo -> str;
-                multi property bar -> str;
-                required single property baz -> str;
-                required multi property spam -> str;
-                overloaded required single property ham -> str;
-                overloaded required multi property eggs -> str;
+                single property foo: str;
+                multi property bar: str;
+                required single property baz: str;
+                required multi property spam: str;
+                overloaded required single property ham: str;
+                overloaded required multi property eggs: str;
             };
         };
         """
@@ -477,27 +477,27 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                single property foo -> str
+                single property foo: str
             }
 
             type Bar {
-                multi property bar -> str
+                multi property bar: str
             }
 
             type Baz {
-                required single property baz -> str
+                required single property baz: str
             }
 
             type Spam {
-                required multi property spam -> str
+                required multi property spam: str
             }
 
             type Ham {
-                overloaded required single property ham -> str
+                overloaded required single property ham: str
             }
 
             type Eggs {
-                overloaded required multi property eggs -> str
+                overloaded required multi property eggs: str
             }
         }
 
@@ -505,27 +505,27 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
         module test {
             type Foo {
-                single property foo -> str;
+                single property foo: str;
             };
 
             type Bar {
-                multi property bar -> str;
+                multi property bar: str;
             };
 
             type Baz {
-                required single property baz -> str;
+                required single property baz: str;
             };
 
             type Spam {
-                required multi property spam -> str;
+                required multi property spam: str;
             };
 
             type Ham {
-                overloaded required single property ham -> str;
+                overloaded required single property ham: str;
             };
 
             type Eggs {
-                overloaded required multi property eggs -> str;
+                overloaded required multi property eggs: str;
             };
         };
         """
@@ -534,11 +534,11 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                single property foo -> str {
+                single property foo: str {
                     constraint max_len_value (10000)
                 }
 
-                multi property bar -> str {
+                multi property bar: str {
                     constraint max_len_value (10000)
                 }
             }
@@ -548,11 +548,11 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
         module test {
             type Foo {
-                single property foo -> str {
+                single property foo: str {
                     constraint max_len_value (10000);
                 };
 
-                multi property bar -> str {
+                multi property bar: str {
                     constraint max_len_value (10000);
                 };
             };
@@ -562,7 +562,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
     def test_eschema_syntax_type_27(self):
         """
         type foo::Bar {
-            property name -> str;
+            property name: str;
         };
         """
 
@@ -570,7 +570,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module foo {
             type Bar {
-                property name -> str;
+                property name: str;
             };
         };
         """
@@ -583,7 +583,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module foo {
             type foo::Bar {
-                property name -> str;
+                property name: str;
             };
         };
         """
@@ -592,17 +592,17 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module foo {
             type Bar {
-                property name -> str;
+                property name: str;
             };
         };
 
         type foo::Bar2 {
-            property name -> str;
+            property name: str;
         };
 
         module foo {
             type Bar3 {
-                property name -> str;
+                property name: str;
             };
         };
         """
@@ -611,17 +611,17 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module foo {
             type Bar {
-                property name -> str;
+                property name: str;
             };
         };
 
         type bar::Bar {
-            property name -> str;
+            property name: str;
         };
 
         module baz {
             type Bar {
-                property name -> str;
+                property name: str;
             };
         };
         """
@@ -643,16 +643,16 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module default {
             type Foo0 {
-                property union -> str;
-                link except -> Object;
+                property union: str;
+                link except: Object;
             };
             type Foo1 {
-                required property union -> str;
-                required link except -> Object;
+                required property union: str;
+                required link except: Object;
             };
             type Foo2 {
-                optional property union -> str;
-                optional link except -> Object;
+                optional property union: str;
+                optional link except: Object;
             };
         };
         """
@@ -661,12 +661,12 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module default {
             type Foo1 {
-                multi property union -> str;
-                multi link except -> Object;
+                multi property union: str;
+                multi link except: Object;
             };
             type Foo2 {
-                single property union -> str;
-                single link except -> Object;
+                single property union: str;
+                single link except: Object;
             };
         };
         """
@@ -675,7 +675,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module default {
             type Foo {
-                property union extending except -> str;
+                property union extending except: str;
             };
         };
         """
@@ -684,8 +684,8 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module default {
             type Foo {
-                link union extending except -> Object {
-                    property intersect -> str;
+                link union extending except: Object {
+                    property intersect: str;
                 };
             };
         };
@@ -695,7 +695,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type User {
-                required link todo -> array<str>;
+                required link todo: array<str>;
             };
         };
         """
@@ -704,7 +704,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type User {
-                required link todo -> tuple<str, int64, float64>;
+                required link todo: tuple<str, int64, float64>;
             };
         };
         """
@@ -713,7 +713,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type User {
-                required link todo ->
+                required link todo:
                     tuple<str, tuple<str, array<str>>, array<float64>>;
             };
         };
@@ -723,7 +723,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type LogEntry extending OwnedObject, Text {
-                required link owner -> User;
+                required link owner: User;
                 index on (SELECT datetime::datetime_current());
             };
         };
@@ -733,7 +733,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             abstract link foobar {
-                property foo -> str {
+                property foo: str {
                     title := 'Sample property';
                 };
                 index on (__subject__@foo);
@@ -756,7 +756,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type User {
-                property name -> str;
+                property name: str;
                 index on (.name);
             };
         };
@@ -766,7 +766,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type User {
-                property name -> str;
+                property name: str;
 
                 index on (.name) {
                     annotation title := 'User name index';
@@ -779,7 +779,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         module test {
             type Foo {
-                property title -> str;
+                property title: str;
                 index pg::gist on (.title);
             };
         };
@@ -792,9 +792,9 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
             alias lowercase := to_json('["lowercase"]');
 
             type Foo {
-                property bar -> str;
-                property baz -> str;
-                property foo -> str;
+                property bar: str;
+                property baz: str;
+                property foo: str;
 
                 index myindex0() on (.bar);
                 index myindex1(tok_filter := eng_stop ++ lowercase)
@@ -842,7 +842,7 @@ type LogEntry extending    OwnedObject,    Text {
             # irrelevant comment indent
         # irrelevant comment indent
 
-  property start_date -> datetime {
+  property start_date: datetime {
 
 
                        default := (
@@ -1222,7 +1222,7 @@ abstract property test::foo {
         """
         module test {
             abstract link coollink {
-                property foo -> int64;
+                property foo: int64;
             };
         };
         """
@@ -1230,8 +1230,8 @@ abstract property test::foo {
     def test_eschema_syntax_link_04(self):
         """
         abstract link test::coollink {
-            property foo -> int64;
-            property bar -> int64;
+            property foo: int64;
+            property bar: int64;
 
             constraint expr {
                 using (self.foo = self.bar);
@@ -1250,7 +1250,7 @@ abstract property test::foo {
             };
 
             abstract link coollink {
-                property foo -> int64 {
+                property foo: int64 {
                     constraint min_value(0);
                     constraint max_value(123456);
                     constraint expr on (__subject__ % 2 = 0) {
@@ -1259,7 +1259,7 @@ abstract property test::foo {
                     default := 2;
                 };
 
-                property bar -> int64;
+                property bar: int64;
 
                 constraint expr on (self.foo = self.bar);
             };
@@ -1271,7 +1271,7 @@ abstract property test::foo {
         """
         module test {
             abstract link coollink {
-                required property foo -> int64;
+                required property foo: int64;
             };
         };
         """
@@ -1280,7 +1280,7 @@ abstract property test::foo {
         """
         module test {
             abstract link time_estimate {
-               property unit -> str {
+               property unit: str {
                    constraint my_constraint(0);
                };
             };
@@ -1291,7 +1291,7 @@ abstract property test::foo {
         """
         module test {
             abstract link time_estimate {
-               property unit -> str {
+               property unit: str {
                    constraint my_constraint(0, <str>(42^2));
                };
             };
@@ -1302,7 +1302,7 @@ abstract property test::foo {
         """
         module test {
             abstract link time_estimate {
-               property unit -> str{
+               property unit: str{
                    constraint my_constraint(')', `)`($$)$$));
                };
             };
@@ -1312,7 +1312,7 @@ abstract property test::foo {
 
         module test {
             abstract link time_estimate {
-               property unit -> str{
+               property unit: str{
                    constraint my_constraint(')', `)`(')'));
                };
             };
@@ -1357,7 +1357,7 @@ abstract property test::foo {
         """
         module test {
             abstract link union extending intersect {
-                property except -> str;
+                property except: str;
             };
         };
         """
@@ -1907,7 +1907,7 @@ annotation test::foo;
                 using (true) {
                    annotation title := 'foo';
                 };
-                property x -> str;
+                property x: str;
             };
         };
         """
@@ -1920,7 +1920,7 @@ annotation test::foo;
                 when (true)
                 deny all
                 using (true);
-                property x -> str;
+                property x: str;
             };
         };
         """
@@ -1966,7 +1966,7 @@ annotation test::foo;
         """
         module test {
             type Foo {
-                property foo -> i64 {
+                property foo: i64 {
                     rewrite insert using (1);
                 };
             };
@@ -1977,7 +1977,7 @@ annotation test::foo;
         """
         module test {
             type Foo {
-                property name_updated_at -> i64 {
+                property name_updated_at: i64 {
                     rewrite update, insert using (
                         datetime_current()
                         if __specified__.name
@@ -1997,7 +1997,7 @@ annotation test::foo;
 % OK %
 
         abstract type test::OwnedObject {
-            required link owner -> User;
+            required link owner: User;
         };
         """
 


### PR DESCRIPTION
Change from -> to : when prettyprinting links and properties, and fix up the resulting havoc in the test suite.

Fixes #5049
