### PR TITLE
Document UUID to object cast

### DIFF
--- a/docs/reference/edgeql/casts.csv
+++ b/docs/reference/edgeql/casts.csv
@@ -1,18 +1,19 @@
-from \\ to,:eql:type:`json <std::json>`,:eql:type:`str <std::str>`,:eql:type:`float32 <std::float32>`,:eql:type:`float64 <std::float64>`,:eql:type:`int16 <std::int16>`,:eql:type:`int32 <std::int32>`,:eql:type:`int64 <std::int64>`,:eql:type:`bigint <std::bigint>`,:eql:type:`decimal <std::decimal>`,:eql:type:`bool <std::bool>`,:eql:type:`bytes <std::bytes>`,:eql:type:`uuid <std::uuid>`,:eql:type:`datetime <std::datetime>`,:eql:type:`duration <std::duration>`,:eql:type:`local_date <cal::local_date>`,:eql:type:`local_datetime <cal::local_datetime>`,:eql:type:`local_time <cal::local_time>`
-:eql:type:`json <std::json>`,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``
-:eql:type:`str <std::str>`,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``
-:eql:type:`float32 <std::float32>`,``<>``,``<>``,,impl,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,
-:eql:type:`float64 <std::float64>`,``<>``,``<>``,``:=``,,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,
-:eql:type:`int16 <std::int16>`,``<>``,``<>``,impl,impl,,impl,impl,impl,impl,,,,,,,,
-:eql:type:`int32 <std::int32>`,``<>``,``<>``,,impl,``<>``,,impl,impl,impl,,,,,,,,
-:eql:type:`int64 <std::int64>`,``<>``,``<>``,``:=``,impl,``:=``,``:=``,,impl,impl,,,,,,,,
-:eql:type:`bigint <std::bigint>`,,,,,,,,,impl,,,,,,,,
-:eql:type:`decimal <std::decimal>`,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,,
-:eql:type:`bool <std::bool>`,``<>``,``<>``,,,,,,,,,,,,,,,
-:eql:type:`bytes <std::bytes>`,,,,,,,,,,,,,,,,,
-:eql:type:`uuid <std::uuid>`,``<>``,``<>``,,,,,,,,,,,,,,,
-:eql:type:`datetime <std::datetime>`,``<>``,``<>``,,,,,,,,,,,,,,,
-:eql:type:`duration <std::duration>`,``<>``,``<>``,,,,,,,,,,,,,,,
-:eql:type:`local_date <cal::local_date>`,``<>``,``<>``,,,,,,,,,,,,,,``<>``,
-:eql:type:`local_datetime <cal::local_datetime>`,``<>``,``<>``,,,,,,,,,,,,,``<>``,,``<>``
+from \\ to,:eql:type:`json <std::json>`,:eql:type:`str <std::str>`,:eql:type:`float32 <std::float32>`,:eql:type:`float64 <std::float64>`,:eql:type:`int16 <std::int16>`,:eql:type:`int32 <std::int32>`,:eql:type:`int64 <std::int64>`,:eql:type:`bigint <std::bigint>`,:eql:type:`decimal <std::decimal>`,:eql:type:`bool <std::bool>`,:eql:type:`bytes <std::bytes>`,:eql:type:`uuid <std::uuid>`,:eql:type:`datetime <std::datetime>`,:eql:type:`duration <std::duration>`,:eql:type:`local_date <cal::local_date>`,:eql:type:`local_datetime <cal::local_datetime>`,:eql:type:`local_time <cal::local_time>`,object
+:eql:type:`json <std::json>`,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,
+:eql:type:`str <std::str>`,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,
+:eql:type:`float32 <std::float32>`,``<>``,``<>``,,impl,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,,
+:eql:type:`float64 <std::float64>`,``<>``,``<>``,``:=``,,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,,
+:eql:type:`int16 <std::int16>`,``<>``,``<>``,impl,impl,,impl,impl,impl,impl,,,,,,,,,
+:eql:type:`int32 <std::int32>`,``<>``,``<>``,,impl,``<>``,,impl,impl,impl,,,,,,,,,
+:eql:type:`int64 <std::int64>`,``<>``,``<>``,``:=``,impl,``:=``,``:=``,,impl,impl,,,,,,,,,
+:eql:type:`bigint <std::bigint>`,,,,,,,,,impl,,,,,,,,,
+:eql:type:`decimal <std::decimal>`,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,,,
+:eql:type:`bool <std::bool>`,``<>``,``<>``,,,,,,,,,,,,,,,,
+:eql:type:`bytes <std::bytes>`,,,,,,,,,,,,,,,,,,
+:eql:type:`uuid <std::uuid>`,``<>``,``<>``,,,,,,,,,,,,,,,,``<>``
+:eql:type:`datetime <std::datetime>`,``<>``,``<>``,,,,,,,,,,,,,,,,
+:eql:type:`duration <std::duration>`,``<>``,``<>``,,,,,,,,,,,,,,,,
+:eql:type:`local_date <cal::local_date>`,``<>``,``<>``,,,,,,,,,,,,,,``<>``,,
+:eql:type:`local_datetime <cal::local_datetime>`,``<>``,``<>``,,,,,,,,,,,,,``<>``,,``<>``,
 :eql:type:`local_time <cal::local_time>`,``<>``,``<>``,,,,,,,,,,,,,,,
+object,,,,,,,,,,,,,,,,,,

--- a/docs/reference/edgeql/casts.rst
+++ b/docs/reference/edgeql/casts.rst
@@ -30,6 +30,8 @@ For example, the following expression casts an integer value into a string:
 See the :eql:op:`type cast operator <cast>` section for more
 information on type casting rules.
 
+.. lint-off
+
 .. versionadded:: 3.0
 
     You can cast a UUID into an object:
@@ -42,15 +44,12 @@ information on type casting rules.
     If you try to cast a UUID that no object of the type has as its ``id``
     property, you'll get an error:
 
-    .. lint-off
-
     .. code-block:: edgeql-repl
 
         db> select <Hero><uuid>'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
         edgedb error: CardinalityViolationError: 'default::Hero' with id 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' does not exist
 
-    .. lint-on
-
+.. lint-on
 
 
 Assignment Casts

--- a/docs/reference/edgeql/casts.rst
+++ b/docs/reference/edgeql/casts.rst
@@ -30,6 +30,27 @@ For example, the following expression casts an integer value into a string:
 See the :eql:op:`type cast operator <cast>` section for more
 information on type casting rules.
 
+.. versionadded:: 3.0
+
+    You can cast a UUID into an object:
+
+    .. code-block:: edgeql-repl
+
+        db> select <Hero><uuid>'01d9cc22-b776-11ed-8bef-73f84c7e91e7';
+        {default::Hero {id: 01d9cc22-b776-11ed-8bef-73f84c7e91e7}}
+
+    If you try to cast a UUID that doesn't exist on the object, you'll get an
+    error:
+
+    .. lint-off
+
+    .. code-block:: edgeql-repl
+
+        db> select <Hero><uuid>'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        edgedb error: CardinalityViolationError: 'default::Hero' with id 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' does not exist
+
+    .. lint-on
+
 
 
 Assignment Casts
@@ -117,6 +138,10 @@ If *implicit* casting is supported for a given pair of types,
 
 Casting Table
 -------------
+
+.. note::
+
+    The UUID-to-object cast is only available in EdgeDB 3.0+.
 
 .. csv-table::
     :file: casts.csv

--- a/docs/reference/edgeql/casts.rst
+++ b/docs/reference/edgeql/casts.rst
@@ -39,8 +39,8 @@ information on type casting rules.
         db> select <Hero><uuid>'01d9cc22-b776-11ed-8bef-73f84c7e91e7';
         {default::Hero {id: 01d9cc22-b776-11ed-8bef-73f84c7e91e7}}
 
-    If you try to cast a UUID that doesn't exist on the object, you'll get an
-    error:
+    If you try to cast a UUID that no object of the type has as its ``id``
+    property, you'll get an error:
 
     .. lint-off
 

--- a/docs/stdlib/uuid.rst
+++ b/docs/stdlib/uuid.rst
@@ -34,6 +34,16 @@ UUIDs
     Every :eql:type:`Object` has a globally unique property ``id``
     represented by a UUID value.
 
+    .. versionadded:: 3.0
+
+        A UUID can be cast to an object type if an object of that type with a
+        matching ID exists.
+
+        .. code-block:: edgeql-repl
+
+            db> select <Hero><uuid>'01d9cc22-b776-11ed-8bef-73f84c7e91e7';
+            {default::Hero {id: 01d9cc22-b776-11ed-8bef-73f84c7e91e7}}
+
 
 ---------
 


### PR DESCRIPTION
~~Depends on https://github.com/edgedb/edgedb.com/pull/580 to allow for version blocks inside description blocks. Without that, the entire UUID type gets marked as "New in 3.0" instead of just the cast to object.~~

Content is ready for review, ~~but this cannot be merged until the PR mentioned above is merged~~.

Update: PR dependency has been merged.