### PR TITLE
Temporarily(?) exclude sys/cfg views from std::BaseObject

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_03_06_00_00
+EDGEDB_CATALOG_VERSION = 2023_03_14_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -20,14 +20,14 @@
 # These definitions are picked up if the EdgeDB instance is bootstrapped
 # with --testmode.
 
-CREATE TYPE cfg::TestSessionConfig {
+CREATE TYPE cfg::TestSessionConfig EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     }
 };
 
 
-CREATE ABSTRACT TYPE cfg::Base {
+CREATE ABSTRACT TYPE cfg::Base EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str
 };
 
@@ -42,7 +42,7 @@ CREATE TYPE cfg::Subclass2 EXTENDING cfg::Base {
 };
 
 
-CREATE TYPE cfg::TestInstanceConfig {
+CREATE TYPE cfg::TestInstanceConfig EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     };

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -20,14 +20,14 @@
 # These definitions are picked up if the EdgeDB instance is bootstrapped
 # with --testmode.
 
-CREATE TYPE cfg::TestSessionConfig EXTENDING std::BaseObject {
+CREATE TYPE cfg::TestSessionConfig EXTENDING cfg::ConfigObject {
     CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     }
 };
 
 
-CREATE ABSTRACT TYPE cfg::Base EXTENDING std::BaseObject {
+CREATE ABSTRACT TYPE cfg::Base EXTENDING cfg::ConfigObject {
     CREATE REQUIRED PROPERTY name -> std::str
 };
 
@@ -42,7 +42,7 @@ CREATE TYPE cfg::Subclass2 EXTENDING cfg::Base {
 };
 
 
-CREATE TYPE cfg::TestInstanceConfig EXTENDING std::BaseObject {
+CREATE TYPE cfg::TestInstanceConfig EXTENDING cfg::ConfigObject {
     CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     };

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3128,7 +3128,14 @@ class CompositeMetaCommand(MetaCommand):
 
         descendants = [
             child for child in obj.descendants(schema)
-            if has_table(child, schema) and child not in exclude_children
+            if has_table(child, schema)
+            and child not in exclude_children
+            # XXX: Exclude sys/cfg tables from non sys/cfg views. This
+            # probably isn't *really* what we want to do, but until we
+            # figure that out, do *something* so that DDL isn't
+            # excruciatingly slow because of the cost of explicit id
+            # checks. See #5168.
+            and (not is_cfg_view(child, schema) or is_cfg_view(obj, schema))
         ]
 
         # Hackily force 'source' to appear in abstract links. We need

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1533,6 +1533,12 @@ class TestIntrospection(tb.QueryTestCase):
         count1 = res[0].z
         self.assertFalse(all(row.z == count1 for row in res))
 
+    @test.xfail("""
+        We pulled sys and cfg back out of std::BaseObject because it
+        had catastrophic performance impacts.
+
+        See #5168.
+    """)
     async def test_edgeql_introspection_cfg_objects_01(self):
         await self.assert_query_result(
             r'''
@@ -1554,6 +1560,23 @@ class TestIntrospection(tb.QueryTestCase):
             r'''
                 SELECT count(cfg::ConfigObject)
                   = count(BaseObject[is cfg::ConfigObject])
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_introspection_cfg_objects_02(self):
+        await self.assert_query_result(
+            r'''
+                SELECT count(sys::Database)
+                  = count(sys::SystemObject[is sys::Database])
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT count(cfg::AbstractConfig)
+                  = count(cfg::ConfigObject[is cfg::AbstractConfig])
             ''',
             [True],
         )


### PR DESCRIPTION
Moving the sys/cfg views into std::BaseObject's inhview (in #5133)
caused catastrophic performance regressions on DDL because of DDL's
reliance on explicit id specification. See #5168.

There is plenty of discussion to be had about what we should do about
this (#5168), but first I want to merge this immediately because the
regression makes our development cycle pretty miserable.

We also move some test config objects under std::BaseObject from
std::Object. (Though of course, they won't show up there now.)

This obviously has to xfail the test that we added in #5133.  Add a
new test that tests some of the other cases that #5133 fixed that we
still support. (Making sure that the abstract parents in sys and cfg
work instead of producing ISEs when used.)