### PR TITLE
Allow globals to be used in defaults

### DIFF
--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -83,6 +83,9 @@ class GlobalCompilerOptions:
     #: error. When this is not None, any DML should cause an error.
     in_ddl_context_name: Optional[str] = None
 
+    #: Whether to just treat all globals as empty instead of compiling them
+    make_globals_empty: bool = False
+
     #: Is this a dev instance of the compiler
     devmode: bool = False
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4033,6 +4033,7 @@ class PointerMetaCommand(
         context: sd.CommandContext,
         *,
         fill_expr: Optional[s_expr.Expression],
+        is_default: bool=False,
     ) -> None:
         new_required = self.scls.get_required(schema)
 
@@ -4125,7 +4126,8 @@ class PointerMetaCommand(
                 schema=schema,
                 orig_schema=orig_schema,
                 context=context,
-                check_non_null=is_required and not is_multi
+                check_non_null=is_required and not is_multi,
+                allow_globals=is_default,
             )
 
             if not is_multi:
@@ -4433,6 +4435,7 @@ class PointerMetaCommand(
         target_as_singleton: bool = True,
         check_non_null: bool = False,
         produce_ctes: bool = True,
+        allow_globals: bool=False,
     ) -> Tuple[
         str,  # SQL
         bool,  # is_nullable
@@ -4468,6 +4471,7 @@ class PointerMetaCommand(
                 context,
                 conv_expr,
                 target_as_singleton=target_as_singleton,
+                make_globals_empty=allow_globals,
                 no_query_rewrites=True,
             )
         ir = conv_expr.irast
@@ -4490,6 +4494,7 @@ class PointerMetaCommand(
                     schema=orig_schema,
                 ),
                 target_as_singleton=target_as_singleton,
+                make_globals_empty=allow_globals,
                 no_query_rewrites=True,
             )
 
@@ -4934,7 +4939,8 @@ class LinkMetaCommand(PointerMetaCommand[s_links.Link]):
                 and not fills_required
             ):
                 self._alter_pointer_optionality(
-                    schema, schema, context, fill_expr=default)
+                    schema, schema, context,
+                    fill_expr=default, is_default=True)
             # If we're creating a required multi pointer without a SET
             # REQUIRED USING inside, run the alter_pointer_optionality
             # path to produce an error if there is existing data.
@@ -5403,7 +5409,8 @@ class PropertyMetaCommand(PointerMetaCommand[s_props.Property]):
                 and not prop.is_link_property(schema)
             ):
                 self._alter_pointer_optionality(
-                    schema, schema, context, fill_expr=default)
+                    schema, schema, context,
+                    fill_expr=default, is_default=True)
             # If we're creating a required multi pointer without a SET
             # REQUIRED USING inside, run the alter_pointer_optionality
             # path to produce an error if there is existing data.

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1437,6 +1437,7 @@ class PointerCommandOrFragment(
         target_as_singleton: bool = False,
         expr_description: Optional[str] = None,
         no_query_rewrites: bool = False,
+        make_globals_empty: bool = False,
         source_context: Optional[parsing.ParserContext] = None,
     ) -> s_expr.CompiledExpression:
         singletons: List[Union[s_types.Type, Pointer]] = []
@@ -1493,6 +1494,7 @@ class PointerCommandOrFragment(
                 apply_query_rewrites=(
                     not context.stdmode and not no_query_rewrites
                 ),
+                make_globals_empty=make_globals_empty,
                 track_schema_ref_exprs=track_schema_ref_exprs,
                 in_ddl_context_name=in_ddl_context_name,
             )


### PR DESCRIPTION
Currently it is supported only on newly created objects and not when
migrating. Compile default conversion expressions in a mode where
defaults are always treated as empty.

Fixes #5223.