### PR TITLE
Untangle the inheritance hierachies in the standard library

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_03_27_00_00
+EDGEDB_CATALOG_VERSION = 2023_03_29_00_00
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -19,10 +19,10 @@
 CREATE MODULE cal;
 
 CREATE SCALAR TYPE cal::local_datetime
-    EXTENDING std::anyscalar, std::anycontiguous;
+    EXTENDING std::anycontiguous;
 
 CREATE SCALAR TYPE cal::local_date
-    EXTENDING std::anyscalar, std::anydiscrete;
+    EXTENDING std::anydiscrete;
 
 CREATE SCALAR TYPE cal::local_time EXTENDING std::anyscalar;
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -277,7 +277,6 @@ CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
 CREATE ABSTRACT TYPE schema::Pointer
     EXTENDING
         schema::ConsistencySubject,
-        schema::InheritingObject,
         schema::AnnotationSubject
 {
     CREATE PROPERTY cardinality -> schema::Cardinality;
@@ -327,7 +326,6 @@ CREATE TYPE schema::ScalarType
     EXTENDING
         schema::PrimitiveType,
         schema::ConsistencySubject,
-        schema::InheritingObject,
         schema::AnnotationSubject
 {
     CREATE PROPERTY default -> std::str;

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -239,7 +239,8 @@ CREATE TYPE schema::Constraint
 };
 
 
-CREATE ABSTRACT TYPE schema::ConsistencySubject EXTENDING schema::Object {
+CREATE ABSTRACT TYPE schema::ConsistencySubject
+      EXTENDING schema::InheritingObject {
     CREATE MULTI LINK constraints EXTENDING schema::reference
     -> schema::Constraint {
         CREATE CONSTRAINT std::exclusive;
@@ -275,7 +276,8 @@ CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
 
 CREATE ABSTRACT TYPE schema::Pointer
     EXTENDING
-        schema::InheritingObject, schema::ConsistencySubject,
+        schema::ConsistencySubject,
+        schema::InheritingObject,
         schema::AnnotationSubject
 {
     CREATE PROPERTY cardinality -> schema::Cardinality;
@@ -323,8 +325,10 @@ CREATE TYPE schema::Alias EXTENDING schema::AnnotationSubject
 
 CREATE TYPE schema::ScalarType
     EXTENDING
-        schema::InheritingObject, schema::ConsistencySubject,
-        schema::AnnotationSubject, schema::PrimitiveType
+        schema::PrimitiveType,
+        schema::ConsistencySubject,
+        schema::InheritingObject,
+        schema::AnnotationSubject
 {
     CREATE PROPERTY default -> std::str;
     CREATE PROPERTY enum_values -> array<std::str>;
@@ -397,8 +401,11 @@ CREATE FUNCTION std::sequence_next(
 
 CREATE TYPE schema::ObjectType
     EXTENDING
-        schema::InheritingObject, schema::ConsistencySubject,
-        schema::AnnotationSubject, schema::Type, schema::Source;
+        schema::Source,
+        schema::ConsistencySubject,
+        schema::InheritingObject,
+        schema::Type,
+        schema::AnnotationSubject;
 
 
 ALTER TYPE std::BaseObject {

--- a/edb/lib/std/10-scalars.edgeql
+++ b/edb/lib/std/10-scalars.edgeql
@@ -39,9 +39,9 @@ CREATE SCALAR TYPE std::str EXTENDING std::anyscalar;
 
 CREATE SCALAR TYPE std::json EXTENDING std::anyscalar;
 
-CREATE SCALAR TYPE std::datetime EXTENDING std::anyscalar, std::anycontiguous;
+CREATE SCALAR TYPE std::datetime EXTENDING std::anycontiguous;
 
-CREATE SCALAR TYPE std::duration EXTENDING std::anyscalar, std::anycontiguous;
+CREATE SCALAR TYPE std::duration EXTENDING std::anycontiguous;
 
 CREATE ABSTRACT SCALAR TYPE std::anyreal EXTENDING std::anyscalar;
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -28,17 +28,23 @@ CREATE SCALAR TYPE sys::VersionStage
     EXTENDING enum<dev, alpha, beta, rc, final>;
 
 
-CREATE ABSTRACT TYPE sys::SystemObject EXTENDING schema::AnnotationSubject;
+CREATE ABSTRACT TYPE sys::SystemObject EXTENDING schema::Object;
+
+CREATE ABSTRACT TYPE sys::ExternalObject EXTENDING sys::SystemObject;
 
 
-CREATE TYPE sys::Database EXTENDING sys::SystemObject {
+CREATE TYPE sys::Database EXTENDING
+        sys::ExternalObject,
+        schema::AnnotationSubject {
     ALTER PROPERTY name {
         CREATE CONSTRAINT std::exclusive;
     };
 };
 
 
-CREATE TYPE sys::ExtensionPackage EXTENDING sys::SystemObject {
+CREATE TYPE sys::ExtensionPackage EXTENDING
+        sys::SystemObject,
+        schema::AnnotationSubject {
     CREATE REQUIRED PROPERTY script -> str;
     CREATE REQUIRED PROPERTY version -> tuple<
                                             major: std::int64,
@@ -57,7 +63,10 @@ ALTER TYPE schema::Extension {
 };
 
 
-CREATE TYPE sys::Role EXTENDING sys::SystemObject {
+CREATE TYPE sys::Role EXTENDING
+        sys::SystemObject,
+        schema::InheritingObject,
+        schema::AnnotationSubject {
     ALTER PROPERTY name {
         CREATE CONSTRAINT std::exclusive;
     };

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -353,6 +353,7 @@ def make_func_param(
 
 class Parameter(
     so.ObjectFragment,
+    so.Object,  # Help reflection figure out the right db MRO
     ParameterLike,
     qlkind=ft.SchemaObjectClass.PARAMETER,
     data_safe=True,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -117,6 +117,7 @@ def is_index_valid_for_type(
 
 class Index(
     referencing.ReferencedInheritingObject,
+    so.InheritingObject,  # Help reflection figure out the right db MRO
     s_anno.AnnotationSubject,
     qlkind=qltypes.SchemaObjectClass.INDEX,
     data_safe=True,

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -28,6 +28,7 @@ from edb.edgeql import qltypes
 
 from . import annos as s_anno
 from . import delta as sd
+from . import objects as so
 from . import schema as s_schema
 
 RESERVED_MODULE_NAMES = {
@@ -38,6 +39,7 @@ RESERVED_MODULE_NAMES = {
 
 class Module(
     s_anno.AnnotationSubject,
+    so.Object,  # Help reflection figure out the right db MRO
     qlkind=qltypes.SchemaObjectClass.MODULE,
     data_safe=False,
 ):

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -75,9 +75,13 @@ class ObjectTypeRefMixin(so.Object):
 
 
 class ObjectType(
-    s_types.InheritingType,
     sources.Source,
     constraints.ConsistencySubject,
+    s_types.InheritingType,
+
+    so.InheritingObject,  # Help reflection figure out the right db MRO
+    s_types.Type,  # Help reflection figure out the right db MRO
+    s_anno.AnnotationSubject,  # Help reflection figure out the right db MRO
     ObjectTypeRefMixin,
     s_abc.ObjectType,
     qlkind=qltypes.SchemaObjectClass.TYPE,

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
 class AccessPolicy(
     referencing.NamedReferencedInheritingObject,
+    so.InheritingObject,  # Help reflection figure out the right db MRO
     s_anno.AnnotationSubject,
     qlkind=qltypes.SchemaObjectClass.ACCESS_POLICY,
     data_safe=True,

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -46,7 +46,11 @@ class SourceCommand(indexes.IndexSourceCommand[Source_T]):
     pass
 
 
-class Source(so.QualifiedObject, indexes.IndexableSubject):
+class Source(
+    so.QualifiedObject,
+    indexes.IndexableSubject,
+    so.Object,  # Help reflection figure out the right db MRO
+):
     pointers_refs = so.RefDict(
         attr='pointers',
         requires_explicit_overloaded=True,

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 class Trigger(
     referencing.ReferencedInheritingObject,
-    s_anno.AnnotationSubject,
+    so.InheritingObject,  # Help reflection figure out the right db MRO
     qlkind=qltypes.SchemaObjectClass.TRIGGER,
     data_safe=True,
 ):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8874,11 +8874,11 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             # the links order is non-deterministic
             """
             CREATE TYPE schema::ObjectType
-            EXTENDING schema::InheritingObject,
+            EXTENDING schema::Source,
                       schema::ConsistencySubject,
-                      schema::AnnotationSubject,
+                      schema::InheritingObject,
                       schema::Type,
-                      schema::Source
+                      schema::AnnotationSubject
             {
                 CREATE MULTI LINK access_policies: schema::AccessPolicy {
                     EXTENDING schema::reference;
@@ -8908,12 +8908,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             'DESCRIBE TYPE schema::ObjectType AS SDL',
 
             """
-            type schema::ObjectType extending
-                    schema::InheritingObject,
-                    schema::ConsistencySubject,
-                    schema::AnnotationSubject,
-                    schema::Type,
-                    schema::Source
+            type schema::ObjectType
+            extending schema::Source,
+                      schema::ConsistencySubject,
+                      schema::InheritingObject,
+                      schema::Type,
+                      schema::AnnotationSubject
             {
                 multi link access_policies: schema::AccessPolicy {
                     extending schema::reference;


### PR DESCRIPTION
Currently there are a bunch of places where we have inheritance orders
that are not valid C3 orders, because the order bases are specified is
not consistent with the inheritance hierarchies of those bases.

For several, this is just because things are broken in the schema. For
many, it is because the code in reflection that computes how to update
the bases was incorrectly figuring out how to combine the python
orders and the edgeql orders. Typically I fixed those by making
the python mirror the schema better.

Work towards fixing #5118.