### PR TITLE
Fix 3-way unions of certain types with policies

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1095,15 +1095,17 @@ def _get_path_output(
     ref: pgast.BaseExpr
     alias = None
     rptr = path_id.rptr()
-    if rptr is not None and irtyputils.is_id_ptrref(rptr) and (
-        src_path_id := path_id.src_path()
-    ) and not (
-        (src_rptr := src_path_id.rptr())
-        and (
-            src_rptr.real_material_ptr.out_cardinality.is_multi()
+    if (
+        rptr is not None
+        and irtyputils.is_id_ptrref(rptr)
+        and (src_path_id := path_id.src_path())
+        and not (
+            (src_rptr := src_path_id.rptr())
+            and src_rptr.real_material_ptr.out_cardinality.is_multi()
             and not irtyputils.is_free_object(src_path_id.target)
         )
-    ) and not has_type_rewrite(src_path_id.target, env=env):
+        and not has_type_rewrite(src_path_id.target, env=env)
+    ):
         # A value reference to Object.id is the same as a value
         # reference to the Object itself. (Though we want to only
         # apply this in the cases that process_set_as_path does this

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1099,6 +1099,7 @@ def _get_path_output(
         rptr is not None
         and irtyputils.is_id_ptrref(rptr)
         and (src_path_id := path_id.src_path())
+        and not disable_output_fusion
         and not (
             (src_rptr := src_path_id.rptr())
             and src_rptr.real_material_ptr.out_cardinality.is_multi()

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2955,6 +2955,29 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_select_setops_29(self):
+        # These queries all produced compiler ISEs in the past
+        # The results aren't super important, so just run them
+        await self.con.query('''
+            select std::BaseObject
+                UNION schema::Object UNION schema::TupleElement;
+        ''')
+
+        await self.con.query('''
+            select std::BaseObject
+                EXCEPT schema::Object EXCEPT schema::TupleElement;
+        ''')
+
+        await self.con.query('''
+            select std::BaseObject
+                EXCEPT schema::Object INTERSECT schema::TupleElement;
+        ''')
+
+        await self.con.query('''
+            select std::BaseObject
+                INTERSECT schema::Object INTERSECT schema::TupleElement;
+        ''')
+
     async def test_edgeql_select_order_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
We were failing to respect the "disable_output_fusion" flag to
_get_path_output in one case, which sometimes led to unbalanced set 
operations.

Fixes #5174.

(The actual fix is a one-liner, and is in the second commit. I
reflowed the conditional it was part of in a separate commit.)