### PR TITLE
Unbreak prod builds (again)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -783,6 +783,7 @@ class build_parsers(setuptools.Command):
     sources = [
         "edb.edgeql.parser.grammar.single",
         "edb.edgeql.parser.grammar.block",
+        "edb.edgeql.parser.grammar.fragment",
         "edb.edgeql.parser.grammar.sdldocument",
         "edb.edgeql.parser.grammar.migration_body",
     ]


### PR DESCRIPTION
Add parser introduced in #5126 to `build_parsers`.  We really need a
lint for this.