### PR TITLE
Optional --binary-endpoint-security under insecure_dev_mode

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1038,6 +1038,8 @@ def parse_args(**kwargs: Any):
             kwargs['security'] = 'strict'
 
     if kwargs['security'] == 'insecure_dev_mode':
+        if kwargs['binary_endpoint_security'] == 'default':
+            kwargs['binary_endpoint_security'] = 'optional'
         if kwargs['http_endpoint_security'] == 'default':
             kwargs['http_endpoint_security'] = 'optional'
         if not kwargs['default_auth_method']:


### PR DESCRIPTION
`--security=insecure_dev_mode` modifies the default
`--http-endpoint-security` to `optional`, we should probably do the same to `--binary-endpoint-security` to be consistent, so that `insecure_dev_mode` is the only option to set in order to allow cleartext under any protocols, while we still preserve the options to accept cleartext in a particular protocol (binary or http).