### PR TITLE
Make `fail_notes` propagate from failed tests even when parallelized

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -213,7 +213,7 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
         return True
 
     def add_fail_notes(self, **kwargs):
-        if not hasattr(self, 'fail_notes'):
+        if getattr(self, 'fail_notes', None) is None:
             self.fail_notes = {}
         self.fail_notes.update(kwargs)
 
@@ -317,6 +317,7 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
             '_subtest': self._subtest,
             '_cleanups': [],
             '_type_equality_funcs': self._type_equality_funcs,
+            'fail_notes': getattr(self, 'fail_notes', None),
         }
 
 


### PR DESCRIPTION
One fewer mystery in my life: the notes got lost when pickled, due to
us having a whitelist of what test case attributes we preserved.

(fail_notes are lightweight annotations on a test failure that should
get printed along with the error; they are useful for when a test runs
multiple queries in a loop, or the like.)