### PR TITLE
Add a hint to the error message about link targets.

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -36,11 +36,11 @@ from . import objects as so
 from . import pointers
 from . import referencing
 from . import sources
+from . import types as s_types
 from . import utils
 
 if TYPE_CHECKING:
     from . import objtypes as s_objtypes
-    from . import types as s_types
     from . import schema as s_schema
 
 
@@ -254,10 +254,19 @@ class LinkCommand(
 
         if not target.is_object_type():
             srcctx = self.get_attribute_source_context('target')
+            if isinstance(target, s_types.Array):
+                # Custom error message for link -> array<...>
+                link_dn = scls.get_displayname(schema)
+                el_dn = target.get_subtypes(schema)[0].get_displayname(schema)
+                hint = f"did you mean 'multi link {link_dn} -> {el_dn}'?"
+            else:
+                hint = None
+
             raise errors.InvalidLinkTargetError(
                 f'invalid link target type, expected object type, got '
                 f'{target.get_verbosename(schema)}',
                 context=srcctx,
+                hint=hint,
             )
 
         if target.is_free_object_type(schema):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2096,6 +2096,30 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             ''')
 
+    async def test_edgeql_ddl_link_target_bad_05(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidLinkTargetError,
+            r"invalid link target type, expected object type, got.+array",
+            _hint="did you mean 'multi link bar -> default::Foo'?",
+        ):
+            await self.con.execute('''
+                create type Foo {
+                    create link bar -> array<Foo>;
+                };
+            ''')
+
+    async def test_edgeql_ddl_link_target_bad_06(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidLinkTargetError,
+            r"invalid link target type, expected object type, got.+array",
+            _hint="did you mean 'multi link bar -> default::Foo'?",
+        ):
+            await self.con.execute('''
+                create type Foo {
+                    create multi link bar -> array<Foo>;
+                };
+            ''')
+
     async def test_edgeql_ddl_link_target_merge_01(self):
         await self.con.execute('''
 


### PR DESCRIPTION
If a link target is an array, it is likely that the intent was to create a multi link instead. The error hint now makes that suggestion.

Fixes #5131