### PR TITLE
Document link property support on backlinks

### DIFF
--- a/docs/guides/cheatsheet/link_properties.rst
+++ b/docs/guides/cheatsheet/link_properties.rst
@@ -158,6 +158,53 @@ Querying
     },
   }
 
+.. note::
+
+    Specifying link properties of a computed backlink in your shape is
+    supported as of EdgeDB 3.0.
+
+    If you have this schema:
+
+    .. code-block:: sdl
+
+        type Person {
+          required name: str;
+          multi follows: Person {
+            followed: datetime {
+              default := datetime_of_statement();
+            };
+          };
+          multi link followers := .<follows[is Person];
+        }
+
+    this query will work as of EdgeDB 3.0:
+
+    .. code-block:: edgeql
+
+        select Person {
+          name,
+          followers: {
+            name,
+            @followed
+          }
+        };
+
+    even though ``@followed`` is a link property of ``follows`` and we are
+    accessing is through the computed backlink ``followers`` instead.
+
+    If you need link properties on backlinks in earlier versions of EdgeDB, you
+    can use this workaround:
+
+    .. code-block:: edgeql
+
+        select Person {
+          name,
+          followers := .<follows[is Person] {
+            name,
+            followed := @followed
+          }
+        };
+
 .. list-table::
   :class: seealso
 


### PR DESCRIPTION
Added this in a guide even thought they are not versioned because that's the only place I find we talk about how to specify a link property. Even though the note talks about 3.0, it's really more for 2.x users anyway since this is less about what 3.0 _can_ do and more about what 2.x _can't_, so I think this is still appropriate for a 2.x guide.