### PR TITLE
Respect enforce_access_policies := false inside functions

### DIFF
--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -100,6 +100,8 @@ class Index(tables.InheritableTableObject):
 
         kwargs = self.metadata.get('kwargs')
         if kwargs is not None:
+            # Escape the expression first
+            expr = expr.replace('{', '{{').replace('}', '}}')
             expr = re.sub(r'(__kw_(\w+?)__)', r'{\2}', expr)
             expr = expr.format(**kwargs)
 

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -65,6 +65,7 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
                       (global cur_user IN __subject__.watchers.name) ?? false
                   )
             };
+            create function count_Issue() -> int64 using (count(Issue));
 
             create type CurOnly extending Dictionary {
                 create access policy cur_only allow all
@@ -1019,4 +1020,21 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
         await self.assert_query_result(
             r'''select X''',
             [{}],
+        )
+
+    async def test_edgeql_policies_function_01(self):
+        await self.con.execute('''
+            set global filter_owned := true;
+        ''')
+        await self.assert_query_result(
+            r'''select (count(Issue), count_Issue())''',
+            [(0, 0)],
+        )
+
+        await self.con.execute('''
+            configure session set apply_access_policies := false;
+        ''')
+        await self.assert_query_result(
+            r'''select (count(Issue), count_Issue())''',
+            [(4, 4)],
         )


### PR DESCRIPTION
When access policies are disabled, add an extra field to the globals
function argument to indicate this, and look for it when evaluating
access policies inside functions.

Fixes #4461.