### PR TITLE
Immutable enum casts to str

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -219,7 +219,8 @@ def get_scalar_backend_name(id, module_name, catenate=True, *, aspect=None):
         "domain",
         "sequence",
         "enum",
-        "enum-cast",
+        "enum-cast-into-str",
+        "enum-cast-from-str",
         "source-del-imm-otl-f",
         "source-del-imm-otl-t",
     ):
@@ -227,7 +228,9 @@ def get_scalar_backend_name(id, module_name, catenate=True, *, aspect=None):
             f'unexpected aspect for scalar backend name: {aspect!r}')
     name = s_name.QualName(module=module_name, name=str(id))
 
-    if aspect == "enum-cast":
+    if aspect.startswith("enum-cast-"):
+        suffix = "_into_str" if aspect == "enum-cast-into-str" else "_from_str"
+        name = s_name.QualName(name.module, name.name + suffix)
         return get_cast_backend_name(name, catenate, aspect="function")
 
     return convert_name(name, aspect, catenate)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10149,6 +10149,8 @@ type default::Foo {
                 create required property status -> Status;
             }
         """)
+
+        # enum casts in constraints
         await self.con.execute("""
             alter type Order {
                 create constraint exclusive on ((Status.open = .status));
@@ -10161,12 +10163,24 @@ type default::Foo {
         """)
         await self.con.execute("""
             alter type Order {
+                create constraint exclusive on (('open' = <str>.status));
+            };
+        """)
+
+        # enum casts in indexes
+        await self.con.execute("""
+            alter type Order {
                 create index on ((Status.open = .status));
             };
         """)
         await self.con.execute("""
             alter type Order {
                 create index on ((<Status>'open' = .status));
+            };
+        """)
+        await self.con.execute("""
+            alter type Order {
+                create index on (('open' = <str>.status));
             };
         """)
 


### PR DESCRIPTION
Closes #5255

A few months back, #4775 implemented a wrapper function that implemented a cast from str to an enum.

This commit adds another function that implements a cast from enum to str.
