### PR TITLE
Infer cardinality of `required multi` pointers as AT_LEAST_ONE

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -640,10 +640,7 @@ def _infer_set_inner(
             else:
                 rptrref_card = rptrref.dir_cardinality(rptr.direction)
 
-            if rptrref_card.is_single():
-                card = cartesian_cardinality((source_card, rptrref_card))
-            else:
-                card = MANY
+            card = cartesian_cardinality((source_card, rptrref_card))
 
     elif isinstance(ir, irast.EmptySet):
         card = AT_MOST_ONE

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -55,6 +55,9 @@ type Card extending Named {
     multi link owners := .<deck[IS User];
     # computable property
     property elemental_cost := <str>.cost ++ ' ' ++ .element;
+
+    required multi link req_awards -> Award;
+    required multi property req_tags -> str;
 }
 
 type SpecialCard extending Card;

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1063,3 +1063,45 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         MANY
         """
+
+    def test_edgeql_ir_card_inference_123(self):
+        """
+        select Card { req_awards }
+% OK %
+        req_awards: AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_124(self):
+        """
+        select Card { x := .req_awards }
+% OK %
+        x: AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_125(self):
+        """
+        select Card { required x := .req_awards }
+% OK %
+        x: AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_126(self):
+        """
+        select Card { req_tags }
+% OK %
+        req_tags: AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_127(self):
+        """
+        select Card { x := .req_tags }
+% OK %
+        x: AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_128(self):
+        """
+        select Card { required x := .req_tags }
+% OK %
+        x: AT_LEAST_ONE
+        """

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -575,6 +575,8 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
                 name := x.1,
                 element := 'test',
                 cost := 0,
+                req_awards := {}, # wtvr
+                req_tags := {}, # wtvr
             }
         )
 % OK %


### PR DESCRIPTION
Currently we only actually compute the cardinality when accessing
single pointers, and explicitly choose MANY for multi pointers.

I'm not totally sure why it was like this. I think maybe the skeleton
of this logic predated `required multi`? I don't know.

This bug was originally filed last year and was spuriously attributed
to a query builder bug and moved to edgedb/edgedb-js#333, and a query
builder workaround (insert assert_exists calls) was inserted. It was
identified as being a compiler bug, though---but the issue was never
moved back to the edgedb repo and then the workaround got merged
and the issue was closed.