### PR TITLE
Doc v3 access policy errors

### DIFF
--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -321,6 +321,64 @@ making the current user able to see their own ``User`` record.
   <ref_eql_sdl_future>` behavior in EdgeDB 2.6 and later by adding the
   following to the schema: ``using future nonrecursive_access_policies;``
 
+Custom error messages
+^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 3.0
+
+When you run a query that attempts a write and is restricted by an access
+policy, you will get a generic error message.
+
+.. code-block::
+
+    edgedb error: AccessPolicyError: access policy violation on insert of
+    <type>
+
+.. note::
+
+    When attempting a ``select`` queries, you simply won't get the data that is
+    being restricted by the access policy.
+
+If you have multiple access policies, it can be useful to know which policy is
+restricting your query and provide a friendly error message. You can do this by
+adding a custom error message to your policy.
+
+.. code-block:: sdl-diff
+
+    global current_user_id -> uuid;
+    global current_user := (
+      select User filter .id = global current_user_id
+    );
+
+    type User {
+      required property email -> str { constraint exclusive; };
+      required property is_admin -> bool { default := false };
+
+      access policy admin_only
+        allow all
+  +     using (global current_user.is_admin ?? false) {
+  +       errmessage := 'Only admins may query Users'
+  +     };
+    }
+
+    type BlogPost {
+      required property title -> str;
+      link author -> User;
+
+      access policy author_has_full_access
+        allow all
+  +     using (global current_user ?= .author.id) {
+  +       errmessage := 'BlogPosts may only be queried by their authors'
+  +     };
+    }
+
+Now if you attempt, for example, a ``User`` insert as a non-admin user, you
+will receive this error:
+
+.. code-block::
+
+    edgedb error: AccessPolicyError: access policy violation on insert of
+    default::User (Only admins may query Users)
 
 Disabling policies
 ^^^^^^^^^^^^^^^^^^

--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -28,10 +28,12 @@ When no access policies are defined, object-level security is not activated.
 Any properly authenticated client can select or modify any object in the
 database.
 
-⚠️ Once a policy is added to a particular object type, **all operations**
-(``select``, ``insert``, ``delete``, and ``update`` etc.) on any object of
-that type are now *disallowed by default* unless specifically allowed by an
-access policy!
+.. warning::
+
+    Once a policy is added to a particular object type, **all operations**
+    (``select``, ``insert``, ``delete``, and ``update`` etc.) on any object of
+    that type are now *disallowed by default* unless specifically allowed by an
+    access policy!
 
 Defining a global
 ^^^^^^^^^^^^^^^^^

--- a/docs/reference/ddl/access_policies.rst
+++ b/docs/reference/ddl/access_policies.rst
@@ -1,12 +1,10 @@
+.. versionadded:: 2.0
+
 .. _ref_eql_ddl_access_policies:
 
 ===============
 Access Policies
 ===============
-
-.. note::
-
-  ⚠️ Only available in EdgeDB 2.0 or later.
 
 This section describes the DDL commands pertaining to access policies.
 

--- a/docs/reference/ddl/access_policies.rst
+++ b/docs/reference/ddl/access_policies.rst
@@ -16,16 +16,16 @@ Create access policy
 :ref:`Declare <ref_eql_sdl_access_policies>` a new object access policy.
 
 .. eql:synopsis::
+    :version-lt: 3.0
 
     [ with <with-item> [, ...] ]
     { create | alter } type <TypeName> "{"
       [ ... ]
-      create access policy <name> "{"
+      create access policy <name>
         [ when (<condition>) ; ]
         { allow | deny } <action> [, <action> ... ; ]
         [ using (<expr>) ; ]
         [ create annotation <annotation-name> := <value> ; ]
-      "}"
     "}"
 
     # where <action> is one of
@@ -34,6 +34,29 @@ Create access policy
     insert
     delete
     update [{ read | write }]
+
+.. eql:synopsis::
+
+    [ with with-item [, ...] ]
+    { create | alter } type TypeName "{"
+      [ ... ]
+      create access policy name
+        [ when (condition) ; ]
+        { allow | deny } action [, action ... ; ]
+        [ using (expr) ; ]
+        [ create annotation annotation-name := value ; ]
+        [ "{"
+           [ set errmessage := value ; ]
+          "}" ; ]
+    "}"
+
+    # where <action> is one of
+    all
+    select
+    insert
+    delete
+    update [{ read | write }]
+
 
 Description
 -----------
@@ -118,6 +141,12 @@ Most sub-commands and options of this command are identical to the
 
 The following subcommands are allowed in the ``create access policy`` block:
 
+.. versionadded:: 3.0
+
+    :eql:synopsis:`set errmessage := <value>`
+        Set a custom error message of :eql:synopsis:`<value>` that is displayed
+        when this access policy prevents a write action.
+
 :eql:synopsis:`create annotation <annotation-name> := <value>`
     Set access policy annotation :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
@@ -132,6 +161,7 @@ Alter access policy
 :ref:`Declare <ref_eql_sdl_access_policies>` a new object access policy.
 
 .. eql:synopsis::
+    :version-lt: 3.0
 
     [ with <with-item> [, ...] ]
     alter type <TypeName> "{"
@@ -141,6 +171,31 @@ Alter access policy
         [ reset when ; ]
         { allow | deny } <action> [, <action> ... ; ]
         [ using (<expr>) ; ]
+        [ reset expression ; ]
+        [ create annotation <annotation-name> := <value> ; ]
+        [ alter annotation <annotation-name> := <value> ; ]
+        [ drop annotation <annotation-name>; ]
+      "}"
+    "}"
+
+    # where <action> is one of
+    all
+    select
+    insert
+    delete
+    update [{ read | write }]
+
+.. eql:synopsis::
+
+    [ with <with-item> [, ...] ]
+    alter type <TypeName> "{"
+      [ ... ]
+      alter access policy <name> "{"
+        [ when (<condition>) ; ]
+        [ reset when ; ]
+        { allow | deny } <action> [, <action> ... ; ]
+        [ using (<expr>) ; ]
+        [ set errmessage := value ; ]
         [ reset expression ; ]
         [ create annotation <annotation-name> := <value> ; ]
         [ alter annotation <annotation-name> := <value> ; ]

--- a/docs/reference/sdl/access_policies.rst
+++ b/docs/reference/sdl/access_policies.rst
@@ -1,13 +1,10 @@
+.. versionadded:: 2.0
+
 .. _ref_eql_sdl_access_policies:
 
 ===============
 Access Policies
 ===============
-
-.. note::
-
-  ⚠️ Only available in EdgeDB 2.0 or later.
-
 
 This section describes the SDL declarations pertaining to access policies.
 

--- a/docs/reference/sdl/access_policies.rst
+++ b/docs/reference/sdl/access_policies.rst
@@ -33,7 +33,8 @@ Declare a schema where users can only see their own profiles:
         # ensure that a user cannot set the "owner" link
         # to anything but themselves.
         access policy owner_only
-            allow all using (.owner = global current_user);
+            allow all using (.owner = global current_user)
+            { errmessage := 'Profile may only be accessed by the owner'; }
     }
 
 .. _ref_eql_sdl_access_policies_syntax:
@@ -45,6 +46,7 @@ Define a new access policy corresponding to the :ref:`more explicit DDL
 commands <ref_eql_ddl_access_policies>`.
 
 .. sdl:synopsis::
+    :version-lt: 3.0
 
     # Access policy used inside a type declaration:
     access policy <name>
@@ -52,6 +54,25 @@ commands <ref_eql_ddl_access_policies>`.
       { allow | deny } <action> [, <action> ... ]
       [ using (<expr>) ]
       [ <annotation-declarations> ] ;
+
+    # where <action> is one of
+    all
+    select
+    insert
+    delete
+    update [{ read | write }]
+
+.. sdl:synopsis::
+
+    # Access policy used inside a type declaration:
+    access policy <name>
+      [ when (<condition>) ]
+      { allow | deny } <action> [, <action> ... ]
+      [ using (<expr>) ]
+      [ <annotation-declarations> ]
+      [ "{"
+         [ errmessage := value ; ]
+        "}" ] ;
 
     # where <action> is one of
     all
@@ -144,6 +165,12 @@ The access policy declaration options are as follows:
 
     When omitted, it is assumed that this policy applies to all eligible
     objects of a given type.
+
+.. versionadded:: 3.0
+
+    :eql:synopsis:`set errmessage := <value>`
+        Set a custom error message of :eql:synopsis:`<value>` that is displayed
+        when this access policy prevents a write action.
 
 :sdl:synopsis:`<annotation-declarations>`
     Set access policy :ref:`annotation <ref_eql_sdl_annotations>`


### PR DESCRIPTION
Also cleaned up a couple of warnings that access policies are a 2.0 feature by replacing those with the `versionadded` directive.