### PR TITLE
Minor EXPLAIN improvements

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1491,7 +1491,8 @@ def _compile_ql_query(
                 global_schema=ir.schema._global_schema,
                 base_schema=s_schema.FlatSchema(),
             )
-        query_asts = pickle.dumps((ql, ir, qtree))
+        config_vals = _get_compilation_config_vals(ctx)
+        query_asts = pickle.dumps((ql, ir, qtree, config_vals))
     else:
         query_asts = None
 
@@ -2498,6 +2499,14 @@ def _get_config_val(
         current_tx.get_system_config(),
         allow_unrecognized=True,
     )
+
+
+def _get_compilation_config_vals(ctx: CompileContext) -> Any:
+    return {
+        k: _get_config_val(ctx, k)
+        for k in ctx.compiler_state.config_spec
+        if ctx.compiler_state.config_spec[k].affects_compilation
+    }
 
 
 _OUTPUT_FORMAT_MAP = {

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -127,6 +127,10 @@ class TestEdgeQLExplain(tb.QueryTestCase):
             'relation_name': 'default::User',
             'contexts': [{'start': 28, 'end': 32, 'buffer_idx': 0}],
         })
+        self.assert_plan(res['config_vals'], {
+            "allow_user_specified_id": False,
+            "apply_access_policies": True
+        })
 
     async def test_edgeql_explain_with_bound_01(self):
         res = await self.explain('''


### PR DESCRIPTION
* Always compile the inner EXPLAIN query in binary mode
 * Expose key configuration settings and what globals are used in EXPLAIN