### PR TITLE
pg-ext: Fix attribute error and simple query sync count

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -536,7 +536,17 @@ class Compiler:
         sql_units = []
         for stmt in stmts:
             # GOTCHA: a setting is frontend-only regardless of its mutability
-            fe_only = stmt.name in fe_settings_mutable
+            if isinstance(
+                stmt,
+                (
+                    pgast.VariableSetStmt,
+                    pgast.VariableResetStmt,
+                    pgast.VariableShowStmt,
+                ),
+            ):
+                fe_only = stmt.name in fe_settings_mutable
+            else:
+                fe_only = False
 
             if isinstance(stmt, pgast.VariableSetStmt):
                 args = {

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -535,20 +535,10 @@ class Compiler:
         stmts = pg_parser.parse(query_str)
         sql_units = []
         for stmt in stmts:
-            # GOTCHA: a setting is frontend-only regardless of its mutability
-            if isinstance(
-                stmt,
-                (
-                    pgast.VariableSetStmt,
-                    pgast.VariableResetStmt,
-                    pgast.VariableShowStmt,
-                ),
-            ):
-                fe_only = stmt.name in fe_settings_mutable
-            else:
-                fe_only = False
-
             if isinstance(stmt, pgast.VariableSetStmt):
+                # GOTCHA: setting is frontend-only regardless of its mutability
+                fe_only = stmt.name in fe_settings_mutable
+
                 args = {
                     "query": pg_codegen.generate_source(stmt),
                     "frontend_only": fe_only,
@@ -573,6 +563,7 @@ class Compiler:
                     args["set_vars"] = {stmt.name: value}
                 unit = dbstate.SQLQueryUnit(**args)
             elif isinstance(stmt, pgast.VariableResetStmt):
+                fe_only = stmt.name in fe_settings_mutable
                 if fe_only and not fe_settings_mutable[stmt.name]:
                     raise errors.QueryError(
                         f'parameter "{stmt.name}" cannot be changed',
@@ -591,7 +582,7 @@ class Compiler:
                 unit = dbstate.SQLQueryUnit(
                     query=source,
                     get_var=stmt.name,
-                    frontend_only=fe_only,
+                    frontend_only=stmt.name in fe_settings_mutable,
                 )
             elif isinstance(stmt, pgast.SetTransactionStmt):
                 args = {"query": pg_codegen.generate_source(stmt)}

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -103,7 +103,7 @@ cdef dict POSTGRES_SHUTDOWN_ERR_CODES = {
 }
 
 cdef bytes INIT_CON_SCRIPT = None
-cdef object EMPTY_SQL_STATE = json.dumps({}).encode('utf-8')
+cdef object EMPTY_SQL_STATE = b"{}"
 
 cdef object logger = logging.getLogger('edb.server')
 
@@ -1623,7 +1623,9 @@ cdef class PGConnection:
                 if mtype == b'3':  # CloseComplete
                     self.buffer.discard_message()
                 elif mtype == b'Z':  # ReadyForQuery
-                    self.buffer.redirect_messages(buf, mtype, 0)
+                    msg_buf = WriteBuffer.new_message(b'Z')
+                    msg_buf.write_byte(self.parse_sync_message())
+                    buf.write_buffer(msg_buf.end_message())
                     break
                 else:
                     # Other messages like ParameterStatus should be forwarded

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -782,3 +782,12 @@ class TestSQL(tb.SQLQueryTestCase):
     async def test_sql_query_version(self):
         version = await self.squery_values("select version()")
         self.assertIn("EdgeDB", version[0][0])
+
+    async def test_sql_transaction_01(self):
+        await self.scon.execute(
+            """
+            BEGIN;
+            SELECT * FROM "Genre" ORDER BY id;
+            COMMIT;
+            """,
+        )

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -791,3 +791,14 @@ class TestSQL(tb.SQLQueryTestCase):
             COMMIT;
             """,
         )
+
+    async def test_sql_transaction_02(self):
+        await self.scon.execute("BEGIN")
+        await self.scon.execute(
+            "SET TRANSACTION ISOLATION LEVEL read uncommitted"
+        )
+        v1 = await self.scon.fetchval("SHOW transaction_isolation")
+        self.assertEqual(v1, "read uncommitted")
+        await self.scon.execute("ROLLBACK")
+        v2 = await self.scon.fetchval("SHOW transaction_isolation")
+        self.assertNotEqual(v1, v2)


### PR DESCRIPTION
* Fix attribute error on SQL statements without a name (caused by #5115)
* Fix bug in simple query sync count (caused by #4957)
