### PR TITLE
Forbid `on target delete deferred restrict` on required links.

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -130,9 +130,7 @@ CREATE ABSTRACT TYPE schema::CollectionType EXTENDING schema::PrimitiveType;
 
 
 CREATE TYPE schema::Array EXTENDING schema::CollectionType {
-    CREATE REQUIRED LINK element_type -> schema::Type {
-        ON TARGET DELETE DEFERRED RESTRICT;
-    };
+    CREATE REQUIRED LINK element_type -> schema::Type;
     CREATE PROPERTY dimensions -> array<std::int16>;
 };
 
@@ -141,9 +139,7 @@ CREATE TYPE schema::ArrayExprAlias EXTENDING schema::Array;
 
 
 CREATE TYPE schema::TupleElement EXTENDING std::BaseObject {
-    CREATE REQUIRED LINK type -> schema::Type {
-        ON TARGET DELETE DEFERRED RESTRICT;
-    };
+    CREATE REQUIRED LINK type -> schema::Type;
     CREATE PROPERTY name -> std::str;
 };
 
@@ -161,9 +157,7 @@ CREATE TYPE schema::TupleExprAlias EXTENDING schema::Tuple;
 
 
 CREATE TYPE schema::Range EXTENDING schema::CollectionType {
-    CREATE REQUIRED LINK element_type -> schema::Type {
-        ON TARGET DELETE DEFERRED RESTRICT;
-    };
+    CREATE REQUIRED LINK element_type -> schema::Type;
 };
 
 
@@ -201,9 +195,7 @@ EXTENDING schema::SubclassableObject {
 
 
 CREATE TYPE schema::Parameter EXTENDING schema::Object {
-    CREATE REQUIRED LINK type -> schema::Type {
-        ON TARGET DELETE DEFERRED RESTRICT;
-    };
+    CREATE REQUIRED LINK type -> schema::Type;
     CREATE REQUIRED PROPERTY typemod -> schema::TypeModifier;
     CREATE REQUIRED PROPERTY kind -> schema::ParameterKind;
     CREATE REQUIRED PROPERTY num -> std::int64;
@@ -218,9 +210,7 @@ CREATE ABSTRACT TYPE schema::CallableObject
         ON TARGET DELETE ALLOW;
     };
 
-    CREATE LINK return_type -> schema::Type {
-        ON TARGET DELETE DEFERRED RESTRICT;
-    };
+    CREATE LINK return_type -> schema::Type;
     CREATE PROPERTY return_typemod -> schema::TypeModifier;
 };
 
@@ -322,7 +312,10 @@ ALTER TYPE schema::Source {
 CREATE TYPE schema::Alias EXTENDING schema::AnnotationSubject
 {
     CREATE REQUIRED PROPERTY expr -> std::str;
-    CREATE REQUIRED LINK type -> schema::Type {
+    # This link is DEFINITELY not optional. This works around
+    # compiler weirdness that forces the DEFERRED RESTRICT
+    # behavior, which prohibits required-ness.
+    CREATE OPTIONAL LINK type -> schema::Type {
         ON TARGET DELETE DEFERRED RESTRICT;
     };
 };
@@ -473,9 +466,7 @@ CREATE TYPE schema::Property EXTENDING schema::Pointer;
 
 ALTER TYPE schema::Pointer {
     CREATE LINK source -> schema::Source;
-    CREATE LINK target -> schema::Type {
-        ON TARGET DELETE DEFERRED RESTRICT;
-    };
+    CREATE LINK target -> schema::Type;
     CREATE MULTI LINK rewrites
             EXTENDING schema::reference -> schema::Rewrite {
         CREATE CONSTRAINT std::exclusive;
@@ -501,7 +492,9 @@ ALTER TYPE schema::ObjectType {
 
 
 CREATE TYPE schema::Global EXTENDING schema::AnnotationSubject {
-    CREATE REQUIRED LINK target -> schema::Type {
+    # This is most definitely NOT optional. It works around some
+    # compiler weirdness which requires the on target delete deferred restrict
+    CREATE OPTIONAL LINK target -> schema::Type {
         ON TARGET DELETE DEFERRED RESTRICT;
     };
     CREATE PROPERTY required -> std::bool;

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -288,6 +288,17 @@ class LinkCommand(
                 context=srcctx,
             )
 
+        if (
+            scls.get_required(schema) and
+            scls.get_on_target_delete(schema) ==
+                qltypes.LinkTargetDeleteAction.DeferredRestrict
+        ):
+            raise errors.InvalidLinkTargetError(
+                'required links may not use `on target delete '
+                'deferred restrict`',
+                context=self.source_context,
+            )
+
     def _get_ast(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -698,9 +698,6 @@ class DeleteLink(
     astnode = [qlast.DropConcreteLink, qlast.DropLink]
     referenced_astnode = qlast.DropConcreteLink
 
-    # NB: target type cleanup (e.g. target compound type) is done by
-    #     the DeleteProperty handler for the @target property.
-
     def _delete_begin(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2097,6 +2097,22 @@ class DeletePointer(
     referencing.DeleteReferencedInheritingObject[Pointer_T],
     PointerCommand[Pointer_T],
 ):
+    def _delete_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._delete_begin(schema, context)
+        if (
+            not context.canonical
+            and (target := self.scls.get_target(schema)) is not None
+            and not self.scls.is_endpoint_pointer(schema)
+            and (del_cmd := target.as_type_delete_if_dead(schema)) is not None
+        ):
+            self.add_caused(del_cmd)
+
+        return schema
+
     def _canonicalize(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -456,22 +456,6 @@ class DeleteProperty(
 
     referenced_astnode = qlast.DropConcreteProperty
 
-    def _delete_begin(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-    ) -> s_schema.Schema:
-        schema = super()._delete_begin(schema, context)
-        if (
-            not context.canonical
-            and (target := self.scls.get_target(schema)) is not None
-            and not self.scls.is_link_source_property(schema)
-            and (del_cmd := target.as_type_delete_if_dead(schema)) is not None
-        ):
-            self.add_caused(del_cmd)
-
-        return schema
-
     def _get_ast(
         self,
         schema: s_schema.Schema,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2120,6 +2120,21 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             ''')
 
+    async def test_edgeql_ddl_link_target_bad_07(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidLinkTargetError,
+            r"required links may not use `on target delete deferred"
+            r" restrict`",
+        ):
+            await self.con.execute('''
+                create type A;
+                create type Foo {
+                    create required link bar -> A {
+                        on target delete deferred restrict;
+                    };
+                };
+            ''')
+
     async def test_edgeql_ddl_link_target_merge_01(self):
         await self.con.execute('''
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -327,6 +327,20 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
         """
 
+    @tb.must_fail(
+        errors.InvalidLinkTargetError,
+        "required links may not use `on target delete deferred restrict`",
+    )
+    def test_schema_bad_link_05(self):
+        """
+            type A;
+            type Foo {
+                required link foo -> A {
+                    on target delete deferred restrict;
+                }
+            };
+        """
+
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
                   "or a scalar collection, got object type 'test::Object'",


### PR DESCRIPTION
We want to forbid `on target delete deferred restrict` for required links: it
allows intermediate queries to observe the NULL, which breaks the schema's
invariants.

Actually doing that is trivial: just check and throw.

HOWEVER, we were using it a bunch of places in the standard library.

Clean up a bunch of them with the following steps:

- Defer if_unused subcommands for object deletions, to try to ensure that the
  generated schema types are deleted after the containing objects.
- Change @target deletetion handling, by moving it directly to DeletePointer,
  cleaning up some cruft between DeleteLink and DeleteProperty in the process.


STILL TODO:
 - Aliases are a mess. Just punt for aliases and globals, instead marking the
   links optional for now.

Fixes #4984.
