### PR TITLE
Properly rebase computed links when changing their definition

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5020,9 +5020,8 @@ class RebaseLink(LinkMetaCommand, adapts=s_links.RebaseLink):
 
         schema = super()._alter_innards(schema, context)
 
-        if not self.scls.is_pure_computable(schema):
-            self.schedule_endpoint_delete_action_update(
-                self.scls, orig_schema, schema, context)
+        self.schedule_endpoint_delete_action_update(
+            self.scls, orig_schema, schema, context)
 
         return schema
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -434,14 +434,14 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
 
         return schema, deleted_refs
 
-    def _rebase_ref(
+    def _rebase_ref_cmd(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
         scls: s_referencing.ReferencedInheritingObject,
         old_bases: Sequence[so.InheritingObject],
         new_bases: Sequence[so.InheritingObject],
-    ) -> Tuple[s_schema.Schema, sd.Command]:
+    ) -> tuple[sd.Command, Optional[sd.Command]]:
         from . import referencing as s_referencing
 
         old_base_names = [b.get_name(schema) for b in old_bases]
@@ -494,6 +494,19 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
             'ancestors',
             ancestors_coll,
         )
+
+        return alter_cmd_root, rebase_cmd
+
+    def _rebase_ref(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        scls: s_referencing.ReferencedInheritingObject,
+        old_bases: Sequence[so.InheritingObject],
+        new_bases: Sequence[so.InheritingObject],
+    ) -> Tuple[s_schema.Schema, sd.Command]:
+        alter_cmd_root, _ = self._rebase_ref_cmd(
+            schema, context, scls, old_bases, new_bases)
 
         schema = alter_cmd_root.apply(schema, context)
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1167,6 +1167,19 @@ class PointerCommandOrFragment(
             # There is an expression, therefore it is a computable.
             self.set_attribute_value('computable', True)
 
+        # If a change to the computable definition might be changing
+        # the bases, we need to create a rebase.
+        if base is not None and isinstance(self, sd.AlterObject):
+            assert isinstance(self, inheriting.InheritingObjectCommand)
+            assert isinstance(base, Pointer)
+            _, cmd = self._rebase_ref_cmd(
+                schema, context, self.scls,
+                self.scls.get_bases(schema).objects(schema),
+                [base],
+            )
+            if cmd:
+                self.add(cmd)
+
         return schema
 
     def _parse_computable(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15019,6 +15019,25 @@ DDLStatement);
             delete Foo;
         """)
 
+    async def test_edgeql_ddl_switch_link_computed_01(self):
+        await self.con.execute(r"""
+            create type Tgt;
+            create type Src {
+                create multi link l1 -> Tgt { create property s1 -> str; };
+                create multi link l2 -> Tgt { create property s2 -> str; };
+                create link c := (.l1);
+            };
+        """)
+        await self.con.execute(r"""
+            select Src { c: {@s1} };
+        """)
+        await self.con.execute(r"""
+            alter type Src alter link c using (.l2);
+        """)
+        await self.con.execute(r"""
+            select Src { c: {@s2} };
+        """)
+
     async def test_edgeql_ddl_set_abs_linkprop_type(self):
         await self.con.execute(r"""
             CREATE ABSTRACT LINK orderable {


### PR DESCRIPTION
Computed links that directly alias some other link treat that link as
a base object in order to inherit its link properties. Make sure to
properly rebase it when we change.