### PR TITLE
Add `:version-lt:` option to code and synopsis blocks

### DIFF
--- a/edb/tools/docs/__init__.py
+++ b/edb/tools/docs/__init__.py
@@ -90,5 +90,6 @@ def setup(app):
 
     app.add_directive('versionadded', VersionAdded, True)
     app.add_directive('versionchanged', VersionChanged, True)
+    app.add_directive('code-block', shared.CodeBlock, True)
 
     app.add_transform(ProhibitedNodeTransform)

--- a/edb/tools/docs/cli.py
+++ b/edb/tools/docs/cli.py
@@ -26,7 +26,7 @@ from edb.tools.pygments.edgeql import EdgeQLLexer
 import pygments.lexers
 
 from sphinx import domains as s_domains
-from docutils.parsers.rst import directives as d_directives
+from docutils.parsers.rst import directives as d_directives  # type: ignore
 
 from . import shared
 

--- a/edb/tools/docs/cli.py
+++ b/edb/tools/docs/cli.py
@@ -26,17 +26,19 @@ from edb.tools.pygments.edgeql import EdgeQLLexer
 import pygments.lexers
 
 from sphinx import domains as s_domains
-from sphinx.directives import code as s_code
+from docutils.parsers.rst import directives as d_directives
 
 from . import shared
 
 
-class CLISynopsisDirective(s_code.CodeBlock):
+class CLISynopsisDirective(shared.CodeBlock):
 
     has_content = True
     optional_arguments = 0
     required_arguments = 0
-    option_spec: Dict[str, Any] = {}
+    option_spec: Dict[str, Any] = {
+        'version-lt': d_directives.unchanged_required
+    }
 
     def run(self):
         self.arguments = ['cli-synopsis']

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -218,6 +218,7 @@ from edb import protocol
 
 from docutils import nodes as d_nodes
 from docutils.parsers import rst as d_rst
+from docutils.parsers.rst import directives as d_directives
 from docutils import utils as d_utils
 
 from sphinx import addnodes as s_nodes
@@ -593,12 +594,14 @@ class EQLKeywordDirective(BaseEQLDirective):
             f'keyword::{name}', sig, signode)
 
 
-class EQLSynopsisDirective(s_code.CodeBlock):
+class EQLSynopsisDirective(shared.CodeBlock):
 
     has_content = True
     optional_arguments = 0
     required_arguments = 0
-    option_spec: Dict[str, Any] = {}
+    option_spec: Dict[str, Any] = {
+        'version-lt': d_directives.unchanged_required
+    }
 
     def run(self):
         self.arguments = ['edgeql-synopsis']

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -218,7 +218,7 @@ from edb import protocol
 
 from docutils import nodes as d_nodes
 from docutils.parsers import rst as d_rst
-from docutils.parsers.rst import directives as d_directives
+from docutils.parsers.rst import directives as d_directives  # type: ignore
 from docutils import utils as d_utils
 
 from sphinx import addnodes as s_nodes
@@ -226,7 +226,6 @@ from sphinx import directives as s_directives
 from sphinx import domains as s_domains
 from sphinx import roles as s_roles
 from sphinx import transforms as s_transforms
-from sphinx.directives import code as s_code
 from sphinx.util import docfields as s_docfields
 from sphinx.util import nodes as s_nodes_utils
 from sphinx.ext.intersphinx import InventoryAdapter

--- a/edb/tools/docs/sdl.py
+++ b/edb/tools/docs/sdl.py
@@ -24,17 +24,19 @@ from typing import *
 from edb.tools.pygments.edgeql import EdgeQLLexer
 
 from sphinx import domains as s_domains
-from sphinx.directives import code as s_code
+from docutils.parsers.rst import directives as d_directives
 
 from . import shared
 
 
-class SDLSynopsisDirective(s_code.CodeBlock):
+class SDLSynopsisDirective(shared.CodeBlock):
 
     has_content = True
     optional_arguments = 0
     required_arguments = 0
-    option_spec: Dict[str, Any] = {}
+    option_spec: Dict[str, Any] = {
+        'version-lt': d_directives.unchanged_required
+    }
 
     def run(self):
         self.arguments = ['sdl-synopsis']

--- a/edb/tools/docs/sdl.py
+++ b/edb/tools/docs/sdl.py
@@ -24,7 +24,7 @@ from typing import *
 from edb.tools.pygments.edgeql import EdgeQLLexer
 
 from sphinx import domains as s_domains
-from docutils.parsers.rst import directives as d_directives
+from docutils.parsers.rst import directives as d_directives  # type: ignore
 
 from . import shared
 

--- a/edb/tools/docs/shared.py
+++ b/edb/tools/docs/shared.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from docutils import nodes as d_nodes
 from docutils import utils as d_utils
 from docutils.parsers.rst import roles as d_roles
+from docutils.parsers.rst import directives as d_directives
+from sphinx.directives import code as s_code
 
 from sphinx import errors as s_errors
 
@@ -49,3 +51,22 @@ class InlineCodeRole:
         node = d_nodes.literal(rawtext, d_utils.unescape(text), **options)
         node['eql-lang'] = self.lang
         return [node], []
+
+
+class CodeBlock(s_code.CodeBlock):
+
+    option_spec = s_code.CodeBlock.option_spec.copy()
+    option_spec.update({
+        'version-lt': d_directives.unchanged_required
+    })
+
+    def run(self):
+        literal = super().run()
+        if 'version-lt' in self.options:
+            if len(self.options) > 1:
+                raise EdgeSphinxExtensionError(
+                    'other options not allowed if :version-lt: option is '
+                    'provided, put other options on latest version code block'
+                )
+            literal[0]['version_lt'] = self.options['version-lt']
+        return literal

--- a/edb/tools/docs/shared.py
+++ b/edb/tools/docs/shared.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from docutils import nodes as d_nodes
 from docutils import utils as d_utils
 from docutils.parsers.rst import roles as d_roles
-from docutils.parsers.rst import directives as d_directives
+from docutils.parsers.rst import directives as d_directives  # type: ignore
 from sphinx.directives import code as s_code
 
 from sphinx import errors as s_errors


### PR DESCRIPTION
Related website PR: https://github.com/edgedb/edgedb.com/pull/580

Example:
```
.. code-block:: sdl
  :version-lt: 3.0
  
  type User {
    property name -> str;
  }

.. code-block:: sdl
  
  type User {
    name: str;
  }
```

Notes:
 - A group of code blocks with the `:version-lt:` option must end with a un-versioned code block.
 - All the blocks in the group must have the same language.
 - Any other code block options must be on the final code block.