### PR TITLE
Make sure the `migration_body` parser is precompiled in prod build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -784,6 +784,7 @@ class build_parsers(setuptools.Command):
         "edb.edgeql.parser.grammar.single",
         "edb.edgeql.parser.grammar.block",
         "edb.edgeql.parser.grammar.sdldocument",
+        "edb.edgeql.parser.grammar.migration_body",
     ]
 
     def initialize_options(self):


### PR DESCRIPTION
All top-level parsers must be precompiled for production builds.