### PR TITLE
Require inheritance order to be consistent with the specified base order

### DIFF
--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -3326,7 +3326,7 @@ def _merge_lineage(
                 break
         else:
             raise errors.SchemaError(
-                f"Could not find consistent ancestor order for {subject_name}"
+                f"could not find consistent ancestor order for {subject_name}"
             )
 
         result.append(candidate)
@@ -3346,6 +3346,7 @@ def _compute_lineage(
 
     for base in bases:
         lineage.append(_compute_lineage(schema, base, subject_name))
+    lineage.append(list(bases))
 
     return _merge_lineage(lineage, subject_name)
 
@@ -3358,8 +3359,15 @@ def compute_lineage(
     lineage = []
     for base in bases:
         lineage.append(_compute_lineage(schema, base, subject_name))
+    lineage.append(list(bases))
 
-    return _merge_lineage(lineage, subject_name)
+    try:
+        return _merge_lineage(lineage, subject_name)
+    except errors.SchemaError as e:
+        sbases = ', '.join(str(base.get_name(schema)) for base in bases)
+        details = f'type has specified bases: {sbases}'
+        e.set_hint_and_details(hint=e.hint, details=details)
+        raise
 
 
 def compute_ancestors(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1384,7 +1384,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
             CREATE MODULE default;
             CREATE TYPE default::A;
             CREATE TYPE default::B EXTENDING A;
-            CREATE TYPE default::C EXTENDING A, B;
+            CREATE TYPE default::C EXTENDING B, A;
         ''')
 
         orig_get_children = type(schema).get_children
@@ -7775,7 +7775,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 abstract type C extending B;
                 abstract type C2 extending C;
                 abstract type D;
-                type F extending C, C2, B;
+                type F extending C2, C, B;
             """,
             r"""
             """,
@@ -7807,8 +7807,8 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 abstract type C extending B;
                 abstract type C2 extending C;
                 abstract type D;
-                type F extending C, C2, B;
-                type F2 extending C, C2, B, F;
+                type F extending C2, C, B;
+                type F2 extending F, C2, C, B;
             """,
             r"""
             """,


### PR DESCRIPTION
It was always, we believe, the intention to implement the C3 ordering
(like Python), and so it was just a bug that this was not enforced in the
past.

Unfortunately this breaks backwards compatability in a pretty obvious way.

This PR does not do include any backward compatability mechanisms, and 
instead will rely on users fixing the issue first and using an 
in-development migration squashing tool (edgedb/edgedb-cli#976), the same
as any other bug fix that impacts compatability.

This one might have a bigger impact than most, though, so maybe we do need
to do something? Or we could just release a beta/RC with it and see if it
seems to cause a lot of grief, and then decide?

Fixes #5118.