### PR TITLE
Support casting between scalars with a common concrete base

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -36,6 +36,7 @@ from edb.schema import constraints as s_constr
 from edb.schema import functions as s_func
 from edb.schema import indexes as s_indexes
 from edb.schema import name as sn
+from edb.schema import scalars as s_scalars
 from edb.schema import types as s_types
 from edb.schema import utils as s_utils
 from edb.schema import name as s_name
@@ -134,9 +135,13 @@ def compile_cast(
             ir_set, orig_stype, new_stype,
             cardinality_mod=cardinality_mod, ctx=ctx)
 
-    if new_stype.issubclass(ctx.env.schema, orig_stype):
-        # The new type is a subtype, so may potentially have
-        # a more restrictive domain, generate a cast call.
+    if (
+        new_stype.issubclass(ctx.env.schema, orig_stype)
+        or _has_common_concrete_scalar(orig_stype, new_stype, ctx=ctx)
+    ):
+        # The new type is a subtype or a sibling type of a shared
+        # ancestor, so may potentially have a more restrictive domain,
+        # generate a cast call.
         return _inheritance_cast_to_ir(
             ir_set, orig_stype, new_stype,
             cardinality_mod=cardinality_mod, ctx=ctx)
@@ -233,6 +238,20 @@ def compile_cast(
         cardinality_mod=cardinality_mod,
         srcctx=srcctx,
         ctx=ctx,
+    )
+
+
+def _has_common_concrete_scalar(
+        orig_stype: s_types.Type,
+        new_stype: s_types.Type, *,
+        ctx: context.ContextLevel) -> bool:
+    return bool(
+        isinstance(orig_stype, s_scalars.ScalarType)
+        and isinstance(new_stype, s_scalars.ScalarType)
+        and (nearest := s_utils.get_class_nearest_common_ancestors(
+            ctx.env.schema, [new_stype, orig_stype]))
+        and len(nearest) == 1
+        and not nearest[0].get_abstract(ctx.env.schema)
     )
 
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -251,7 +251,10 @@ def _has_common_concrete_scalar(
         and (nearest := s_utils.get_class_nearest_common_ancestors(
             ctx.env.schema, [new_stype, orig_stype]))
         and len(nearest) == 1
-        and not nearest[0].get_abstract(ctx.env.schema)
+        and (
+            nearest[0].maybe_get_topmost_concrete_base(ctx.env.schema)
+            is not None
+        )
     )
 
 
@@ -443,7 +446,8 @@ def _find_cast(
     # Don't try to pick up casts when there is a direct subtyping
     # relationship.
     if (orig_stype.issubclass(ctx.env.schema, new_stype)
-            or new_stype.issubclass(ctx.env.schema, orig_stype)):
+            or new_stype.issubclass(ctx.env.schema, orig_stype)
+            or _has_common_concrete_scalar(orig_stype, new_stype, ctx=ctx)):
         return None
 
     casts = ctx.env.schema.get_casts_to_type(new_stype)

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -245,16 +245,13 @@ def _has_common_concrete_scalar(
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
         ctx: context.ContextLevel) -> bool:
+    schema = ctx.env.schema
     return bool(
         isinstance(orig_stype, s_scalars.ScalarType)
         and isinstance(new_stype, s_scalars.ScalarType)
-        and (nearest := s_utils.get_class_nearest_common_ancestors(
-            ctx.env.schema, [new_stype, orig_stype]))
-        and len(nearest) == 1
-        and (
-            nearest[0].maybe_get_topmost_concrete_base(ctx.env.schema)
-            is not None
-        )
+        and (orig_base := orig_stype.maybe_get_topmost_concrete_base(schema))
+        and (new_base := new_stype.maybe_get_topmost_concrete_base(schema))
+        and orig_base == new_base
     )
 
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2581,6 +2581,27 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 SELECT <array<custom_str_t>><array<bar>>['test']
             """)
 
+    async def test_edgeql_casts_custom_scalar_04(self):
+        await self.con.execute('''
+            create abstract scalar type abs extending int64;
+            create scalar type foo2 extending abs;
+            create scalar type bar2 extending abs;
+        ''')
+
+        await self.assert_query_result(
+            """
+                SELECT <foo2><bar2>42
+            """,
+            [42],
+        )
+
+        await self.assert_query_result(
+            """
+                SELECT <array<foo2>><array<bar2>>[42]
+            """,
+            [[42]],
+        )
+
     async def test_edgeql_casts_tuple_params_01(self):
         # insert tuples into a nested array
         def nest(data):

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2544,6 +2544,43 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             await self.con.query(
                 "SELECT <custom_str_t>'123'")
 
+    async def test_edgeql_casts_custom_scalar_02(self):
+        await self.assert_query_result(
+            """
+                SELECT <foo><bar>'test'
+            """,
+            ['test'],
+        )
+
+        await self.assert_query_result(
+            """
+                SELECT <array<foo>><array<bar>>['test']
+            """,
+            [['test']],
+        )
+
+    async def test_edgeql_casts_custom_scalar_03(self):
+        await self.assert_query_result(
+            """
+                SELECT <array<custom_str_t>><array<bar>>['TEST']
+            """,
+            [['TEST']],
+        )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, r'invalid'
+        ):
+            await self.con.query("""
+                SELECT <custom_str_t><bar>'test'
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, r'invalid'
+        ):
+            await self.con.query("""
+                SELECT <array<custom_str_t>><array<bar>>['test']
+            """)
+
     async def test_edgeql_casts_tuple_params_01(self):
         # insert tuples into a nested array
         def nest(data):
@@ -2791,20 +2828,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             ''',
             [],
         )
-
-    async def test_edgeql_casts_custom_scalars_01(self):
-        async with self.assertRaisesRegexTx(
-                edgedb.QueryError, r'cannot cast'):
-            await self.con.execute("""
-                SELECT <foo><bar>'test'
-            """)
-
-    async def test_edgeql_casts_custom_scalars_02(self):
-        async with self.assertRaisesRegexTx(
-                edgedb.QueryError, r'cannot cast'):
-            await self.con.execute("""
-                SELECT <array<foo>><array<bar>>['test']
-            """)
 
     async def test_edgeql_casts_std_enum_01(self):
         await self.assert_query_result(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2602,6 +2602,28 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             [[42]],
         )
 
+    async def test_edgeql_casts_custom_scalar_05(self):
+        await self.con.execute('''
+            create abstract scalar type xfoo extending int64;
+            create abstract scalar type xbar extending int64;
+            create scalar type bar1 extending xfoo, xbar;
+            create scalar type bar2 extending xfoo, xbar;
+        ''')
+
+        await self.assert_query_result(
+            """
+                SELECT <bar1><bar2>42
+            """,
+            [42],
+        )
+
+        await self.assert_query_result(
+            """
+                SELECT <array<bar1>><array<bar2>>[42]
+            """,
+            [[42]],
+        )
+
     async def test_edgeql_casts_tuple_params_01(self):
         # insert tuples into a nested array
         def nest(data):


### PR DESCRIPTION
Seems like this was not supported because of an oversight, and then I
unthinkingly added a test that asserted the behavior after I permuted
some related code in #3662.