### PR TITLE
Document tuple parameters

### DIFF
--- a/docs/edgeql/parameters.rst
+++ b/docs/edgeql/parameters.rst
@@ -94,7 +94,7 @@ language-native types.
 Parameter types and JSON
 ------------------------
 
-In EdgeDB 2.0, parameters can be only :ref:`scalars
+Prior to EdgeDB 3.0, parameters can be only :ref:`scalars
 <ref_datamodel_scalar_types>` or arrays of scalars. In EdgeDB 3.0, parameters
 can also be tuples. This may seem limiting at first, but in actuality this
 doesn't impose any practical limitation on what can be parameterized. To pass


### PR DESCRIPTION
I'm not entirely sure about this documentation I have written. We've pitched JSON as an alternative since the types of parameters are limited. Does having tuple parameters fix that? I know there are still times when JSON might be preferable, but I wonder if I need to frame this differently. Should I save the mention of tuple params for after the discussion of the JSON alternative and say that in 3.0 users may not need JSON as much since tuples are an option? Should I relegate the JSON section to <3.0?

Open to suggestions here, but this at least tells users what we have now in 3.0 and shows some examples.