### PR TITLE
Fix simultaneous deletion of objects related by multi links

### DIFF
--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -214,7 +214,7 @@ def ptrcls_from_ptrref(  # NoQA: F811
 def ptr_to_ptrref(
     ptrcls: s_pointers.Pointer, *,
     ctx: context.ContextLevel,
-) -> irast.BasePointerRef:
+) -> irast.PointerRef:
     return irtyputils.ptrref_from_ptrcls(
         schema=ctx.env.schema,
         ptrcls=ptrcls,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1160,6 +1160,11 @@ class UpdateStmt(MutatingStmt, FilteredStmt):
 class DeleteStmt(MutatingStmt, FilteredStmt):
     _material_type: TypeRef | None = None
 
+    links_to_delete: typing.Dict[
+        uuid.UUID,
+        typing.Tuple[PointerRef, ...]
+    ] = ast.field(factory=dict)
+
     @property
     def material_type(self) -> TypeRef:
         assert self._material_type

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -209,8 +209,14 @@ def compile_DeleteStmt(
         assert range_cte is not None
         ctx.toplevel_stmt.append_cte(range_cte)
 
-        for delete_cte, _ in parts.dml_ctes.values():
-            ctx.toplevel_stmt.append_cte(delete_cte)
+        for typeref, (delete_cte, _) in parts.dml_ctes.items():
+            dml.process_delete_body(
+                ir_stmt=stmt,
+                delete_cte=delete_cte,
+                dml_parts=parts,
+                typeref=typeref,
+                ctx=ctx,
+            )
 
         # Wrap up.
         return dml.fini_dml_stmt(

--- a/tests/schemas/link_tgt_del.esdl
+++ b/tests/schemas/link_tgt_del.esdl
@@ -23,7 +23,9 @@ abstract type Named {
     }
 }
 
-type Target1 extending Named;
+type Target1 extending Named {
+     multi link extra_tgt -> Target1;
+};
 type Target1Child extending Target1;
 
 type Source1 extending Named {
@@ -82,6 +84,7 @@ type Source2 extending Named {
     link src1_del_source -> Source1 {
         on target delete delete source;
     }
+    multi link tgt_m2m -> Target1;
 }
 
 type Source3 extending Source1;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13821,10 +13821,7 @@ DDLStatement);
             INSERT Foo { tgt := (INSERT Tgt) };
         """)
 
-        async with self.assertRaisesRegexTx(
-            edgedb.ConstraintViolationError,
-            'prohibited by link target policy',
-        ):
+        async with self._run_and_rollback():
             await self.con.execute("""
                 WITH D := Foo,
                 SELECT {(DELETE D.tgt), (DELETE D)};


### PR DESCRIPTION
Currently we always use triggers to clean up link tables when
an object is deleted.
This causes trouble in cases where we simultaneously delete
a source and a target object: whether it works depends on
whether the source link table cleanup trigger or the
target link policy restrict trigger runs first.

Solve this by doing link table cleanup in the query itself in normal
(non "delete target") cases.

We still generate triggers to cleanup the link tables in cases where
an object might be deleted by another trigger. This lets us avoid
adding another level of nonlocal dependence to triggers.

In cases where an object has outbound multi pointers but no inbound
links, this change will eliminate a trigger and so might speed things
up a bunch. That's probably not super common though.

Fixes #4836.