### PR TITLE
Store the rel_overlays in immutable data structures

### DIFF
--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -71,6 +71,13 @@ class OutputFormat(enum.Enum):
 NO_STMT = pgast.SelectStmt()
 
 
+OverlayEntry = tuple[
+    str,
+    Union[pgast.BaseRelation, pgast.CommonTableExpr],
+    'irast.PathId',
+]
+
+
 class CompilerContextLevel(compiler.ContextLevel):
     #: static compilation environment
     env: Environment
@@ -173,13 +180,7 @@ class CompilerContextLevel(compiler.ContextLevel):
         Optional[irast.MutatingLikeStmt],
         DefaultDict[
             uuid.UUID,
-            List[
-                Tuple[
-                    str,
-                    Union[pgast.BaseRelation, pgast.CommonTableExpr],
-                    irast.PathId,
-                ]
-            ],
+            tuple[OverlayEntry, ...],
         ],
     ]
 
@@ -189,12 +190,12 @@ class CompilerContextLevel(compiler.ContextLevel):
         Optional[irast.MutatingLikeStmt],
         DefaultDict[
             Tuple[uuid.UUID, str],
-            List[
+            Tuple[
                 Tuple[
                     str,
                     Union[pgast.BaseRelation, pgast.CommonTableExpr],
                     irast.PathId,
-                ]
+                ], ...
             ],
         ],
     ]
@@ -257,9 +258,9 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.scope_tree = scope_tree
             self.dml_stmt_stack = []
             self.type_rel_overlays = collections.defaultdict(
-                lambda: collections.defaultdict(list))
+                lambda: collections.defaultdict(tuple))
             self.ptr_rel_overlays = collections.defaultdict(
-                lambda: collections.defaultdict(list))
+                lambda: collections.defaultdict(tuple))
 
             self.external_rels = {}
             self.enclosing_cte_iterator = None

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -28,6 +28,8 @@ import dataclasses
 import enum
 import uuid
 
+import immutables as immu
+
 from edb.common import compiler
 
 from edb.pgsql import ast as pgast
@@ -83,20 +85,19 @@ OverlayEntry = tuple[
 class RelOverlays:
     #: Relations used to "overlay" the main table for
     #: the type.  Mostly used with DML statements.
-    type: DefaultDict[
+    type: immu.Map[
         Optional[irast.MutatingLikeStmt],
-        DefaultDict[
+        immu.Map[
             uuid.UUID,
             tuple[OverlayEntry, ...],
         ],
-    ] = dataclasses.field(default_factory=lambda: collections.defaultdict(
-        lambda: collections.defaultdict(tuple)))
+    ] = immu.Map()
 
     #: Relations used to "overlay" the main table for
     #: the pointer.  Mostly used with DML statements.
-    ptr: DefaultDict[
+    ptr: immu.Map[
         Optional[irast.MutatingLikeStmt],
-        DefaultDict[
+        immu.Map[
             Tuple[uuid.UUID, str],
             Tuple[
                 Tuple[
@@ -106,12 +107,10 @@ class RelOverlays:
                 ], ...
             ],
         ],
-    ] = dataclasses.field(default_factory=lambda: collections.defaultdict(
-        lambda: collections.defaultdict(tuple)))
+    ] = immu.Map()
 
     def copy(self) -> RelOverlays:
-        # N.B: THIS IS STILL A (semi?) SHALLOW COPY
-        return RelOverlays(type=self.type.copy(), ptr=self.ptr.copy())
+        return RelOverlays(type=self.type, ptr=self.ptr)
 
 
 class CompilerContextLevel(compiler.ContextLevel):

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -841,7 +841,7 @@ def merge_overlays_globally(
     *,
     ctx: context.CompilerContextLevel,
 ) -> None:
-    relctx.clone_rel_overlays(ctx=ctx)
+    ctx.rel_overlays = ctx.rel_overlays.copy()
 
     type_overlay = ctx.rel_overlays.type.get(None, immu.Map())
     ptr_overlay = ctx.rel_overlays.ptr.get(None, immu.Map())
@@ -852,13 +852,13 @@ def merge_overlays_globally(
         for k, v in ctx.rel_overlays.type.get(ir_stmt, immu.Map()).items():
             els = set(type_overlay.get(k, ()))
             n_els = (
-                type_overlay.get(k, ()) + tuple([e for e in v if e not in els])
+                type_overlay.get(k, ()) + tuple(e for e in v if e not in els)
             )
             type_overlay = type_overlay.set(k, n_els)
         for k2, v2 in ctx.rel_overlays.ptr.get(ir_stmt, immu.Map()).items():
             els = set(ptr_overlay.get(k2, ()))
             n_els = (
-                ptr_overlay.get(k2, ()) + tuple([e for e in v2 if e not in els])
+                ptr_overlay.get(k2, ()) + tuple(e for e in v2 if e not in els)
             )
             ptr_overlay = ptr_overlay.set(k2, n_els)
 
@@ -2155,7 +2155,7 @@ def process_link_update(
             with ctx.new() as subctx:
                 # TODO: Do we really need a copy here? things /seem/
                 # to work without it
-                relctx.clone_rel_overlays(ctx=ctx)
+                subctx.rel_overlays = subctx.rel_overlays.copy()
                 relctx.add_ptr_rel_overlay(
                     ptrref, 'except', delcte, path_id=path_id, ctx=subctx)
 
@@ -2314,7 +2314,7 @@ def process_link_update(
             ctx=octx)
 
     if policy_ctx:
-        relctx.clone_rel_overlays(ctx=policy_ctx)
+        policy_ctx.rel_overlays = policy_ctx.rel_overlays.copy()
         register_overlays(data_cte, policy_ctx)
 
     register_overlays(updcte, ctx)
@@ -2611,7 +2611,7 @@ def compile_trigger(
 
     # Produce a CTE containing all of the affected objects for this trigger
     with ctx.newrel() as ictx:
-        relctx.clear_rel_overlays(ctx=ictx)
+        ictx.rel_overlays = context.RelOverlays()
         ictx.rel_overlays.type = immu.Map({
             None: immu.Map({trigger.source_type.id: tuple(overlays)})
         })

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -839,8 +839,7 @@ def merge_overlays_globally(
     *,
     ctx: context.CompilerContextLevel,
 ) -> None:
-    relctx.clone_type_rel_overlays(ctx=ctx)
-    relctx.clone_ptr_rel_overlays(ctx=ctx)
+    relctx.clone_rel_overlays(ctx=ctx)
 
     type_overlay = ctx.type_rel_overlays[None]
     ptr_overlay = ctx.ptr_rel_overlays[None]
@@ -2307,7 +2306,7 @@ def process_link_update(
             ctx=octx)
 
     if policy_ctx:
-        relctx.clone_ptr_rel_overlays(ctx=policy_ctx)
+        relctx.clone_rel_overlays(ctx=policy_ctx)
         register_overlays(data_cte, policy_ctx)
 
     register_overlays(updcte, ctx)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1396,10 +1396,7 @@ def range_for_material_objtype(
                 # rewrites *to include* overlays, so that we can't peek
                 # at all newly created objects that we can't see
                 if not ctx.trigger_mode:
-                    sctx.type_rel_overlays = collections.defaultdict(
-                        lambda: collections.defaultdict(list))
-                    sctx.ptr_rel_overlays = collections.defaultdict(
-                        lambda: collections.defaultdict(list))
+                    clear_rel_overlays(ctx=sctx)
                 dispatch.visit(rewrite, ctx=sctx)
                 # If we are expanding inhviews, we also expand type
                 # rewrites, so don't populate type_ctes. The normal
@@ -2175,23 +2172,22 @@ def get_ptr_rel_overlays(
     return ctx.ptr_rel_overlays[dml_source][typeref.id, ptrref.shortname.name]
 
 
-def clone_type_rel_overlays(
-    *,
-    ctx: context.CompilerContextLevel,
-) -> None:
+def clone_rel_overlays(*, ctx: context.CompilerContextLevel) -> None:
     ctx.type_rel_overlays = ctx.type_rel_overlays.copy()
     for k, v in ctx.type_rel_overlays.items():
         ctx.type_rel_overlays[k] = v.copy()
         for k2, v2 in v.items():
             v[k2] = list(v2)
 
-
-def clone_ptr_rel_overlays(
-    *,
-    ctx: context.CompilerContextLevel,
-) -> None:
     ctx.ptr_rel_overlays = ctx.ptr_rel_overlays.copy()
-    for k, v in ctx.ptr_rel_overlays.items():
-        ctx.ptr_rel_overlays[k] = v.copy()
-        for k2, v2 in v.items():
-            v[k2] = list(v2)
+    for pk, pv in ctx.ptr_rel_overlays.items():
+        ctx.ptr_rel_overlays[pk] = pv.copy()
+        for pk2, pv2 in pv.items():
+            pv[pk2] = list(pv2)
+
+
+def clear_rel_overlays(*, ctx: context.CompilerContextLevel) -> None:
+    ctx.type_rel_overlays = collections.defaultdict(
+        lambda: collections.defaultdict(list))
+    ctx.ptr_rel_overlays = collections.defaultdict(
+        lambda: collections.defaultdict(list))

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -2035,15 +2035,11 @@ def _add_type_rel_overlay(
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> None:
     entry = (op, rel, path_id)
-    if dml_stmts:
-        for dml_stmt in dml_stmts:
-            overlays = ctx.rel_overlays.type[dml_stmt][typeid]
-            if entry not in overlays:
-                ctx.rel_overlays.type[dml_stmt][typeid] += (entry,)
-    else:
-        overlays = ctx.rel_overlays.type[None][typeid]
+    dml_stmts2 = dml_stmts if dml_stmts else (None,)
+    for dml_stmt in dml_stmts2:
+        overlays = ctx.rel_overlays.type[dml_stmt][typeid]
         if entry not in overlays:
-            ctx.rel_overlays.type[None][typeid] += (entry,)
+            ctx.rel_overlays.type[dml_stmt][typeid] += (entry,)
 
 
 def add_type_rel_overlay(
@@ -2119,15 +2115,11 @@ def _add_ptr_rel_overlay(
         ctx: context.CompilerContextLevel) -> None:
 
     entry = (op, rel, path_id)
-    if dml_stmts:
-        for dml_stmt in dml_stmts:
-            overlays = ctx.rel_overlays.ptr[dml_stmt][typeid, ptrref_name]
-            if entry not in overlays:
-                ctx.rel_overlays.ptr[dml_stmt][typeid, ptrref_name] += (entry,)
-    else:
-        overlays = ctx.rel_overlays.ptr[None][typeid, ptrref_name]
+    dml_stmts2 = dml_stmts if dml_stmts else (None,)
+    for dml_stmt in dml_stmts2:
+        overlays = ctx.rel_overlays.ptr[dml_stmt][typeid, ptrref_name]
         if entry not in overlays:
-            ctx.rel_overlays.ptr[None][typeid, ptrref_name] += (entry,)
+            ctx.rel_overlays.ptr[dml_stmt][typeid, ptrref_name] += (entry,)
 
 
 def add_ptr_rel_overlay(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1397,7 +1397,7 @@ def range_for_material_objtype(
                 # rewrites *to include* overlays, so that we can't peek
                 # at all newly created objects that we can't see
                 if not ctx.trigger_mode:
-                    clear_rel_overlays(ctx=sctx)
+                    sctx.rel_overlays = context.RelOverlays()
                 dispatch.visit(rewrite, ctx=sctx)
                 # If we are expanding inhviews, we also expand type
                 # rewrites, so don't populate type_ctes. The normal
@@ -2165,11 +2165,3 @@ def get_ptr_rel_overlays(
     else:
         key = typeref.id, ptrref.shortname.name
         return ctx.rel_overlays.ptr[dml_source].get(key, ())
-
-
-def clone_rel_overlays(*, ctx: context.CompilerContextLevel) -> None:
-    ctx.rel_overlays = ctx.rel_overlays.copy()
-
-
-def clear_rel_overlays(*, ctx: context.CompilerContextLevel) -> None:
-    ctx.rel_overlays = context.RelOverlays()

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -23,7 +23,6 @@
 from __future__ import annotations
 from typing import *
 
-import collections
 import contextlib
 
 from edb import errors
@@ -3735,10 +3734,7 @@ def process_encoded_param(
         with ctx.newrel() as sctx:
             sctx.pending_query = sctx.rel
             sctx.volatility_ref = ()
-            sctx.type_rel_overlays = collections.defaultdict(
-                lambda: collections.defaultdict(list))
-            sctx.ptr_rel_overlays = collections.defaultdict(
-                lambda: collections.defaultdict(list))
+            relctx.clear_rel_overlays(ctx=sctx)
             arg_ref = dispatch.compile(decoder, ctx=sctx)
 
             # Force it into a real tuple so we can just always grab it

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3734,7 +3734,7 @@ def process_encoded_param(
         with ctx.newrel() as sctx:
             sctx.pending_query = sctx.rel
             sctx.volatility_ref = ()
-            relctx.clear_rel_overlays(ctx=sctx)
+            sctx.rel_overlays = context.RelOverlays()
             arg_ref = dispatch.compile(decoder, ctx=sctx)
 
             # Force it into a real tuple so we can just always grab it

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -579,6 +579,16 @@ class TestTriggers(tb.QueryTestCase):
             };
         ''')
 
+        await self.con.query('''
+            with c := (select Subordinate filter .name = "c"),
+            select {
+                (update InsertTest filter .name = "2"
+                set { subordinates -= c }),
+                (update InsertTest filter .name = "1"
+                set { subordinates += c }),
+            };
+        ''')
+
     async def test_edgeql_triggers_enforce_errors_02(self):
         # Simulate a multi-table constraint that we can't do with constraints:
         # ensure the *sum* of the val fields in subordinates is zero


### PR DESCRIPTION
In conflict clauses, and triggers, and policies, and probably soon in
rewrites, we set up temporary modifications to the overlay state.
Overlays are currently stored as dicts of dicts of lists, and so doing
anything short of a full clone terrifies me, but a full clone of a 3
level nested data structure is also definitely a smell.

Switch to using immutable data structures for it. Since *usually*
though we want to make mutable updates to it that affect other
contexts, we store pointers to it in a new RelOverlays object.

See the comments in the PR for more info. I also wrote a big new
comment about overlays in general, which we'll want to include even if
I don't merge this PR. I think I'm like 80% on merging this, but want
to try fixing a triggers bug on top of it first.