### PR TITLE
Replace `twoway` with `memchr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,11 +215,11 @@ version = "0.1.0"
 dependencies = [
  "base32",
  "combine 4.6.6",
+ "memchr",
  "serde",
  "sha2",
  "snafu",
  "thiserror",
- "twoway",
  "unicode-width",
  "wasm-bindgen",
 ]
@@ -527,26 +527,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "twoway"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
-dependencies = [
- "memchr",
- "unchecked-index",
-]
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "unchecked-index"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicode-ident"

--- a/edb/edgeql-parser/Cargo.toml
+++ b/edb/edgeql-parser/Cargo.toml
@@ -11,7 +11,7 @@ base32 = "0.4.0"
 sha2 = "0.10.2"
 snafu = "0.7.0"
 combine = "4.5.2"
-twoway = "0.2.1"
+memchr = "2.5.0"
 wasm-bindgen = { version="0.2", features=["serde-serialize"], optional=true }
 serde = { version="1.0.106", features=["derive"], optional=true }
 thiserror = "1.0.23"

--- a/edb/edgeql-parser/src/preparser.rs
+++ b/edb/edgeql-parser/src/preparser.rs
@@ -1,4 +1,4 @@
-use twoway::find_bytes;
+use memchr::memmem::find;
 
 #[derive(Debug, PartialEq)]
 pub struct Continuation {
@@ -96,9 +96,8 @@ pub fn full_statement(data: &[u8], continuation: Option<Continuation>)
             b'$' => {
                 match iter.next() {
                     Some((end_idx, b'$')) => {
-                        if let Some(end) = find_bytes(&data[end_idx+1..],
-                                                      b"$$")
-                        {
+                        let end = find(&data[end_idx+1..], b"$$");
+                        if let Some(end) = end {
                             iter.nth(end + end_idx - idx);
                             continue 'outer;
                         }
@@ -131,8 +130,8 @@ pub fn full_statement(data: &[u8], continuation: Option<Continuation>)
                         b'$' => {
                             let end_idx = c_idx + 1;
                             let marker_size = end_idx - idx;
-                            if let Some(end) = find_bytes(&data[end_idx..],
-                                                          &data[idx..end_idx])
+                            if let Some(end) = find(&data[end_idx..],
+                                                    &data[idx..end_idx])
                             {
                                 iter.nth(1 + end + marker_size - 1);
                                 continue 'outer;

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 use std::borrow::Cow;
 
-use combine::{StreamOnce, Positioned};
+use combine::easy::{Error, Errors};
 use combine::error::{StreamError};
 use combine::stream::{ResetStream};
-use combine::easy::{Error, Errors};
-use twoway::find_str;
+use combine::{StreamOnce, Positioned};
+use memchr::memmem::find;
 
 use crate::position::Pos;
 
@@ -414,9 +414,9 @@ impl<'a> TokenStream<'a> {
                 if let Some((_, c)) = iter.next() {
                     match c {
                         '$' => {
-                            if let Some(end) = find_str(
-                                &self.buf[self.off+2..], "$$")
-                            {
+                            let suffix = &self.buf[self.off+2..];
+                            let end = find(suffix.as_bytes(), b"$$");
+                            if let Some(end) = end {
                                 for c in self.buf[self.off+2..][..end].chars() {
                                     check_prohibited(c, false)?;
                                 }
@@ -495,9 +495,9 @@ impl<'a> TokenStream<'a> {
                                 return Err(Error::unexpected_static_message(
                                     "dollar quote supports only ascii chars"));
                             }
-                            if let Some(end) = find_str(
-                                &self.buf[self.off+msize..],
-                                &marker)
+                            if let Some(end) = find(
+                                self.buf[self.off+msize..].as_bytes(),
+                                marker.as_bytes())
                             {
                                 let data = &self.buf[self.off+msize..][..end];
                                 for c in data.chars() {


### PR DESCRIPTION
The former is unmaintained so `cargo audit` shows a warning