### PR TITLE
Disallow variadic arguments with optional types in user code.

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1879,6 +1879,20 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                         f'{p_type.get_displayname(schema)}',
                         context=self.source_context)
 
+        # Make sure variadic parameters do not contain optional types in
+        # user-defined functions
+        if language == qlast.Language.EdgeQL:
+            if variadic := params.find_variadic(schema):
+                typemod = variadic.get_typemod(schema)
+                if typemod is ft.TypeModifier.OptionalType:
+                    raise errors.InvalidFunctionDefinitionError(
+                        f'cannot create the `{signature}` function: '
+                        f'variadic argument '
+                        f'`{variadic.get_displayname(schema)}` '
+                        f'illegally declared with optional type in '
+                        f'user-defined function',
+                        context=self.source_context)
+
         return schema
 
     @classmethod

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4763,6 +4763,20 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 $$;
             """)
 
+    async def test_edgeql_ddl_function_36(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidFunctionDefinitionError,
+            r"cannot create the `default::broken_edgeql_func36\("
+            r"VARIADIC foo: OPTIONAL array<std::int64>\)` function: "
+            r"variadic argument `foo` illegally declared with "
+            r"optional type in user-defined function"
+        ):
+            await self.con.execute(r"""
+                CREATE FUNCTION broken_edgeql_func36(
+                    variadic foo: optional std::int64) -> array<std::int64>
+                USING (assert_exists(foo));
+            """)
+
     async def test_edgeql_ddl_function_rename_01(self):
         await self.con.execute("""
             CREATE FUNCTION foo(s: str) -> str {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -793,6 +793,19 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """
 
+    @tb.must_fail(
+        errors.InvalidFunctionDefinitionError,
+        r"cannot create the `test::foo\(VARIADIC bar: "
+        r"OPTIONAL array<std::int64>\)` function: "
+        r"variadic argument `bar` illegally declared "
+        r"with optional type in user-defined function"
+    )
+    def test_schema_func_optional_variadic_01(self):
+        """
+            function foo(variadic bar: optional int64) -> array<int64>
+                using (assert_exists(bar));
+        """
+
     def test_schema_refs_01(self):
         schema = self.load_schema("""
             type Object1;


### PR DESCRIPTION
optionally typed variadic arguments are fraught, because we cannot put `null`
into arrays. Rather than try to find a roundabout solution, just ban optionally
typed variadic parameters in user code.

Fixes #4982.
