### PR TITLE
Add a variety of cast with a more restricted implicit cast behavior

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_02_23_00_00
+EDGEDB_CATALOG_VERSION = 2023_02_27_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1436,6 +1436,7 @@ class CastCommand(ObjectDDL):
 class CreateCast(CreateObject, CastCommand):
     code: CastCode
     allow_implicit: bool
+    allow_pseudo_implicit: bool
     allow_assignment: bool
 
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -447,6 +447,12 @@ def _find_cast(
         (CastCallableWrapper(c) for c in casts), args=args, kwargs={}, ctx=ctx)
 
     if len(matched) == 1:
+        # We allow (somewhat unfortunately) implicit casts to apply
+        # before an explicit cast, but we disallow "pseudo implicit"
+        # casts.
+        arg = matched[0].args[0]
+        if arg.cast_distance >= s_casts.PSEUDO_IMPLICIT_DISTANCE:
+            return None
         return cast(CastCallableWrapper, matched[0].func)._cast
     elif len(matched) > 1:
         raise errors.QueryError(

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2804,6 +2804,9 @@ class CastAllowedUse(Nonterm):
     def reduce_ALLOW_IMPLICIT(self, *kids):
         self.val = CastUseValue(use=kids[1].val.upper())
 
+    def reduce_ALLOW_PSEUDO_IMPLICIT(self, *kids):
+        self.val = CastUseValue(use=kids[1].val.upper())
+
     def reduce_ALLOW_ASSIGNMENT(self, *kids):
         self.val = CastUseValue(use=kids[1].val.upper())
 
@@ -2881,6 +2884,7 @@ class CreateCastStmt(Nonterm):
         from_expr = False
         from_cast = False
         allow_implicit = False
+        allow_pseudo_implicit = False
         allow_assignment = False
         code = None
 
@@ -2926,6 +2930,8 @@ class CreateCastStmt(Nonterm):
                     allow_implicit = True
                 elif node.use == 'ASSIGNMENT':
                     allow_assignment = True
+                elif node.use == 'PSEUDO':
+                    allow_pseudo_implicit = True
                 else:
                     raise EdgeQLSyntaxError(
                         'unexpected ALLOW clause',
@@ -2962,6 +2968,7 @@ class CreateCastStmt(Nonterm):
             )
 
             props['allow_implicit'] = allow_implicit
+            props['allow_pseudo_implicit'] = allow_pseudo_implicit
             props['allow_assignment'] = allow_assignment
 
         if commands:

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -1228,7 +1228,7 @@ CREATE CAST FROM cal::local_date TO cal::local_datetime {
     SET volatility := 'Immutable';
     USING SQL CAST;
     # Analogous to implicit cast from int64 to float64.
-    ALLOW IMPLICIT;
+    ALLOW PSEUDO IMPLICIT;
 };
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -543,6 +543,7 @@ CREATE TYPE schema::Cast
     CREATE LINK from_type -> schema::Type;
     CREATE LINK to_type -> schema::Type;
     CREATE PROPERTY allow_implicit -> std::bool;
+    CREATE PROPERTY allow_pseudo_implicit -> std::bool;
     CREATE PROPERTY allow_assignment -> std::bool;
 };
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1178,7 +1178,10 @@ class FlatSchema(Schema):
 
         casts = []
         for castobj in all_casts:
-            if implicit and not castobj.get_allow_implicit(self):
+            if implicit and not (
+                castobj.get_allow_implicit(self)
+                or castobj.get_allow_pseudo_implicit(self)
+            ):
                 continue
             if assignment and not castobj.get_allow_assignment(self):
                 continue


### PR DESCRIPTION
Currently, implicit casts are applied not just when searching for
functions to apply, but when searching for *casts* to apply.
This is going to cause problems if we add an `fts::language` type with
an implicit cast from str, but as I tried to fix this I discovered
it already *did* cause a problem: it caused us to support casting
from `cal::local_date` to `cal::local_time`, but actually doing so
would produce an ISE.

Add a new category of implicit cast that doesn't have this behavior.

I had originally wanted to get rid of this behavior entirely, which
required adding in a large number of numeric casts, but this then
caused a bunch of knock-on trouble as things that relied on implicit
cast *distance* no longer worked right, which required adding a lot
more overloads. I pushed that WIP to `no-chained-implicit-casts`; it
still needs a dozen or so more overloads of `=` and friends to be made
fully operational.

I could finish with that approach, if that seems better to people, or
maybe someone has a better idea.