### PR TITLE
Support link properties on computed backlinks

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -589,7 +589,19 @@ class AlterLinkOwned(
     referrer_context_class=LinkSourceCommandContext,
     field='owned',
 ):
-    pass
+    def _alter_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._alter_begin(schema, context)
+
+        # Ownership status can impact the details of how backlinks are compiled
+        if not context.canonical:
+            desc = self.get_friendly_description(schema=schema)
+            schema = self._propagate_if_expr_refs(schema, context, action=desc)
+
+        return schema
 
 
 class SetTargetDeletePolicy(sd.Command):

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -500,6 +500,7 @@ def _trace_op(
         op: sd.AlterObjectProperty,
         parent_op: sd.ObjectCommand[so.Object],
     ) -> str:
+        nvn = None
         if isinstance(op.new_value, (so.Object, so.ObjectShell)):
             obj = op.new_value
             nvn = obj.get_name(new_schema)
@@ -524,7 +525,6 @@ def _trace_op(
         if isinstance(op.old_value, (so.Object, so.ObjectShell)):
             assert old_schema is not None
             ovn = op.old_value.get_name(old_schema)
-            nvn = op.new_value.get_name(new_schema)
             if ovn != nvn:
                 ov_item = get_deps(('delete', str(ovn)))
                 ov_item.deps.add((tag, graph_key))

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -535,6 +535,8 @@ def _populate_migration(
     # The actual check for whether the schema matches is done
     # by DESCRIBE CURRENT MIGRATION AS JSON, to populate the
     # 'complete' flag.
+    if debug.flags.delta_plan:
+        debug.header('Populate Migration Applied Diff')
     for cmd in new_ddl:
         reloaded_diff = s_ddl.delta_from_ddl(
             cmd,
@@ -543,6 +545,9 @@ def _populate_migration(
             **_get_delta_context_args(ctx),
         )
         schema = reloaded_diff.apply(schema, delta_context)
+        if debug.flags.delta_plan:
+            debug.dump(reloaded_diff, schema=schema)
+
     current_tx.update_schema(schema)
 
     return dbstate.MigrationControlQuery(


### PR DESCRIPTION
Replicating the machinery that non-schema computed backlinks use
(faking inheritance to get the link properties inherited, then undoing
it) turned out to require a huge amount of pain to transplant to a
schema context, so we dropped that whole system and instead check for
link properties on computed backlinks dynamically at compile time.

Fixes #4825.