### PR TITLE
Add new SDL syntax

### DIFF
--- a/docs/datamodel/aliases.rst
+++ b/docs/datamodel/aliases.rst
@@ -39,14 +39,25 @@ Object type aliases can include a *shape* that declare additional computed
 properties or links.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Post {
-    required property title -> str;
-  }
+    type Post {
+      required property title -> str;
+    }
 
-  alias PostAlias := Post {
-    trimmed_title := str_trim(.title)
-  }
+    alias PostAlias := Post {
+      trimmed_title := str_trim(.title)
+    }
+
+.. code-block:: sdl
+
+    type Post {
+      required title: str;
+    }
+
+    alias PostAlias := Post {
+      trimmed_title := str_trim(.title)
+    }
 
 In effect, this creates a *virtual subtype* of the base type, which can be
 referenced in queries just like any other type.
@@ -57,16 +68,29 @@ Aliases can correspond to an arbitrary EdgeQL expression, including entire
 queries.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    required property title -> str;
-    required property is_published -> bool;
-  }
+    type BlogPost {
+      required property title -> str;
+      required property is_published -> bool;
+    }
 
-  alias PublishedPosts := (
-    select BlogPost
-    filter .is_published = true
-  );
+    alias PublishedPosts := (
+      select BlogPost
+      filter .is_published = true
+    );
+
+.. code-block:: sdl
+
+    type BlogPost {
+      required title: str;
+      required is_published: bool;
+    }
+
+    alias PublishedPosts := (
+      select BlogPost
+      filter .is_published = true
+    );
 
 .. note::
 

--- a/docs/datamodel/annotations.rst
+++ b/docs/datamodel/annotations.rst
@@ -22,12 +22,24 @@ The following are the annotations which can be set on any schema item:
 For example, consider the following declaration:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Status {
         annotation title := 'Activity status';
         annotation description := 'All possible user activities';
 
         required property name -> str {
+            constraint exclusive
+        }
+    }
+
+.. code-block:: sdl
+
+    type Status {
+        annotation title := 'Activity status';
+        annotation description := 'All possible user activities';
+
+        required name: str {
             constraint exclusive
         }
     }

--- a/docs/datamodel/comparison.rst
+++ b/docs/datamodel/comparison.rst
@@ -37,15 +37,27 @@ In EdgeDB, connections between tables are represented with :ref:`Links
 <ref_datamodel_links>`.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
-    required link director -> Person;
-  }
+    type Movie {
+      required property title -> str;
+      required link director -> Person;
+    }
 
-  type Person {
-    required property name -> str;
-  }
+    type Person {
+      required property name -> str;
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      required director: Person;
+    }
+
+    type Person {
+      required name: str;
+    }
 
 This approach makes it simple to write queries that traverse this link, no
 JOINs required.

--- a/docs/datamodel/computeds.rst
+++ b/docs/datamodel/computeds.rst
@@ -16,11 +16,19 @@ and links are not persisted in the database. Instead, they are evaluated *on
 the fly* whenever that field is queried.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property name -> str;
-    property all_caps_name := str_upper(__subject__.name);
-  }
+    type Person {
+      property name -> str;
+      property all_caps_name := str_upper(__subject__.name);
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      name: str;
+      property all_caps_name := str_upper(__subject__.name);
+    }
 
 Computed fields are associated with an EdgeQL expression. This expression
 can be an *arbitrary* EdgeQL query. This expression is evaluated whenever the
@@ -55,12 +63,21 @@ an object type declaration, you can omit it entirely and use the ``.<name>``
 shorthand.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property first_name -> str;
-    property last_name -> str;
-    property full_name := .first_name ++ ' ' ++ .last_name;
-  }
+    type Person {
+      property first_name -> str;
+      property last_name -> str;
+      property full_name := .first_name ++ ' ' ++ .last_name;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      first_name: str;
+      last_name: str;
+      property full_name := .first_name ++ ' ' ++ .last_name;
+    }
 
 Type and cardinality inference
 ------------------------------
@@ -73,13 +90,23 @@ EdgeQL expression disagrees with the modifiers, an error will be thrown the
 next time you try to :ref:`create a migration <ref_intro_migrations>`.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property first_name -> str;
+    type Person {
+      property first_name -> str;
 
-    # this is invalid, because first_name is not a required property
-    required property first_name_upper := str_upper(.first_name);
-  }
+      # this is invalid, because first_name is not a required property
+      required property first_name_upper := str_upper(.first_name);
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      first_name: str;
+
+      # this is invalid, because first_name is not a required property
+      required property first_name_upper := str_upper(.first_name);
+    }
 
 Common use cases
 ----------------
@@ -91,18 +118,33 @@ If you find yourself writing the same ``filter`` expression repeatedly in
 queries, consider defining a computed field that encapsulates the filter.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Club {
-    multi link members -> Person;
-    multi link active_members := (
-      select .members filter .is_active = true
-    )
-  }
+    type Club {
+      multi link members -> Person;
+      multi link active_members := (
+        select .members filter .is_active = true
+      )
+    }
 
-  type Person {
-    property name -> str;
-    property is_active -> bool;
-  }
+    type Person {
+      property name -> str;
+      property is_active -> bool;
+    }
+
+.. code-block:: sdl
+
+    type Club {
+      multi members: Person;
+      multi link active_members := (
+        select .members filter .is_active = true
+      )
+    }
+
+    type Person {
+      name: str;
+      is_active: bool;
+    }
 
 .. _ref_datamodel_links_backlinks:
 
@@ -114,16 +156,29 @@ links are *directional*; they have a source and a target. Often it's convenient
 to traverse a link in the *reverse* direction.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    property title -> str;
-    link author -> User;
-  }
+    type BlogPost {
+      property title -> str;
+      link author -> User;
+    }
 
-  type User {
-    property name -> str;
-    multi link blog_posts := .<author[is BlogPost]
-  }
+    type User {
+      property name -> str;
+      multi link blog_posts := .<author[is BlogPost]
+    }
+
+.. code-block:: sdl
+
+    type BlogPost {
+      title: str;
+      author: User;
+    }
+
+    type User {
+      name: str;
+      multi link blog_posts := .<author[is BlogPost]
+    }
 
 The ``User.blog_posts`` expression above uses the *backlink operator* ``.<`` in
 conjunction with a *type filter* ``[is BlogPost]`` to fetch all the
@@ -137,15 +192,27 @@ Using a computed property, you can timestamp when an object was created in your
 database.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    property title -> str;
-    link author -> User;
-    required property created_at -> datetime {
-      readonly := true;
-      default := datetime_of_statement();
+    type BlogPost {
+      property title -> str;
+      link author -> User;
+      required property created_at -> datetime {
+        readonly := true;
+        default := datetime_of_statement();
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type BlogPost {
+      title: str;
+      author: User;
+      required created_at: datetime {
+        readonly := true;
+        default := datetime_of_statement();
+      }
+    }
 
 When a ``BlogPost`` is created, :eql:func:`datetime_of_statement` will be
 called to supply it with a timestamp as the ``created_at`` property. You might

--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -17,12 +17,21 @@ valid. They can be defined on :ref:`properties <ref_datamodel_props>`,
 Below is a simple property constraint.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property username -> str {
-      constraint exclusive;
+    type User {
+      required property username -> str {
+        constraint exclusive;
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type User {
+      required username: str {
+        constraint exclusive;
+      }
+    }
 
 .. _ref_datamodel_constraints_builtin:
 
@@ -41,16 +50,29 @@ The constraint below uses the built-in :eql:func:`len` function, which returns
 the length of a string.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property username -> str {
-      # usernames must be unique
-      constraint exclusive;
+    type User {
+      required property username -> str {
+        # usernames must be unique
+        constraint exclusive;
 
-      # max length (built-in)
-      constraint max_len_value(25);
-    };
-  }
+        # max length (built-in)
+        constraint max_len_value(25);
+      };
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required username: str {
+        # usernames must be unique
+        constraint exclusive;
+
+        # max length (built-in)
+        constraint max_len_value(25);
+      };
+    }
 
 Custom constraints
 ^^^^^^^^^^^^^^^^^^
@@ -60,13 +82,23 @@ custom constraints, the keyword ``__subject__`` can used to reference the
 *value* being constrained.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property username -> str {
-      # max length (as custom constraint)
-      constraint expression on (len(__subject__) <= 25);
-    };
-  }
+    type User {
+      required property username -> str {
+        # max length (as custom constraint)
+        constraint expression on (len(__subject__) <= 25);
+      };
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required username: str {
+        # max length (as custom constraint)
+        constraint expression on (len(__subject__) <= 25);
+      };
+    }
 
 .. _ref_datamodel_constraints_objects:
 
@@ -83,30 +115,54 @@ constraint logic must reference multiple links or properties.
   (e.g. ``.<name>``).
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type ConstrainedVector {
-    required property x -> float64;
-    required property y -> float64;
+    type ConstrainedVector {
+      required property x -> float64;
+      required property y -> float64;
 
-    constraint expression on (
-      .x ^ 2 + .y ^ 2 <= 25
-    );
-  }
+      constraint expression on (
+        .x ^ 2 + .y ^ 2 <= 25
+      );
+    }
+
+.. code-block:: sdl
+
+    type ConstrainedVector {
+      required x: float64;
+      required y: float64;
+
+      constraint expression on (
+        .x ^ 2 + .y ^ 2 <= 25
+      );
+    }
 
 Note that the constraint expression cannot contain arbitrary EdgeQL! Due to
 how constraints are implemented, you can only reference ``single`` (non-multi)
 properties and links defined on the object type.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  # Not valid!
-  type User {
-    required property username -> str;
-    multi link friends -> User;
+    # Not valid!
+    type User {
+      required property username -> str;
+      multi link friends -> User;
 
-    # ❌ constraints cannot contain paths with more than one hop
-    constraint expression on ('bob' in .friends.username);
-  }
+      # ❌ constraints cannot contain paths with more than one hop
+      constraint expression on ('bob' in .friends.username);
+    }
+
+.. code-block:: sdl
+
+    # Not valid!
+    type User {
+      required username: str;
+      multi friends: User;
+
+      # ❌ constraints cannot contain paths with more than one hop
+      constraint expression on ('bob' in .friends.username);
+    }
 
 Computed constraints
 ^^^^^^^^^^^^^^^^^^^^
@@ -114,13 +170,23 @@ Computed constraints
 Constraints can be defined on computed properties.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property username -> str;
-    required property clean_username := str_trim(str_lower(.username));
+    type User {
+      required property username -> str;
+      required property clean_username := str_trim(str_lower(.username));
 
-    constraint exclusive on (.clean_username);
-  }
+      constraint exclusive on (.clean_username);
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required username: str;
+      required property clean_username := str_trim(str_lower(.username));
+
+      constraint exclusive on (.clean_username);
+    }
 
 
 Composite constraints
@@ -130,35 +196,62 @@ To define a composite constraint, create an ``exclusive`` constraint on a
 tuple of properties or links.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    property username -> str;
-  }
+    type User {
+      property username -> str;
+    }
 
-  type BlogPost {
-    property title -> str;
-    link author -> User;
+    type BlogPost {
+      property title -> str;
+      link author -> User;
 
-    constraint exclusive on ((.title, .author));
-  }
+      constraint exclusive on ((.title, .author));
+    }
+
+.. code-block:: sdl
+
+    type User {
+      username: str;
+    }
+
+    type BlogPost {
+      title: str;
+      author: User;
+
+      constraint exclusive on ((.title, .author));
+    }
 
 .. _ref_datamodel_constraints_partial:
 
-Partial constraints #New
-^^^^^^^^^^^^^^^^^^^^^^^^
+Partial constraints
+^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.0
 
 Constraints on object types can be made partial, so that they don't apply
 when some condition holds.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property username -> str;
-    property deleted -> bool;
+    type User {
+      required property username -> str;
+      property deleted -> bool;
 
-    # Not deleted usernames must be unique
-    constraint exclusive on (.username) except (.deleted);
-  }
+      # Usernames must be unique unless marked deleted
+      constraint exclusive on (.username) except (.deleted);
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required username: str;
+      deleted: bool;
+
+      # Usernames must be unique unless marked deleted
+      constraint exclusive on (.username) except (.deleted);
+    }
 
 
 .. _ref_datamodel_constraints_links:
@@ -171,16 +264,29 @@ itself*. This is commonly used add constraints to :ref:`link properties
 <ref_datamodel_link_properties>`.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    property name -> str;
-    multi link friends -> User {
-      single property strength -> float64;
-      constraint expression on (
-        __subject__@strength >= 0
-      );
+    type User {
+      property name -> str;
+      multi link friends -> User {
+        single property strength -> float64;
+        constraint expression on (
+          __subject__@strength >= 0
+        );
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type User {
+      name: str;
+      multi friends: User {
+        single strength: float64;
+        constraint expression on (
+          __subject__@strength >= 0
+        );
+      }
+    }
 
 
 .. _ref_datamodel_constraints_scalars:

--- a/docs/datamodel/globals.rst
+++ b/docs/datamodel/globals.rst
@@ -9,8 +9,13 @@ Globals
 Schemas can contain scalar-typed *global variables*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  global current_user_id -> uuid;
+    global current_user_id -> uuid;
+
+.. code-block:: sdl
+
+    global current_user_id: uuid;
 
 These provide a useful mechanism for specifying session-level data that can be
 referenced in queries with the ``global`` keyword.
@@ -110,10 +115,17 @@ Global variables can be marked ``required``; in this case, you must specify a
 default value.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  required global one_string -> str {
-    default := "Hi Mom!"
-  };
+    required global one_string -> str {
+      default := "Hi Mom!"
+    };
+
+.. code-block:: sdl
+
+    required global one_string: str {
+      default := "Hi Mom!"
+    };
 
 Computed globals
 ----------------
@@ -133,16 +145,29 @@ Computed globals are not subject to the same constraints as non-computed ones;
 specifically, they can be object-typed and have a ``multi`` cardinality.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  global current_user_id -> uuid;
+    global current_user_id -> uuid;
 
-  # object-typed global
-  global current_user := (
-    select User filter .id = global current_user_id
-  );
+    # object-typed global
+    global current_user := (
+      select User filter .id = global current_user_id
+    );
 
-  # multi global
-  global current_user_friends := (global current_user).friends;
+    # multi global
+    global current_user_friends := (global current_user).friends;
+
+.. code-block:: sdl
+
+    global current_user_id: uuid;
+
+    # object-typed global
+    global current_user := (
+      select User filter .id = global current_user_id
+    );
+
+    # multi global
+    global current_user_friends := (global current_user).friends;
 
 
 Usage in schema
@@ -175,21 +200,38 @@ Unlike query parameters, globals can be referenced
 *inside your schema declarations*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    property name -> str;
-    property is_self := (.id = global current_user_id)
-  };
+    type User {
+      property name -> str;
+      property is_self := (.id = global current_user_id)
+    };
+
+
+.. code-block:: sdl
+
+    type User {
+      name: str;
+      property is_self := (.id = global current_user_id)
+    };
 
 This is particularly useful when declaring :ref:`access policies
 <ref_datamodel_access_policies>`.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    required property name -> str;
-    access policy my_policy allow all using (.id = global current_user_id);
-  }
+    type Person {
+      required property name -> str;
+      access policy my_policy allow all using (.id = global current_user_id);
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      required name: str;
+      access policy my_policy allow all using (.id = global current_user_id);
+    }
 
 Refer to :ref:`Access Policies <ref_datamodel_access_policies>` for complete
 documentation.

--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -34,26 +34,39 @@ Language).
 SDL
 ---
 
-Your schema is defined inside ``.esdl`` files. Its common to define your
-entire schema in a single file called ``default.esdl``, but you can split it
-across multiple files if you wish.
+Your schema is defined inside ``.esdl`` files. Its common to define your entire
+schema in a single file called ``default.esdl``, but you can split it across
+multiple files if you wish.
 
-By convention, your schema
-files should live in a directory called ``dbschema`` in the root of your
-project.
+By convention, your schema files should live in a directory called ``dbschema``
+in the root of your project.
+
+.. code-block:: sdl
+    :version-lt: 3.0
+
+    # dbschema/default.esdl
+
+    type Movie {
+      required property title -> str;
+      required link director -> Person;
+    }
+
+    type Person {
+      required property name -> str;
+    }
 
 .. code-block:: sdl
 
-  # dbschema/default.esdl
+    # dbschema/default.esdl
 
-  type Movie {
-    required property title -> str;
-    required link director -> Person;
-  }
+    type Movie {
+      required title: str;
+      required director: Person;
+    }
 
-  type Person {
-    required property name -> str;
-  }
+    type Person {
+      required name: str;
+    }
 
 .. important::
 

--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -23,11 +23,19 @@ Below, we are referencing the ``User.name`` property with the :ref:`dot
 notation shorthand <ref_dot_notation>`: ``.name``.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property name -> str;
-    index on (.name);
-  }
+    type User {
+      required property name -> str;
+      index on (.name);
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required name: str;
+      index on (.name);
+    }
 
 By indexing on ``User.name``, queries that filter by the ``name`` property will
 be faster, as the database can lookup a name in the index instead of scanning
@@ -45,12 +53,21 @@ references multiple properties of the enclosing object type.
   one* element. As such, you can't index on a ``multi`` property.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property first_name -> str;
-    required property last_name -> str;
-    index on (str_lower(.firstname + ' ' + .lastname));
-  }
+    type User {
+      required property first_name -> str;
+      required property last_name -> str;
+      index on (str_lower(.firstname + ' ' + .lastname));
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required first_name: str;
+      required last_name: str;
+      index on (str_lower(.firstname + ' ' + .lastname));
+    }
 
 Index on multiple properties
 ----------------------------
@@ -60,12 +77,21 @@ speed up queries that filter or sort on *both properties*. In EdgeDB, this is
 accomplished by indexing on a ``tuple`` of properties.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property name -> str;
-    required property email -> str;
-    index on ((.name, .email));
-  }
+    type User {
+      required property name -> str;
+      required property email -> str;
+      index on ((.name, .email));
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required name: str;
+      required email: str;
+      index on ((.name, .email));
+    }
 
 Index on a link property
 ------------------------
@@ -73,15 +99,29 @@ Index on a link property
 Link properties can also be indexed.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract link friendship {
-    property strength -> float64;
-    index on (__subject__@strength);
-  }
+    abstract link friendship {
+      property strength -> float64;
+      index on (__subject__@strength);
+    }
 
-  type User {
-    multi link friends extending friendship -> User;
-  }
+    type User {
+      multi link friends extending friendship -> User;
+    }
+
+.. code-block:: sdl
+
+    abstract link friendship {
+      strength: float64;
+      index on (__subject__@strength);
+    }
+
+    type User {
+      multi friends: User {
+        extending friendship;
+      };
+    }
 
 Annotate an index
 -----------------
@@ -89,13 +129,23 @@ Annotate an index
 Indexes can be augmented with annotations.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    property name -> str;
-    index on (.name) {
-      annotation description := 'Indexing all users by name.';
-    };
-  }
+    type User {
+      property name -> str;
+      index on (.name) {
+        annotation description := 'Indexing all users by name.';
+      };
+    }
+
+.. code-block:: sdl
+
+    type User {
+      name: str;
+      index on (.name) {
+        annotation description := 'Indexing all users by name.';
+      };
+    }
 
 .. important::
 

--- a/docs/datamodel/inheritance.rst
+++ b/docs/datamodel/inheritance.rst
@@ -27,14 +27,26 @@ Object types can *extend* other object types. The extending type (AKA the
 *supertypes*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Animal {
-    property species -> str;
-  }
+    abstract type Animal {
+      property species -> str;
+    }
 
-  type Dog extending Animal {
-    property breed -> str;
-  }
+    type Dog extending Animal {
+      property breed -> str;
+    }
+
+.. code-block:: sdl
+
+    abstract type Animal {
+      species: str;
+    }
+
+    type Dog extending Animal {
+      breed: str;
+    }
+
 
 For details on querying polymorphic data, see :ref:`EdgeQL > Select >
 Polymorphic queries <ref_eql_select_polymorphic>`.
@@ -50,19 +62,35 @@ than one type <ref_eql_sdl_object_types_inheritance>` — that's called
 types out of combinations of more basic types.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type HasName {
-    property first_name -> str;
-    property last_name -> str;
-  }
+    abstract type HasName {
+      property first_name -> str;
+      property last_name -> str;
+    }
 
-  abstract type HasEmail {
-    property email -> str;
-  }
+    abstract type HasEmail {
+      property email -> str;
+    }
 
-  type Person extending HasName, HasEmail {
-    property profession -> str;
-  }
+    type Person extending HasName, HasEmail {
+      property profession -> str;
+    }
+
+.. code-block:: sdl
+
+    abstract type HasName {
+      first_name: str;
+      last_name: str;
+    }
+
+    abstract type HasEmail {
+      email: str;
+    }
+
+    type Person extending HasName, HasEmail {
+      profession: str;
+    }
 
 
 .. _ref_datamodel_overloading:
@@ -75,18 +103,34 @@ declarations must be prefixed with the ``overloaded`` prefix to avoid
 unintentional overloads.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Person {
-    property name -> str;
-    multi link friends -> Person;
-  }
-
-  type Student extending Person {
-    overloaded property name -> str {
-      constraint exclusive;
+    abstract type Person {
+      property name -> str;
+      multi link friends -> Person;
     }
-    overloaded multi link friends -> Student;
-  }
+
+    type Student extending Person {
+      overloaded property name -> str {
+        constraint exclusive;
+      }
+      overloaded multi link friends -> Student;
+    }
+
+.. code-block:: sdl
+
+    abstract type Person {
+      name: str;
+      multi friends: Person;
+    }
+
+    type Student extending Person {
+      overloaded name: str {
+        constraint exclusive;
+      }
+      overloaded multi friends: Student;
+    }
+
 
 Overloaded fields cannot *generalize* the associated type; it can only make it
 *more specific* by setting the type to a subtype of the original or adding
@@ -118,16 +162,29 @@ It's possible to define ``abstract`` links that aren't tied to a particular
 annotations, property declarations, constraints, and indexes.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract link link_with_strength {
-    property strength -> float64;
-    index on (__subject__@strength);
-  }
+    abstract link link_with_strength {
+      property strength -> float64;
+      index on (__subject__@strength);
+    }
 
-  type Person {
-    multi link friends extending link_with_strength -> Person;
-  }
+    type Person {
+      multi link friends extending link_with_strength -> Person;
+    }
 
+.. code-block:: sdl
+
+    abstract link link_with_strength {
+      strength: float64;
+      index on (__subject__@strength);
+    }
+
+    type Person {
+      multi friends: Person {
+        extending link_with_strength;
+      };
+    }
 
 .. _ref_datamodel_inheritance_constraints:
 
@@ -138,19 +195,33 @@ Constraints
 Use ``abstract`` to declare reusable, user-defined constraint types.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract constraint in_range(min: anyreal, max: anyreal) {
-    errmessage :=
-      'Value must be in range [{min}, {max}].';
-    using (max > __subject__ and __subject__ >= min);
-  }
-
-  type Player {
-    property points -> int64 {
-      constraint in_range(0, 100);
+    abstract constraint in_range(min: anyreal, max: anyreal) {
+      errmessage :=
+        'Value must be in range [{min}, {max}].';
+      using (max > __subject__ and __subject__ >= min);
     }
-  }
 
+    type Player {
+      property points -> int64 {
+        constraint in_range(0, 100);
+      }
+    }
+
+.. code-block:: sdl
+
+    abstract constraint in_range(min: anyreal, max: anyreal) {
+      errmessage :=
+        'Value must be in range [{min}, {max}].';
+      using (max > __subject__ and __subject__ >= min);
+    }
+
+    type Player {
+      points: int64 {
+        constraint in_range(0, 100);
+      }
+    }
 
 .. _ref_datamodel_inheritance_annotations:
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -13,10 +13,17 @@ Defining links
 --------------
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    link best_friend -> Person;
-  }
+    type Person {
+      link best_friend -> Person;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      best_friend: Person;
+    }
 
 Links are *directional*; they have a source (the object type on which they are
 declared) and a *target* (the type they point to).
@@ -29,10 +36,17 @@ All links have a cardinality: either ``single`` or ``multi``. The default is
 link.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    multi link friends -> Person;
-  }
+    type Person {
+      multi link friends -> Person;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      multi friends: Person;
+    }
 
 Required links
 --------------
@@ -43,23 +57,41 @@ point to *at least one* target instance. In this scenario, every ``Person``
 must have a ``best_friend``:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    required link best_friend -> Person;
-  }
+    type Person {
+      required link best_friend -> Person;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      required best_friend: Person;
+    }
 
 Links with cardinality ``multi`` can also be ``required``;
 ``required multi`` links must point to *at least one* target object.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property name -> str;
-  }
+    type Person {
+      property name -> str;
+    }
 
-  type GroupChat {
-    required multi link members -> Person;
-  }
+    type GroupChat {
+      required multi link members -> Person;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      name: str;
+    }
+
+    type GroupChat {
+      required multi members: Person;
+    }
 
 In this scenario, each ``GroupChat`` must contain at least one person.
 Attempting to create a ``GroupChat`` with no members would fail.
@@ -71,16 +103,29 @@ You can add an ``exclusive`` constraint to a link to guarantee that no other
 instances can link to the same target(s).
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property name -> str;
-  }
-
-  type GroupChat {
-    required multi link members -> Person {
-      constraint exclusive;
+    type Person {
+      property name -> str;
     }
-  }
+
+    type GroupChat {
+      required multi link members -> Person {
+        constraint exclusive;
+      }
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      name: str;
+    }
+
+    type GroupChat {
+      required multi members: Person {
+        constraint exclusive;
+      }
+    }
 
 In the ``GroupChat`` example, the ``GroupChat.members`` link is now
 ``exclusive``. Two ``GroupChat`` objects cannot link to the same ``Person``;
@@ -123,15 +168,27 @@ membership, or hierarchies. For example, ``Person`` and ``Shirt``. One person
 may own many shirts, and a shirt is (usually) owned by just one person.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    required property name -> str
-  }
+    type Person {
+      required property name -> str
+    }
 
-  type Shirt {
-    required property color -> str;
-    link owner -> Person;
-  }
+    type Shirt {
+      required property color -> str;
+      link owner -> Person;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      required name: str
+    }
+
+    type Shirt {
+      required color: str;
+      owner: Person;
+    }
 
 Since links are ``single`` by default, each ``Shirt`` only corresponds to
 one ``Person``. In the absence of any exclusivity constraints, multiple shirts
@@ -150,21 +207,36 @@ One-to-many
 
 Conceptually, one-to-many and many-to-one relationships are identical; the
 "directionality" of a relation is just a matter of perspective. Here, the
-same "shirt owner" relationship is represented with a ``multi link``.
+same "shirt owner" relationship is represented with a ``multi`` link.
+
+.. code-block:: sdl
+    :version-lt: 3.0
+
+    type Person {
+      required property name -> str;
+      multi link shirts -> Shirt {
+        # ensures a one-to-many relationship
+        constraint exclusive;
+      }
+    }
+
+    type Shirt {
+      required property color -> str;
+    }
 
 .. code-block:: sdl
 
-  type Person {
-    required property name -> str;
-    multi link shirts -> Shirt {
-      # ensures a one-to-many relationship
-      constraint exclusive;
+    type Person {
+      required name: str;
+      multi shirts: Shirt {
+        # ensures a one-to-many relationship
+        constraint exclusive;
+      }
     }
-  }
 
-  type Shirt {
-    required property color -> str;
-  }
+    type Shirt {
+      required color: str;
+    }
 
 .. note::
 
@@ -172,11 +244,11 @@ same "shirt owner" relationship is represented with a ``multi link``.
   ``Shirt`` corresponds to a single ``Person``. Without it, the relationship
   will be many-to-many.
 
-Under the hood, a ``multi link`` is stored in an intermediate `association
-table <https://en.wikipedia.org/wiki/Associative_entity>`_, whereas a ``single
-link`` is stored as a column in the object type where it is declared. As a
-result, single links are marginally more efficient. Generally ``single`` links
-are recommended when modeling 1:N relations.
+Under the hood, a ``multi`` link is stored in an intermediate `association
+table <https://en.wikipedia.org/wiki/Associative_entity>`_, whereas a
+``single`` link is stored as a column in the object type where it is declared.
+As a result, single links are marginally more efficient. Generally ``single``
+links are recommended when modeling 1:N relations.
 
 .. _ref_guide_one_to_one:
 
@@ -188,17 +260,31 @@ of the target type, and vice versa. As an example consider a schema to
 represent assigned parking spaces.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Employee {
-    required property name -> str;
-    link assigned_space -> ParkingSpace {
-      constraint exclusive;
+    type Employee {
+      required property name -> str;
+      link assigned_space -> ParkingSpace {
+        constraint exclusive;
+      }
     }
-  }
 
-  type ParkingSpace {
-    required property number -> int64;
-  }
+    type ParkingSpace {
+      required property number -> int64;
+    }
+
+.. code-block:: sdl
+
+    type Employee {
+      required name: str;
+      assigned_space: ParkingSpace {
+        constraint exclusive;
+      }
+    }
+
+    type ParkingSpace {
+      required number: int64;
+    }
 
 All links are ``single`` unless otherwise specified, so no ``Employee`` can
 have more than one ``assigned_space``. Moreover, the
@@ -216,14 +302,25 @@ is no exclusivity or cardinality constraints in either direction. As an example
 consider a simple app where a ``User`` can "like" their favorite ``Movies``.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property name -> str;
-    multi link likes -> Movie;
-  }
-  type Movie {
-    required property title -> str;
-  }
+    type User {
+      required property name -> str;
+      multi link likes -> Movie;
+    }
+    type Movie {
+      required property title -> str;
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required name: str;
+      multi likes: Movie;
+    }
+    type Movie {
+      required title: str;
+    }
 
 A user can like multiple movies. And in the absence of an ``exclusive``
 constraint, each movie can be liked by multiple users. Thus this is a
@@ -238,14 +335,23 @@ expression, which will be executed upon insertion. In the example below, new
 people are automatically assigned three random friends.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    required property name -> str;
-    multi link friends -> Person {
-      default := (select Person order by random() limit 3);
+    type Person {
+      required property name -> str;
+      multi link friends -> Person {
+        default := (select Person order by random() limit 3);
+      }
     }
-  }
 
+.. code-block:: sdl
+
+    type Person {
+      required name: str;
+      multi friends: Person {
+        default := (select Person order by random() limit 3);
+      }
+    }
 
 .. _ref_datamodel_link_properties:
 
@@ -257,13 +363,23 @@ can be used to store metadata about links, such as *when* they were created or
 the *nature/strength* of the relationship.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property name -> str;
-    multi link family_members -> Person {
-      property relationship -> str;
+    type Person {
+      property name -> str;
+      multi link family_members -> Person {
+        property relationship -> str;
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type Person {
+      name: str;
+      multi family_members: Person {
+        relationship: str;
+      }
+    }
 
 Above, we model a family tree with a single ``Person`` type. The ``Person.
 family_members`` link is a many-to-many relation; each ``family_members`` link
@@ -309,17 +425,31 @@ Target deletion policies determine what action should be taken when the
 delete`` clause.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type MessageThread {
-    property title -> str;
-  }
-
-  type Message {
-    property content -> str;
-    link chat -> MessageThread {
-      on target delete delete source;
+    type MessageThread {
+      property title -> str;
     }
-  }
+
+    type Message {
+      property content -> str;
+      link chat -> MessageThread {
+        on target delete delete source;
+      }
+    }
+
+.. code-block:: sdl
+
+    type MessageThread {
+      title: str;
+    }
+
+    type Message {
+      content: str;
+      chat: MessageThread {
+        on target delete delete source;
+      }
+    }
 
 The ``Message.chat`` link in the example uses the ``delete source`` policy.
 There are 4 available target deletion policies.
@@ -353,17 +483,31 @@ Source deletion policies determine what action should be taken when the
 delete`` clause.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type MessageThread {
-    property title -> str;
-    multi link messages -> Message {
-      on source delete delete target;
+    type MessageThread {
+      property title -> str;
+      multi link messages -> Message {
+        on source delete delete target;
+      }
     }
-  }
 
-  type Message {
-    property content -> str;
-  }
+    type Message {
+      property content -> str;
+    }
+
+.. code-block:: sdl
+
+    type MessageThread {
+      title: str;
+      multi messages: Message {
+        on source delete delete target;
+      }
+    }
+
+    type Message {
+      content: str;
+    }
 
 Under this policy, deleting a ``MessageThread`` will *unconditionally* delete
 its ``messages`` as well.
@@ -373,14 +517,25 @@ objects via their ``message`` link, append ``if orphan`` to that link's
 deletion policy.
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
-    type MessageThread {
-      property title -> str;
-      multi link messages -> Message {
-  -     on source delete delete target;
-  +     on source delete delete target if orphan;
+      type MessageThread {
+        property title -> str;
+        multi link messages -> Message {
+    -     on source delete delete target;
+    +     on source delete delete target if orphan;
+        }
       }
-    }
+
+.. code-block:: sdl-diff
+
+      type MessageThread {
+        title: str;
+        multi messages: Message {
+    -     on source delete delete target;
+    +     on source delete delete target if orphan;
+        }
+      }
 
 .. note::
 
@@ -412,29 +567,52 @@ Links can have ``abstract`` targets, in which case the link is considered
 **polymorphic**. Consider the following schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Person {
-    property name -> str;
-  }
+    abstract type Person {
+      property name -> str;
+    }
 
-  type Hero extending Person {
-    # additional fields
-  }
+    type Hero extending Person {
+      # additional fields
+    }
 
-  type Villain extending Person {
-    # additional fields
-  }
+    type Villain extending Person {
+      # additional fields
+    }
+
+.. code-block:: sdl
+
+    abstract type Person {
+      name: str;
+    }
+
+    type Hero extending Person {
+      # additional fields
+    }
+
+    type Villain extending Person {
+      # additional fields
+    }
 
 The ``abstract`` type ``Person`` has two concrete subtypes: ``Hero`` and
 ``Villain``. Despite being abstract, ``Person`` can be used as a link target in
 concrete object types.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    property title -> str;
-    multi link characters -> Person;
-  }
+    type Movie {
+      property title -> str;
+      multi link characters -> Person;
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      title: str;
+      multi characters: Person;
+    }
 
 In practice, the ``Movie.characters`` link can point to a ``Hero``,
 ``Villain``, or any other non-abstract subtype of ``Person``. For details on
@@ -451,15 +629,29 @@ of properties, annotations, constraints, or indexes, abstract links can be used
 to eliminate repetitive SDL.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract link link_with_strength {
-    property strength -> float64;
-    index on (__subject__@strength);
-  }
+    abstract link link_with_strength {
+      property strength -> float64;
+      index on (__subject__@strength);
+    }
 
-  type Person {
-    multi link friends extending link_with_strength -> Person;
-  }
+    type Person {
+      multi link friends extending link_with_strength -> Person;
+    }
+
+.. code-block:: sdl
+
+    abstract link link_with_strength {
+      strength: float64;
+      index on (__subject__@strength);
+    }
+
+    type Person {
+      multi friends: Person {
+        extending link_with_strength;
+      };
+    }
 
 
 .. list-table::

--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -13,20 +13,35 @@ declared with the ``property`` keyword. For the full documentation on
 properties, see :ref:`Properties <ref_datamodel_props>`.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property email -> str;
-  }
-
-Links are used to define relationships between object types. They are declared
-with the ``link`` keyword. For the full documentation on links, see :ref:`Links
-<ref_datamodel_links>`.
+    type Person {
+      property email -> str;
+    }
 
 .. code-block:: sdl
 
-  type Person {
-    link best_friend -> Person;
-  }
+    type Person {
+      email: str;
+    }
+
+Links are used to define relationships between object types. Prior to EdgeDB
+3.0, they must be declared with the ``link`` keyword, but the keyword is not
+required in 3.0+ unless the link is computed (e.g., backlinks). For the full
+documentation on links, see :ref:`Links <ref_datamodel_links>`.
+
+.. code-block:: sdl
+    :version-lt: 3.0
+
+    type Person {
+      link best_friend -> Person;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      best_friend: Person;
+    }
 
 
 IDs
@@ -47,11 +62,19 @@ but they're a useful way to share functionality and structure among
 other object types.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type HasName {
-    property first_name -> str;
-    property last_name -> str;
-  }
+    abstract type HasName {
+      property first_name -> str;
+      property last_name -> str;
+    }
+
+.. code-block:: sdl
+
+    abstract type HasName {
+      first_name: str;
+      last_name: str;
+    }
 
 Abstract types are commonly used in tandem with inheritance.
 
@@ -65,14 +88,25 @@ Object types can *extend* other object types. The extending type (AKA the
 *supertypes*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Animal {
-    property species -> str;
-  }
+    abstract type Animal {
+      property species -> str;
+    }
 
-  type Dog extending Animal {
-    property breed -> str;
-  }
+    type Dog extending Animal {
+      property breed -> str;
+    }
+
+.. code-block:: sdl
+
+    abstract type Animal {
+      species: str;
+    }
+
+    type Dog extending Animal {
+      breed: str;
+    }
 
 .. _ref_datamodel_objects_multiple_inheritance:
 
@@ -85,19 +119,35 @@ than one type <ref_eql_sdl_object_types_inheritance>` — that's called
 types out of combinations of more basic types.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type HasName {
-    property first_name -> str;
-    property last_name -> str;
-  }
+    abstract type HasName {
+      property first_name -> str;
+      property last_name -> str;
+    }
 
-  abstract type HasEmail {
-    property email -> str;
-  }
+    abstract type HasEmail {
+      property email -> str;
+    }
 
-  type Person extending HasName, HasEmail {
-    property profession -> str;
-  }
+    type Person extending HasName, HasEmail {
+      property profession -> str;
+    }
+
+.. code-block:: sdl
+
+    abstract type HasName {
+      first_name: str;
+      last_name: str;
+    }
+
+    abstract type HasEmail {
+      email: str;
+    }
+
+    type Person extending HasName, HasEmail {
+      profession: str;
+    }
 
 If multiple supertypes share links or properties, those properties must be
 of the same type and cardinality.

--- a/docs/datamodel/primitives.rst
+++ b/docs/datamodel/primitives.rst
@@ -28,12 +28,21 @@ To represent an enum, declare a custom scalar that extends the abstract
 :ref:`enum <ref_std_enum>` type.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  scalar type Color extending enum<Red, Green, Blue>;
+    scalar type Color extending enum<Red, Green, Blue>;
 
-  type Shirt {
-    property color -> Color;
-  }
+    type Shirt {
+      property color -> Color;
+    }
+
+.. code-block:: sdl
+
+    scalar type Color extending enum<Red, Green, Blue>;
+
+    type Shirt {
+      color: Color;
+    }
 
 .. important::
 
@@ -52,17 +61,31 @@ Arrays store zero or more primitive values of the same type in an ordered list.
 Arrays cannot contain object types or other arrays.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    property str_array -> array<str>;
-    property json_array -> array<json>;
+    type Person {
+      property str_array -> array<str>;
+      property json_array -> array<json>;
 
-    # INVALID: arrays of object types not allowed
-    # property friends -> array<Person>
+      # INVALID: arrays of object types not allowed
+      # property friends -> array<Person>
 
-    # INVALID: arrays cannot be nested
-    # property nested_array -> array<array<str>>
-  }
+      # INVALID: arrays cannot be nested
+      # property nested_array -> array<array<str>>
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      str_array: array<str>;
+      json_array: array<json>;
+
+      # INVALID: arrays of object types not allowed
+      # property friends -> array<Person>
+
+      # INVALID: arrays cannot be nested
+      # property nested_array -> array<array<str>>
+    }
 
 For a full reference on array types, see the :ref:`Array docs <ref_std_array>`.
 
@@ -77,24 +100,42 @@ each element of a tuple can have a distinct type. Tuple elements can be *any
 type*, including primitives, objects, arrays, and other tuples.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
+    type Person {
 
-    property unnamed_tuple -> tuple<str, bool, int64>;
-    property nested_tuple -> tuple<tuple<str, tuple<bool, int64>>>;
-    property tuple_of_arrays -> tuple<array<str>, array<int64>>;
+      property unnamed_tuple -> tuple<str, bool, int64>;
+      property nested_tuple -> tuple<tuple<str, tuple<bool, int64>>>;
+      property tuple_of_arrays -> tuple<array<str>, array<int64>>;
 
-  }
+    }
+
+.. code-block:: sdl
+
+    type Person {
+
+      unnamed_tuple: tuple<str, bool, int64>;
+      nested_tuple: tuple<tuple<str, tuple<bool, int64>>>;
+      tuple_of_arrays: tuple<array<str>, array<int64>>;
+
+    }
 
 Optionally, you can assign a *key* to each element of the tuple. Tuples
 containing explicit keys are known as *named tuples*. You must assign keys to
 all elements (or none of them).
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    property metadata -> tuple<title: str, published: bool, upvotes: int64>;
-  }
+    type BlogPost {
+      property metadata -> tuple<title: str, published: bool, upvotes: int64>;
+    }
+
+.. code-block:: sdl
+
+    type BlogPost {
+      metadata: tuple<title: str, published: bool, upvotes: int64>;
+    }
 
 Named and unnamed tuples are the same data structure under the hood. You can
 add, remove, and change keys in a tuple type after it's been declared. For
@@ -128,10 +169,17 @@ some scalar types have corresponding range types:
 - ``range<cal::local_date>``
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type DieRoll {
-    property values -> range<int64>;
-  }
+    type DieRoll {
+      property values -> range<int64>;
+    }
+
+.. code-block:: sdl
+
+    type DieRoll {
+      values: range<int64>;
+    }
 
 For a full reference on ranges, functions and operators see the :ref:`Range
 docs <ref_std_range>`.
@@ -146,11 +194,19 @@ object is created. All properties that point to the same sequence type will
 share the counter.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  scalar type ticket_number extending sequence;
-  type Ticket {
-    property number -> ticket_number;
-  }
+    scalar type ticket_number extending sequence;
+    type Ticket {
+      property number -> ticket_number;
+    }
+
+.. code-block:: sdl
+
+    scalar type ticket_number extending sequence;
+    type Ticket {
+      number: ticket_number;
+    }
 
 For a full reference on sequences, see the :ref:`Sequence docs
 <ref_std_sequence>`.

--- a/docs/datamodel/properties.rst
+++ b/docs/datamodel/properties.rst
@@ -11,12 +11,21 @@ Properties are used to associate primitive data with an :ref:`object type
 
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Player {
-    property email -> str;
-    property points -> int64;
-    property is_online -> bool;
-  }
+    type Player {
+      property email -> str;
+      property points -> int64;
+      property is_online -> bool;
+    }
+
+.. code-block:: sdl
+
+    type Player {
+      email: str;
+      points: int64;
+      is_online: bool;
+    }
 
 Properties are associated with a *key* (e.g. ``first_name``) and a primitive
 type (e.g. ``str``). The term *primitive type* is an umbrella term that
@@ -31,10 +40,17 @@ Required properties
 Properties can be either ``optional`` (the default) or ``required``.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property email -> str;
-  }
+    type User {
+      required property email -> str;
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required email: str;
+    }
 
 Property cardinality
 --------------------
@@ -44,19 +60,35 @@ Properties have a **cardinality**, either ``single`` (the default) or
 strings.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
+    type User {
 
-    # single isn't necessary here
-    # properties are single by default
-    single property name -> str;
+      # single isn't necessary here
+      # properties are single by default
+      single property name -> str;
 
-    # an unordered set of strings
-    multi property nicknames -> str;
+      # an unordered set of strings
+      multi property nicknames -> str;
 
-    # an unordered set of string arrays
-    multi property set_of_arrays -> array<str>;
-  }
+      # an unordered set of string arrays
+      multi property set_of_arrays -> array<str>;
+    }
+
+.. code-block:: sdl
+
+    type User {
+
+      # single isn't necessary here
+      # properties are single by default
+      single name: str;
+
+      # an unordered set of strings
+      multi nicknames: str;
+
+      # an unordered set of string arrays
+      multi set_of_arrays: array<str>;
+    }
 
 **Comparison to arrays**
 
@@ -73,16 +105,29 @@ Properties can have a default value. This default can be a static value or an
 arbitrary EdgeQL expression, which will be evaluated upon insertion.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Player {
-    required property points -> int64 {
-      default := 0;
+    type Player {
+      required property points -> int64 {
+        default := 0;
+      }
+
+      required property latitude -> float64 {
+        default := (360 * random() - 180);
+      }
     }
 
-    required property latitude -> float64 {
-      default := (360 * random() - 180);
+.. code-block:: sdl
+
+    type Player {
+      required points: int64 {
+        default := 0;
+      }
+
+      required latitude: float64 {
+        default := (360 * random() - 180);
+      }
     }
-  }
 
 Readonly properties
 -------------------
@@ -92,13 +137,21 @@ Properties can be marked as ``readonly``. In the example below, the
 modified thereafter.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property external_id -> uuid {
-      readonly := true;
+    type User {
+      required property external_id -> uuid {
+        readonly := true;
+      }
     }
-  }
 
+.. code-block:: sdl
+
+    type User {
+      required external_id: uuid {
+        readonly := true;
+      }
+    }
 
 Constraints
 -----------
@@ -107,38 +160,70 @@ Properties can be augmented wth constraints. The example below showcases a
 subset of EdgeDB's built-in constraints.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    property title -> str {
-      constraint exclusive; # all post titles must be unique
-      constraint min_len_value(8);
-      constraint max_len_value(30);
-      constraint regexp(r'^[A-Za-z0-9 ]+$');
+    type BlogPost {
+      property title -> str {
+        constraint exclusive; # all post titles must be unique
+        constraint min_len_value(8);
+        constraint max_len_value(30);
+        constraint regexp(r'^[A-Za-z0-9 ]+$');
+      }
+
+      property status -> str {
+        constraint one_of('Draft', 'InReview', 'Published');
+      }
+
+      property upvotes -> int64 {
+        constraint min_value(0);
+        constraint max_value(9999);
+      }
     }
 
-    property status -> str {
-      constraint one_of('Draft', 'InReview', 'Published');
-    }
+.. code-block:: sdl
 
-    property upvotes -> int64 {
-      constraint min_value(0);
-      constraint max_value(9999);
+    type BlogPost {
+      title: str {
+        constraint exclusive; # all post titles must be unique
+        constraint min_len_value(8);
+        constraint max_len_value(30);
+        constraint regexp(r'^[A-Za-z0-9 ]+$');
+      }
+
+      status: str {
+        constraint one_of('Draft', 'InReview', 'Published');
+      }
+
+      upvotes: int64 {
+        constraint min_value(0);
+        constraint max_value(9999);
+      }
     }
-  }
 
 You can constrain properties with arbitrary :ref:`EdgeQL <ref_edgeql>`
 expressions returning ``bool``. To reference the value of the property, use the
 special scope keyword ``__subject__``.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    property title -> str {
-      constraint expression on (
-        __subject__ = str_trim(__subject__)
-      );
+    type BlogPost {
+      property title -> str {
+        constraint expression on (
+          __subject__ = str_trim(__subject__)
+        );
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type BlogPost {
+      title: str {
+        constraint expression on (
+          __subject__ = str_trim(__subject__)
+        );
+      }
+    }
 
 The constraint above guarantees that ``BlogPost.title`` doesn't contain any
 leading or trailing whitespace by checking that the raw string is equal to the
@@ -156,14 +241,25 @@ annotations are ``title``, ``description``, and ``deprecated``. You may also
 declare :ref:`custom annotation types <ref_datamodel_inheritance_annotations>`.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    property email -> str {
-      annotation title := 'Email address';
-      annotation description := "The user's email address.";
-      annotation deprecated := 'Use NewUser instead.';
+    type User {
+      property email -> str {
+        annotation title := 'Email address';
+        annotation description := "The user's email address.";
+        annotation deprecated := 'Use NewUser instead.';
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type User {
+      email: str {
+        annotation title := 'Email address';
+        annotation description := "The user's email address.";
+        annotation deprecated := 'Use NewUser instead.';
+      }
+    }
 
 
 Abstract properties
@@ -174,16 +270,31 @@ are declared independent of a source or target, can contain :ref:`annotations
 <ref_datamodel_annotations>`, and can be marked as ``readonly``.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract property email_prop {
-    annotation title := 'An email address';
-    readonly := true;
-  }
+    abstract property email_prop {
+      annotation title := 'An email address';
+      readonly := true;
+    }
 
-  type Student {
-    # inherits annotations and "readonly := true"
-    property email extending email_prop -> str;
-  }
+    type Student {
+      # inherits annotations and "readonly := true"
+      property email extending email_prop -> str;
+    }
+
+.. code-block:: sdl
+
+    abstract property email_prop {
+      annotation title := 'An email address';
+      readonly := true;
+    }
+
+    type Student {
+      # inherits annotations and "readonly := true"
+      email: str {
+        extending email_prop;
+      };
+    }
 
 
 Link properties

--- a/docs/edgeql/delete.rst
+++ b/docs/edgeql/delete.rst
@@ -57,15 +57,27 @@ To avoid this behavior, we could update the ``Movie.characters`` link to use
 the ``allow`` deletion policy.
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
-    type Movie {
-      required property title -> str { constraint exclusive };
-      required property release_year -> int64;
-  -   multi link characters -> Person;
-  +   multi link characters -> Person {
-  +     on target delete allow;
-  +   };
-    }
+      type Movie {
+        required property title -> str { constraint exclusive };
+        required property release_year -> int64;
+    -   multi link characters -> Person;
+    +   multi link characters -> Person {
+    +     on target delete allow;
+    +   };
+      }
+
+.. code-block:: sdl-diff
+
+      type Movie {
+        required title: str { constraint exclusive };
+        required release_year: int64;
+    -   multi characters: Person;
+    +   multi characters: Person {
+    +     on target delete allow;
+    +   };
+      }
 
 
 Cascading deletes

--- a/docs/edgeql/insert.rst
+++ b/docs/edgeql/insert.rst
@@ -7,27 +7,51 @@ The ``insert`` command is used to create instances of object types. The code
 samples on this page assume the following schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  module default {
-    abstract type Person {
-      required property name -> str { constraint exclusive };
+    module default {
+      abstract type Person {
+        required property name -> str { constraint exclusive };
+      }
+
+      type Hero extending Person {
+        property secret_identity -> str;
+        multi link villains := .<nemesis[is Villain];
+      }
+
+      type Villain extending Person {
+        link nemesis -> Hero;
+      }
+
+      type Movie {
+        required property title -> str { constraint exclusive };
+        required property release_year -> int64;
+        multi link characters -> Person;
+      }
     }
 
-    type Hero extending Person {
-      property secret_identity -> str;
-      multi link villains := .<nemesis[is Villain];
-    }
+.. code-block:: sdl
 
-    type Villain extending Person {
-      link nemesis -> Hero;
-    }
+    module default {
+      abstract type Person {
+        required name: str { constraint exclusive };
+      }
 
-    type Movie {
-      required property title -> str { constraint exclusive };
-      required property release_year -> int64;
-      multi link characters -> Person;
+      type Hero extending Person {
+        secret_identity: str;
+        multi link villains := .<nemesis[is Villain];
+      }
+
+      type Villain extending Person {
+        nemesis: Hero;
+      }
+
+      type Movie {
+        required title: str { constraint exclusive };
+        required release_year: int64;
+        multi characters: Person;
+      }
     }
-  }
 
 
 .. _ref_eql_insert_basic:

--- a/docs/edgeql/paths.rst
+++ b/docs/edgeql/paths.rst
@@ -12,16 +12,29 @@ source set of objects.
 Consider the following schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property email -> str;
-    multi link friends -> User;
-  }
+    type User {
+      required property email -> str;
+      multi link friends -> User;
+    }
 
-  type BlogPost {
-    required property title -> str;
-    required link author -> User;
-  }
+    type BlogPost {
+      required property title -> str;
+      required link author -> User;
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required email: str;
+      multi friends: User;
+    }
+
+    type BlogPost {
+      required title: str;
+      required author: User;
+    }
 
 The simplest path is simply ``User``. This is a :ref:`set reference
 <ref_eql_set_references>` that refers to all ``User`` objects in the database.
@@ -78,18 +91,34 @@ several links named ``author`` that point to ``User``.
 Consider the following addition to the schema:
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
-    type User {
-      # as before
-    }
+      type User {
+        # as before
+      }
 
-    type BlogPost {
-      required link author -> User;
-    }
+      type BlogPost {
+        required link author -> User;
+      }
 
-  + type Comment {
-  +   required link author -> User;
-  + }
+    + type Comment {
+    +   required link author -> User;
+    + }
+
+.. code-block:: sdl-diff
+
+      type User {
+        # as before
+      }
+
+      type BlogPost {
+        required author: User;
+      }
+
+    + type Comment {
+    +   required author: User;
+    + }
+
 
 With the above schema, the path ``User.<author`` would return a mixed set of
 ``BlogPost`` and ``Comment`` objects. This may be desirable in some cases, but
@@ -112,14 +141,25 @@ with ``@`` notation. To demonstrate this, let's add a property to the ``User.
 friends`` link:
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
-    type User {
-      required property email -> str;
-  -   multi link friends -> User;
-  +   multi link friends -> User {
-  +     property since -> cal::local_date;
-  +   }
-    }
+      type User {
+        required property email -> str;
+    -   multi link friends -> User;
+    +   multi link friends -> User {
+    +     property since -> cal::local_date;
+    +   }
+      }
+
+.. code-block:: sdl-diff
+
+      type User {
+        required email: str;
+    -   multi friends: User;
+    +   multi friends: User {
+    +     since: cal::local_date;
+    +   }
+      }
 
 The following represents a set of all dates on which friendships were formed.
 

--- a/docs/edgeql/select.rst
+++ b/docs/edgeql/select.rst
@@ -52,27 +52,51 @@ However most queries are selecting *objects* that live in the database. For
 demonstration purposes, the queries below assume the following schema.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  module default {
-    abstract type Person {
-      required property name -> str { constraint exclusive };
+    module default {
+      abstract type Person {
+        required property name -> str { constraint exclusive };
+      }
+
+      type Hero extending Person {
+        property secret_identity -> str;
+        multi link villains := .<nemesis[is Villain];
+      }
+
+      type Villain extending Person {
+        link nemesis -> Hero;
+      }
+
+      type Movie {
+        required property title -> str { constraint exclusive };
+        required property release_year -> int64;
+        multi link characters -> Person;
+      }
     }
 
-    type Hero extending Person {
-      property secret_identity -> str;
-      multi link villains := .<nemesis[is Villain];
-    }
+.. code-block:: sdl
 
-    type Villain extending Person {
-      link nemesis -> Hero;
-    }
+    module default {
+      abstract type Person {
+        required name: str { constraint exclusive };
+      }
 
-    type Movie {
-      required property title -> str { constraint exclusive };
-      required property release_year -> int64;
-      multi link characters -> Person;
+      type Hero extending Person {
+        secret_identity: str;
+        multi link villains := .<nemesis[is Villain];
+      }
+
+      type Villain extending Person {
+        nemesis: Hero;
+      }
+
+      type Movie {
+        required title: str { constraint exclusive };
+        required release_year: int64;
+        multi characters: Person;
+      }
     }
-  }
 
 Let's start by selecting all ``Villain`` objects in the database. In this
 example, there are only three. Remember, ``Villain`` is a :ref:`reference
@@ -706,13 +730,23 @@ Instead of re-declaring backlinks inside every query where they're needed, it's
 common to add them directly into your schema as computed links.
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
-    abstract type Person {
-      required property name -> str {
-        constraint exclusive;
-      };
-  +   multi link movies := .<characters[is Movie]
-    }
+      abstract type Person {
+        required property name -> str {
+          constraint exclusive;
+        };
+    +   multi link movies := .<characters[is Movie]
+      }
+
+.. code-block:: sdl-diff
+
+      abstract type Person {
+        required name: str {
+          constraint exclusive;
+        };
+    +   multi link movies := .<characters[is Movie]
+      }
 
 .. note::
 

--- a/docs/edgeql/select.rst
+++ b/docs/edgeql/select.rst
@@ -212,18 +212,18 @@ If you have this schema:
       }
 
       type Hero extending Person {
-        property secret_identity: str;
+        secret_identity: str;
         multi link villains := .<nemesis[is Villain];
       }
 
       type Villain extending Person {
-        link nemesis: Hero;
+        nemesis: Hero;
       }
 
       type Movie {
-        required property title: str { constraint exclusive };
-        required property release_year: int64;
-        multi link characters: Person;
+        required title: str { constraint exclusive };
+        required release_year: int64;
+        multi characters: Person;
       }
     }
 
@@ -750,7 +750,7 @@ common to add them directly into your schema as computed links.
 
 .. note::
 
-  In the example above, the ``Person.movies`` is a ``multi link``. Including
+  In the example above, the ``Person.movies`` is a ``multi`` link. Including
   these keywords is optional, since EdgeDB can infer this from the assigned
   expression ``.<characters[is Movie]``. However, it's a good practice to
   include the explicit keywords to make the schema more readable and "sanity

--- a/docs/edgeql/sets.rst
+++ b/docs/edgeql/sets.rst
@@ -287,18 +287,33 @@ you may declare an abstract object type ``Media`` that is extended by ``Movie``
 and ``TVShow``.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Media {
-    required property title -> str;
-  }
+    abstract type Media {
+      required property title -> str;
+    }
 
-  type Movie extending Media {
-    property release_year -> int64;
-  }
+    type Movie extending Media {
+      property release_year -> int64;
+    }
 
-  type TVShow extending Media {
-    property num_seasons -> int64;
-  }
+    type TVShow extending Media {
+      property num_seasons -> int64;
+    }
+
+.. code-block:: sdl
+
+    abstract type Media {
+      required title: str;
+    }
+
+    type Movie extending Media {
+      release_year: int64;
+    }
+
+    type TVShow extending Media {
+      num_seasons: int64;
+    }
 
 A set of type ``Media`` may contain both ``Movie`` and ``TVShow``
 objects.

--- a/docs/guides/cheatsheet/annotations.rst
+++ b/docs/guides/cheatsheet/annotations.rst
@@ -6,12 +6,25 @@ Declaring annotations
 Use annotations to add descriptions to types and links:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Label {
         annotation description :=
             'Special label to stick on reviews';
         required property comments -> str;
         link review -> Review {
+            annotation description :=
+                'This review needs some attention';
+        };
+    }
+
+.. code-block:: sdl
+
+    type Label {
+        annotation description :=
+            'Special label to stick on reviews';
+        required comments: str;
+        review: Review {
             annotation description :=
                 'This review needs some attention';
         };

--- a/docs/guides/cheatsheet/link_properties.rst
+++ b/docs/guides/cheatsheet/link_properties.rst
@@ -27,30 +27,55 @@ Let's a create a ``Person.friends`` link with a ``strength`` property
 corresponding to the strength of the friendship.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    required property name -> str { constraint exclusive };
+    type Person {
+      required property name -> str { constraint exclusive };
 
-    multi link friends -> Person {
-      property strength -> float64;
+      multi link friends -> Person {
+        property strength -> float64;
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type Person {
+      required name: str { constraint exclusive };
+
+      multi friends: Person {
+        strength: float64;
+      }
+    }
 
 Constraints
 -----------
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Person {
-    required property name -> str { constraint exclusive };
+    type Person {
+      required property name -> str { constraint exclusive };
 
-    multi link friends -> Person {
-      property strength -> float64;
-      constraint expression on (
-        __subject__@strength >= 0
-      );
+      multi link friends -> Person {
+        property strength -> float64;
+        constraint expression on (
+          __subject__@strength >= 0
+        );
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type Person {
+      required name: str { constraint exclusive };
+
+      multi friends: Person {
+        strength: float64;
+        constraint expression on (
+          __subject__@strength >= 0
+        );
+      }
+    }
 
 Indexes
 -------
@@ -58,16 +83,31 @@ Indexes
 To index on a link property, you must declare an abstract link and extend it.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract link friendship {
-    property strength -> float64;
-    index on (__subject__@strength);
-  }
+    abstract link friendship {
+      property strength -> float64;
+      index on (__subject__@strength);
+    }
 
-  type Person {
-    required property name -> str { constraint exclusive };
-    multi link friends extending friendship -> Person;
-  }
+    type Person {
+      required property name -> str { constraint exclusive };
+      multi link friends extending friendship -> Person;
+    }
+
+.. code-block:: sdl
+
+    abstract link friendship {
+      strength: float64;
+      index on (__subject__@strength);
+    }
+
+    type Person {
+      required name: str { constraint exclusive };
+      multi friends: Person {
+        extending friendship;
+      };
+    }
 
 
 Inserting

--- a/docs/guides/migrations/backlink.rst
+++ b/docs/guides/migrations/backlink.rst
@@ -11,10 +11,20 @@ events.
 We'll start with this schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Event {
       required property name -> str;
       link prev -> Event;
+
+      # ... more properties and links
+    }
+
+.. code-block:: sdl
+
+    type Event {
+      required name: str;
+      prev: Event;
 
       # ... more properties and links
     }
@@ -56,11 +66,21 @@ define it as a computed link by using :ref:`backlink
 <ref_datamodel_links>` notation:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Event {
       required property name -> str;
 
       link prev -> Event;
+      link next := .<prev[is Event];
+    }
+
+.. code-block:: sdl
+
+    type Event {
+      required name: str;
+
+      prev: Event;
       link next := .<prev[is Event];
     }
 
@@ -112,11 +132,23 @@ Let's fix that by making the link ``prev`` a one-to-one, after all
 we're interested in building event chains, not trees.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Event {
       required property name -> str;
 
       link prev -> Event {
+        constraint exclusive;
+      };
+      link next := .<prev[is Event];
+    }
+
+.. code-block:: sdl
+
+    type Event {
+      required name: str;
+
+      prev: Event {
         constraint exclusive;
       };
       link next := .<prev[is Event];

--- a/docs/guides/migrations/names.rst
+++ b/docs/guides/migrations/names.rst
@@ -13,9 +13,16 @@ as the needs of the project evolve.
 We'll start with a fairly simple schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
       property name -> str;
+    }
+
+.. code-block:: sdl
+
+    type User {
+      name: str;
     }
 
 At this stage we don't think that this property needs to be unique or
@@ -39,9 +46,16 @@ that for a little while we realize that we want to make ``name`` a
 file:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
       required property name -> str;
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required name: str;
     }
 
 Next we try to migrate:
@@ -69,9 +83,18 @@ avoid confusion or to use them as reliable human-readable identifiers
 (unlike ``id``). We update the schema again:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
       required property name -> str {
+        constraint exclusive;
+      }
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required name: str {
         constraint exclusive;
       }
     }

--- a/docs/guides/migrations/proptolink.rst
+++ b/docs/guides/migrations/proptolink.rst
@@ -10,12 +10,22 @@ character in an adventure game as the type of data we will evolve.
 Let's start with this schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     scalar type CharacterClass extending enum<warrior, scholar, rogue>;
 
     type Character {
       required property name -> str;
       required property class -> CharacterClass;
+    }
+
+.. code-block:: sdl
+
+    scalar type CharacterClass extending enum<warrior, scholar, rogue>;
+
+    type Character {
+      required name: str;
+      required class: CharacterClass;
     }
 
 We edit the schema file and perform our first migration:
@@ -53,6 +63,7 @@ between the two explicitly. This means that we will need to have both
 the old and the new "class" information to begin with:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     scalar type CharacterClass extending enum<warrior, scholar, rogue>;
 
@@ -65,6 +76,21 @@ the old and the new "class" information to begin with:
       required property name -> str;
       required property class -> CharacterClass;
       link new_class -> NewClass;
+    }
+
+.. code-block:: sdl
+
+    scalar type CharacterClass extending enum<warrior, scholar, rogue>;
+
+    type NewClass {
+      required name: str;
+      multi skills: str;
+    }
+
+    type Character {
+      required name: str;
+      required class: CharacterClass;
+      new_class: NewClass;
     }
 
 We update the schema file and migrate to the new state:
@@ -181,6 +207,7 @@ Everything seems to be in order. It is time to clean up the old
 property and ``CharacterClass`` :eql:type:`enum`:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type NewClass {
       required property name -> str;
@@ -190,6 +217,18 @@ property and ``CharacterClass`` :eql:type:`enum`:
     type Character {
       required property name -> str;
       link new_class -> NewClass;
+    }
+
+.. code-block:: sdl
+
+    type NewClass {
+      required name: str;
+      multi skills: str;
+    }
+
+    type Character {
+      required name: str;
+      new_class: NewClass;
     }
 
 The migration tools should have no trouble detecting the things we
@@ -214,6 +253,7 @@ the "new" components, so that they become ``class`` link and
 ``CharacterClass`` type, respectively:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type CharacterClass {
       required property name -> str;
@@ -223,6 +263,18 @@ the "new" components, so that they become ``class`` link and
     type Character {
       required property name -> str;
       link class -> CharacterClass;
+    }
+
+.. code-block:: sdl
+
+    type CharacterClass {
+      required name: str;
+      multi skills: str;
+    }
+
+    type Character {
+      required name: str;
+      class: CharacterClass;
     }
 
 The migration tools pick up the changes without any issues again. It

--- a/docs/guides/migrations/proptype.rst
+++ b/docs/guides/migrations/proptype.rst
@@ -10,10 +10,18 @@ character in an adventure game as the type of data we will evolve.
 Let's start with this schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Character {
       required property name -> str;
       required property description -> str;
+    }
+
+.. code-block:: sdl
+
+    type Character {
+      required name: str;
+      required description: str;
     }
 
 We edit the schema file and perform our first migration:
@@ -47,10 +55,18 @@ is less of a "description" and more of a "character class", so at
 first we just rename the property to reflect that:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Character {
       required property name -> str;
       required property class -> str;
+    }
+
+.. code-block:: sdl
+
+    type Character {
+      required name: str;
+      required class: str;
     }
 
 The migration gives us this:
@@ -136,12 +152,22 @@ be a :eql:type:`str` anymore, instead we can use an :eql:type:`enum`
 to make sure that we don't accidentally use some invalid value for it.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     scalar type CharacterClass extending enum<warrior, scholar, rogue>;
 
     type Character {
       required property name -> str;
       required property class -> CharacterClass;
+    }
+
+.. code-block:: sdl
+
+    scalar type CharacterClass extending enum<warrior, scholar, rogue>;
+
+    type Character {
+      required name: str;
+      required class: CharacterClass;
     }
 
 Fortunately, we've already updated the ``class`` strings to match the

--- a/docs/guides/migrations/reqlink.rst
+++ b/docs/guides/migrations/reqlink.rst
@@ -10,9 +10,16 @@ character in an adventure game as the type of data we will evolve.
 Let's start with this schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Character {
       required property name -> str;
+    }
+
+.. code-block:: sdl
+
+    type Character {
+      required name: str;
     }
 
 We edit the schema file and perform our first migration:
@@ -107,6 +114,7 @@ we will add the ``required link class`` right away, without any intermediate
 properties. So we end up with a schema like this:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type CharacterClass {
       required property name -> str;
@@ -116,6 +124,18 @@ properties. So we end up with a schema like this:
     type Character {
       required property name -> str;
       required link class -> CharacterClass;
+    }
+
+.. code-block:: sdl
+
+    type CharacterClass {
+      required name: str;
+      multi skills: str;
+    }
+
+    type Character {
+      required name: str;
+      required class: CharacterClass;
     }
 
 We go ahead and try to apply this new schema:
@@ -141,6 +161,7 @@ not *required* so that we can write some custom queries to handle
 the character classes:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type CharacterClass {
       required property name -> str;
@@ -150,6 +171,18 @@ the character classes:
     type Character {
       required property name -> str;
       link class -> CharacterClass;
+    }
+
+.. code-block:: sdl
+
+    type CharacterClass {
+      required name: str;
+      multi skills: str;
+    }
+
+    type Character {
+      required name: str;
+      class: CharacterClass;
     }
 
 We can now create a migration for our new schema, but we won't apply
@@ -267,6 +300,7 @@ We're finally ready to make the ``class`` link *required*. We update
 the schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type CharacterClass {
       required property name -> str;
@@ -276,6 +310,18 @@ the schema:
     type Character {
       required property name -> str;
       required link class -> CharacterClass;
+    }
+
+.. code-block:: sdl
+
+    type CharacterClass {
+      required name: str;
+      multi skills: str;
+    }
+
+    type Character {
+      required name: str;
+      required class: CharacterClass;
     }
 
 And we perform our final migration:

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -799,18 +799,33 @@ Polymorphic queries
 Consider the following schema.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Content {
-    required property title -> str;
-  }
+    abstract type Content {
+      required property title -> str;
+    }
 
-  type Movie extending Content {
-    property release_year -> int64;
-  }
+    type Movie extending Content {
+      property release_year -> int64;
+    }
 
-  type TVShow extending Content {
-    property num_seasons -> int64;
-  }
+    type TVShow extending Content {
+      property num_seasons -> int64;
+    }
+
+.. code-block:: sdl
+
+    abstract type Content {
+      required title: str;
+    }
+
+    type Movie extending Content {
+      release_year: int64;
+    }
+
+    type TVShow extending Content {
+      num_seasons: int64;
+    }
 
 We can ``select`` the abstract type ``Content`` to simultaneously fetch all
 objects that extend it, and use the ``[is <type>]`` syntax to select

--- a/docs/intro/migrations.rst
+++ b/docs/intro/migrations.rst
@@ -30,15 +30,27 @@ your codebase.
 The schema itself is written using EdgeDB's schema definition language.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type User {
-    required property name -> str;
-  }
+    type User {
+      required property name -> str;
+    }
 
-  type Post {
-    required property title -> str;
-    required link author -> User;
-  }
+    type Post {
+      required property title -> str;
+      required link author -> User;
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required name: str;
+    }
+
+    type Post {
+      required title: str;
+      required author: User;
+    }
 
 
 It's common to keep your entire schema in a single file, typically called
@@ -66,19 +78,35 @@ As your application evolves, directly edit your schema files to reflect your
 desired data model.
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
-    type User {
-      required property name -> str;
-    }
+      type User {
+        required property name -> str;
+      }
 
-    type BlogPost {
-      property title -> str;
-      required link author -> User;
-    }
+      type BlogPost {
+        property title -> str;
+        required link author -> User;
+      }
 
-  + type Comment {
-  +   required property content -> str;
-  + }
+    + type Comment {
+    +   required property content -> str;
+    + }
+
+.. code-block:: sdl-diff
+
+      type User {
+        required name: str;
+      }
+
+      type BlogPost {
+        title: str;
+        required author: User;
+      }
+
+    + type Comment {
+    +   required content: str;
+    + }
 
 3. Generate a migration
 -----------------------
@@ -133,16 +161,29 @@ EdgeQL expression to map the contents of your database to the new schema. To
 see this happen, let's make the ``title`` property ``required``.
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
-    type User {
-      required property name -> str;
-    }
+      type User {
+        required property name -> str;
+      }
 
-    type BlogPost {
-  -   property title -> str;
-  +   required property title -> str;
-      required link author -> User;
-    }
+      type BlogPost {
+    -   property title -> str;
+    +   required property title -> str;
+        required link author -> User;
+      }
+
+.. code-block:: sdl-diff
+
+      type User {
+        required name: str;
+      }
+
+      type BlogPost {
+    -   title: str;
+    +   required title: str;
+        required author: User;
+      }
 
 Then we'll create another migration.
 

--- a/docs/intro/quickstart.rst
+++ b/docs/intro/quickstart.rst
@@ -164,17 +164,31 @@ Let's build a simple movie database. We'll need to define two **object types**
 ``dbschema/default.esdl`` in your editor of choice and paste the following:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  module default {
-    type Person {
-      required property name -> str;
-    }
+    module default {
+      type Person {
+        required property name -> str;
+      }
 
-    type Movie {
-      property title -> str;
-      multi link actors -> Person;
-    }
-  };
+      type Movie {
+        property title -> str;
+        multi link actors -> Person;
+      }
+    };
+
+.. code-block:: sdl
+
+    module default {
+      type Person {
+        required name: str;
+      }
+
+      type Movie {
+        title: str;
+        multi actors: Person;
+      }
+    };
 
 
 A few things to note here.
@@ -243,13 +257,21 @@ Before we proceed, let's try making a small change to our schema: making the
 ``title`` property of ``Movie`` required. First, update the schema file:
 
 .. code-block:: sdl-diff
+    :version-lt: 3.0
 
+        type Movie {
+    -     property title -> str;
+    +     required property title -> str;
+          multi link actors -> Person;
+        }
 
-      type Movie {
-  -     property title -> str;
-  +     required property title -> str;
-        multi link actors -> Person;
-      }
+.. code-block:: sdl-diff
+
+        type Movie {
+    -     title: str;
+    +     required title: str;
+          multi actors: Person;
+        }
 
 Then create another migration. Because this isn't the initial migration, we
 see something a little different than before.

--- a/docs/intro/schema.rst
+++ b/docs/intro/schema.rst
@@ -68,10 +68,17 @@ Properties
 The ``property`` keyword is used to declare a property.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    property title -> str;
-  }
+    type Movie {
+      property title -> str;
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      title: str;
+    }
 
 See :ref:`Schema > Object types <ref_std_object_types>`.
 
@@ -82,11 +89,19 @@ Properties are optional by default. Use the ``required`` keyword to make them
 required.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;       # required
-    property release_year -> int64;       # optional
-  }
+    type Movie {
+      required property title -> str;       # required
+      property release_year -> int64;       # optional
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;       # required
+      release_year: int64;       # optional
+    }
 
 See :ref:`Schema > Properties <ref_datamodel_props>`.
 
@@ -97,14 +112,25 @@ Add a pair of curly braces after the property to define additional
 information, including constraints.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str {
-      constraint exclusive;
-      constraint min_len_value(8);
-      constraint regexp(r'^[A-Za-z0-9 ]+$');
+    type Movie {
+      required property title -> str {
+        constraint exclusive;
+        constraint min_len_value(8);
+        constraint regexp(r'^[A-Za-z0-9 ]+$');
+      }
     }
-  }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str {
+        constraint exclusive;
+        constraint min_len_value(8);
+        constraint regexp(r'^[A-Za-z0-9 ]+$');
+      }
+    }
 
 See :ref:`Schema > Constraints <ref_datamodel_constraints>`.
 
@@ -117,11 +143,19 @@ expressions. This expression is dynamically computed whenever the property is
 queried.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
-    property uppercase_title := str_upper(.title);
-  }
+    type Movie {
+      required property title -> str;
+      property uppercase_title := str_upper(.title);
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      property uppercase_title := str_upper(.title);
+    }
 
 See :ref:`Schema > Computeds <ref_datamodel_computed>`.
 
@@ -131,49 +165,92 @@ Links
 Object types can have links to other object types.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
-    link director -> Person;
-  }
+    type Movie {
+      required property title -> str;
+      link director -> Person;
+    }
 
-  type Person {
-    required property name -> str;
-  }
+    type Person {
+      required property name -> str;
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      director: Person;
+    }
+
+    type Person {
+      required name: str;
+    }
 
 Use the ``required`` and ``multi`` keywords to specify the cardinality of the
 relation.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
+    type Movie {
+      required property title -> str;
 
-    link cinematographer -> Person;             # zero or one
-    required link director -> Person;           # exactly one
-    multi link writers -> Person;               # zero or more
-    required multi link actors -> Person;       # one or more
-  }
+      link cinematographer -> Person;             # zero or one
+      required link director -> Person;           # exactly one
+      multi link writers -> Person;               # zero or more
+      required multi link actors -> Person;       # one or more
+    }
 
-  type Person {
-    required property name -> str;
-  }
+    type Person {
+      required property name -> str;
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+
+      cinematographer: Person;             # zero or one
+      required director: Person;           # exactly one
+      multi writers: Person;               # zero or more
+      required multi actors: Person;       # one or more
+    }
+
+    type Person {
+      required name: str;
+    }
 
 To define a one-to-one relation, use an ``exclusive`` constraint.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
-    required link stats -> MovieStats {
-      constraint exclusive;
-    };
-  }
+    type Movie {
+      required property title -> str;
+      required link stats -> MovieStats {
+        constraint exclusive;
+      };
+    }
 
-  type MovieStats {
-    required property budget -> int64;
-    required property box_office -> int64;
-  }
+    type MovieStats {
+      required property budget -> int64;
+      required property box_office -> int64;
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      required stats: MovieStats {
+        constraint exclusive;
+      };
+    }
+
+    type MovieStats {
+      required budget: int64;
+      required box_office: int64;
+    }
 
 See :ref:`Schema > Links <ref_datamodel_links>`.
 
@@ -185,17 +262,31 @@ objects. Computed links are dynamically computed when they are referenced in
 queries. The example below defines a backlink.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
-    multi link actors -> Person;
+    type Movie {
+      required property title -> str;
+      multi link actors -> Person;
 
-    # returns all movies with same title
-    multi link same_title := (
-      with t := .title
-      select Movie filter .title = t
-    )
-  }
+      # returns all movies with same title
+      multi link same_title := (
+        with t := .title
+        select Movie filter .title = t
+      )
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      multi actors: Person;
+
+      # returns all movies with same title
+      multi link same_title := (
+        with t := .title
+        select Movie filter .title = t
+      )
+    }
 
 Backlinks
 ^^^^^^^^^
@@ -203,16 +294,29 @@ Backlinks
 A common use case for computed links is *backlinks*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
-    multi link actors -> Person;
-  }
+    type Movie {
+      required property title -> str;
+      multi link actors -> Person;
+    }
 
-  type Person {
-    required property name -> str;
-    multi link acted_in := .<actors[is Movie];
-  }
+    type Person {
+      required property name -> str;
+      multi link acted_in := .<actors[is Movie];
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      multi actors: Person;
+    }
+
+    type Person {
+      required name: str;
+      multi link acted_in := .<actors[is Movie];
+    }
 
 The computed link ``acted_in`` returns all ``Movie`` objects with a link
 called ``actors`` that points to the current ``Person``. The easiest way to
@@ -236,24 +340,45 @@ Constraints
 Constraints can also be defined at the *object level*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    property title -> str;
-    link author -> User;
+    type BlogPost {
+      property title -> str;
+      link author -> User;
 
-    constraint exclusive on ((.title, .author));
-  }
+      constraint exclusive on ((.title, .author));
+    }
+
+
+.. code-block:: sdl
+
+    type BlogPost {
+      title: str;
+      author: User;
+
+      constraint exclusive on ((.title, .author));
+    }
 
 Constraints can contain exceptions; these are called *partial constraints*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type BlogPost {
-    property title -> str;
-    property published -> bool;
+    type BlogPost {
+      property title -> str;
+      property published -> bool;
 
-    constraint exclusive on (.title) except (not .published);
-  }
+      constraint exclusive on (.title) except (not .published);
+    }
+
+.. code-block:: sdl
+
+    type BlogPost {
+      title: str;
+      published: bool;
+
+      constraint exclusive on (.title) except (not .published);
+    }
 
 Indexes
 -------
@@ -261,15 +386,27 @@ Indexes
 Use ``index on`` to define indexes on an object type.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  type Movie {
-    required property title -> str;
-    required property release_year -> int64;
+    type Movie {
+      required property title -> str;
+      required property release_year -> int64;
 
-    index on (.title);                        # simple index
-    index on ((.title, .release_year));       # composite index
-    index on (str_trim(str_lower(.title)));   # computed index
-  }
+      index on (.title);                        # simple index
+      index on ((.title, .release_year));       # composite index
+      index on (str_trim(str_lower(.title)));   # computed index
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      required release_year: int64;
+
+      index on (.title);                        # simple index
+      index on ((.title, .release_year));       # composite index
+      index on (str_trim(str_lower(.title)));   # computed index
+    }
 
 The ``id`` property, all links, and all properties with ``exclusive``
 constraints are automatically indexed.
@@ -283,34 +420,64 @@ Object types can be declared as ``abstract``. Non-abstract types can *extend*
 abstract types.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Content {
-    required property title -> str;
-  }
+    abstract type Content {
+      required property title -> str;
+    }
 
-  type Movie extending Content {
-    required property release_year -> int64;
-  }
+    type Movie extending Content {
+      required property release_year -> int64;
+    }
 
-  type TVShow extending Content {
-    required property num_seasons -> int64;
-  }
+    type TVShow extending Content {
+      required property num_seasons -> int64;
+    }
+
+.. code-block:: sdl
+
+    abstract type Content {
+      required title: str;
+    }
+
+    type Movie extending Content {
+      required release_year: int64;
+    }
+
+    type TVShow extending Content {
+      required num_seasons: int64;
+    }
 
 Multiple inheritance is supported.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type HasTitle {
-    required property title -> str;
-  }
+    abstract type HasTitle {
+      required property title -> str;
+    }
 
-  abstract type HasReleaseYear {
-    required property release_year -> int64;
-  }
+    abstract type HasReleaseYear {
+      required property release_year -> int64;
+    }
 
-  type Movie extending HasTitle, HasReleaseYear {
-    link sequel_to -> Movie;
-  }
+    type Movie extending HasTitle, HasReleaseYear {
+      link sequel_to -> Movie;
+    }
+
+.. code-block:: sdl
+
+    abstract type HasTitle {
+      required title: str;
+    }
+
+    abstract type HasReleaseYear {
+      required release_year: int64;
+    }
+
+    type Movie extending HasTitle, HasReleaseYear {
+      sequel_to: Movie;
+    }
 
 See :ref:`Schema > Object types > Inheritance
 <ref_datamodel_objects_inheritance>`.
@@ -321,23 +488,43 @@ Polymorphism
 Links can correspond to abstract types. These are known as *polymorphic links*.
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
-  abstract type Content {
-    required property title -> str;
-  }
+    abstract type Content {
+      required property title -> str;
+    }
 
-  type Movie extending Content {
-    required property release_year -> int64;
-  }
+    type Movie extending Content {
+      required property release_year -> int64;
+    }
 
-  type TVShow extending Content {
-    required property num_seasons -> int64;
-  }
+    type TVShow extending Content {
+      required property num_seasons -> int64;
+    }
 
-  type Franchise {
-    required property name -> str;
-    multi link entries -> Content;
-  }
+    type Franchise {
+      required property name -> str;
+      multi link entries -> Content;
+    }
+
+.. code-block:: sdl
+
+    abstract type Content {
+      required title: str;
+    }
+
+    type Movie extending Content {
+      required release_year: int64;
+    }
+
+    type TVShow extending Content {
+      required num_seasons: int64;
+    }
+
+    type Franchise {
+      required name: str;
+      multi entries: Content;
+    }
 
 See :ref:`Schema > Links > Polymorphism
 <ref_datamodel_link_polymorphic>` and :ref:`EdgeQL > Select > Polymorphic

--- a/docs/reference/edgeql/describe.rst
+++ b/docs/reference/edgeql/describe.rst
@@ -116,6 +116,7 @@ Examples
 Consider the following schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     abstract type Named {
         required property name -> str {
@@ -125,6 +126,20 @@ Consider the following schema:
 
     type User extending Named {
         required property email -> str {
+            annotation title := 'Contact email';
+        }
+    }
+
+.. code-block:: sdl
+
+    abstract type Named {
+        required name: str {
+            delegated constraint exclusive;
+        }
+    }
+
+    type User extending Named {
+        required email: str {
             annotation title := 'Contact email';
         }
     }

--- a/docs/reference/edgeql/shapes.rst
+++ b/docs/reference/edgeql/shapes.rst
@@ -65,10 +65,18 @@ names associated with the given user" in a database defined by the
 following schema:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
         required property name -> str;
         multi link friends -> User;
+    }
+
+.. code-block:: sdl
+
+    type User {
+        required name: str;
+        multi friends: User;
     }
 
 If we only concern ourselves with getting the values, then a

--- a/docs/reference/edgeql/update.rst
+++ b/docs/reference/edgeql/update.rst
@@ -96,6 +96,7 @@ assignments using ``:=``:
 For usage of ``+=`` and ``-=`` consider the following ``Post`` type:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     # ... Assume some User type is already defined
     type Post {
@@ -104,6 +105,17 @@ For usage of ``+=`` and ``-=`` consider the following ``Post`` type:
         # A "tags" property containing a set of strings
         multi property tags -> str;
         link author -> User;
+    }
+
+.. code-block:: sdl
+
+    # ... Assume some User type is already defined
+    type Post {
+        required title: str;
+        required body: str;
+        # A "tags" property containing a set of strings
+        multi tags: str;
+        author: User;
     }
 
 The following queries add or remove tags from some user's posts:

--- a/docs/reference/sdl/access_policies.rst
+++ b/docs/reference/sdl/access_policies.rst
@@ -17,6 +17,7 @@ Examples
 Declare a schema where users can only see their own profiles:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     # Declare some global variables to store "current user"
     # information.
@@ -31,6 +32,29 @@ Declare a schema where users can only see their own profiles:
 
     type Profile {
         link owner -> User;
+
+        # Only allow reading to the owner, but also
+        # ensure that a user cannot set the "owner" link
+        # to anything but themselves.
+        access policy owner_only
+            allow all using (.owner = global current_user);
+    }
+
+.. code-block:: sdl
+
+    # Declare some global variables to store "current user"
+    # information.
+    global current_user_id: uuid;
+    global current_user := (
+        select User filter .id = global current_user_id
+    );
+
+    type User {
+        required name: str;
+    }
+
+    type Profile {
+        owner: User;
 
         # Only allow reading to the owner, but also
         # ensure that a user cannot set the "owner" link

--- a/docs/reference/sdl/annotations.rst
+++ b/docs/reference/sdl/annotations.rst
@@ -20,10 +20,20 @@ Declare a new annotation:
 Specify the value of an annotation for a type:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Status {
         annotation admin_note := 'system-critical';
         required property name -> str {
+            constraint exclusive
+        }
+    }
+
+.. code-block:: sdl
+
+    type Status {
+        annotation admin_note := 'system-critical';
+        required name: str {
             constraint exclusive
         }
     }

--- a/docs/reference/sdl/constraints.rst
+++ b/docs/reference/sdl/constraints.rst
@@ -33,10 +33,21 @@ Declare a *concrete* constraint on an integer type:
 Declare a *concrete* constraint on an object type:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type Vector {
         required property x -> float64;
         required property y -> float64;
+        constraint expression on (
+            __subject__.x^2 + __subject__.y^2 < 25
+        );
+    }
+
+.. code-block:: sdl
+
+    type Vector {
+        required x: float64;
+        required y: float64;
         constraint expression on (
             __subject__.x^2 + __subject__.y^2 < 25
         );

--- a/docs/reference/sdl/index.rst
+++ b/docs/reference/sdl/index.rst
@@ -23,6 +23,38 @@ keywords omitted.  The typical SDL structure is to use :ref:`module
 blocks <ref_eql_sdl_modules>` with the rest of the declarations being
 nested in their respective modules.
 
+.. versionadded:: 3.0
+
+    EdgeDB 3.0 introduces a new SDL syntax which diverges slightly from DDL.
+    The old SDL syntax is still fully supported, but the new syntax allows for
+    cleaner and less verbose expression of your schemas.
+
+    * Pointers no longer require an arrow (``->``). You may instead use a colon
+      after the name of the link or property.
+    * The ``link`` and ``property`` keywords are now optional for non-computed
+      pointers when the target type is explicitly specified.
+
+    That means that this type definition:
+
+    .. code-block:: sdl
+
+        type User {
+          required property email -> str;
+        }
+
+    could be replaced with this equivalent one in EdgeDB 3+:
+
+    .. code-block:: sdl
+
+        type User {
+          required email: str;
+        }
+
+    When reading our documentation, the version selection dropdown will update
+    the syntax of most SDL examples to the preferred syntax for the version
+    selected. This is only true for versioned sections of the documentation.
+
+
 Since SDL is declarative in nature, the specific order of
 declarations of module blocks or individual items does not matter.
 
@@ -30,6 +62,7 @@ The built-in :ref:`migration tools<ref_cli_edgedb_migration>` expect
 the schema to be given in SDL format. For example:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     # "default" module block
     module default {
@@ -46,6 +79,23 @@ the schema to be given in SDL format. For example:
         }
     }
 
+.. code-block:: sdl
+
+    # "default" module block
+    module default {
+        type Movie {
+            required title: str;
+            # the year of release
+            year: int64;
+            required director: Person;
+            required multi actors: Person;
+        }
+        type Person {
+            required first_name: str;
+            required last_name: str;
+        }
+    }
+
 It is possible to also omit the module blocks, but then individual
 declarations must use :ref:`fully-qualified names
 <ref_name_resolution>` so that they can be assigned
@@ -53,6 +103,7 @@ to their respective modules. For example, the following is equivalent
 to the previous migration:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     # no module block
     type default::Movie {
@@ -65,6 +116,21 @@ to the previous migration:
     type default::Person {
         required property first_name -> str;
         required property last_name -> str;
+    }
+
+.. code-block:: sdl
+
+    # no module block
+    type default::Movie {
+        required title: str;
+        # the year of release
+        year: int64;
+        required director: default::Person;
+        required multi actors: default::Person;
+    }
+    type default::Person {
+        required first_name: str;
+        required last_name: str;
     }
 
 .. toctree::

--- a/docs/reference/sdl/indexes.rst
+++ b/docs/reference/sdl/indexes.rst
@@ -14,6 +14,7 @@ Example
 Declare an index for a "User" based on the "name" property:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
         required property name -> str;
@@ -27,6 +28,19 @@ Declare an index for a "User" based on the "name" property:
         }
     }
 
+.. code-block:: sdl
+
+    type User {
+        required name: str;
+        address: str;
+
+        multi friends: User;
+
+        # define an index for User based on name
+        index on (.name) {
+            annotation title := 'User name index';
+        }
+    }
 
 .. _ref_eql_sdl_indexes_syntax:
 

--- a/docs/reference/sdl/links.rst
+++ b/docs/reference/sdl/links.rst
@@ -23,12 +23,26 @@ Declare an *abstract* link "friends_base" with a helpful title:
 Declare a *concrete* link "friends" within a "User" type:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
         required property name -> str;
         property address -> str;
         # define a concrete link "friends"
-        multi link friends extending friends_base-> User;
+        multi link friends extending friends_base -> User;
+
+        index on (__subject__.name);
+    }
+
+.. code-block:: sdl
+
+    type User {
+        required name: str;
+        address: str;
+        # define a concrete link "friends"
+        multi link friends: User {
+            extending friends_base;
+        };
 
         index on (__subject__.name);
     }
@@ -44,15 +58,29 @@ type, for example), the ``overloaded`` keyword must be used. This is
 to prevent unintentional overloading due to name clashes:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     abstract type Friendly {
         # this type can have "friends"
-        link friends -> Friendly;
+        multi link friends -> Friendly;
     }
 
     type User extending Friendly {
         # overload the link target to be User, specifically
         overloaded multi link friends -> User;
+        # ... other links and properties
+    }
+
+.. code-block:: sdl
+
+    abstract type Friendly {
+        # this type can have "friends"
+        multi friends: Friendly;
+    }
+
+    type User extending Friendly {
+        # overload the link target to be User, specifically
+        overloaded multi friends: User;
         # ... other links and properties
     }
 
@@ -65,6 +93,7 @@ Define a new link corresponding to the :ref:`more explicit DDL
 commands <ref_eql_ddl_links>`.
 
 .. sdl:synopsis::
+    :version-lt: 3.0
 
     # Concrete link form used inside type declaration:
     [ overloaded ] [{required | optional}] [{single | multi}]
@@ -96,7 +125,7 @@ commands <ref_eql_ddl_links>`.
           ...
         "}" ]
 
-   # Abstract link form:
+    # Abstract link form:
     abstract link <name> [extending <base> [, ...]]
     [ "{"
         [ readonly := {true | false} ; ]
@@ -107,17 +136,61 @@ commands <ref_eql_ddl_links>`.
         ...
       "}" ]
 
+.. sdl:synopsis::
+
+    # Concrete link form used inside type declaration:
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      [ link ] <name> : <type>
+      [ "{"
+          [ extending <base> [, ...] ; ]
+          [ default := <expression> ; ]
+          [ readonly := {true | false} ; ]
+          [ on target delete <action> ; ]
+          [ <annotation-declarations> ]
+          [ <property-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+
+    # Computed link form used inside type declaration:
+    [{required | optional}] [{single | multi}]
+      link <name> := <expression>;
+
+    # Computed link form used inside type declaration (extended):
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      link <name> [: <type>]
+      [ "{"
+          using (<expression>) ;
+          [ extending <base> [, ...] ; ]
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+    # Abstract link form:
+    abstract link <name>
+    [ "{"
+        [extending <base> [, ...] ; ]
+        [ readonly := {true | false} ; ]
+        [ <annotation-declarations> ]
+        [ <property-declarations> ]
+        [ <constraint-declarations> ]
+        [ <index-declarations> ]
+        ...
+      "}" ]
+
+
 Description
 -----------
 
-There are several forms of ``link`` declaration, as shown in the
-syntax synopsis above.  The first form is the canonical definition
-form, the second and third forms are used for defining a
-:ref:`computed link <ref_datamodel_computed>`, and the last one
-is a form to define an ``abstract link``.  The abstract form
-allows declaring the link directly inside a :ref:`module
-<ref_eql_sdl_modules>`.  Concrete link forms are always used as
-sub-declarations for an :ref:`object type <ref_eql_sdl_object_types>`.
+There are several forms of link declaration, as shown in the syntax synopsis
+above. The first form is the canonical definition form, the second form is used
+for defining a :ref:`computed link <ref_datamodel_computed>`, and the last form
+is used to define an abstract link. The abstract form allows declaring the link
+directly inside a :ref:`module <ref_eql_sdl_modules>`. Concrete link forms are
+always used as sub-declarations of an :ref:`object type
+<ref_eql_sdl_object_types>`.
 
 The following options are available:
 
@@ -162,6 +235,12 @@ The following options are available:
     then the data types of the property targets must be *compatible*.
     If there is no conflict, the link properties are merged to form a
     single property in the new link item.
+
+    .. versionadded:: 3.0
+
+        As of EdgeDB 3.0, the ``extended`` clause is now a sub-declaration of
+        the link and included inside the curly braces rather than an option as
+        in earlier versions.
 
 :eql:synopsis:`<type>`
     The type must be a valid :ref:`type expression <ref_eql_types>`

--- a/docs/reference/sdl/modules.rst
+++ b/docs/reference/sdl/modules.rst
@@ -21,10 +21,19 @@ Declare an empty module:
 Declare a module with some content:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     module my_module {
         type User {
             required property name -> str;
+        }
+    }
+
+.. code-block:: sdl
+
+    module my_module {
+        type User {
+            required name: str;
         }
     }
 
@@ -58,6 +67,7 @@ all blocks with the same name are merged into a single module under
 that name. For example:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     module my_module {
         abstract type Named {
@@ -69,13 +79,36 @@ that name. For example:
         type User extending Named;
     }
 
+.. code-block:: sdl
+
+    module my_module {
+        abstract type Named {
+            required name: str;
+        }
+    }
+
+    module my_module {
+        type User extending Named;
+    }
+
 The above is equivalent to:
+
+.. code-block:: sdl
+    :version-lt: 3.0
+
+    module my_module {
+        abstract type Named {
+            required property name -> str;
+        }
+
+        type User extending Named;
+    }
 
 .. code-block:: sdl
 
     module my_module {
         abstract type Named {
-            required property name -> str;
+            required name: str;
         }
 
         type User extending Named;
@@ -94,9 +127,18 @@ schema.  The following declaration is equivalent to the previous
 examples, but it declares module ``my_module`` implicitly:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     abstract type my_module::Named {
         required property name -> str;
+    }
+
+    type my_module::User extending my_module::Named;
+
+.. code-block:: sdl
+
+    abstract type my_module::Named {
+        required name: str;
     }
 
     type my_module::User extending my_module::Named;

--- a/docs/reference/sdl/objects.rst
+++ b/docs/reference/sdl/objects.rst
@@ -14,6 +14,7 @@ Example
 Consider a ``User`` type with a few properties:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
         # define some properties and a link
@@ -26,6 +27,19 @@ Consider a ``User`` type with a few properties:
         index on (__subject__.name);
     }
 
+.. code-block:: sdl
+
+    type User {
+        # define some properties and a link
+        required name: str;
+        address: str;
+
+        multi friends: User;
+
+        # define an index for User based on name
+        index on (__subject__.name);
+    }
+
 .. _ref_eql_sdl_object_types_inheritance:
 
 An alternative way to define the same ``User`` type could be by using
@@ -33,6 +47,7 @@ abstract types. These abstract types can then be re-used in other type
 definitions as well:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     abstract type Named {
         required property name -> str;
@@ -45,6 +60,24 @@ definitions as well:
     type User extending Named, HasAddress {
         # define some user-specific properties and a link
         multi link friends -> User;
+
+        # define an index for User based on name
+        index on (__subject__.name);
+    }
+
+.. code-block:: sdl
+
+    abstract type Named {
+        required name: str;
+    }
+
+    abstract type HasAddress {
+        address: str;
+    }
+
+    type User extending Named, HasAddress {
+        # define some user-specific properties and a link
+        multi friends: User;
 
         # define an index for User based on name
         index on (__subject__.name);

--- a/docs/reference/sdl/properties.rst
+++ b/docs/reference/sdl/properties.rst
@@ -23,13 +23,28 @@ Declare an *abstract* property "address_base" with a helpful title:
 Declare *concrete* properties "name" and "address" within a "User" type:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type User {
         # define concrete properties
         required property name -> str;
-        property address extending address_base -> str;
+        property address extending address_base: str;
 
         multi link friends -> User;
+
+        index on (__subject__.name);
+    }
+
+.. code-block:: sdl
+
+    type User {
+        # define concrete properties
+        required name: str;
+        property address: str {
+            extending address_base;
+        };
+
+        multi friends: User;
 
         index on (__subject__.name);
     }
@@ -40,6 +55,7 @@ is being overloaded (by adding more constraints, for example), the
 overloading due to name clashes:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     abstract type Named {
         property name -> str;
@@ -48,6 +64,18 @@ overloading due to name clashes:
     type User extending Named {
         # define concrete properties
         overloaded required property name -> str;
+        # ... other links and properties
+    }
+
+.. code-block:: sdl
+
+    abstract type Named {
+        name: str;
+    }
+
+    type User extending Named {
+        # define concrete properties
+        overloaded required name: str;
         # ... other links and properties
     }
 
@@ -60,6 +88,7 @@ Define a new property corresponding to the :ref:`more explicit DDL
 commands <ref_eql_ddl_props>`.
 
 .. sdl:synopsis::
+    :version-lt: 3.0
 
     # Concrete property form used inside type declaration:
     [ overloaded ] [{required | optional}] [{single | multi}]
@@ -95,6 +124,45 @@ commands <ref_eql_ddl_props>`.
         [ <annotation-declarations> ]
         ...
       "}" ]
+
+.. sdl:synopsis::
+
+    # Concrete property form used inside type declaration:
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      [ property ] <name> : <type>
+      [ "{"
+          [ extending <base> [, ...] ; ]
+          [ default := <expression> ; ]
+          [ readonly := {true | false} ; ]
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+    # Computed property form used inside type declaration:
+    [{required | optional}] [{single | multi}]
+      property <name> := <expression>;
+
+    # Computed property form used inside type declaration (extended):
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      property <name> [: <type>]
+      [ "{"
+          using (<expression>) ;
+          [ extending <base> [, ...] ; ]
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+    # Abstract property form:
+    abstract property [<module>::]<name>
+    [ "{"
+        [extending <base> [, ...] ; ]
+        [ readonly := {true | false} ; ]
+        [ <annotation-declarations> ]
+        ...
+      "}" ]
+
 
 Description
 -----------
@@ -146,6 +214,12 @@ The following options are available:
     Use of ``extending`` creates a persistent schema relationship
     between the new property and its parents.  Schema modifications
     to the parent(s) propagate to the child.
+
+    .. versionadded:: 3.0
+
+        As of EdgeDB 3.0, the ``extended`` clause is now a sub-declaration of
+        the property and included inside the curly braces rather than an option
+        as in earlier versions.
 
 :eql:synopsis:`<type>`
     The type must be a valid :ref:`type expression <ref_eql_types>`

--- a/docs/reference/sdl/properties.rst
+++ b/docs/reference/sdl/properties.rst
@@ -28,7 +28,7 @@ Declare *concrete* properties "name" and "address" within a "User" type:
     type User {
         # define concrete properties
         required property name -> str;
-        property address extending address_base: str;
+        property address extending address_base -> str;
 
         multi link friends -> User;
 

--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -129,10 +129,18 @@ Reference
     Array types may also appear in schema declarations:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         type Person {
             property str_array -> array<str>;
             property json_array -> array<json>;
+        }
+
+    .. code-block:: sdl
+
+        type Person {
+            str_array: array<str>;
+            json_array: array<json>;
         }
 
     See also the list of standard :ref:`array functions <ref_std_array>`, as

--- a/docs/stdlib/constraints.rst
+++ b/docs/stdlib/constraints.rst
@@ -24,10 +24,21 @@ Constraints
     object properties to restrict maximum magnitude for a vector:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         type Vector {
             required property x -> float64;
             required property y -> float64;
+            constraint expression on (
+                __subject__.x^2 + __subject__.y^2 < 25
+            );
+        }
+
+    .. code-block:: sdl
+
+        type Vector {
+            required x: float64;
+            required y: float64;
             constraint expression on (
                 __subject__.x^2 + __subject__.y^2 < 25
             );
@@ -157,6 +168,7 @@ Constraints
     Example:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         type User {
             # Make sure user names are unique.
@@ -171,16 +183,42 @@ Constraints
             }
         }
 
+    .. code-block:: sdl
+
+        type User {
+            # Make sure user names are unique.
+            required name: str {
+                constraint exclusive;
+            }
+
+            # Make sure none of the "owned" items belong
+            # to any other user.
+            multi owns: Item {
+                constraint exclusive;
+            }
+        }
+
     Sometimes it's necessary to create a type where each combination
     of properties is unique. This can be achieved by defining an
     ``exclusive`` constraint for the type, rather than on each
     property:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         type UniqueCoordinates {
             required property x -> int64;
             required property y -> int64;
+
+            # Each combination of x and y must be unique.
+            constraint exclusive on ( (.x, .y) );
+        }
+
+    .. code-block:: sdl
+
+        type UniqueCoordinates {
+            required x: int64;
+            required y: int64;
 
             # Each combination of x and y must be unique.
             constraint exclusive on ( (.x, .y) );

--- a/docs/stdlib/sequence.rst
+++ b/docs/stdlib/sequence.rst
@@ -28,11 +28,22 @@ Sequences
     <ref_datamodel_props>`:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         scalar type TicketNo extending sequence;
 
         type Ticket {
             property number -> TicketNo {
+                constraint exclusive;
+            }
+        }
+
+    .. code-block:: sdl
+
+        scalar type TicketNo extending sequence;
+
+        type Ticket {
+            number: TicketNo {
                 constraint exclusive;
             }
         }

--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -304,6 +304,7 @@ Sets
     Consider the following types:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         type User {
             required property name -> str;
@@ -319,6 +320,24 @@ Sets
 
         type Comment extending Owned {
             required property body -> str;
+        }
+
+    .. code-block:: sdl
+
+        type User {
+            required name: str;
+        }
+
+        abstract type Owned {
+            required owner: User;
+        }
+
+        type Issue extending Owned {
+            required title: str;
+        }
+
+        type Comment extending Owned {
+            required body: str;
         }
 
     The following expression will get all :eql:type:`Objects <Object>`

--- a/docs/stdlib/tuple.rst
+++ b/docs/stdlib/tuple.rst
@@ -104,10 +104,18 @@ Any type can be used as a tuple element type.
 Here's an example of using this syntax in a schema definition:
 
 .. code-block:: sdl
+    :version-lt: 3.0
 
     type GameElement {
         required property name -> str;
         required property position -> tuple<x: int64, y: int64>;
+    }
+
+.. code-block:: sdl
+
+    type GameElement {
+        required name: str;
+        required position: tuple<x: int64, y: int64>;
     }
 
 Here's a few examples of using tuple types in EdgeQL queries:

--- a/docs/stdlib/type.rst
+++ b/docs/stdlib/type.rst
@@ -83,6 +83,7 @@ Types
     object must satisfy ``object is (A | B | C)``.
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         abstract type Named {
             required property name -> str;
@@ -98,6 +99,24 @@ Types
 
         type User extending Named {
             multi link stuff -> Named | Text;
+        }
+
+    .. code-block:: sdl
+
+        abstract type Named {
+            required name: str;
+        }
+
+        abstract type Text {
+            required body: str;
+        }
+
+        type Item extending Named;
+
+        type Note extending Text;
+
+        type User extending Named {
+            multi stuff: Named | Text;
         }
 
     With the above schema, the following would be valid:
@@ -259,10 +278,20 @@ Types
     that don't indicate their respective target types:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         type Foo {
             property bar -> int16;
             link baz -> Bar;
+        }
+
+        type Bar extending Foo;
+
+    .. code-block:: sdl
+
+        type Foo {
+            bar: int16;
+            baz: Bar;
         }
 
         type Bar extending Foo;
@@ -327,10 +356,20 @@ Types
     that don't indicate their respective target types:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         type Foo {
             property bar -> int16;
             link baz -> Bar;
+        }
+
+        type Bar extending Foo;
+
+    .. code-block:: sdl
+
+        type Foo {
+            bar: int16;
+            baz: Bar;
         }
 
         type Bar extending Foo;

--- a/edb/tools/docs/shared.py
+++ b/edb/tools/docs/shared.py
@@ -53,20 +53,27 @@ class InlineCodeRole:
         return [node], []
 
 
-class CodeBlock(s_code.CodeBlock):
+def make_CodeBlock(parent):
+    class CodeBlock(parent):
 
-    option_spec = s_code.CodeBlock.option_spec.copy()
-    option_spec.update({
-        'version-lt': d_directives.unchanged_required
-    })
+        option_spec = s_code.CodeBlock.option_spec.copy()
+        option_spec.update({
+            'version-lt': d_directives.unchanged_required
+        })
 
-    def run(self):
-        literal = super().run()
-        if 'version-lt' in self.options:
-            if len(self.options) > 1:
-                raise EdgeSphinxExtensionError(
-                    'other options not allowed if :version-lt: option is '
-                    'provided, put other options on latest version code block'
-                )
-            literal[0]['version_lt'] = self.options['version-lt']
-        return literal
+        def run(self):
+            literal = super().run()
+            if 'version-lt' in self.options:
+                if len(self.options) > 1:
+                    raise EdgeSphinxExtensionError(
+                        'other options not allowed if :version-lt: option '
+                        'is provided, put other options on latest version '
+                        'code block'
+                    )
+                literal[0]['version_lt'] = self.options['version-lt']
+            return literal
+
+    return CodeBlock
+
+
+CodeBlock = make_CodeBlock(s_code.CodeBlock)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -23,6 +23,7 @@ try:
     import docutils.parsers
     import docutils.utils
     import docutils.frontend
+    import docutils.parsers.rst.directives.body
 except ImportError:
     docutils = None  # type: ignore
 
@@ -34,6 +35,13 @@ except ImportError:
 from graphql.language import parser as graphql_parser
 
 from edb.edgeql import parser as ql_parser
+
+from edb.tools.docs.shared import make_CodeBlock
+
+docutils.parsers.rst.directives.register_directive(
+    'code-block',
+    make_CodeBlock(docutils.parsers.rst.directives.body.CodeBlock)
+)
 
 
 def find_edgedb_root():
@@ -194,7 +202,8 @@ class TestDocSnippets(unittest.TestCase):
                                 'code' in node.attributes['classes'])
                         )
                         for subdir in subdirs:
-                            subdir.line += node_parent_line
+                            if subdir.line is not None:
+                                subdir.line += node_parent_line
                             directives.append(subdir)
 
         for directive in directives:


### PR DESCRIPTION
This is a big PR. The good news is that most of it consists of mirroring the existing SDL examples in the new syntax and marking the pre-3.0 syntax examples with `:version-lt: 3.0`.

Other stuff that's included:
- making sure all the code blocks I touched are indented by 4 spaces
- unwrapping "link" as inline code since the keyword is no longer required in SDL in most cases (in datamodel/links.rst for example)
- adding descriptions of the new syntax in prose where that made sense
- adding new 3.0 SDL synopses for links and properties
- fixes for very minor unrelated issues I found
  - `#New` label switched to a `versionadded` directive in `datamodel/constraints.rst` "Partial constraints" heading
  - various other spacing fixes

Stuff that *isn't* included:
- New SDL examples for the introspection guide
  - The introspection guide is being moved as part of #5157. I'm afraid of what the merge might be like if I also make changes to it in this PR, so I will circle back after that PR is merged to add new SDL examples there.
- Updated SDL in other guides
  - Guides will not be versioned, so we will circle back to the few SDL samples in them and update them to the new syntax once 3.0 launches.