### PR TITLE
Document deprecation policy

### DIFF
--- a/docs/changelog/deprecation.rst
+++ b/docs/changelog/deprecation.rst
@@ -1,0 +1,10 @@
+.. _ref_changelog_deprecation:
+
+==================
+Deprecation Policy
+==================
+
+* We continue to support one previous version of EdgeDB with critical bug fixes
+  only.
+* Client bindings support the current and previous versions.
+* CLI supports all versions from version 1.

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -12,3 +12,4 @@ Changes introduced in all of the releases of EdgeDB so far:
 
     1_x
     2_x
+    deprecation


### PR DESCRIPTION
I'm not sure about the placement of this. It's the best I could come up with. Open to suggestions.

I don't think it fits cleanly under any of our existing sections. I didn't want to add a new section for it. I reasoned that it might be relevant to people who are looking at changelogs, so that's where I have it currently.