### PR TITLE
Make triggers chain but disallow recursion

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -206,7 +206,7 @@ class Environment:
     functions) that appear in a function body.
     """
 
-    dml_stmts: Set[irast.MutatingStmt]
+    dml_stmts: list[irast.MutatingStmt]
     """A list of DML statements in the query"""
 
     #: A list of bindings that should be assumed to be singletons.
@@ -296,7 +296,7 @@ class Environment:
         self.ptr_ref_cache = PointerRefCache()
         self.type_ref_cache = {}
         self.dml_exprs = []
-        self.dml_stmts = set()
+        self.dml_stmts = []
         self.pointer_derivation_map = collections.defaultdict(list)
         self.pointer_specified_info = {}
         self.singletons = []

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1166,7 +1166,7 @@ def fini_stmt(
     path_id: Optional[irast.PathId]
 
     if isinstance(irstmt, irast.MutatingStmt):
-        ctx.env.dml_stmts.add(irstmt)
+        ctx.env.dml_stmts.append(irstmt)
         irstmt.rewrites = ctx.env.dml_rewrites.pop(irstmt.subject, None)
 
     if (isinstance(t, s_pseudo.PseudoType)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -148,7 +148,7 @@ def fini_expression(
         ir = setgen.scoped_set(ir, ctx=ctx)
 
     # Compile any triggers that were triggered by the query
-    ir_triggers = triggers.compile_triggers(ctx.env.dml_stmts, ctx=ctx)
+    ir_triggers = triggers.compile_triggers(ctx=ctx)
 
     # Collect all of the expressions stored in various side sets
     # that can make it into the output, so that we can make sure
@@ -164,7 +164,7 @@ def fini_expression(
         p.sub_params.decoder_ir for p in ctx.env.query_parameters.values()
         if p.sub_params and p.sub_params.decoder_ir
     ]
-    extra_exprs += [trigger.expr for trigger in ir_triggers]
+    extra_exprs += [trigger.expr for stage in ir_triggers for trigger in stage]
 
     all_exprs = [ir] + extra_exprs
 

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -150,7 +150,7 @@ def compile_triggers_phase(
                     ctx.env.schema, defining_trigger_on):
                 name = str(defining_trigger_on.get_name(ctx.env.schema))
                 raise errors.SchemaDefinitionError(
-                    f"trigger on {name} would need to fire recursively"
+                    f"trigger on {name} is recursive"
                 )
 
             for trigger in subtype.get_relevant_triggers(kind, schema):

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -24,11 +24,14 @@ from __future__ import annotations
 
 from typing import *
 
+from edb import errors
+
 from edb.ir import ast as irast
 
 from edb.schema import name as sn
 from edb.schema import objtypes as s_objtypes
 from edb.schema import triggers as s_triggers
+from edb.schema import types as s_types
 
 from edb.edgeql import qltypes
 
@@ -49,6 +52,7 @@ TRIGGER_KINDS = {
 def compile_trigger(
     trigger: s_triggers.Trigger,
     affected: set[tuple[s_objtypes.ObjectType, irast.MutatingStmt]],
+    all_typs: set[s_objtypes.ObjectType],
     *,
     ctx: context.ContextLevel,
 ) -> irast.Trigger:
@@ -96,6 +100,9 @@ def compile_trigger(
     taffected = {
         (typegen.type_to_typeref(t, env=ctx.env), ir) for t, ir in affected
     }
+    tall = {
+        typegen.type_to_typeref(t, env=ctx.env) for t in all_typs
+    }
 
     return irast.Trigger(
         expr=trigger_set,
@@ -103,13 +110,15 @@ def compile_trigger(
         scope=scope,
         source_type=typeref,
         affected=taffected,
+        all_affected_types=tall,
         new_set=new_set,
         old_set=old_set,
     )
 
 
-def compile_triggers(
+def compile_triggers_phase(
     dml_stmts: Collection[irast.MutatingStmt],
+    defining_trigger_on: Optional[s_types.Type],
     *,
     ctx: context.ContextLevel,
 ) -> tuple[irast.Trigger, ...]:
@@ -117,7 +126,10 @@ def compile_triggers(
 
     trigger_map: dict[
         s_triggers.Trigger,
-        set[tuple[s_objtypes.ObjectType, irast.MutatingStmt]],
+        tuple[
+            set[tuple[s_objtypes.ObjectType, irast.MutatingStmt]],
+            set[s_objtypes.ObjectType],
+        ],
     ] = {}
     for stmt in dml_stmts:
         kind = TRIGGER_KINDS[type(stmt)]
@@ -134,10 +146,17 @@ def compile_triggers(
 
         # Process all the types, starting with the base type
         for subtype in sorted(stypes, key=lambda t: t != stype):
+            if defining_trigger_on and subtype.issubclass(
+                    ctx.env.schema, defining_trigger_on):
+                name = str(defining_trigger_on.get_name(ctx.env.schema))
+                raise errors.SchemaDefinitionError(
+                    f"trigger on {name} would need to fire recursively"
+                )
+
             for trigger in subtype.get_relevant_triggers(kind, schema):
                 mro = (trigger, *trigger.get_ancestors(schema).objects(schema))
                 base = mro[-1]
-                tmap = trigger_map.setdefault(base, set())
+                tmap, all_typs = trigger_map.setdefault(base, (set(), set()))
                 # N.B: If the *base type* of the DML appears, that
                 # suffices, because it covers everything, and we don't
                 # need to duplicate.  This is a specific interaction
@@ -147,10 +166,47 @@ def compile_triggers(
                 # a grandchild.
                 if (stype, stmt) not in tmap:
                     tmap.add((subtype, stmt))
+                all_typs.add(subtype)
 
     # sort these by name just to avoid weird nondeterminism
     return tuple(
-        compile_trigger(trigger, affected, ctx=ctx)
-        for trigger, affected
+        compile_trigger(trigger, affected, all_typs, ctx=ctx)
+        for trigger, (affected, all_typs)
         in sorted(trigger_map.items(), key=lambda t: t[0].get_name(schema))
     )
+
+
+def compile_triggers(
+    *, ctx: context.ContextLevel,
+) -> tuple[tuple[irast.Trigger, ...], ...]:
+    defining_trigger = (
+        ctx.env.options.schema_object_context == s_triggers.Trigger)
+    defining_trigger_on = None
+    if defining_trigger:
+        defining_trigger_on = setgen.get_set_type(
+            ctx.anchors['__trigger_type__'], ctx=ctx)
+
+    ir_triggers: list[tuple[irast.Trigger, ...]] = []
+    start = 0
+    all_trigger_types: set[irast.TypeRef] = set()
+    while start < len(ctx.env.dml_stmts):
+        end = len(ctx.env.dml_stmts)
+        new = compile_triggers_phase(
+            ctx.env.dml_stmts[start:], defining_trigger_on, ctx=ctx)
+        new_types = {x for t in new for x in t.all_affected_types}
+
+        # Any given type is allowed allowed to have its triggers fire
+        # in *one* phase of trigger execution, since the semantics get
+        # a little unclear otherwise. We might relax this later.
+        overlap = new_types & all_trigger_types
+        if overlap:
+            names = sorted(str(t.name_hint) for t in overlap)
+            raise errors.QueryError(
+                f"trigger would need to be executed in multiple stages on "
+                f"{', '.join(names)}"
+            )
+        all_trigger_types |= new_types
+        ir_triggers.append(new)
+        start = end
+
+    return tuple(ir_triggers)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -702,7 +702,7 @@ class Statement(Command):
     dml_exprs: typing.List[qlast.Base]
     type_rewrites: typing.Dict[typing.Tuple[uuid.UUID, bool], Set]
     singletons: typing.List[PathId]
-    triggers: tuple[Trigger, ...]
+    triggers: tuple[tuple[Trigger, ...], ...]
 
 
 class TypeIntrospection(ImmutableExpr):
@@ -1116,13 +1116,14 @@ class Trigger(Base):
     expr: Set
     # All the relevant dml
     affected: set[tuple[TypeRef, MutatingStmt]]
+    all_affected_types: set[TypeRef]
     source_type: TypeRef
     kinds: set[qltypes.TriggerKind]
     scope: qltypes.TriggerScope
 
     # N.B: Semantically and in the external language, delete triggers
     # don't have a __new__ set, but we give it one in the
-    # implementation (identical) to the old set, to help make the
+    # implementation (identical to the old set), to help make the
     # implementation more uniform.
     new_set: Set
     old_set: typing.Optional[Set]

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -71,7 +71,7 @@ def compile_ir_to_sql_tree(
         query_params = []
         query_globals = []
         type_rewrites = {}
-        triggers: tuple[irast.Trigger, ...] = ()
+        triggers: tuple[tuple[irast.Trigger, ...], ...] = ()
 
         singletons = []
         if isinstance(ir_expr, irast.Statement):

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1665,6 +1665,7 @@ def range_for_typeref(
             lateral=lateral,
             include_descendants=include_descendants,
             ignore_rewrites=ignore_rewrites,
+            include_overlays=not for_mutation,
             for_mutation=for_mutation,
             dml_source=dml_source,
             ctx=ctx,

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -998,7 +998,7 @@ class TestTriggers(tb.QueryTestCase):
     async def test_edgeql_triggers_chain_02(self):
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaDefinitionError,
-                'default::InsertTest would need to fire recursively'):
+                'trigger on default::InsertTest is recursive'):
             await self.con.execute('''
                 alter type InsertTest {
                   create trigger log after insert for each do (


### PR DESCRIPTION
The semantics here is that triggers fire off in "phases"; phase 1 is
all triggers that were triggered by the real query, phase 2 has
triggers that were triggered by phase 1, etc.

Currently we disallow firing the same trigger in multiple phases.

Progress on #5186.