### PR TITLE
Fix errmessage interpolation

### DIFF
--- a/docs/reference/sdl/constraints.rst
+++ b/docs/reference/sdl/constraints.rst
@@ -139,6 +139,10 @@ The valid SDL sub-declarations are listed below:
       scalar type, property or link on which the constraint is
       defined.
 
+    If the content of curly braces does not match any variables,
+    the curly braces are emitted as-is. They can also be escaped by 
+    using double curly braces.
+
 :sdl:synopsis:`<annotation-declarations>`
     Set constraint :ref:`annotation <ref_eql_sdl_annotations>`
     to a given *value*.

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 from typing import *
+import re
 
 from edb import errors
 from edb.common import verutils
@@ -235,7 +236,7 @@ class Constraint(
         schema: s_schema.Schema,
         subjtitle: str,
     ) -> str:
-        errmsg = self.get_errmessage(schema)
+        errmsg: Optional[str] = self.get_errmessage(schema)
         args = self.get_args(schema)
         if args:
             args_ql: List[qlast.Base] = [
@@ -264,9 +265,7 @@ class Constraint(
             args_map = {'__subject__': subjtitle}
 
         assert errmsg is not None
-        formatted = errmsg.format(**args_map)
-
-        return formatted
+        return interpolate_errmessage(errmsg, args_map)
 
     def as_alter_delta(
         self,
@@ -1568,3 +1567,23 @@ class RebaseConstraint(
         bases: Tuple[so.ObjectShell[Constraint], ...],
     ) -> Tuple[so.ObjectShell[Constraint], ...]:
         return ()
+
+
+def interpolate_errmessage(message: str, args: Dict[str, str]) -> str:
+    """
+    Converts "hello {world}! {nope}" and {"world":"Alice", "hell":"Eve"}
+    into "hello Alice! {nope}".
+    """
+    formatted = ""
+    last_start = 0
+    for match in re.finditer(r"\{([A-Za-z_0-9]+)\}", message, flags=0):
+        formatted += message[last_start : match.start()]
+        last_start = match.end()
+
+        if match[1] in args:
+            formatted += args[match[1]]
+        else:
+            formatted += match[0]
+
+    formatted += message[last_start:]
+    return formatted

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -46,6 +46,7 @@ from edb import buildmeta
 from edb.common import exceptions
 from edb.common import devmode
 from edb.common import signalctl
+from edb.common import debug
 
 from . import args as srvargs
 from . import daemon
@@ -454,6 +455,11 @@ async def run_server(
     logger.debug(
         f"defaulting to the '{args.default_auth_method}' authentication method"
     )
+
+    if debug.flags.pydebug_listen:
+        import debugpy
+
+        debugpy.listen(38782)
 
     _init_parsers()
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -978,14 +978,14 @@ class TestConstraintsDDL(tb.DDLTestCase):
             CREATE type ConstraintOnTest4_2 {
                 CREATE required property email -> str {
                     CREATE constraint min_len_value(4) {
-                        SET errmessage := '{"json": "message {must} {min}."}';
+                        SET errmessage := '{"json": "{nope} {{min}} {min}"}';
                     };
                 };
             };
         """)
         async with self.assertRaisesRegexTx(
             edgedb.ConstraintViolationError,
-            '{"json": "message {must} 4."}',
+            '{"json": "{nope} {min} 4"}',
         ):
             await self.con.execute("""
                 INSERT ConstraintOnTest4_2 { email := '' };

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -973,6 +973,24 @@ class TestConstraintsDDL(tb.DDLTestCase):
                 };
             """)
 
+        # testing interpolation
+        await self.con.execute(r"""
+            CREATE type ConstraintOnTest4_2 {
+                CREATE required property email -> str {
+                    CREATE constraint min_len_value(4) {
+                        SET errmessage := '{"json": "message {must} {min}."}';
+                    };
+                };
+            };
+        """)
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            '{"json": "message {must} 4."}',
+        ):
+            await self.con.execute("""
+                INSERT ConstraintOnTest4_2 { email := '' };
+            """)
+
     async def test_constraints_ddl_05(self):
         # Test that constraint expression returns a boolean.
 


### PR DESCRIPTION
Closes #5257

Problem was in errmessage containing json where a JSON object in
curly braces was recognized as an interpolation in Python's `.format`.

Because `errmessage` was not documented to have the whole functionality
that `.format` has, I just replaced `.format` with a regex search and replace.

This will ignore any interpolations that have params (e.g. `{var:02f}`).
It will also not throw InternalServerError when you use interpolations of variables
that were are not provided. This was the reason for this error.
