### PR TITLE
Add missing parser pickle in Python packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -783,6 +783,7 @@ class build_parsers(setuptools.Command):
     sources = [
         "edb.edgeql.parser.grammar.single",
         "edb.edgeql.parser.grammar.block",
+        "edb.edgeql.parser.grammar.migration_body",
         "edb.edgeql.parser.grammar.sdldocument",
     ]
 


### PR DESCRIPTION
Refs #5171

Should've fixed the [failing nightly](https://github.com/edgedb/edgedb/actions/runs/4485949982/jobs/7888345271)