### PR TITLE
Make CompilerContextLevel.new use self as the previous level

### DIFF
--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -349,7 +349,7 @@ def compile_dml_write_policies(
     if not ctx.env.type_rewrites.get((stype, False)):
         return None
 
-    with ctx.detached() as _, ctx.newscope(fenced=True) as subctx:
+    with ctx.detached() as _, _.newscope(fenced=True) as subctx:
         # TODO: can we make sure to always avoid generating needless
         # select filters
         _prepare_dml_policy_context(stype, result, ctx=subctx)
@@ -394,7 +394,7 @@ def compile_dml_read_policies(
     if not ctx.env.type_rewrites.get((stype, False)):
         return None
 
-    with ctx.detached() as _, ctx.newscope(fenced=True) as subctx:
+    with ctx.detached() as _, _.newscope(fenced=True) as subctx:
         # TODO: can we make sure to always avoid generating needless
         # select filters
         _prepare_dml_policy_context(stype, result, ctx=subctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -511,7 +511,7 @@ def compile_InsertQuery(
             )
 
         if pol_condition := policies.compile_dml_write_policies(
-            mat_stype, result, mode=qltypes.AccessKind.Insert, ctx=ctx
+            mat_stype, result, mode=qltypes.AccessKind.Insert, ctx=ictx
         ):
             stmt.write_policies[mat_stype.id] = pol_condition
 
@@ -630,11 +630,11 @@ def compile_UpdateQuery(
 
         for dtype in schemactx.get_all_concrete(mat_stype, ctx=ctx):
             if read_pol := policies.compile_dml_read_policies(
-                dtype, result, mode=qltypes.AccessKind.UpdateRead, ctx=ctx
+                dtype, result, mode=qltypes.AccessKind.UpdateRead, ctx=ictx
             ):
                 stmt.read_policies[dtype.id] = read_pol
             if write_pol := policies.compile_dml_write_policies(
-                dtype, result, mode=qltypes.AccessKind.UpdateWrite, ctx=ctx
+                dtype, result, mode=qltypes.AccessKind.UpdateWrite, ctx=ictx
             ):
                 stmt.write_policies[dtype.id] = write_pol
 
@@ -750,7 +750,7 @@ def compile_DeleteQuery(
 
         for dtype in schemactx.get_all_concrete(mat_stype, ctx=ctx):
             if pol_cond := policies.compile_dml_read_policies(
-                dtype, result, mode=qltypes.AccessKind.Delete, ctx=ctx
+                dtype, result, mode=qltypes.AccessKind.Delete, ctx=ictx
             ):
                 stmt.read_policies[dtype.id] = pol_cond
 
@@ -1030,7 +1030,7 @@ def compile_Shape(
         ctx.env.compiled_stmts[subctx.qlstmt] = stmt
         subctx.class_view_overrides = subctx.class_view_overrides.copy()
 
-        with ctx.new() as exposed_ctx:
+        with subctx.new() as exposed_ctx:
             exposed_ctx.expr_exposed = context.Exposure.UNEXPOSED
             expr = dispatch.compile(shape_expr, ctx=exposed_ctx)
 

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -58,7 +58,7 @@ def compile_trigger(
     kinds = set(trigger.get_kinds(schema))
     source = trigger.get_subject(schema)
 
-    with ctx.detached() as _, ctx.newscope(fenced=True) as sctx:
+    with ctx.detached() as _, _.newscope(fenced=True) as sctx:
         sctx.anchors = sctx.anchors.copy()
 
         anchors = {}

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -262,7 +262,7 @@ def compile_filter_clause(
 
         assert cardinality != qltypes.Cardinality.UNKNOWN
         if cardinality.is_single():
-            where_clause = dispatch.compile(ir_set, ctx=ctx)
+            where_clause = dispatch.compile(ir_set, ctx=ctx1)
         else:
             # In WHERE we compile ir.Set as a boolean disjunction:
             #    EXISTS(SELECT FROM SetRel WHERE SetRel.value)

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -249,7 +249,7 @@ def _compile_group(
             # TODO: Be able to directly output the final serialized version
             # if it is consumed directly.
             with context.output_format(ctx, context.OutputFormat.NATIVE), (
-                    ctx.new()) as matctx:
+                    groupctx.new()) as matctx:
                 matctx.materializing |= {stmt}
                 matctx.expr_exposed = True
 
@@ -370,13 +370,13 @@ def _compile_group(
             query.where_clause = astutils.extend_binop(
                 query.where_clause,
                 clauses.compile_filter_clause(
-                    stmt.where, stmt.where_card, ctx=ctx))
+                    stmt.where, stmt.where_card, ctx=ictx))
 
         # The ORDER BY clause
         if stmt.orderby is not None:
-            with ctx.new() as ictx:
+            with ictx.new() as octx:
                 query.sort_clause = clauses.compile_orderby_clause(
-                    stmt.orderby, ctx=ictx)
+                    stmt.orderby, ctx=octx)
 
     return query
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -800,7 +800,7 @@ def process_set_as_link_property_ref(
             source_scope_stmt, link_path_id, aspect='source', env=ctx.env)
 
         if link_rvar is None:
-            src_rvar = get_set_rvar(ir_source, ctx=ctx)
+            src_rvar = get_set_rvar(ir_source, ctx=newctx)
             assert link_prefix.rptr is not None
             link_rvar = relctx.new_pointer_rvar(
                 link_prefix.rptr, src_rvar=src_rvar,
@@ -1765,7 +1765,7 @@ def process_set_as_coalesce(
             with newctx.subrel() as subctx:
                 left = dispatch.compile(left_ir, ctx=subctx)
 
-                with newctx.subrel() as rightctx:
+                with subctx.subrel() as rightctx:
                     dispatch.compile(right_ir, ctx=rightctx)
                     pathctx.get_path_value_output(
                         rightctx.rel,
@@ -1820,7 +1820,7 @@ def process_set_as_coalesce(
             with newctx.subrel() as subctx:
                 subqry = subctx.rel
 
-                with ctx.subrel() as sub2ctx:
+                with subctx.subrel() as sub2ctx:
 
                     with sub2ctx.subrel() as scopectx:
                         larg = scopectx.rel
@@ -2117,7 +2117,7 @@ def process_set_as_type_cast(
 
             subctx.env.output_format = orig_output_format
         else:
-            set_expr = dispatch.compile(expr, ctx=ctx)
+            set_expr = dispatch.compile(expr, ctx=subctx)
 
             # A proper path var mapping way would be to wrap
             # the inner expression in a subquery, but that
@@ -3472,7 +3472,7 @@ def process_set_as_agg_expr_inner(
 
         if serialization_safe and aspect == 'serialized':
             # Serialization has changed the output type.
-            with newctx.new() as ivctx:
+            with ctx.new() as ivctx:
                 iv = dispatch.compile(iv_ir, ctx=ivctx)
 
                 iv = output.serialize_expr_if_needed(
@@ -3480,7 +3480,7 @@ def process_set_as_agg_expr_inner(
                 set_expr = output.serialize_expr_if_needed(
                     set_expr, path_id=ir_set.path_id, ctx=ctx)
         else:
-            with newctx.new() as ivctx:
+            with ctx.new() as ivctx:
                 iv = dispatch.compile(iv_ir, ctx=ivctx)
 
         pathctx.put_path_var(

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -98,13 +98,13 @@ def compile_SelectStmt(
                 query.where_clause = astutils.extend_binop(
                     query.where_clause,
                     clauses.compile_filter_clause(
-                        stmt.where, stmt.where_card, ctx=ctx))
+                        stmt.where, stmt.where_card, ctx=ictx))
 
             # The ORDER BY clause
             if stmt.orderby is not None:
-                with ctx.new() as ictx:
+                with ictx.new() as octx:
                     query.sort_clause = clauses.compile_orderby_clause(
-                        stmt.orderby, ctx=ictx)
+                        stmt.orderby, ctx=octx)
 
         if outvar.nullable and query is ctx.toplevel_stmt:
             # A nullable var has bubbled up to the top,


### PR DESCRIPTION
Currently in `new` and friends on context levels, self is passed
through as `prevlevel` to `CompilerContext.push`, where it is ignored
and the current most recent level is used instead.

It seems like this behavior may have been introduced by accident in
2019 while adding type annotations 854a52d673, but of course much code
grew to depend on it.

I lost a bunch of time today to a bizarre bug caused by this and
decided to get rid of it.

Though, instead of *actually* making the claimed change, I decided to
leave in the assertion that I used to catch all of the cases that were
relying on the old behavior.
We can decide later if we want to actually remove the assert.

Supporting the assert required adding a mechanism to reenter a
context.