### PR TITLE
SQL pg_dump

### DIFF
--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -955,6 +955,7 @@ def _build_a_expr(n: Node, c: Context) -> pgast.BaseExpr:
 
 def _build_func_call(n: Node, c: Context) -> pgast.FuncCall:
     n = _unwrap(n, "FuncCall")
+
     return pgast.FuncCall(
         name=tuple(_list(n, c, "funcname", _build_str)),
         args=_maybe_list(n, c, "args", _build_base_expr) or [],

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -306,6 +306,7 @@ def resolve_SortBy(
 func_calls_remapping: Dict[Tuple[str, ...], Tuple[str, ...]] = {
     ('information_schema', '_pg_truetypid'): ('edgedbsql', '_pg_truetypid'),
     ('information_schema', '_pg_truetypmod'): ('edgedbsql', '_pg_truetypmod'),
+    ('pg_catalog', 'format_type'): ('edgedb', '_format_type'),
 }
 
 

--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -82,6 +82,9 @@ def eval_BaseConstant(
 def eval_TypeCast(
     expr: pgast.TypeCast, *, ctx: Context
 ) -> Optional[pgast.BaseExpr]:
+    if expr.type_name.array_bounds:
+        return None
+
     pg_catalog_name = name_in_pg_catalog(expr.type_name.name)
     if pg_catalog_name == 'regclass':
         return cast_to_regclass(expr.arg, ctx)
@@ -106,7 +109,6 @@ def eval_TypeCast(
             if 'false'.startswith(string) or 'no'.startswith(string):
                 return pgast.BooleanConstant(val=False)
             raise errors.QueryError('invalid cast', context=expr.arg)
-        return arg
 
     return None
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -25,6 +25,7 @@ from typing import *
 import asyncio
 import atexit
 import contextlib
+import dataclasses
 import functools
 import heapq
 import http
@@ -51,8 +52,10 @@ import edgedb
 from edb.edgeql import quote as qlquote
 from edb.server import args as edgedb_args
 from edb.server import cluster as edgedb_cluster
+from edb.server import pgcluster
 from edb.server import defines as edgedb_defines
 from edb.server import main as edgedb_main
+from edb.server import pgconnparams
 
 from edb.common import assert_data_shape
 from edb.common import devmode
@@ -67,6 +70,7 @@ from edb.testbase import connection as tconn
 
 
 if TYPE_CHECKING:
+    import asyncpg
     DatabaseName = str
     SetupScript = str
 
@@ -1244,6 +1248,7 @@ class QueryTestCase(BaseQueryTestCase):
 
 
 class SQLQueryTestCase(BaseQueryTestCase):
+
     BASE_TEST_CLASS = True
 
     @classmethod
@@ -1438,6 +1443,235 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
             self.__class__.con = oldcon
             await con2.aclose()
             await drop_db(self.con, q_tgt_dbname)
+
+
+class StablePGDumpTestCase(BaseQueryTestCase):
+
+    BASE_TEST_CLASS = True
+    ISOLATED_METHODS = False
+    STABLE_DUMP = True
+    TRANSACTION_ISOLATION = False
+
+    def run_pg_dump(self, *args, input: Optional[str] = None) -> None:
+        conargs = self.get_connect_args()
+        self.run_pg_dump_on_connection(conargs, *args, input=input)
+
+    @classmethod
+    def run_pg_dump_on_connection(
+        cls, conargs: Dict[str, Any], *args, input: Optional[str] = None
+    ) -> None:
+        dsn = (
+            f"postgres://{conargs['user']}:{conargs['password']}@"
+            f"{conargs['host']}:{conargs['port']}/{cls.con.dbname}?"
+            f"sslrootcert={conargs['tls_ca_file']}"
+        )
+        cmd = [cls._pg_bin_dir / 'pg_dump', '--dbname', dsn]
+        cmd += args
+        try:
+            subprocess.run(
+                cmd,
+                input=input.encode() if input else None,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            output = '\n'.join(getattr(out, 'decode', out.__str__)()
+                               for out in [e.output, e.stderr] if out)
+            raise AssertionError(
+                f'command {cmd} returned non-zero exit status {e.returncode}'
+                f'\n{output}'
+            ) from e
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import asyncpg
+        except ImportError:
+            raise unittest.SkipTest('SQL tests skipped: asyncpg not installed')
+
+        super().setUpClass()
+        conargs = cls.get_connect_args()
+        src_dbname = cls.con.dbname
+        tgt_dbname = f'restored_{src_dbname}'
+
+        cls._pg_bin_dir = cls.loop.run_until_complete(
+            pgcluster.get_pg_bin_dir())
+
+        # Get the connection to the Postgres backend
+        settings = cls.con.get_settings()
+        pgaddr = settings.get('pgaddr')
+        if pgaddr is None:
+            raise unittest.SkipTest('SQL tests skipped: not in devmode')
+        pgaddr = json.loads(pgaddr)
+
+        # Try to grab a password from the specified DSN, if one is
+        # present, since the pgaddr won't have a real one. (The non
+        # specified DSN test suite setup doesn't have one, so it is
+        # fine.)
+        password = None
+        spec_dsn = os.environ.get('EDGEDB_TEST_BACKEND_DSN')
+        if spec_dsn:
+            _, params = pgconnparams.parse_dsn(spec_dsn)
+            password = params.password
+
+        pgparams = (
+            f'?user={pgaddr["user"]}'
+            f'&port={pgaddr["port"]}&host={pgaddr["host"]}'
+        )
+        if password is not None:
+            pgparams += f'&password={password}'
+
+        cls.backend = cls.loop.run_until_complete(
+            asyncpg.connect(f'postgres:///{pgaddr["database"]}' + pgparams))
+
+        # Run pg_dump to create the dump data for an existing EdgeDB database.
+        with tempfile.NamedTemporaryFile() as f:
+            cls.run_pg_dump_on_connection(conargs, '-f', f.name)
+            # Create a new Postgres database to be used for dump tests.
+            db_exists = cls.loop.run_until_complete(
+                cls.backend.fetch(f'''
+                    SELECT oid
+                    FROM pg_database
+                    WHERE datname = {tgt_dbname!r}
+                ''')
+            )
+            if list(db_exists):
+                cls.loop.run_until_complete(
+                    cls.backend.execute(f'drop database {tgt_dbname}')
+                )
+            cls.loop.run_until_complete(
+                cls.backend.execute(f'create database {tgt_dbname}')
+            )
+
+            newdsn = f'postgres:///{tgt_dbname}' + pgparams
+            # Populate the new database using the dump
+            cmd = [
+                cls._pg_bin_dir / 'psql',
+                '-a',
+                '--dbname', newdsn,
+                '-f', f.name,
+                '-v', 'ON_ERROR_STOP=on',
+            ]
+            try:
+                subprocess.run(
+                    cmd,
+                    input=None,
+                    check=True,
+                    capture_output=True,
+                )
+            except subprocess.CalledProcessError as e:
+                output = '\n'.join(getattr(out, 'decode', out.__str__)()
+                                   for out in [e.output, e.stderr] if out)
+                raise AssertionError(
+                    f'command {cmd} returned non-zero exit status '
+                    f'{e.returncode}\n{output}'
+                ) from e
+
+        # Connect to the newly created database.
+        cls.scon = cls.loop.run_until_complete(
+            asyncpg.connect(f'postgres:///{tgt_dbname}' + pgparams))
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.loop.run_until_complete(cls.scon.close())
+            # Give event loop another iteration so that connection
+            # transport has a chance to properly close.
+            cls.loop.run_until_complete(asyncio.sleep(0))
+            cls.scon = None
+
+            tgt_dbname = f'restored_{cls.con.dbname}'
+            cls.loop.run_until_complete(
+                cls.backend.execute(f'drop database {tgt_dbname}')
+            )
+            cls.loop.run_until_complete(cls.backend.close())
+            cls.loop.run_until_complete(asyncio.sleep(0))
+        finally:
+            super().tearDownClass()
+
+    def assert_shape(
+        self,
+        sqlres: Iterable[Any],
+        eqlres: Iterable[asyncpg.Record],
+    ) -> None:
+        """
+        Compare the shape of results produced by a SQL query and an EdgeQL
+        query.
+        """
+
+        assert_data_shape.assert_data_shape(
+            list(sqlres),
+            [dataclasses.asdict(r) for r in eqlres],
+            self.fail,
+            from_sql=True,
+        )
+
+    def multi_prop_subquery(self, source: str, prop: str) -> str:
+        "Propduce a subquery fetching a multi prop as an array."
+
+        return (
+            f'(SELECT array_agg(target) FROM "{source}.{prop}"'
+            f' WHERE source = "{source}".id) AS {prop}'
+        )
+
+    def single_link_subquery(
+        self,
+        source: str,
+        link: str,
+        target: str,
+        link_props: Optional[Iterable[str]] = None
+    ) -> str:
+        """Propduce a subquery fetching a single link as a record.
+
+        If no link properties are specified then the array of records will be
+        made up of target types.
+
+        If the link properties are specified then the array of records will be
+        made up of link records.
+        """
+
+        if link_props:
+            return (
+                f'(SELECT x FROM "{target}"'
+                f' JOIN "{source}.{link}" x ON x.target = "{target}".id'
+                f' WHERE x.source = "{source}".id) AS _{link}'
+            )
+
+        else:
+            return (
+                f'(SELECT "{target}" FROM "{target}"'
+                f' WHERE "{target}".id = "{source}".{link}_id) AS {link}'
+            )
+
+    def multi_link_subquery(
+        self,
+        source: str,
+        link: str,
+        target: str,
+        link_props: Optional[Iterable[str]] = None
+    ) -> str:
+        """Propduce a subquery fetching a multi link as an array or records.
+
+        If no link properties are specified then the array of records will be
+        made up of target types.
+
+        If the link properties are specified then the array of records will be
+        made up of link records.
+        """
+
+        if link_props:
+            return (
+                f'(SELECT array_agg(x) FROM "{target}"'
+                f' JOIN "{source}.{link}" x ON x.target = "{target}".id'
+                f' WHERE x.source = "{source}".id) AS _{link}'
+            )
+
+        else:
+            return (
+                f'(SELECT array_agg("{target}") FROM "{target}"'
+                f' JOIN "{source}.{link}" x ON x.target = "{target}".id'
+                f' WHERE x.source = "{source}".id) AS {link}'
+            )
 
 
 def get_test_cases_setup(

--- a/tests/schemas/pg_dump01_default.esdl
+++ b/tests/schemas/pg_dump01_default.esdl
@@ -1,0 +1,124 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+type A {
+    annotation title := 'A';
+
+    property p_bool -> bool {
+        annotation title := 'single bool';
+    }
+    property p_str -> str;
+    property p_datetime -> datetime;
+    property p_local_datetime -> cal::local_datetime;
+    property p_local_date -> cal::local_date;
+    property p_local_time -> cal::local_time;
+    property p_duration -> duration;
+    property p_relative_duration -> cal::relative_duration;
+    property p_date_duration -> cal::date_duration;
+    property p_int16 -> int16;
+    property p_int32 -> int32;
+    property p_int64 -> int64;
+    property p_float32 -> float32;
+    property p_float64 -> float64;
+    property p_bigint -> bigint;
+    property p_decimal -> decimal;
+    property p_json -> json;
+    property p_bytes -> bytes;
+}
+
+type B {
+    annotation title := 'B';
+
+    property arr_bool -> array<bool>;
+    property arr_str -> array<str>;
+    property arr_datetime -> array<datetime>;
+    property arr_local_datetime -> array<cal::local_datetime>;
+    property arr_local_date -> array<cal::local_date>;
+    property arr_local_time -> array<cal::local_time>;
+    property arr_duration -> array<duration>;
+    property arr_relative_duration -> array<cal::relative_duration>;
+    property arr_date_duration -> array<cal::date_duration>;
+    property arr_int16 -> array<int16>;
+    property arr_int32 -> array<int32>;
+    property arr_int64 -> array<int64>;
+    property arr_float32 -> array<float32>;
+    property arr_float64 -> array<float64>;
+    property arr_bigint -> array<bigint>;
+    property arr_decimal -> array<decimal>;
+    property arr_json -> array<json>;
+    property arr_bytes -> array<bytes>;
+}
+
+type C {
+    annotation title := 'C';
+
+    property tup0 -> tuple<bool, str, datetime>;
+    property tup1 -> tuple<
+                        cal::local_datetime,
+                        cal::local_date,
+                        cal::local_time,
+                        duration
+                     >;
+    property tup2 -> tuple<
+                        cal::relative_duration,
+                        cal::date_duration,
+                        json,
+                        bytes
+                     >;
+    property tup3 -> tuple<
+                        int16,
+                        int32,
+                        int64,
+                        float32,
+                        float64,
+                        bigint,
+                        decimal
+                     >;
+
+    property nested0 -> array<tuple<array<tuple<array<int64>>>>>;
+    property nested1 -> tuple<
+                            Positive,
+                            str,
+                            tuple<
+                                tuple<
+                                    float64,
+                                    bool,
+                                >,
+                                tuple<
+                                    cal::local_date,
+                                    cal::local_time,
+                                >,
+                            >,
+                        >;
+
+    property r_int32 -> range<std::int32>;
+    property r_int64 -> range<std::int64>;
+    property r_float32 -> range<std::float32>;
+    property r_float64 -> range<std::float64>;
+    property r_decimal -> range<std::decimal>;
+    property r_datetime -> range<std::datetime>;
+    property r_local_datetime -> range<cal::local_datetime>;
+    property r_local_date -> range<cal::local_date>;
+
+    property pos -> Positive;
+}
+
+scalar type Positive extending int64 {
+  constraint min_value(1);
+};

--- a/tests/schemas/pg_dump01_setup.edgeql
+++ b/tests/schemas/pg_dump01_setup.edgeql
@@ -1,0 +1,120 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+SET MODULE default;
+
+INSERT A {
+    p_bool := True,
+    p_str := 'Hello',
+    p_datetime := <datetime>'2018-05-07T20:01:22.306916+00:00',
+    p_local_datetime := <cal::local_datetime>'2018-05-07T20:01:22.306916',
+    p_local_date := <cal::local_date>'2018-05-07',
+    p_local_time := <cal::local_time>'20:01:22.306916',
+    p_duration := <duration>'20 hrs',
+    p_relative_duration := <cal::relative_duration>'3 days 4 hrs',
+    p_date_duration := <cal::date_duration>'2 months 5 days',
+    p_int16 := 12345,
+    p_int32 := 1234567890,
+    p_int64 := 1234567890123,
+    p_float32 := 2.5,
+    p_float64 := 2.5,
+    p_bigint := 123456789123456789123456789n,
+    p_decimal := 123456789123456789123456789.123456789123456789123456789n,
+    p_json := to_json('[{"a": null, "b": true}, 1, 2.5, "foo"]'),
+    p_bytes := b'Hello',
+};
+
+INSERT B {
+    arr_bool := [True, False],
+    arr_str := ['Hello', 'world'],
+    arr_datetime := [<datetime>'2018-05-07T20:01:22.306916+00:00'],
+    arr_local_datetime := [<cal::local_datetime>'2018-05-07T20:01:22.306916'],
+    arr_local_date := [<cal::local_date>'2018-05-07'],
+    arr_local_time := [<cal::local_time>'20:01:22.306916'],
+    arr_duration := [<duration>'20 hrs'],
+    arr_relative_duration := [<cal::relative_duration>'3 days 4 hrs'],
+    arr_date_duration := [<cal::date_duration>'2 months 5 days'],
+    arr_int16 := [12345],
+    arr_int32 := [1234567890],
+    arr_int64 := [1234567890123],
+    arr_float32 := [2.5],
+    arr_float64 := [2.5],
+    arr_bigint := [123456789123456789123456789n],
+    arr_decimal := [123456789123456789123456789.123456789123456789123456789n],
+    arr_json := [to_json('[{"a": null, "b": true}, 1, 2.5, "foo"]')],
+    arr_bytes := [b'Hello', b'world'],
+};
+
+INSERT C {
+    tup0 := (
+      True,
+      'Hello',
+      <datetime>'2018-05-07T20:01:22.306916+00:00',
+    ),
+    tup1 := (
+      <cal::local_datetime>'2018-05-07T20:01:22.306916',
+      <cal::local_date>'2018-05-07',
+      <cal::local_time>'20:01:22.306916',
+      <duration>'20 hrs',
+    ),
+    tup2 := (
+      <cal::relative_duration>'3 days 4 hrs',
+      <cal::date_duration>'2 months 5 days',
+      to_json('[{"a": null, "b": true}, 1, 2.5, "foo"]'),
+      b'Hello',
+    ),
+    tup3 := (
+      12345,
+      1234567890,
+      1234567890123,
+      2.5,
+      2.5,
+      123456789123456789123456789n,
+      123456789123456789123456789.123456789123456789123456789n,
+    ),
+
+    nested0 := [
+        ([([0, 1],), ([2, 3, 4],)],),
+        ([([5, 6],), (<array<int64>>[],)],),
+    ],
+    nested1 := (
+        <Positive>2,
+        'some string',
+        (
+            (-1.2, False),
+            (
+                <cal::local_date>'2023-05-17',
+                <cal::local_time>'21:43:56',
+            ),
+        ),
+    ),
+
+    r_int32 := range(<int32>1, <int32>20),
+    r_int64 := range(2, 123456789012),
+    r_float32 := range(<float32>1.1, <float32>2.2),
+    r_float64 := range(0.1, 2.3),
+    r_decimal := range(1.2n, 3.4n),
+    r_datetime := range(<datetime>'2022-01-31T11:22:33Z',
+                        <datetime>'2024-03-31T17:28:04Z'),
+    r_local_datetime := range(<cal::local_datetime>'2022-02-15T11:22:33',
+                              <cal::local_datetime>'2024-04-25T17:28:04'),
+    r_local_date := range(<cal::local_date>'2022-03-17',
+                          <cal::local_date>'2024-05-31'),
+    pos := <Positive>1234,
+};

--- a/tests/schemas/pg_dump02_default.esdl
+++ b/tests/schemas/pg_dump02_default.esdl
@@ -1,0 +1,71 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+abstract annotation `🍿`;
+
+abstract constraint `🚀🍿`(max: int64) extending max_len_value;
+
+function `💯`(NAMED ONLY `🙀`: int64) -> int64 {
+    using (
+        SELECT 100 - `🙀`
+    );
+
+    annotation `🍿` := 'fun!🚀';
+    volatility := 'Immutable';
+}
+
+type `S p a M` {
+    required property `🚀` -> int32;
+    property c100 := (SELECT `💯`(`🙀` := .`🚀`));
+}
+
+type A {
+    required link `s p A m 🤞` -> `S p a M`;
+}
+
+scalar type 你好 extending str;
+
+scalar type مرحبا extending 你好 {
+    constraint `🚀🍿`(100);
+};
+
+scalar type `🚀🚀🚀` extending مرحبا;
+
+type Łukasz {
+    required property `Ł🤞` -> `🚀🚀🚀` {
+        default := <`🚀🚀🚀`>'你好🤞'
+    }
+    index on (.`Ł🤞`);
+
+    link `Ł💯` -> A {
+        property `🙀🚀🚀🚀🙀` -> `🚀🚀🚀`;
+        property `🙀مرحبا🙀` -> مرحبا {
+            constraint `🚀🍿`(200);
+        }
+    };
+}
+
+type Tree {
+    required property val -> str {
+        constraint exclusive;
+    };
+
+    link parent -> Tree;
+    link children := .<parent[IS Tree];
+    property child_vals := .children.val;
+}

--- a/tests/schemas/pg_dump02_setup.edgeql
+++ b/tests/schemas/pg_dump02_setup.edgeql
@@ -1,0 +1,72 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+SET MODULE default;
+
+# Not sure if the esdl filename will handle this on all systems, so
+# I'm adding stuff here.
+CREATE MODULE `💯💯💯`;
+
+CREATE MODULE `back``ticked`;
+
+CREATE FUNCTION `💯💯💯`::`🚀🙀🚀`(`🤞`: default::`🚀🚀🚀`) -> `🚀🚀🚀`
+USING (
+    SELECT <`🚀🚀🚀`>(`🤞` ++ 'Ł🙀')
+);
+
+CREATE TYPE `💯💯💯`::`🚀🙀🚀Type` {
+  CREATE PROPERTY p_你好 -> 你好;
+};
+
+CREATE TYPE `back``ticked`::`Ticked``Type` {
+    CREATE PROPERTY `p_``ticked` -> str;
+};
+# end of DDL
+
+INSERT `S p a M` {
+    `🚀` := 42
+};
+
+INSERT A {
+    `s p A m 🤞` := assert_single((SELECT `S p a M` FILTER .`🚀` = 42))
+};
+
+INSERT Łukasz;
+
+INSERT Łukasz {
+    `Ł🤞` := 'simple 🚀',
+    `Ł💯` := (
+        SELECT A
+        {
+            `🙀🚀🚀🚀🙀`:= 'Łink prop 🙀🚀🚀🚀🙀',
+            `🙀مرحبا🙀`:=
+                `💯💯💯`::`🚀🙀🚀`('Łink prop 🙀مرحبا🙀'),
+        }
+        FILTER .`s p A m 🤞`.`🚀` = 42
+        LIMIT 1
+    )
+};
+
+INSERT `💯💯💯`::`🚀🙀🚀Type` {
+    p_你好 := 'plain text',
+};
+
+INSERT `back``ticked`::`Ticked``Type` {
+    `p_``ticked` := 'no backticks here',
+};

--- a/tests/test_pg_dump.py
+++ b/tests/test_pg_dump.py
@@ -1,0 +1,421 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+from edb.testbase import server as tb
+
+
+class TestPGDump01(tb.StablePGDumpTestCase):
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'pg_dump01_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'pg_dump01_setup.edgeql')
+
+    async def test_pgdump01_dump_restore_01(self):
+        eqlres = await self.con.query('select A {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "A"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump01_dump_restore_02(self):
+        eqlres = await self.con.query('select B {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "B"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump01_dump_restore_03(self):
+        eqlres = await self.con.query('select C {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "C"')
+        self.assert_shape(sqlres, eqlres)
+
+
+class TestPGDump02(tb.StablePGDumpTestCase):
+
+    SCHEMA_TEST = os.path.join(os.path.dirname(__file__), 'schemas',
+                               'dump01_test.esdl')
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump01_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump01_setup.edgeql')
+
+    async def test_pgdump02_dump_restore_01(self):
+        eqlres = await self.con.query('select A {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "A"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_02(self):
+        props = [
+            'p_bool', 'p_str', 'p_datetime', 'p_local_datetime',
+            'p_local_date', 'p_local_time', 'p_duration', 'p_int16',
+            'p_int32', 'p_int64', 'p_float32', 'p_float64', 'p_bigint',
+            'p_decimal', 'p_json', 'p_bytes',
+        ]
+        eqlres = await self.con.query(f'select B {{id, {", ".join(props)}}}')
+
+        sql = f'''
+            SELECT
+                id,
+                {", ".join(self.multi_prop_subquery("B", p) for p in props)}
+            FROM "B"
+
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_03(self):
+        eqlres = await self.con.query('select C {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "C"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_04(self):
+        eqlres = await self.con.query('''
+            select D {
+                id,
+                num,
+                single_link: {*},
+                multi_link: {*}
+            }
+        ''')
+
+        sql = f'''
+            SELECT
+                id,
+                num,
+                {self.single_link_subquery("D", "single_link", "C")},
+                {self.multi_link_subquery("D", "multi_link", "C")}
+            FROM "D"
+
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_05(self):
+        eqlres = await self.con.query('''
+            select E {
+                id,
+                num,
+                _single_link := .single_link {
+                    source := @source.id,
+                    lp0 := @lp0,
+                    target := .id,
+                },
+                _multi_link := .multi_link {
+                    source := @source.id,
+                    lp1 := @lp1,
+                    target := .id,
+                },
+            }
+        ''')
+
+        sql = f'''
+            SELECT
+                id,
+                num,
+                {self.single_link_subquery("E", "single_link", "C", ["lp0"])},
+                {self.multi_link_subquery("E", "multi_link", "C", ["lp1"])}
+            FROM "E"
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_06(self):
+        eqlres = await self.con.query('''
+            select F {
+                id,
+                num,
+                single_link: {*},
+                multi_link: {*}
+            }
+        ''')
+
+        sql = f'''
+            SELECT
+                id,
+                num,
+                {self.single_link_subquery("F", "single_link", "C")},
+                {self.multi_link_subquery("F", "multi_link", "C")}
+            FROM "F"
+
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_07(self):
+        eqlres = await self.con.query('select M {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "M"')
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('select N {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "N"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_08(self):
+        eqlres = await self.con.query('select O {id, o0, o1}')
+        sqlres = await self.scon.fetch('SELECT * FROM "O"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_09(self):
+        eqlres = await self.con.query('select P {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "P"')
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('select Q {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "Q"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_10(self):
+        # Inheritance
+        #
+        # R - S - T
+        #           \
+        #         U - V
+
+        eqlres = await self.con.query('select R {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "R"')
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('select S {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "S"')
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('select T {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "T"')
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('select U {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "U"')
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('select V {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "V"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_11(self):
+        eqlres = await self.con.query('''
+            select W {
+                id,
+                name,
+                w_id := .w.id,
+            }
+        ''')
+        sqlres = await self.scon.fetch('SELECT * FROM "W"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_12(self):
+        eqlres = await self.con.query('''
+            select X {
+                id,
+                name,
+                y: {*},
+            }
+        ''')
+
+        sql = f'''
+            SELECT
+                id,
+                name,
+                {self.single_link_subquery("X", "y", "Y")}
+            FROM "X"
+
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('''
+            select Y {
+                id,
+                name,
+                x: {*},
+            }
+        ''')
+
+        sql = f'''
+            SELECT
+                id,
+                name,
+                {self.single_link_subquery("Y", "x", "X")}
+            FROM "Y"
+
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump02_dump_restore_13(self):
+        # We're using this type later, so we want to validate its integrity.
+        eqlres = await self.con.query('select K {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "K"')
+        self.assert_shape(sqlres, eqlres)
+
+        # Emulating shapes with union types is messy in SQL and unnecessary
+        # for validating the data as the individual types have been validated
+        # in earlier tests.
+        eqlres = await self.con.query('''
+            select Z {
+                id,
+                ck_id := .ck.id,
+                stw_ids := (select .stw order by <str>.id).id
+            };
+        ''')
+        sqlres = await self.scon.fetch(f'''
+            SELECT
+                id,
+                ck_id,
+                (
+                    SELECT array_agg(x.target ORDER BY x.target::text)
+                    FROM "Z.stw" x
+                    WHERE x.source = "Z".id
+                ) as stw_ids
+            FROM "Z"
+        ''')
+        self.assert_shape(sqlres, eqlres)
+
+
+class TestPGDump03(tb.StablePGDumpTestCase):
+    DEFAULT_MODULE = 'test'
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'pg_dump02_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'pg_dump02_setup.edgeql')
+
+    TEARDOWN = '''
+        CONFIGURE CURRENT DATABASE RESET allow_dml_in_functions;
+    '''
+
+    async def test_pgdump03_dump_restore_01(self):
+        eqlres = await self.con.query('select `S p a M` {id, `🚀`}')
+        sqlres = await self.scon.fetch('SELECT * FROM "S p a M"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump03_dump_restore_02(self):
+        eqlres = await self.con.query('select A {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "A"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump03_dump_restore_03(self):
+        eqlres = await self.con.query('''
+            select Tree {
+                id,
+                val,
+                parent_id := .parent.id,
+            }
+        ''')
+        sqlres = await self.scon.fetch('SELECT * FROM "Tree"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump03_dump_restore_04(self):
+        eqlres = await self.con.query('''
+            select Łukasz {
+                id,
+                `Ł🤞`,
+                `_Ł💯` := .`Ł💯` {
+                    source := @source.id,
+                    `🙀🚀🚀🚀🙀` := @`🙀🚀🚀🚀🙀`,
+                    `🙀مرحبا🙀` := @`🙀مرحبا🙀`,
+                    target := .id,
+                },
+            }
+        ''')
+        sql = f'''
+            SELECT
+                id,
+                "Ł🤞",
+                {self.single_link_subquery(
+                    "Łukasz", "Ł💯", "A", ["🙀🚀🚀🚀🙀", "🙀مرحبا🙀"])}
+            FROM "Łukasz"
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump03_dump_restore_05(self):
+        eqlres = await self.con.query('select `💯💯💯`::`🚀🙀🚀Type` {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "💯💯💯"."🚀🙀🚀Type"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump03_dump_restore_06(self):
+        eqlres = await self.con.query(
+            'select `back``ticked`::`Ticked``Type` {*}')
+        sqlres = await self.scon.fetch(
+            'SELECT * FROM "back`ticked"."Ticked`Type"')
+        self.assert_shape(sqlres, eqlres)
+
+
+class TestPGDump04(tb.StablePGDumpTestCase):
+    DEFAULT_MODULE = 'test'
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump03_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump03_setup.edgeql')
+
+    async def test_pgdump04_dump_restore_01(self):
+        eqlres = await self.con.query('select Test{*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "Test"')
+        self.assert_shape(sqlres, eqlres)
+
+
+class TestPGDump05(tb.StablePGDumpTestCase):
+    DEFAULT_MODULE = 'test'
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump_v2_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump_v2_setup.edgeql')
+
+    async def test_pgdump05_dump_restore_01(self):
+        eqlres = await self.con.query('select Test1 {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "Test1"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump05_dump_restore_02(self):
+        eqlres = await self.con.query('select Test2 {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "Test2"')
+        self.assert_shape(sqlres, eqlres)
+
+    async def test_pgdump05_dump_restore_03(self):
+        eqlres = await self.con.query('select TargetA {*}')
+        sqlres = await self.scon.fetch('SELECT * FROM "TargetA"')
+        self.assert_shape(sqlres, eqlres)
+
+        eqlres = await self.con.query('''
+            select SourceA {
+                id,
+                name,
+                link1: {*},
+                link2: {*},
+            }
+        ''')
+        sql = f'''
+            SELECT
+                id,
+                name,
+                {self.single_link_subquery(
+                    "SourceA", "link1", "TargetA")},
+                {self.single_link_subquery(
+                    "SourceA", "link2", "TargetA")}
+            FROM "SourceA"
+
+        '''
+        sqlres = await self.scon.fetch(sql)
+        self.assert_shape(sqlres, eqlres)

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -775,6 +775,14 @@ class TestSQL(tb.SQLQueryTestCase):
         assert isinstance(res1, int)
         assert isinstance(res2, int)
 
+        res = await self.squery_values(
+            r'''
+            SELECT tbloid
+            FROM unnest('{11}'::pg_catalog.oid[]) as src(tbloid)
+            '''
+        )
+        self.assertEqual(res, [[11]])
+
     async def test_sql_query_be_state(self):
         con = await self.connect(database=self.con.dbname)
         try:


### PR DESCRIPTION
Things that still need to be exposed for the SQL dump:
- [x] - Base built-in scalar types
- [x] - Built-in ranges
- [x] - User-defined scalar types
- [x] - Tuples

We generally need to make sure that whatever derived type is used in the schema it is reflected for the `pg_dump`. This means that we need to make sure that arbitrary nested `array<tuple<array<tuple<...>>>` types get reflected in addition to the base types.