### PR TITLE
Refactor away a few unused args

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -97,14 +97,14 @@ def compile_cast(
             f'`...[IS {new_stype.get_displayname(ctx.env.schema)}]` instead',
             context=srcctx)
 
-    uuid_t = ctx.env.get_track_schema_type(sn.QualName('std', 'uuid'))
+    uuid_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'uuid'))
     if (
         orig_stype.issubclass(ctx.env.schema, uuid_t)
         and new_stype.is_object_type()
     ):
         return _find_object_by_id(ir_expr, new_stype, ctx=ctx)
 
-    json_t = ctx.env.get_track_schema_type(
+    json_t = ctx.env.get_schema_type_and_track(
         sn.QualName('std', 'json'))
 
     if isinstance(ir_set.expr, irast.Array):
@@ -164,7 +164,7 @@ def compile_cast(
             # Casts from json to enums need some special handling
             # here, where we have access to the enum type. Just turn
             # it into json->str and str->enum.
-            str_typ = ctx.env.get_track_schema_type(sn.QualName('std', 'str'))
+            str_typ = ctx.env.get_schema_type_and_track(sn.QualName('std', 'str'))
             str_ir = compile_cast(ir_expr, str_typ, srcctx=srcctx, ctx=ctx)
             return compile_cast(
                 str_ir,
@@ -729,7 +729,7 @@ def _cast_json_to_range(
 
         range_el_t = new_stype.get_element_type(ctx.env.schema)
         ql_range_el_t = typegen.type_to_ql_typeref(range_el_t, ctx=subctx)
-        bool_t = ctx.env.get_track_schema_type(sn.QualName('std', 'bool'))
+        bool_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'bool'))
         ql_bool_t = typegen.type_to_ql_typeref(bool_t, ctx=subctx)
 
         cast = qlast.FunctionCall(

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -104,8 +104,7 @@ def compile_cast(
     ):
         return _find_object_by_id(ir_expr, new_stype, ctx=ctx)
 
-    json_t = ctx.env.get_schema_type_and_track(
-        sn.QualName('std', 'json'))
+    json_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'json'))
 
     if isinstance(ir_set.expr, irast.Array):
         return _cast_array_literal(
@@ -164,7 +163,9 @@ def compile_cast(
             # Casts from json to enums need some special handling
             # here, where we have access to the enum type. Just turn
             # it into json->str and str->enum.
-            str_typ = ctx.env.get_schema_type_and_track(sn.QualName('std', 'str'))
+            str_typ = ctx.env.get_schema_type_and_track(
+                sn.QualName('std', 'str')
+            )
             str_ir = compile_cast(ir_expr, str_typ, srcctx=srcctx, ctx=ctx)
             return compile_cast(
                 str_ir,

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -54,7 +54,7 @@ def compile_where_clause(
         subctx.path_scope.unnest_fence = True
         subctx.disallow_dml = "in a FILTER clause"
         ir_expr = dispatch.compile(where, ctx=subctx)
-        bool_t = ctx.env.get_track_schema_type(sn.QualName('std', 'bool'))
+        bool_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'bool'))
         ir_set = setgen.scoped_set(ir_expr, typehint=bool_t, ctx=subctx)
 
     return ir_set
@@ -143,7 +143,7 @@ def compile_limit_offset_clause(
             subctx.partial_path_prefix = None
 
             ir_expr = dispatch.compile(expr, ctx=subctx)
-            int_t = ctx.env.get_track_schema_type(
+            int_t = ctx.env.get_schema_type_and_track(
                 sn.QualName('std', 'int64'))
             ir_set = setgen.scoped_set(
                 ir_expr, force_reassign=True, typehint=int_t, ctx=subctx)

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -177,7 +177,7 @@ def compile_ConfigInsert(
             f'CONFIGURE {expr.scope} INSERT is not supported'
         )
 
-    subject = ctx.env.get_track_schema_object(
+    subject = ctx.env.get_schema_object_and_track(
         sn.QualName('cfg', expr.name.name), expr.name, default=None)
     if subject is None:
         raise errors.ConfigurationError(
@@ -266,7 +266,7 @@ def _validate_config_object(
 def _validate_global_op(
         expr: qlast.ConfigOp, *,
         ctx: context.ContextLevel) -> SettingInfo:
-    glob = ctx.env.get_track_schema_object(
+    glob = ctx.env.get_schema_object_and_track(
         s_utils.ast_ref_to_name(expr.name), expr.name,
         modaliases=ctx.modaliases, type=s_globals.Global)
     assert isinstance(glob, s_globals.Global)
@@ -296,7 +296,7 @@ def _validate_op(
         )
 
     name = expr.name.name
-    cfg_host_type = ctx.env.get_track_schema_type(
+    cfg_host_type = ctx.env.get_schema_type_and_track(
         sn.QualName('cfg', 'AbstractConfig'))
     assert isinstance(cfg_host_type, s_objtypes.ObjectType)
     cfg_type = None
@@ -315,7 +315,7 @@ def _validate_op(
             )
 
         # expr.name is the name of the configuration type
-        cfg_type = ctx.env.get_track_schema_type(
+        cfg_type = ctx.env.get_schema_type_and_track(
             sn.QualName('cfg', name), default=None)
         if cfg_type is None:
             raise errors.ConfigurationError(

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -319,7 +319,7 @@ class Environment:
             self.schema_ref_exprs.setdefault(sobj, set()).add(expr)
 
     @overload
-    def get_track_schema_object(  # NoQA: F811
+    def get_schema_object_and_track(  # NoQA: F811
         self,
         name: s_name.Name,
         expr: Optional[qlast.Base],
@@ -333,7 +333,7 @@ class Environment:
         ...
 
     @overload
-    def get_track_schema_object(  # NoQA: F811
+    def get_schema_object_and_track(  # NoQA: F811
         self,
         name: s_name.Name,
         expr: Optional[qlast.Base],
@@ -346,7 +346,7 @@ class Environment:
     ) -> Optional[s_obj.Object]:
         ...
 
-    def get_track_schema_object(  # NoQA: F811
+    def get_schema_object_and_track(  # NoQA: F811
         self,
         name: s_name.Name,
         expr: Optional[qlast.Base],
@@ -381,7 +381,7 @@ class Environment:
 
         return sobj
 
-    def get_track_schema_type(
+    def get_schema_type_and_track(
         self,
         name: s_name.Name,
         expr: Optional[qlast.Base]=None,
@@ -392,7 +392,7 @@ class Environment:
         condition: Optional[Callable[[s_obj.Object], bool]]=None,
     ) -> s_types.Type:
 
-        stype = self.get_track_schema_object(
+        stype = self.get_schema_object_and_track(
             name, expr, modaliases=modaliases, default=default, label=label,
             condition=condition, type=s_types.Type,
         )

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -268,7 +268,7 @@ def compile_BaseConstant(
         raise RuntimeError(f'unexpected constant type: {type(expr)}')
 
     ct = typegen.type_to_typeref(
-        ctx.env.get_track_schema_type(std_type),
+        ctx.env.get_schema_type_and_track(std_type),
         env=ctx.env,
     )
     return setgen.ensure_set(node_cls(value=value, typeref=ct), ctx=ctx)
@@ -466,7 +466,7 @@ def compile_UnaryOp(
 @dispatch.compile.register(qlast.GlobalExpr)
 def compile_GlobalExpr(
         expr: qlast.GlobalExpr, *, ctx: context.ContextLevel) -> irast.Set:
-    glob = ctx.env.get_track_schema_object(
+    glob = ctx.env.get_schema_object_and_track(
         s_utils.ast_ref_to_name(expr.name), expr.name,
         modaliases=ctx.modaliases, type=s_globals.Global)
     assert isinstance(glob, s_globals.Global)
@@ -571,7 +571,7 @@ def compile_TypeCast(
                     context=expr.expr.context)
 
             typeref = typegen.type_to_typeref(
-                ctx.env.get_track_schema_type(sn.QualName('std', 'json')),
+                ctx.env.get_schema_type_and_track(sn.QualName('std', 'json')),
                 env=ctx.env,
             )
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -280,7 +280,7 @@ def try_bind_call_args(
             # being called with no arguments.
             bargs: List[BoundArg] = []
             if has_inlined_defaults:
-                bytes_t = ctx.env.get_track_schema_type(
+                bytes_t = ctx.env.get_schema_type_and_track(
                     sn.QualName('std', 'bytes'))
                 typeref = typegen.type_to_typeref(bytes_t, env=ctx.env)
                 argval = setgen.ensure_set(
@@ -515,7 +515,7 @@ def try_bind_call_args(
     if has_inlined_defaults:
         # If we are compiling an EdgeQL function, inject the defaults
         # bit-mask as a first argument.
-        bytes_t = ctx.env.get_track_schema_type(
+        bytes_t = ctx.env.get_schema_type_and_track(
             sn.QualName('std', 'bytes'))
         bm = defaults_mask.to_bytes(nparams // 8 + 1, 'little')
         typeref = typegen.type_to_typeref(bytes_t, env=ctx.env)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -80,7 +80,7 @@ def get_schema_object(
         return view
 
     try:
-        stype = ctx.env.get_track_schema_object(
+        stype = ctx.env.get_schema_object_and_track(
             name=name,
             expr=ref,
             modaliases=ctx.modaliases,

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1056,7 +1056,7 @@ def enum_indirection_set(
         ctx: context.ContextLevel) -> irast.Set:
 
     strref = typegen.type_to_typeref(
-        ctx.env.get_track_schema_type(s_name.QualName('std', 'str')),
+        ctx.env.get_schema_type_and_track(s_name.QualName('std', 'str')),
         env=ctx.env,
     )
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -812,7 +812,7 @@ def compile_DescribeStmt(
                     f'cannot describe full schema as {ql.language}')
 
             ct = typegen.type_to_typeref(
-                ctx.env.get_track_schema_type(
+                ctx.env.get_schema_type_and_track(
                     s_name.QualName('std', 'str')),
                 env=ctx.env,
             )
@@ -1035,7 +1035,7 @@ def compile_DescribeStmt(
                 text += masked
 
             ct = typegen.type_to_typeref(
-                ctx.env.get_track_schema_type(
+                ctx.env.get_schema_type_and_track(
                     s_name.QualName('std', 'str')),
                 env=ctx.env,
             )

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1679,10 +1679,10 @@ def _normalize_view_ptr_expr(
             src_scls = view_scls
 
         if ptr_target.is_object_type():
-            base = ctx.env.get_track_schema_object(
+            base = ctx.env.get_schema_object_and_track(
                 sn.QualName('std', 'link'), expr=None)
         else:
-            base = ctx.env.get_track_schema_object(
+            base = ctx.env.get_schema_object_and_track(
                 sn.QualName('std', 'property'), expr=None)
 
         if base_ptrcls is not None:
@@ -1883,11 +1883,11 @@ def derive_ptrcls(
     if view_rptr.ptrcls is None:
         if view_rptr.base_ptrcls is None:
             if target_scls.is_object_type():
-                base = ctx.env.get_track_schema_object(
+                base = ctx.env.get_schema_object_and_track(
                     sn.QualName('std', 'link'), expr=None)
                 view_rptr.base_ptrcls = cast(s_links.Link, base)
             else:
-                base = ctx.env.get_track_schema_object(
+                base = ctx.env.get_schema_object_and_track(
                     sn.QualName('std', 'property'), expr=None)
                 view_rptr.base_ptrcls = cast(s_props.Property, base)
 

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -421,8 +421,7 @@ def _rewrite_config_insert(
         overwrite_query, ir_set.path_id, id_expr, force=True)
     pathctx.put_path_source_rvar(
         overwrite_query, ir_set.path_id,
-        relctx.rvar_for_rel(pgast.NullRelation(), ctx=ctx),
-        env=ctx.env)
+        relctx.rvar_for_rel(pgast.NullRelation(), ctx=ctx))
 
     relctx.add_type_rel_overlay(
         ir_set.typeref,

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -416,12 +416,16 @@ def _rewrite_config_insert(
         args=[],
     )
     pathctx.put_path_identity_var(
-        overwrite_query, ir_set.path_id, id_expr, force=True)
+        overwrite_query, ir_set.path_id, id_expr, force=True
+    )
     pathctx.put_path_value_var(
-        overwrite_query, ir_set.path_id, id_expr, force=True)
+        overwrite_query, ir_set.path_id, id_expr, force=True
+    )
     pathctx.put_path_source_rvar(
-        overwrite_query, ir_set.path_id,
-        relctx.rvar_for_rel(pgast.NullRelation(), ctx=ctx))
+        overwrite_query,
+        ir_set.path_id,
+        relctx.rvar_for_rel(pgast.NullRelation(), ctx=ctx),
+    )
 
     relctx.add_type_rel_overlay(
         ir_set.typeref,

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -416,9 +416,9 @@ def _rewrite_config_insert(
         args=[],
     )
     pathctx.put_path_identity_var(
-        overwrite_query, ir_set.path_id, id_expr, force=True, env=ctx.env)
+        overwrite_query, ir_set.path_id, id_expr, force=True)
     pathctx.put_path_value_var(
-        overwrite_query, ir_set.path_id, id_expr, force=True, env=ctx.env)
+        overwrite_query, ir_set.path_id, id_expr, force=True)
     pathctx.put_path_source_rvar(
         overwrite_query, ir_set.path_id,
         relctx.rvar_for_rel(pgast.NullRelation(), ctx=ctx),

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -2066,7 +2066,6 @@ def process_update_shape(
                 pathctx.put_path_var(
                     rel, element.path_id, aspect='value',
                     var=val,
-                    env=ctx.env,
                 )
                 pathctx._put_path_output_var(
                     rel, element.path_id, aspect='value',
@@ -3161,9 +3160,9 @@ def compile_trigger(
             new_ident = pathctx.get_path_identity_var(
                 ictx.rel, new_path, env=ctx.env)
             pathctx.put_path_identity_var(
-                ictx.rel, old_path, new_ident, env=ctx.env)
+                ictx.rel, old_path, new_ident)
             pathctx.put_path_value_var(
-                ictx.rel, old_path, new_ident, env=ctx.env)
+                ictx.rel, old_path, new_ident)
 
         contents_cte = pgast.CommonTableExpr(
             query=ictx.rel,

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -260,9 +260,9 @@ def gen_dml_cte(
     if isinstance(dml_stmt, pgast.DMLQuery):
         dml_stmt.relation = relation
     pathctx.put_path_value_rvar(
-        dml_stmt, target_path_id, relation, env=ctx.env)
+        dml_stmt, target_path_id, relation)
     pathctx.put_path_source_rvar(
-        dml_stmt, target_path_id, relation, env=ctx.env)
+        dml_stmt, target_path_id, relation)
     # Skip the path bond for inserts, since it doesn't help and
     # interferes when inserting in an UNLESS CONFLICT ELSE
     if not isinstance(ir_stmt, irast.InsertStmt):
@@ -299,9 +299,9 @@ def gen_dml_cte(
         if pol_expr := ir_stmt.read_policies.get(typeref.id):
             with ctx.newrel() as sctx:
                 pathctx.put_path_value_rvar(
-                    sctx.rel, target_path_id, relation, env=ctx.env)
+                    sctx.rel, target_path_id, relation)
                 pathctx.put_path_source_rvar(
-                    sctx.rel, target_path_id, relation, env=ctx.env)
+                    sctx.rel, target_path_id, relation)
 
                 val = clauses.compile_filter_clause(
                     pol_expr.expr, pol_expr.cardinality, ctx=sctx)
@@ -384,7 +384,7 @@ def merge_iterator(
         for other_path, aspect in iterator.other_paths:
             pathctx.put_path_rvar(
                 select, other_path, iterator_rvar,
-                aspect=aspect, env=ctx.env,
+                aspect=aspect
             )
 
 
@@ -664,9 +664,9 @@ def process_insert_body(
     fallback_rvar = pgast.DynamicRangeVar(
         dynamic_get_path=_mk_dynamic_get_path(ptr_map, typeref))
     pathctx.put_path_source_rvar(
-        select, ir_stmt.subject.path_id, fallback_rvar, env=ctx.env)
+        select, ir_stmt.subject.path_id, fallback_rvar)
     pathctx.put_path_value_rvar(
-        select, ir_stmt.subject.path_id, fallback_rvar, env=ctx.env)
+        select, ir_stmt.subject.path_id, fallback_rvar)
 
     # compile contents CTE
     elements: List[Tuple[irast.Set, irast.BasePointerRef]] = []
@@ -915,9 +915,9 @@ def process_insert_rewrites(
         dynamic_get_path=_mk_dynamic_get_path(
             nptr_map, typeref, iterator_rvar))
     pathctx.put_path_source_rvar(
-        rew_stmt, object_path_id, fallback_rvar, env=ctx.env)
+        rew_stmt, object_path_id, fallback_rvar)
     pathctx.put_path_value_rvar(
-        rew_stmt, object_path_id, fallback_rvar, env=ctx.env)
+        rew_stmt, object_path_id, fallback_rvar)
 
     # If there are any single links that were compiled externally,
     # populate the field from the link overlays.
@@ -1644,13 +1644,11 @@ def process_update_body(
             contents_select,
             ir_stmt.subject.path_id,
             fallback_rvar,
-            env=ctx.env,
         )
         pathctx.put_path_value_rvar(
             contents_select,
             ir_stmt.subject.path_id,
             fallback_rvar,
-            env=ctx.env,
         )
 
     update_stmt = None
@@ -1768,10 +1766,10 @@ def process_update_body(
             target=update_stmt, source=contents_rvar, ctx=ctx
         )
         pathctx.put_path_value_rvar(
-            update_stmt, subject_path_id, table_relation, env=ctx.env
+            update_stmt, subject_path_id, table_relation
         )
         pathctx.put_path_source_rvar(
-            update_stmt, subject_path_id, table_relation, env=ctx.env
+            update_stmt, subject_path_id, table_relation
         )
 
         update_cte.query = update_stmt
@@ -1947,9 +1945,9 @@ def process_update_rewrites(
                 nptr_map, typeref, contents_rvar),
         )
         pathctx.put_path_source_rvar(
-            rctx.rel, object_path_id, fallback_rvar, env=ctx.env)
+            rctx.rel, object_path_id, fallback_rvar)
         pathctx.put_path_value_rvar(
-            rctx.rel, object_path_id, fallback_rvar, env=ctx.env)
+            rctx.rel, object_path_id, fallback_rvar)
 
         rewrites_cte = pgast.CommonTableExpr(
             query=rctx.rel, name=ctx.env.aliases.get("upd_rewrites")
@@ -2583,7 +2581,7 @@ def process_link_update(
             )
 
         pathctx.put_path_value_rvar(
-            delcte.query, path_id.ptr_path(), target_rvar, env=ctx.env)
+            delcte.query, path_id.ptr_path(), target_rvar)
 
         # Record the effect of this removal in the relation overlay
         # context to ensure that references to the link in the result
@@ -2759,7 +2757,7 @@ def process_link_update(
     )
 
     pathctx.put_path_value_rvar(
-        updcte.query, path_id.ptr_path(), target_rvar, env=ctx.env)
+        updcte.query, path_id.ptr_path(), target_rvar)
 
     def register_overlays(
         overlay_cte: pgast.CommonTableExpr, octx: context.CompilerContextLevel

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -910,7 +910,7 @@ def process_insert_rewrites(
     )
 
     iterator_rvar = pathctx.get_path_rvar(
-        rew_stmt, path_id=subject_path_id, aspect='value', env=ctx.env)
+        rew_stmt, path_id=subject_path_id, aspect='value')
     fallback_rvar = pgast.DynamicRangeVar(
         dynamic_get_path=_mk_dynamic_get_path(
             nptr_map, typeref, iterator_rvar))

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1041,7 +1041,7 @@ def process_insert_shape(
     for aspect in ('value', 'identity'):
         pathctx._put_path_output_var(
             select, ir_stmt.subject.path_id, aspect=aspect,
-            var=pgast.ColumnRef(name=['id']), env=ctx.env,
+            var=pgast.ColumnRef(name=['id']),
         )
 
     return external_inserts
@@ -2070,7 +2070,6 @@ def process_update_shape(
                 pathctx._put_path_output_var(
                     rel, element.path_id, aspect='value',
                     var=pgast.ColumnRef(name=[ptr_info.column_name]),
-                    env=ctx.env,
                 )
 
         if link_ptr_info and link_ptr_info.table_type == "link":
@@ -3000,7 +2999,6 @@ def process_link_values(
         pathctx._put_path_output_var(
             row_query, col_path_id, aspect='value',
             var=pgast.ColumnRef(name=[col]),
-            env=ctx.env,
         )
 
     link_rows = pgast.CommonTableExpr(

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -98,7 +98,7 @@ def _compile_set_impl(
         value = dispatch.compile(ir_set.expr, ctx=ctx)
         if is_toplevel:
             ctx.rel = ctx.toplevel_stmt = pgast.SelectStmt()
-        pathctx.put_path_value_var(ctx.rel, ir_set.path_id, value, env=ctx.env)
+        pathctx.put_path_value_var(ctx.rel, ir_set.path_id, value)
         if (output.in_serialization_ctx(ctx) and ir_set.shape
                 and not ctx.env.ignore_object_shapes):
             _compile_shape(ir_set, ir_set.shape, ctx=ctx)
@@ -711,7 +711,7 @@ def _compile_set(
         for element in shape_tuple.elements:
             pathctx.put_path_var_if_not_exists(
                 ctx.rel, element.path_id, element.val,
-                aspect='value', env=ctx.env)
+                aspect='value')
 
 
 def _compile_shape(
@@ -729,7 +729,7 @@ def _compile_shape(
         # it already: see the "unfortunate hack" in
         # process_set_as_tuple.)
         pathctx.put_path_serialized_var(
-            ctx.rel, element.path_id, element.val, force=True, env=ctx.env)
+            ctx.rel, element.path_id, element.val, force=True)
 
     # When we compile a shape during materialization, stash the
     # set away so we can consume it in unpack_rvar.
@@ -753,7 +753,7 @@ def _compile_shape(
     sval = output.serialize_expr(
         ser_result, path_id=ir_set.path_id, env=ctx.env)
     pathctx.put_path_serialized_var(
-        ctx.rel, ir_set.path_id, sval, force=True, env=ctx.env)
+        ctx.rel, ir_set.path_id, sval, force=True)
 
     return result
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -710,8 +710,8 @@ def _compile_set(
         shape_tuple = shapecomp.compile_shape(ir_set, ir_set.shape, ctx=ctx)
         for element in shape_tuple.elements:
             pathctx.put_path_var_if_not_exists(
-                ctx.rel, element.path_id, element.val,
-                aspect='value')
+                ctx.rel, element.path_id, element.val, aspect='value'
+            )
 
 
 def _compile_shape(
@@ -729,7 +729,8 @@ def _compile_shape(
         # it already: see the "unfortunate hack" in
         # process_set_as_tuple.)
         pathctx.put_path_serialized_var(
-            ctx.rel, element.path_id, element.val, force=True)
+            ctx.rel, element.path_id, element.val, force=True
+        )
 
     # When we compile a shape during materialization, stash the
     # set away so we can consume it in unpack_rvar.
@@ -751,9 +752,9 @@ def _compile_shape(
 
     ser_result = pgast.TupleVar(elements=ser_elements, named=True)
     sval = output.serialize_expr(
-        ser_result, path_id=ir_set.path_id, env=ctx.env)
-    pathctx.put_path_serialized_var(
-        ctx.rel, ir_set.path_id, sval, force=True)
+        ser_result, path_id=ir_set.path_id, env=ctx.env
+    )
+    pathctx.put_path_serialized_var(ctx.rel, ir_set.path_id, sval, force=True)
 
     return result
 

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -330,7 +330,7 @@ def _compile_group(
         if group_use:
             pathctx.put_path_rvar(
                 query, group_use.path_id,
-                group_rvar, aspect='value', env=ctx.env)
+                group_rvar, aspect='value')
 
     vol_ref = None
 

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -157,7 +157,7 @@ def _compile_grouping_binding(
     pathctx.put_path_var(
         ctx.rel, stmt.grouping_binding.path_id,
         _compile_grouping_value(stmt, used_args=used_args, ctx=ctx),
-        aspect='value', env=ctx.env)
+        aspect='value')
 
 
 def _compile_group(
@@ -239,7 +239,7 @@ def _compile_group(
                 pathctx.get_path_value_output(
                     rel=hoistctx.rel, path_id=group_use.path_id, env=ctx.env)
                 pathctx.put_path_value_var(
-                    grouprel, group_use.path_id, hoistctx.rel, env=ctx.env
+                    grouprel, group_use.path_id, hoistctx.rel
                 )
 
         packed = False
@@ -273,7 +273,7 @@ def _compile_group(
                 pathctx.put_path_var(
                     grouprel, stmt.group_binding.path_id, mat_qry,
                     aspect='value',
-                    flavor='packed', env=ctx.env
+                    flavor='packed'
                 )
 
         used_args = desugar_group.collect_grouping_atoms(stmt.by)
@@ -299,7 +299,7 @@ def _compile_group(
                 uvar = output.output_as_value(uvar, env=ctx.env)
                 pathctx.put_path_var(
                     grouprel, using_val.path_id, uvar,
-                    aspect='value', force=True, env=ctx.env)
+                    aspect='value', force=True)
 
             uout = pathctx.get_path_output(
                 grouprel, using_val.path_id, aspect='value', env=ctx.env)

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -187,8 +187,7 @@ def _compile_group(
 
         subj_rvar = relctx.rvar_for_rel(
             subjctx.rel, ctx=groupctx, lateral=True)
-        aspects = pathctx.list_path_aspects(
-            subjctx.rel, stmt.subject.path_id, env=ctx.env)
+        aspects = pathctx.list_path_aspects(subjctx.rel, stmt.subject.path_id)
 
         pathctx.put_path_id_map(
             subjctx.rel,
@@ -304,7 +303,7 @@ def _compile_group(
             uout = pathctx.get_path_output(
                 grouprel, using_val.path_id, aspect='value', env=ctx.env)
             pathctx._put_path_output_var(
-                grouprel, using_val.path_id, 'serialized', uout, env=ctx.env)
+                grouprel, using_val.path_id, 'serialized', uout)
 
         grouprel.group_clause = [
             compile_grouping_el(el, stmt, ctx=groupctx) for el in stmt.by

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -157,7 +157,8 @@ def _compile_grouping_binding(
     pathctx.put_path_var(
         ctx.rel, stmt.grouping_binding.path_id,
         _compile_grouping_value(stmt, used_args=used_args, ctx=ctx),
-        aspect='value')
+        aspect='value',
+    )
 
 
 def _compile_group(
@@ -272,7 +273,7 @@ def _compile_group(
                 pathctx.put_path_var(
                     grouprel, stmt.group_binding.path_id, mat_qry,
                     aspect='value',
-                    flavor='packed'
+                    flavor='packed',
                 )
 
         used_args = desugar_group.collect_grouping_atoms(stmt.by)
@@ -297,13 +298,18 @@ def _compile_group(
             if isinstance(uvar, pgast.TupleVarBase):
                 uvar = output.output_as_value(uvar, env=ctx.env)
                 pathctx.put_path_var(
-                    grouprel, using_val.path_id, uvar,
-                    aspect='value', force=True)
+                    grouprel,
+                    using_val.path_id,
+                    uvar,
+                    aspect='value',
+                    force=True,
+                )
 
             uout = pathctx.get_path_output(
                 grouprel, using_val.path_id, aspect='value', env=ctx.env)
             pathctx._put_path_output_var(
-                grouprel, using_val.path_id, 'serialized', uout)
+                grouprel, using_val.path_id, 'serialized', uout
+            )
 
         grouprel.group_clause = [
             compile_grouping_el(el, stmt, ctx=groupctx) for el in stmt.by
@@ -329,8 +335,8 @@ def _compile_group(
     ]:
         if group_use:
             pathctx.put_path_rvar(
-                query, group_use.path_id,
-                group_rvar, aspect='value')
+                query, group_use.path_id, group_rvar, aspect='value'
+            )
 
     vol_ref = None
 

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -256,7 +256,7 @@ def get_path_var(
             rel_rvar = var
         elif var:
             put_path_var(
-                rel, path_id, var, aspect=aspect, flavor=flavor, env=env)
+                rel, path_id, var, aspect=aspect, flavor=flavor)
             return var
         else:
             rel_rvar = None
@@ -287,13 +287,13 @@ def get_path_var(
         source_rel, path_id, aspect=aspect, flavor=flavor, env=env)
 
     var = astutils.get_rvar_var(rel_rvar, outvar)
-    put_path_var(rel, path_id, var, aspect=aspect, flavor=flavor, env=env)
+    put_path_var(rel, path_id, var, aspect=aspect, flavor=flavor)
 
     if isinstance(var, pgast.TupleVar):
         for element in var.elements:
             put_path_var_if_not_exists(rel, element.path_id, element.val,
                                        flavor=flavor,
-                                       aspect=aspect, env=env)
+                                       aspect=aspect)
 
     return var
 
@@ -359,7 +359,7 @@ def _find_rel_rvar(
         var = rel.path_namespace.get((path_id, alt_aspect))
         if var is not None:
             put_path_var(
-                rel, path_id, var, aspect=aspect, flavor=flavor, env=env)
+                rel, path_id, var, aspect=aspect, flavor=flavor)
             return src_aspect, None, var
 
     return src_aspect, rel_rvar, None
@@ -394,7 +394,7 @@ def _get_path_var_in_setop(
                 new_path_id = map_path_id(path_id, subrel.view_path_id_map)
                 put_path_var(
                     subrel, new_path_id, new,
-                    force=True, env=env, aspect=aspect)
+                    force=True, aspect=aspect)
 
     # We disable the find_path_output optimization when doing
     # UNIONs to avoid situations where they have different numbers
@@ -460,7 +460,7 @@ def _get_path_var_in_setop(
     # This is necessary to correctly join heterogeneous UNIONs.
     var = astutils.strip_output_var(
         first, optional=optional, nullable=optional or nullable)
-    put_path_var(rel, path_id, var, aspect=aspect, flavor=flavor, env=env)
+    put_path_var(rel, path_id, var, aspect=aspect, flavor=flavor)
     return var
 
 
@@ -532,7 +532,7 @@ def _find_in_output_tuple(
         ):
             for name, src in reversed(steps):
                 var = astutils.tuple_getattr(var, src.target, name)
-            put_path_var(rel, path_id, var, aspect=aspect, env=env)
+            put_path_var(rel, path_id, var, aspect=aspect)
             return var
 
         ptrref = src_path_id.rptr()
@@ -615,8 +615,7 @@ def maybe_get_path_serialized_var(
 
 def put_path_var(
         rel: pgast.BaseRelation, path_id: irast.PathId, var: pgast.BaseExpr, *,
-        aspect: str, flavor: str='normal', force: bool=False,
-        env: context.Environment) -> None:
+        aspect: str, flavor: str='normal', force: bool=False) -> None:
     if flavor == 'packed':
         if rel.packed_path_namespace is None:
             rel.packed_path_namespace = {}
@@ -633,46 +632,46 @@ def put_path_var(
 def put_path_var_if_not_exists(
         rel: pgast.Query, path_id: irast.PathId, var: pgast.BaseExpr, *,
         flavor: str='normal',
-        aspect: str, env: context.Environment) -> None:
+        aspect: str) -> None:
     try:
-        put_path_var(rel, path_id, var, aspect=aspect, flavor=flavor, env=env)
+        put_path_var(rel, path_id, var, aspect=aspect, flavor=flavor)
     except KeyError:
         pass
 
 
 def put_path_identity_var(
         rel: pgast.BaseRelation, path_id: irast.PathId, var: pgast.BaseExpr, *,
-        force: bool=False, env: context.Environment) -> None:
-    put_path_var(rel, path_id, var, aspect='identity', force=force, env=env)
+        force: bool=False) -> None:
+    put_path_var(rel, path_id, var, aspect='identity', force=force)
 
 
 def put_path_value_var(
         rel: pgast.BaseRelation, path_id: irast.PathId, var: pgast.BaseExpr, *,
-        force: bool = False, env: context.Environment) -> None:
-    put_path_var(rel, path_id, var, aspect='value', force=force, env=env)
+        force: bool = False) -> None:
+    put_path_var(rel, path_id, var, aspect='value', force=force)
 
 
 def put_path_serialized_var(
         rel: pgast.BaseRelation, path_id: irast.PathId, var: pgast.BaseExpr, *,
-        force: bool = False, env: context.Environment) -> None:
-    put_path_var(rel, path_id, var, aspect='serialized', force=force, env=env)
+        force: bool = False) -> None:
+    put_path_var(rel, path_id, var, aspect='serialized', force=force)
 
 
 def put_path_value_var_if_not_exists(
         rel: pgast.BaseRelation, path_id: irast.PathId, var: pgast.BaseExpr, *,
-        force: bool = False, env: context.Environment) -> None:
+        force: bool = False) -> None:
     try:
-        put_path_var(rel, path_id, var, aspect='value', force=force, env=env)
+        put_path_var(rel, path_id, var, aspect='value', force=force)
     except KeyError:
         pass
 
 
 def put_path_serialized_var_if_not_exists(
         rel: pgast.BaseRelation, path_id: irast.PathId, var: pgast.BaseExpr, *,
-        force: bool = False, env: context.Environment) -> None:
+        force: bool = False) -> None:
     try:
         put_path_var(rel, path_id, var, aspect='serialized',
-                     force=force, env=env)
+                     force=force)
     except KeyError:
         pass
 

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -310,13 +310,13 @@ def _find_rel_rvar(
     """
     src_aspect = aspect
     rel_rvar = maybe_get_path_rvar(
-        rel, path_id, aspect=aspect, flavor=flavor, env=env)
+        rel, path_id, aspect=aspect, flavor=flavor)
 
     if rel_rvar is None:
         alt_aspect = get_less_specific_aspect(path_id, aspect)
         if alt_aspect is not None:
             rel_rvar = maybe_get_path_rvar(
-                rel, path_id, aspect=alt_aspect, env=env)
+                rel, path_id, aspect=alt_aspect)
     else:
         alt_aspect = None
 
@@ -337,21 +337,21 @@ def _find_rel_rvar(
                 return src_aspect, None, var
 
             rel_rvar = maybe_get_path_rvar(
-                rel, src_path_id, aspect=src_aspect, env=env)
+                rel, src_path_id, aspect=src_aspect)
 
             if rel_rvar is None:
                 _src_path_id_prefix = src_path_id.src_path()
                 if _src_path_id_prefix is not None:
                     rel_rvar = maybe_get_path_rvar(
-                        rel, _src_path_id_prefix, aspect=src_aspect, env=env)
+                        rel, _src_path_id_prefix, aspect=src_aspect)
         else:
             rel_rvar = maybe_get_path_rvar(
-                rel, src_path_id, aspect=src_aspect, env=env)
+                rel, src_path_id, aspect=src_aspect)
 
         if (rel_rvar is None
                 and src_aspect != 'source' and path_id != src_path_id):
             rel_rvar = maybe_get_path_rvar(
-                rel, src_path_id, aspect='source', env=env)
+                rel, src_path_id, aspect='source')
 
     if rel_rvar is None and alt_aspect is not None and flavor == 'normal':
         # There is no source range var for the requested aspect,
@@ -788,7 +788,7 @@ def has_rvar(stmt: pgast.Query, rvar: pgast.PathRangeVar) -> bool:
 def put_path_rvar_if_not_exists(
         stmt: pgast.Query, path_id: irast.PathId, rvar: pgast.PathRangeVar, *,
         flavor: str='normal',
-        aspect: str, env: context.Environment) -> None:
+        aspect: str) -> None:
     if (path_id, aspect) not in stmt.get_rvar_map(flavor):
         put_path_rvar(
             stmt, path_id, rvar, aspect=aspect, flavor=flavor)
@@ -797,9 +797,9 @@ def put_path_rvar_if_not_exists(
 def get_path_rvar(
         stmt: pgast.Query, path_id: irast.PathId, *,
         flavor: str='normal',
-        aspect: str, env: context.Environment) -> pgast.PathRangeVar:
+        aspect: str) -> pgast.PathRangeVar:
     rvar = maybe_get_path_rvar(
-        stmt, path_id, aspect=aspect, flavor=flavor, env=env)
+        stmt, path_id, aspect=aspect, flavor=flavor)
     if rvar is None:
         raise LookupError(
             f'there is no range var for {path_id} {aspect} in {stmt}')
@@ -808,8 +808,7 @@ def get_path_rvar(
 
 def maybe_get_path_rvar(
         stmt: pgast.Query, path_id: irast.PathId, *, aspect: str,
-        flavor: str='normal',
-        env: context.Environment) -> Optional[pgast.PathRangeVar]:
+        flavor: str='normal') -> Optional[pgast.PathRangeVar]:
     rvar = None
     path_rvar_map = stmt.maybe_get_rvar_map(flavor)
     if path_rvar_map is not None:
@@ -851,9 +850,9 @@ def list_path_aspects(stmt: pgast.Query, path_id: irast.PathId) -> Set[str]:
 
 
 def maybe_get_path_value_rvar(
-        stmt: pgast.Query, path_id: irast.PathId, *,
-        env: context.Environment) -> Optional[pgast.BaseRangeVar]:
-    return maybe_get_path_rvar(stmt, path_id, aspect='value', env=env)
+    stmt: pgast.Query, path_id: irast.PathId
+) -> Optional[pgast.BaseRangeVar]:
+    return maybe_get_path_rvar(stmt, path_id, aspect='value')
 
 
 def _same_expr(expr1: pgast.BaseExpr, expr2: pgast.BaseExpr) -> bool:

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -761,28 +761,24 @@ def get_rvar_output_var_as_col_list(
 def put_path_rvar(
         stmt: pgast.Query, path_id: irast.PathId, rvar: pgast.PathRangeVar, *,
         flavor: str='normal',
-        aspect: str, env: context.Environment) -> None:
+        aspect: str) -> None:
     assert isinstance(path_id, irast.PathId)
     stmt.get_rvar_map(flavor)[path_id, aspect] = rvar
 
 
 def put_path_value_rvar(
         stmt: pgast.Query, path_id: irast.PathId, rvar: pgast.PathRangeVar, *,
-        flavor: str='normal',
-        env: context.Environment) -> None:
-    put_path_rvar(stmt, path_id, rvar, aspect='value', flavor=flavor, env=env)
+        flavor: str='normal') -> None:
+    put_path_rvar(stmt, path_id, rvar, aspect='value', flavor=flavor)
 
 
 def put_path_source_rvar(
         stmt: pgast.Query, path_id: irast.PathId, rvar: pgast.PathRangeVar, *,
-        flavor: str='normal',
-        env: context.Environment) -> None:
-    put_path_rvar(stmt, path_id, rvar, aspect='source', flavor=flavor, env=env)
+        flavor: str='normal') -> None:
+    put_path_rvar(stmt, path_id, rvar, aspect='source', flavor=flavor)
 
 
-def has_rvar(
-        stmt: pgast.Query, rvar: pgast.PathRangeVar, *,
-        env: context.Environment) -> bool:
+def has_rvar(stmt: pgast.Query, rvar: pgast.PathRangeVar) -> bool:
     return any(
         rvar in set(stmt.get_rvar_map(flavor).values())
         for flavor in ('normal', 'packed')
@@ -795,7 +791,7 @@ def put_path_rvar_if_not_exists(
         aspect: str, env: context.Environment) -> None:
     if (path_id, aspect) not in stmt.get_rvar_map(flavor):
         put_path_rvar(
-            stmt, path_id, rvar, aspect=aspect, flavor=flavor, env=env)
+            stmt, path_id, rvar, aspect=aspect, flavor=flavor)
 
 
 def get_path_rvar(
@@ -836,9 +832,8 @@ def _has_path_aspect(
 
 
 def has_path_aspect(
-        stmt: pgast.Query, path_id: irast.PathId, *,
-        aspect: str,
-        env: context.Environment) -> bool:
+    stmt: pgast.Query, path_id: irast.PathId, *, aspect: str
+) -> bool:
     path_id = map_path_id(path_id, stmt.view_path_id_map)
     return _has_path_aspect(stmt, path_id, aspect=aspect)
 

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -235,7 +235,7 @@ def get_path_var(
 
     # Find which rvar will have path_id as an output
     src_aspect, rel_rvar, found_path_var = _find_rel_rvar(
-        rel, path_id, src_path_id, aspect=aspect, flavor=flavor, env=env)
+        rel, path_id, src_path_id, aspect=aspect, flavor=flavor)
 
     if found_path_var:
         return found_path_var
@@ -300,7 +300,7 @@ def get_path_var(
 
 def _find_rel_rvar(
     rel: pgast.Query, path_id: irast.PathId, src_path_id: irast.PathId, *,
-    aspect: str, flavor: str, env: context.Environment,
+    aspect: str, flavor: str,
 ) -> Tuple[str, Optional[pgast.PathRangeVar], Optional[pgast.BaseExpr]]:
     """Rummage around rel looking for an appropriate rvar for path_id.
 
@@ -333,7 +333,7 @@ def _find_rel_rvar(
                 src_aspect = 'value'
 
             if (var := _find_in_output_tuple(
-                    rel, path_id, src_aspect, env=env)):
+                    rel, path_id, src_aspect)):
                 return src_aspect, None, var
 
             rel_rvar = maybe_get_path_rvar(
@@ -497,8 +497,7 @@ def _find_rvar_in_intersection_by_typeref(
 def _find_in_output_tuple(
         rel: pgast.Query,
         path_id: irast.PathId,
-        aspect: str,
-        env: context.Environment) -> Optional[pgast.BaseExpr]:
+        aspect: str) -> Optional[pgast.BaseExpr]:
     """Try indirecting a source tuple already present as an output.
 
     Normally tuple indirections are handled by

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -472,7 +472,7 @@ def deep_copy_primitive_rvar_path_var(
         rref = pathctx.get_path_output(
             rvar.query, orig_id, aspect='identity', env=env)
         pathctx.put_rvar_path_output(
-            rvar, new_id, aspect='identity', var=rref, env=env)
+            rvar, new_id, aspect='identity', var=rref)
 
 
 def new_primitive_rvar(
@@ -632,17 +632,21 @@ def _new_mapped_pointer_rvar(
 
     ptr_rvar.query.path_id = ptr_pid
     pathctx.put_rvar_path_bond(ptr_rvar, src_pid)
-    pathctx.put_rvar_path_output(ptr_rvar, src_pid, aspect='identity',
-                                 var=near_ref, env=ctx.env)
-    pathctx.put_rvar_path_output(ptr_rvar, src_pid, aspect='value',
-                                 var=near_ref, env=ctx.env)
-    pathctx.put_rvar_path_output(ptr_rvar, tgt_pid, aspect='value',
-                                 var=far_ref, env=ctx.env)
+    pathctx.put_rvar_path_output(
+        ptr_rvar, src_pid, aspect='identity', var=near_ref
+    )
+    pathctx.put_rvar_path_output(
+        ptr_rvar, src_pid, aspect='value', var=near_ref
+    )
+    pathctx.put_rvar_path_output(
+        ptr_rvar, tgt_pid, aspect='value', var=far_ref
+    )
 
     if tgt_pid.is_objtype_path():
         pathctx.put_rvar_path_bond(ptr_rvar, tgt_pid)
-        pathctx.put_rvar_path_output(ptr_rvar, tgt_pid, aspect='identity',
-                                     var=far_ref, env=ctx.env)
+        pathctx.put_rvar_path_output(
+            ptr_rvar, tgt_pid, aspect='identity', var=far_ref
+        )
 
     return ptr_rvar
 
@@ -824,7 +828,7 @@ def set_to_array(
     )
 
     result = pgast.SelectStmt()
-    aspects = pathctx.list_path_aspects(subrvar.query, path_id, env=ctx.env)
+    aspects = pathctx.list_path_aspects(subrvar.query, path_id)
     include_rvar(result, subrvar, path_id=path_id, aspects=aspects, ctx=ctx)
 
     val: Optional[pgast.BaseExpr] = (

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -111,10 +111,12 @@ def _pull_path_namespace(
                 continue
 
             rvar = pathctx.maybe_get_path_rvar(
-                target, path_id, aspect=aspect, flavor=flavor)
+                target, path_id, aspect=aspect, flavor=flavor
+            )
             if rvar is None or flavor == 'packed':
                 pathctx.put_path_rvar(
-                    target, path_id, source, aspect=aspect, flavor=flavor)
+                    target, path_id, source, aspect=aspect, flavor=flavor
+                )
 
 
 def pull_path_namespace(
@@ -165,15 +167,16 @@ def find_rvar(
                                aspect='value', flavor=flavor, ctx=ctx)
     if rvar is not None:
         pathctx.put_path_rvar_if_not_exists(
-            stmt, path_id, rvar, aspect='value', flavor=flavor)
+            stmt, path_id, rvar, aspect='value', flavor=flavor
+        )
 
         src_rvar = maybe_get_path_rvar(source_stmt, path_id=path_id,
                                        aspect='source', flavor=flavor, ctx=ctx)
 
         if src_rvar is not None:
             pathctx.put_path_rvar_if_not_exists(
-                stmt, path_id, src_rvar,
-                aspect='source', flavor=flavor)
+                stmt, path_id, src_rvar, aspect='source', flavor=flavor
+            )
 
     return rvar
 
@@ -270,10 +273,12 @@ def include_specific_rvar(
     for aspect in aspects:
         if overwrite_path_rvar:
             pathctx.put_path_rvar(
-                stmt, path_id, rvar, flavor=flavor, aspect=aspect)
+                stmt, path_id, rvar, flavor=flavor, aspect=aspect
+            )
         else:
             pathctx.put_path_rvar_if_not_exists(
-                stmt, path_id, rvar, flavor=flavor, aspect=aspect)
+                stmt, path_id, rvar, flavor=flavor, aspect=aspect
+            )
 
     if update_mask:
         scopes = [ctx.scope_tree]
@@ -329,12 +334,14 @@ def _maybe_get_path_rvar(
     qry: Optional[pgast.Query] = stmt
     while qry is not None:
         rvar = pathctx.maybe_get_path_rvar(
-            qry, path_id, aspect=aspect, flavor=flavor)
+            qry, path_id, aspect=aspect, flavor=flavor
+        )
         if rvar is not None:
             if qry is not stmt:
                 # Cache the rvar reference.
-                pathctx.put_path_rvar(stmt, path_id, rvar,
-                                      flavor=flavor, aspect=aspect)
+                pathctx.put_path_rvar(
+                    stmt, path_id, rvar, flavor=flavor, aspect=aspect
+                )
             return rvar, path_id
         qry = ctx.rel_hierarchy.get(qry)
 
@@ -464,14 +471,14 @@ def deep_copy_primitive_rvar_path_var(
     if isinstance(rvar, pgast.RangeSubselect):
         for component in astutils.each_query_in_set(rvar.query):
             rref = pathctx.get_path_var(
-                component, orig_id, aspect='identity', env=env)
-            pathctx.put_path_var(
-                component, new_id, rref, aspect='identity')
+                component, orig_id, aspect='identity', env=env
+            )
+            pathctx.put_path_var(component, new_id, rref, aspect='identity')
     else:
         rref = pathctx.get_path_output(
-            rvar.query, orig_id, aspect='identity', env=env)
-        pathctx.put_rvar_path_output(
-            rvar, new_id, aspect='identity', var=rref)
+            rvar.query, orig_id, aspect='identity', env=env
+        )
+        pathctx.put_rvar_path_output(rvar, new_id, aspect='identity', var=rref)
 
 
 def new_primitive_rvar(
@@ -750,8 +757,7 @@ def ensure_transient_identity_for_path(
         args=[],
     )
 
-    pathctx.put_path_identity_var(
-        stmt, path_id, id_expr, force=True)
+    pathctx.put_path_identity_var(stmt, path_id, id_expr, force=True)
     pathctx.put_path_bond(stmt, path_id)
 
     if isinstance(stmt, pgast.SelectStmt):
@@ -836,12 +842,9 @@ def set_to_array(
     )
 
     if val is None:
-        value_var = pathctx.get_path_value_var(
-            result, path_id, env=ctx.env)
-        val = output.serialize_expr(
-            value_var, path_id=path_id, env=ctx.env)
-        pathctx.put_path_serialized_var(
-            result, path_id, val, force=True)
+        value_var = pathctx.get_path_value_var(result, path_id, env=ctx.env)
+        val = output.serialize_expr(value_var, path_id=path_id, env=ctx.env)
+        pathctx.put_path_serialized_var(result, path_id, val, force=True)
 
     if isinstance(val, pgast.TupleVarBase):
         val = output.serialize_expr(
@@ -1137,16 +1140,12 @@ def unpack_var(
         cur_ref = el.ref or pgast.ColumnRef(name=[el.colname])
 
         for aspect in ('value', 'serialized'):
-            pathctx.put_path_var(
-                qry, el_id, cur_ref, aspect=aspect
-            )
+            pathctx.put_path_var(qry, el_id, cur_ref, aspect=aspect)
 
         if not el.packed:
-            pathctx.put_path_rvar(
-                stmt, el_id, rvar, aspect='value')
+            pathctx.put_path_rvar(stmt, el_id, rvar, aspect='value')
 
-            pathctx.put_path_rvar(
-                ctx.rel, el_id, rvar, aspect='value')
+            pathctx.put_path_rvar(ctx.rel, el_id, rvar, aspect='value')
         else:
             cref = pathctx.get_path_output(
                 qry, el_id, aspect='value', env=ctx.env)
@@ -1198,9 +1197,7 @@ def unpack_var(
             pathctx.put_path_var(
                 qry, view_path_id, sval, aspect=aspect, force=True
             )
-            pathctx.put_path_rvar(
-                ctx.rel, view_path_id, rvar, aspect=aspect
-            )
+            pathctx.put_path_rvar(ctx.rel, view_path_id, rvar, aspect=aspect)
 
     return rvar
 
@@ -1652,9 +1649,7 @@ def range_for_typeref(
 
         int_rvar = pgast.IntersectionRangeVar(component_rvars=component_rvars)
         for aspect in ('source', 'value'):
-            pathctx.put_path_rvar(
-                wrapper, path_id, int_rvar, aspect=aspect
-            )
+            pathctx.put_path_rvar(wrapper, path_id, int_rvar, aspect=aspect)
 
         pathctx.put_path_bond(wrapper, path_id)
         rvar = rvar_for_rel(wrapper, lateral=lateral, typeref=typeref, ctx=ctx)
@@ -1926,10 +1921,8 @@ def range_for_ptrref(
         # the source rvar so that linkprops can be found here.
         if path_id:
             target_ref = qry.target_list[1].val
-            pathctx.put_path_identity_var(
-                qry, path_id, var=target_ref)
-            pathctx.put_path_source_rvar(
-                qry, path_id, table)
+            pathctx.put_path_identity_var(qry, path_id, var=target_ref)
+            pathctx.put_path_source_rvar(qry, path_id, table)
 
         # Only fire off the overlays at the end of each expanded inhview.
         # This only matters when we are doing expand_inhviews, and prevents
@@ -1957,9 +1950,9 @@ def range_for_ptrref(
                     target_ref = pgast.ColumnRef(
                         name=[rvar.alias.aliasname, cols[1]])
                     pathctx.put_path_identity_var(
-                        qry, cte_path_id, var=target_ref)
-                    pathctx.put_path_source_rvar(
-                        qry, cte_path_id, rvar)
+                        qry, cte_path_id, var=target_ref
+                    )
+                    pathctx.put_path_source_rvar(qry, cte_path_id, rvar)
                     pathctx.put_path_id_map(qry, path_id, cte_path_id)
 
                 set_ops.append((op, qry))

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -111,7 +111,7 @@ def _pull_path_namespace(
                 continue
 
             rvar = pathctx.maybe_get_path_rvar(
-                target, path_id, aspect=aspect, flavor=flavor, env=ctx.env)
+                target, path_id, aspect=aspect, flavor=flavor)
             if rvar is None or flavor == 'packed':
                 pathctx.put_path_rvar(
                     target, path_id, source, aspect=aspect, flavor=flavor)
@@ -165,7 +165,7 @@ def find_rvar(
                                aspect='value', flavor=flavor, ctx=ctx)
     if rvar is not None:
         pathctx.put_path_rvar_if_not_exists(
-            stmt, path_id, rvar, aspect='value', flavor=flavor, env=ctx.env)
+            stmt, path_id, rvar, aspect='value', flavor=flavor)
 
         src_rvar = maybe_get_path_rvar(source_stmt, path_id=path_id,
                                        aspect='source', flavor=flavor, ctx=ctx)
@@ -173,7 +173,7 @@ def find_rvar(
         if src_rvar is not None:
             pathctx.put_path_rvar_if_not_exists(
                 stmt, path_id, src_rvar,
-                aspect='source', flavor=flavor, env=ctx.env)
+                aspect='source', flavor=flavor)
 
     return rvar
 
@@ -273,7 +273,7 @@ def include_specific_rvar(
                 stmt, path_id, rvar, flavor=flavor, aspect=aspect)
         else:
             pathctx.put_path_rvar_if_not_exists(
-                stmt, path_id, rvar, flavor=flavor, aspect=aspect, env=ctx.env)
+                stmt, path_id, rvar, flavor=flavor, aspect=aspect)
 
     if update_mask:
         scopes = [ctx.scope_tree]
@@ -329,7 +329,7 @@ def _maybe_get_path_rvar(
     qry: Optional[pgast.Query] = stmt
     while qry is not None:
         rvar = pathctx.maybe_get_path_rvar(
-            qry, path_id, aspect=aspect, flavor=flavor, env=ctx.env)
+            qry, path_id, aspect=aspect, flavor=flavor)
         if rvar is not None:
             if qry is not stmt:
                 # Cache the rvar reference.

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -114,8 +114,7 @@ def _pull_path_namespace(
                 target, path_id, aspect=aspect, flavor=flavor, env=ctx.env)
             if rvar is None or flavor == 'packed':
                 pathctx.put_path_rvar(
-                    target, path_id, source, aspect=aspect, flavor=flavor,
-                    env=ctx.env)
+                    target, path_id, source, aspect=aspect, flavor=flavor)
 
 
 def pull_path_namespace(
@@ -214,7 +213,8 @@ def include_rvar(
         if path_id.is_objtype_path():
             if isinstance(rvar, pgast.RangeSubselect):
                 if pathctx.has_path_aspect(
-                        rvar.query, path_id, aspect='source', env=ctx.env):
+                    rvar.query, path_id, aspect='source'
+                ):
                     aspects += ('source',)
             else:
                 aspects += ('source',)
@@ -270,7 +270,7 @@ def include_specific_rvar(
     for aspect in aspects:
         if overwrite_path_rvar:
             pathctx.put_path_rvar(
-                stmt, path_id, rvar, flavor=flavor, aspect=aspect, env=ctx.env)
+                stmt, path_id, rvar, flavor=flavor, aspect=aspect)
         else:
             pathctx.put_path_rvar_if_not_exists(
                 stmt, path_id, rvar, flavor=flavor, aspect=aspect, env=ctx.env)
@@ -299,7 +299,7 @@ def has_rvar(
         return True
 
     while curstmt is not None:
-        if pathctx.has_rvar(curstmt, rvar, env=ctx.env):
+        if pathctx.has_rvar(curstmt, rvar):
             return True
         curstmt = ctx.rel_hierarchy.get(curstmt)
 
@@ -334,8 +334,7 @@ def _maybe_get_path_rvar(
             if qry is not stmt:
                 # Cache the rvar reference.
                 pathctx.put_path_rvar(stmt, path_id, rvar,
-                                      flavor=flavor, aspect=aspect,
-                                      env=ctx.env)
+                                      flavor=flavor, aspect=aspect)
             return rvar, path_id
         qry = ctx.rel_hierarchy.get(qry)
 
@@ -1144,10 +1143,10 @@ def unpack_var(
 
         if not el.packed:
             pathctx.put_path_rvar(
-                stmt, el_id, rvar, aspect='value', env=ctx.env)
+                stmt, el_id, rvar, aspect='value')
 
             pathctx.put_path_rvar(
-                ctx.rel, el_id, rvar, aspect='value', env=ctx.env)
+                ctx.rel, el_id, rvar, aspect='value')
         else:
             cref = pathctx.get_path_output(
                 qry, el_id, aspect='value', env=ctx.env)
@@ -1156,7 +1155,7 @@ def unpack_var(
             pathctx.put_path_packed_output(qry, el_id, val=cref)
 
             pathctx.put_path_rvar(
-                stmt, el_id, rvar, flavor='packed', aspect='value', env=ctx.env
+                stmt, el_id, rvar, flavor='packed', aspect='value'
             )
 
     # When we're producing an exposed shape, we need to rewrite the
@@ -1200,7 +1199,7 @@ def unpack_var(
                 qry, view_path_id, sval, aspect=aspect, force=True
             )
             pathctx.put_path_rvar(
-                ctx.rel, view_path_id, rvar, aspect=aspect, env=ctx.env
+                ctx.rel, view_path_id, rvar, aspect=aspect
             )
 
     return rvar
@@ -1471,8 +1470,8 @@ def range_for_material_objtype(
             )
             qry = pgast.SelectStmt(from_clause=[rvar])
             sub_path_id = path_id
-            pathctx.put_path_value_rvar(qry, sub_path_id, rvar, env=env)
-            pathctx.put_path_source_rvar(qry, sub_path_id, rvar, env=env)
+            pathctx.put_path_value_rvar(qry, sub_path_id, rvar)
+            pathctx.put_path_source_rvar(qry, sub_path_id, rvar)
 
             ops.append(('union', qry))
 
@@ -1525,9 +1524,9 @@ def range_for_material_objtype(
 
         qry = pgast.SelectStmt()
         qry.from_clause.append(rvar)
-        pathctx.put_path_value_rvar(qry, path_id, rvar, env=env)
+        pathctx.put_path_value_rvar(qry, path_id, rvar)
         if path_id.is_objtype_path():
-            pathctx.put_path_source_rvar(qry, path_id, rvar, env=env)
+            pathctx.put_path_source_rvar(qry, path_id, rvar)
         pathctx.put_path_bond(qry, path_id)
 
         set_ops.append(('union', qry))
@@ -1539,9 +1538,9 @@ def range_for_material_objtype(
                 from_clause=[rvar],
             )
 
-            pathctx.put_path_value_rvar(qry, cte_path_id, rvar, env=env)
+            pathctx.put_path_value_rvar(qry, cte_path_id, rvar)
             if path_id.is_objtype_path():
-                pathctx.put_path_source_rvar(qry, cte_path_id, rvar, env=env)
+                pathctx.put_path_source_rvar(qry, cte_path_id, rvar)
             pathctx.put_path_bond(qry, cte_path_id)
             pathctx.put_path_id_map(qry, path_id, cte_path_id)
 
@@ -1555,9 +1554,9 @@ def range_for_material_objtype(
             qry2 = pgast.SelectStmt(
                 from_clause=[qry_rvar]
             )
-            pathctx.put_path_value_rvar(qry2, path_id, qry_rvar, env=env)
+            pathctx.put_path_value_rvar(qry2, path_id, qry_rvar)
             if path_id.is_objtype_path():
-                pathctx.put_path_source_rvar(qry2, path_id, qry_rvar, env=env)
+                pathctx.put_path_source_rvar(qry2, path_id, qry_rvar)
             pathctx.put_path_bond(qry2, path_id)
 
             if op == 'replace':
@@ -1619,9 +1618,9 @@ def range_for_typeref(
                 from_clause=[c_rvar],
             )
 
-            pathctx.put_path_value_rvar(qry, path_id, c_rvar, env=ctx.env)
+            pathctx.put_path_value_rvar(qry, path_id, c_rvar)
             if path_id.is_objtype_path():
-                pathctx.put_path_source_rvar(qry, path_id, c_rvar, env=ctx.env)
+                pathctx.put_path_source_rvar(qry, path_id, c_rvar)
 
             pathctx.put_path_bond(qry, path_id)
 
@@ -1654,7 +1653,7 @@ def range_for_typeref(
         int_rvar = pgast.IntersectionRangeVar(component_rvars=component_rvars)
         for aspect in ('source', 'value'):
             pathctx.put_path_rvar(
-                wrapper, path_id, int_rvar, aspect=aspect, env=ctx.env
+                wrapper, path_id, int_rvar, aspect=aspect
             )
 
         pathctx.put_path_bond(wrapper, path_id)
@@ -1930,7 +1929,7 @@ def range_for_ptrref(
             pathctx.put_path_identity_var(
                 qry, path_id, var=target_ref)
             pathctx.put_path_source_rvar(
-                qry, path_id, table, env=ctx.env)
+                qry, path_id, table)
 
         # Only fire off the overlays at the end of each expanded inhview.
         # This only matters when we are doing expand_inhviews, and prevents
@@ -1960,7 +1959,7 @@ def range_for_ptrref(
                     pathctx.put_path_identity_var(
                         qry, cte_path_id, var=target_ref)
                     pathctx.put_path_source_rvar(
-                        qry, cte_path_id, rvar, env=ctx.env)
+                        qry, cte_path_id, rvar)
                     pathctx.put_path_id_map(qry, path_id, cte_path_id)
 
                 set_ops.append((op, qry))

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -442,8 +442,8 @@ def new_free_object_rvar(
             name=('edgedbext', 'uuid_generate_v4',), args=[]
         )
 
-        pathctx.put_path_identity_var(qry, path_id, id_expr, env=ctx.env)
-        pathctx.put_path_value_var(qry, path_id, id_expr, env=ctx.env)
+        pathctx.put_path_identity_var(qry, path_id, id_expr)
+        pathctx.put_path_value_var(qry, path_id, id_expr)
         apply_volatility_ref(qry, ctx=subctx)
 
     return rvar_for_rel(qry, typeref=typeref, lateral=lateral, ctx=ctx)
@@ -467,8 +467,7 @@ def deep_copy_primitive_rvar_path_var(
             rref = pathctx.get_path_var(
                 component, orig_id, aspect='identity', env=env)
             pathctx.put_path_var(
-                component, new_id, rref, aspect='identity',
-                env=env)
+                component, new_id, rref, aspect='identity')
     else:
         rref = pathctx.get_path_output(
             rvar.query, orig_id, aspect='identity', env=env)
@@ -596,7 +595,7 @@ def _new_inline_pointer_rvar(
         src_rvar, far_pid, env=ctx.env)
 
     pathctx.put_rvar_path_bond(ptr_rvar, far_pid)
-    pathctx.put_path_identity_var(ptr_rel, far_pid, var=far_ref, env=ctx.env)
+    pathctx.put_path_identity_var(ptr_rel, far_pid, var=far_ref)
 
     return ptr_rvar
 
@@ -749,7 +748,7 @@ def ensure_transient_identity_for_path(
     )
 
     pathctx.put_path_identity_var(
-        stmt, path_id, id_expr, force=True, env=ctx.env)
+        stmt, path_id, id_expr, force=True)
     pathctx.put_path_bond(stmt, path_id)
 
     if isinstance(stmt, pgast.SelectStmt):
@@ -839,7 +838,7 @@ def set_to_array(
         val = output.serialize_expr(
             value_var, path_id=path_id, env=ctx.env)
         pathctx.put_path_serialized_var(
-            result, path_id, val, force=True, env=ctx.env)
+            result, path_id, val, force=True)
 
     if isinstance(val, pgast.TupleVarBase):
         val = output.serialize_expr(
@@ -1136,7 +1135,7 @@ def unpack_var(
 
         for aspect in ('value', 'serialized'):
             pathctx.put_path_var(
-                qry, el_id, cur_ref, aspect=aspect, env=ctx.env,
+                qry, el_id, cur_ref, aspect=aspect
             )
 
         if not el.packed:
@@ -1183,8 +1182,7 @@ def unpack_var(
                     continue
                 reqry = reserialize_object(el, tel, ctx=ctx)
                 pathctx.put_path_var(
-                    qry, tel.path_id, reqry, aspect='serialized',
-                    env=ctx.env, force=True
+                    qry, tel.path_id, reqry, aspect='serialized', force=True
                 )
 
         for aspect in rewrite_aspects:
@@ -1195,7 +1193,7 @@ def unpack_var(
                 output.serialize_expr(tv, path_id=path_id, env=ctx.env)
             )
             pathctx.put_path_var(
-                qry, view_path_id, sval, aspect=aspect, env=ctx.env, force=True
+                qry, view_path_id, sval, aspect=aspect, force=True
             )
             pathctx.put_path_rvar(
                 ctx.rel, view_path_id, rvar, aspect=aspect, env=ctx.env
@@ -1926,7 +1924,7 @@ def range_for_ptrref(
         if path_id:
             target_ref = qry.target_list[1].val
             pathctx.put_path_identity_var(
-                qry, path_id, var=target_ref, env=ctx.env)
+                qry, path_id, var=target_ref)
             pathctx.put_path_source_rvar(
                 qry, path_id, table, env=ctx.env)
 
@@ -1956,7 +1954,7 @@ def range_for_ptrref(
                     target_ref = pgast.ColumnRef(
                         name=[rvar.alias.aliasname, cols[1]])
                     pathctx.put_path_identity_var(
-                        qry, cte_path_id, var=target_ref, env=ctx.env)
+                        qry, cte_path_id, var=target_ref)
                     pathctx.put_path_source_rvar(
                         qry, cte_path_id, rvar, env=ctx.env)
                     pathctx.put_path_id_map(qry, path_id, cte_path_id)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -246,7 +246,6 @@ def get_set_rvar(
                 path_id,
                 result_rvar,
                 aspect=aspect,
-                env=ctx.env,
             )
 
     return result_rvar
@@ -297,7 +296,6 @@ def _process_toplevel_query(
                 ir_set.path_id,
                 result_rvar,
                 aspect=aspect,
-                env=ctx.env,
             )
     else:
         result_rvar = rvars.main.rvar
@@ -663,7 +661,7 @@ def finalize_optional_rel(
         for aspect in rvars.main.aspects:
             pathctx.put_path_rvar_if_not_exists(
                 setrel, ir_set.path_id, rvars.main.rvar,
-                aspect=aspect, env=subctx.env)
+                aspect=aspect)
 
         lvar = pathctx.get_path_value_var(
             setrel, path_id=ir_set.path_id, env=subctx.env)
@@ -796,7 +794,7 @@ def process_set_as_link_property_ref(
             ir_source.path_id, ctx=newctx)
 
         link_rvar = pathctx.maybe_get_path_rvar(
-            source_scope_stmt, link_path_id, aspect='source', env=ctx.env)
+            source_scope_stmt, link_path_id, aspect='source')
 
         if link_rvar is None:
             src_rvar = get_set_rvar(ir_source, ctx=newctx)
@@ -1402,7 +1400,7 @@ def process_set_as_subquery(
     # also expose a pointer path source. See tests like
     # test_edgeql_select_linkprop_rebind_01
     if pathctx.maybe_get_path_rvar(
-            stmt, inner_id.ptr_path(), aspect='source', env=ctx.env):
+            stmt, inner_id.ptr_path(), aspect='source'):
         rvars.new.append(
             SetRVar(
                 rvars.main.rvar,
@@ -3374,7 +3372,6 @@ def process_set_as_agg_expr_inner(
                             ctx.rel,
                             ir_arg.path_id,
                             aspect='value',
-                            env=argctx.env,
                         )
                         query = qrvar.query
                         assert isinstance(query, pgast.SelectStmt)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -102,7 +102,7 @@ def new_stmt_set_rvar(
     if aspects is not None:
         aspects = tuple(aspects)
     else:
-        aspects = pathctx.list_path_aspects(stmt, ir_set.path_id, env=ctx.env)
+        aspects = pathctx.list_path_aspects(stmt, ir_set.path_id)
     return new_simple_set_rvar(ir_set, rvar, aspects=aspects)
 
 
@@ -769,7 +769,7 @@ def process_set_as_link_property_ref(
             src_rvar, ir_source.path_id, aspect='value', env=ctx.env)
 
         pathctx.put_rvar_path_output(
-            src_rvar, ir_set.path_id, aspect='value', var=val, env=ctx.env)
+            src_rvar, ir_set.path_id, aspect='value', var=val)
 
         return SetRVars(
             main=SetRVar(rvar=src_rvar, path_id=ir_set.path_id), new=[])
@@ -1195,7 +1195,7 @@ def _new_subquery_stmt_set_rvar(
     ctx: context.CompilerContextLevel,
 ) -> SetRVars:
     aspects = pathctx.list_path_aspects(
-        stmt, ir_set.path_id, env=ctx.env)
+        stmt, ir_set.path_id)
     if ir_set.path_id.is_tuple_path():
         # If we are wrapping a tuple expression, make sure not to
         # over-represent it in terms of the exposed aspects.
@@ -1540,8 +1540,8 @@ def process_set_as_setop(
             dispatch.visit(right, ctx=scopectx)
 
     aspects = (
-        pathctx.list_path_aspects(larg, left.path_id, env=ctx.env)
-        & pathctx.list_path_aspects(rarg, right.path_id, env=ctx.env)
+        pathctx.list_path_aspects(larg, left.path_id)
+        & pathctx.list_path_aspects(rarg, right.path_id)
     )
 
     with ctx.subrel() as subctx:
@@ -1688,8 +1688,8 @@ def process_set_as_ifelse(
             )
 
         aspects = (
-            pathctx.list_path_aspects(larg, if_expr.path_id, env=ctx.env)
-            & pathctx.list_path_aspects(rarg, else_expr.path_id, env=ctx.env)
+            pathctx.list_path_aspects(larg, if_expr.path_id)
+            & pathctx.list_path_aspects(rarg, else_expr.path_id)
         )
 
         with ctx.subrel() as subctx:
@@ -1890,9 +1890,8 @@ def process_set_as_coalesce(
                 )
 
             aspects = (
-                pathctx.list_path_aspects(larg, left_ir.path_id, env=ctx.env)
-                & pathctx.list_path_aspects(
-                    rarg, right_ir.path_id, env=ctx.env)
+                pathctx.list_path_aspects(larg, left_ir.path_id)
+                & pathctx.list_path_aspects(rarg, right_ir.path_id)
             )
 
             subrvar = relctx.rvar_for_rel(subqry, lateral=True, ctx=newctx)
@@ -1951,7 +1950,7 @@ def process_set_as_tuple(
 
             el_rvar = relctx.new_rel_rvar(ir_set, newctx.rel, ctx=ctx)
             aspects = pathctx.list_path_aspects(
-                newctx.rel, element.val.path_id, env=ctx.env)
+                newctx.rel, element.val.path_id)
             # update_mask=False because we are doing this solely to remap
             # elements individually and don't want to affect the mask.
             relctx.include_rvar(
@@ -2312,7 +2311,7 @@ def process_set_as_singleton_assertion(
         pathctx.put_path_id_map(newctx.rel, ir_set.path_id, ir_arg_set.path_id)
 
     aspects = pathctx.list_path_aspects(
-        newctx.rel, ir_arg_set.path_id, env=ctx.env)
+        newctx.rel, ir_arg_set.path_id)
     func_rvar = relctx.new_rel_rvar(ir_set, newctx.rel, ctx=ctx)
     relctx.include_rvar(stmt, func_rvar, ir_set.path_id,
                         aspects=aspects, ctx=ctx)
@@ -2455,7 +2454,7 @@ def process_set_as_multiplicity_assertion(
             sub_rvar = relctx.new_rel_rvar(ir_arg_set, subctx.rel, ctx=subctx)
 
             aspects = pathctx.list_path_aspects(
-                subctx.rel, ir_arg_set.path_id, env=ctx.env)
+                subctx.rel, ir_arg_set.path_id)
             relctx.include_rvar(
                 newctx.rel, sub_rvar, ir_arg_set.path_id,
                 aspects=aspects, ctx=subctx,
@@ -2624,7 +2623,7 @@ def process_set_as_simple_enumerate(
             newctx.rel, ir_set.path_id, set_expr, aspect='value')
 
     aspects = pathctx.list_path_aspects(
-        newctx.rel, ir_arg.path_id, env=ctx.env) | {'source'}
+        newctx.rel, ir_arg.path_id) | {'source'}
 
     pathctx.put_path_id_map(newctx.rel, expr.tuple_path_ids[1], ir_arg.path_id)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -444,9 +444,9 @@ def ensure_source_rvar(
             else:
                 rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
                 relctx.include_rvar(
-                    scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
-            pathctx.put_path_rvar(
-                stmt, ir_set.path_id, rvar, aspect='source')
+                    scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx
+                )
+            pathctx.put_path_rvar(stmt, ir_set.path_id, rvar, aspect='source')
 
     return rvar
 
@@ -660,8 +660,8 @@ def finalize_optional_rel(
 
         for aspect in rvars.main.aspects:
             pathctx.put_path_rvar_if_not_exists(
-                setrel, ir_set.path_id, rvars.main.rvar,
-                aspect=aspect)
+                setrel, ir_set.path_id, rvars.main.rvar, aspect=aspect
+            )
 
         lvar = pathctx.get_path_value_var(
             setrel, path_id=ir_set.path_id, env=subctx.env)
@@ -767,7 +767,8 @@ def process_set_as_link_property_ref(
             src_rvar, ir_source.path_id, aspect='value', env=ctx.env)
 
         pathctx.put_rvar_path_output(
-            src_rvar, ir_set.path_id, aspect='value', var=val)
+            src_rvar, ir_set.path_id, aspect='value', var=val
+        )
 
         return SetRVars(
             main=SetRVar(rvar=src_rvar, path_id=ir_set.path_id), new=[])
@@ -794,7 +795,8 @@ def process_set_as_link_property_ref(
             ir_source.path_id, ctx=newctx)
 
         link_rvar = pathctx.maybe_get_path_rvar(
-            source_scope_stmt, link_path_id, aspect='source')
+            source_scope_stmt, link_path_id, aspect='source'
+        )
 
         if link_rvar is None:
             src_rvar = get_set_rvar(ir_source, ctx=newctx)
@@ -1190,8 +1192,7 @@ def _new_subquery_stmt_set_rvar(
     *,
     ctx: context.CompilerContextLevel,
 ) -> SetRVars:
-    aspects = pathctx.list_path_aspects(
-        stmt, ir_set.path_id)
+    aspects = pathctx.list_path_aspects(stmt, ir_set.path_id)
     if ir_set.path_id.is_tuple_path():
         # If we are wrapping a tuple expression, make sure not to
         # over-represent it in terms of the exposed aspects.
@@ -1399,8 +1400,7 @@ def process_set_as_subquery(
     # If the inner set also exposes a pointer path source, we need to
     # also expose a pointer path source. See tests like
     # test_edgeql_select_linkprop_rebind_01
-    if pathctx.maybe_get_path_rvar(
-            stmt, inner_id.ptr_path(), aspect='source'):
+    if pathctx.maybe_get_path_rvar(stmt, inner_id.ptr_path(), aspect='source'):
         rvars.new.append(
             SetRVar(
                 rvars.main.rvar,
@@ -1535,10 +1535,9 @@ def process_set_as_setop(
             pathctx.put_path_id_map(rarg, ir_set.path_id, right.path_id)
             dispatch.visit(right, ctx=scopectx)
 
-    aspects = (
-        pathctx.list_path_aspects(larg, left.path_id)
-        & pathctx.list_path_aspects(rarg, right.path_id)
-    )
+    aspects = pathctx.list_path_aspects(
+        larg, left.path_id
+    ) & pathctx.list_path_aspects(rarg, right.path_id)
 
     with ctx.subrel() as subctx:
         subqry = subctx.rel
@@ -1683,10 +1682,9 @@ def process_set_as_ifelse(
                 astutils.new_unop('NOT', condref)
             )
 
-        aspects = (
-            pathctx.list_path_aspects(larg, if_expr.path_id)
-            & pathctx.list_path_aspects(rarg, else_expr.path_id)
-        )
+        aspects = pathctx.list_path_aspects(
+            larg, if_expr.path_id
+        ) & pathctx.list_path_aspects(rarg, else_expr.path_id)
 
         with ctx.subrel() as subctx:
             subqry = subctx.rel
@@ -1769,7 +1767,8 @@ def process_set_as_coalesce(
                 set_expr = pgast.CoalesceExpr(args=[left, right])
 
                 pathctx.put_path_value_var_if_not_exists(
-                    subctx.rel, ir_set.path_id, set_expr)
+                    subctx.rel, ir_set.path_id, set_expr
+                )
 
                 sub_rvar = relctx.rvar_for_rel(
                     subctx.rel,
@@ -1885,10 +1884,9 @@ def process_set_as_coalesce(
                     )
                 )
 
-            aspects = (
-                pathctx.list_path_aspects(larg, left_ir.path_id)
-                & pathctx.list_path_aspects(rarg, right_ir.path_id)
-            )
+            aspects = pathctx.list_path_aspects(
+                larg, left_ir.path_id
+            ) & pathctx.list_path_aspects(rarg, right_ir.path_id)
 
             subrvar = relctx.rvar_for_rel(subqry, lateral=True, ctx=newctx)
 
@@ -1946,7 +1944,8 @@ def process_set_as_tuple(
 
             el_rvar = relctx.new_rel_rvar(ir_set, newctx.rel, ctx=ctx)
             aspects = pathctx.list_path_aspects(
-                newctx.rel, element.val.path_id)
+                newctx.rel, element.val.path_id
+            )
             # update_mask=False because we are doing this solely to remap
             # elements individually and don't want to affect the mask.
             relctx.include_rvar(
@@ -1973,8 +1972,7 @@ def process_set_as_tuple(
                 stmt, element.val.path_id,
                 aspect='serialized', env=subctx.env)
             if var is not None:
-                pathctx.put_path_var(stmt, path_id, var,
-                                     aspect='serialized')
+                pathctx.put_path_var(stmt, path_id, var, aspect='serialized')
 
         set_expr = pgast.TupleVarBase(
             elements=elements,
@@ -2050,7 +2048,8 @@ def process_set_as_tuple_indirection(
             )
 
             pathctx.put_path_var_if_not_exists(
-                stmt, ir_set.path_id, set_expr, aspect='value')
+                stmt, ir_set.path_id, set_expr, aspect='value'
+            )
 
             rvar = relctx.new_rel_rvar(ir_set, stmt, ctx=subctx)
 
@@ -2103,8 +2102,7 @@ def process_set_as_type_cast(
                 )
 
                 pathctx.put_path_serialized_var(
-                    stmt, inner_set.path_id, serialized,
-                    force=True
+                    stmt, inner_set.path_id, serialized, force=True
                 )
 
             subctx.env.output_format = orig_output_format
@@ -2119,8 +2117,7 @@ def process_set_as_type_cast(
             # populated above.
             stmt.view_path_id_map.pop(ir_set.path_id)
 
-    pathctx.put_path_value_var_if_not_exists(
-        stmt, ir_set.path_id, set_expr)
+    pathctx.put_path_value_var_if_not_exists(stmt, ir_set.path_id, set_expr)
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
@@ -2205,9 +2202,7 @@ def process_set_as_expr(
         assert ir_set.expr is not None
         set_expr = dispatch.compile(ir_set.expr, ctx=newctx)
 
-    pathctx.put_path_value_var_if_not_exists(
-        ctx.rel, ir_set.path_id, set_expr
-    )
+    pathctx.put_path_value_var_if_not_exists(ctx.rel, ir_set.path_id, set_expr)
 
     return new_stmt_set_rvar(ir_set, ctx.rel, ctx=ctx)
 
@@ -2302,12 +2297,12 @@ def process_set_as_singleton_assertion(
         )
 
         pathctx.put_path_var_if_not_exists(
-            newctx.rel, ir_set.path_id, arg_val, aspect='value')
+            newctx.rel, ir_set.path_id, arg_val, aspect='value'
+        )
 
         pathctx.put_path_id_map(newctx.rel, ir_set.path_id, ir_arg_set.path_id)
 
-    aspects = pathctx.list_path_aspects(
-        newctx.rel, ir_arg_set.path_id)
+    aspects = pathctx.list_path_aspects(newctx.rel, ir_arg_set.path_id)
     func_rvar = relctx.new_rel_rvar(ir_set, newctx.rel, ctx=ctx)
     relctx.include_rvar(stmt, func_rvar, ir_set.path_id,
                         aspects=aspects, ctx=ctx)
@@ -2417,9 +2412,7 @@ def process_set_as_multiplicity_assertion(
         # If the argument has been statically proven to be distinct,
         # elide the entire assertion.
         arg_ref = dispatch.compile(ir_arg_set, ctx=ctx)
-        pathctx.put_path_value_var(
-            ctx.rel, ir_set.path_id, arg_ref
-        )
+        pathctx.put_path_value_var(ctx.rel, ir_set.path_id, arg_ref)
         pathctx.put_path_id_map(ctx.rel, ir_set.path_id, ir_arg_set.path_id)
         return new_stmt_set_rvar(ir_set, ctx.rel, ctx=ctx)
 
@@ -2449,8 +2442,7 @@ def process_set_as_multiplicity_assertion(
             arg_val = output.output_as_value(arg_ref, env=newctx.env)
             sub_rvar = relctx.new_rel_rvar(ir_arg_set, subctx.rel, ctx=subctx)
 
-            aspects = pathctx.list_path_aspects(
-                subctx.rel, ir_arg_set.path_id)
+            aspects = pathctx.list_path_aspects(subctx.rel, ir_arg_set.path_id)
             relctx.include_rvar(
                 newctx.rel, sub_rvar, ir_arg_set.path_id,
                 aspects=aspects, ctx=subctx,
@@ -2606,20 +2598,27 @@ def process_set_as_simple_enumerate(
 
         for element in set_expr.elements:
             pathctx.put_path_value_var(
-                newctx.rel, element.path_id, element.val)
+                newctx.rel, element.path_id, element.val
+            )
 
         var = pathctx.maybe_get_path_var(
             newctx.rel, ir_arg.path_id,
             aspect='serialized', env=newctx.env)
         if var is not None:
-            pathctx.put_path_var(newctx.rel, set_expr.elements[1].path_id, var,
-                                 aspect='serialized')
+            pathctx.put_path_var(
+                newctx.rel,
+                set_expr.elements[1].path_id,
+                var,
+                aspect='serialized',
+            )
 
         pathctx.put_path_var_if_not_exists(
-            newctx.rel, ir_set.path_id, set_expr, aspect='value')
+            newctx.rel, ir_set.path_id, set_expr, aspect='value'
+        )
 
-    aspects = pathctx.list_path_aspects(
-        newctx.rel, ir_arg.path_id) | {'source'}
+    aspects = pathctx.list_path_aspects(newctx.rel, ir_arg.path_id) | {
+        'source'
+    }
 
     pathctx.put_path_id_map(newctx.rel, expr.tuple_path_ids[1], ir_arg.path_id)
 
@@ -2951,15 +2950,13 @@ def _process_set_func_with_ordinality(
     )
 
     for element in set_expr.elements:
-        pathctx.put_path_value_var(
-            ctx.rel, element.path_id, element.val)
+        pathctx.put_path_value_var(ctx.rel, element.path_id, element.val)
 
     if arg_is_tuple:
         arg_tuple = set_expr.elements[1].val
         assert isinstance(arg_tuple, pgast.TupleVar)
         for element in arg_tuple.elements:
-            pathctx.put_path_value_var(
-                ctx.rel, element.path_id, element.val)
+            pathctx.put_path_value_var(ctx.rel, element.path_id, element.val)
 
     # If there is a shape specified on the argument to enumerate, we need
     # to compile it here manually, since we are skipping the normal
@@ -2972,8 +2969,9 @@ def _process_set_func_with_ordinality(
     var = pathctx.maybe_get_path_var(
         ctx.rel, ir_set.path_id, aspect='serialized', env=ctx.env)
     if var is not None:
-        pathctx.put_path_var(ctx.rel, set_expr.elements[1].path_id, var,
-                             aspect='serialized')
+        pathctx.put_path_var(
+            ctx.rel, set_expr.elements[1].path_id, var, aspect='serialized'
+        )
 
     return set_expr
 
@@ -3051,7 +3049,8 @@ def _process_set_func(
 
         for element in set_expr.elements:
             pathctx.put_path_value_var_if_not_exists(
-                ctx.rel, element.path_id, element.val)
+                ctx.rel, element.path_id, element.val
+            )
 
     return set_expr
 
@@ -3068,7 +3067,8 @@ def _compile_func_epilogue(
         relctx.apply_volatility_ref(func_rel, ctx=ctx)
 
     pathctx.put_path_var_if_not_exists(
-        func_rel, ir_set.path_id, set_expr, aspect='value')
+        func_rel, ir_set.path_id, set_expr, aspect='value'
+    )
 
     aspects: Tuple[str, ...] = ('value',)
 
@@ -3471,9 +3471,7 @@ def process_set_as_agg_expr_inner(
             with ctx.new() as ivctx:
                 iv = dispatch.compile(iv_ir, ctx=ivctx)
 
-        pathctx.put_path_var(
-            stmt, ir_set.path_id, set_expr, aspect=aspect
-        )
+        pathctx.put_path_var(stmt, ir_set.path_id, set_expr, aspect=aspect)
         out = pathctx.get_path_output(
             stmt, ir_set.path_id, aspect=aspect, env=ctx.env
         )
@@ -3491,8 +3489,7 @@ def process_set_as_agg_expr_inner(
         set_expr = pgast.CoalesceExpr(
             args=[val, iv], ser_safe=serialization_safe)
 
-        pathctx.put_path_var(
-            wrapper, ir_set.path_id, set_expr, aspect=aspect)
+        pathctx.put_path_var(wrapper, ir_set.path_id, set_expr, aspect=aspect)
         stmt = wrapper
 
     pathctx.put_path_var_if_not_exists(
@@ -3560,10 +3557,8 @@ def process_set_as_exists_expr(
         ir_expr = expr.args[0].expr
         set_ref = dispatch.compile(ir_expr, ctx=subctx)
 
-        pathctx.put_path_value_var(
-            wrapper, ir_set.path_id, set_ref)
-        pathctx.get_path_value_output(
-            wrapper, ir_set.path_id, env=ctx.env)
+        pathctx.put_path_value_var(wrapper, ir_set.path_id, set_ref)
+        pathctx.get_path_value_output(wrapper, ir_set.path_id, env=ctx.env)
 
         wrapper.where_clause = astutils.extend_binop(
             wrapper.where_clause, pgast.NullTest(arg=set_ref, negated=True))
@@ -3609,9 +3604,7 @@ def process_set_as_json_object_pack(
 
     # declare that the 'aspect=value' of ir_set (original set)
     # can be found by in ctx.rel, by using set_expr
-    pathctx.put_path_value_var_if_not_exists(
-        ctx.rel, ir_set.path_id, set_expr
-    )
+    pathctx.put_path_value_var_if_not_exists(ctx.rel, ir_set.path_id, set_expr)
 
     # return subquery as set_rvar
     return new_stmt_set_rvar(ir_set, ctx.rel, ctx=ctx)
@@ -3698,15 +3691,11 @@ def process_set_as_array_expr(
                 )
             )
 
-        pathctx.put_path_serialized_var(
-            ctx.rel, ir_set.path_id, set_expr
-        )
+        pathctx.put_path_serialized_var(ctx.rel, ir_set.path_id, set_expr)
     else:
         set_expr = build_array_expr(expr, elements, ctx=ctx)
 
-    pathctx.put_path_value_var_if_not_exists(
-        ctx.rel, ir_set.path_id, set_expr
-    )
+    pathctx.put_path_value_var_if_not_exists(ctx.rel, ir_set.path_id, set_expr)
 
     return new_stmt_set_rvar(ir_set, ctx.rel, ctx=ctx)
 
@@ -3730,7 +3719,8 @@ def process_encoded_param(
             # from a subquery below.
             arg_val = output.output_as_value(arg_ref, env=sctx.env)
             pathctx.put_path_value_var(
-                sctx.rel, decoder.path_id, arg_val, force=True)
+                sctx.rel, decoder.path_id, arg_val, force=True
+            )
 
             param_cte = pgast.CommonTableExpr(
                 name=ctx.env.aliases.get('p'),

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -448,7 +448,7 @@ def ensure_source_rvar(
                 relctx.include_rvar(
                     scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
             pathctx.put_path_rvar(
-                stmt, ir_set.path_id, rvar, aspect='source', env=ctx.env)
+                stmt, ir_set.path_id, rvar, aspect='source')
 
     return rvar
 
@@ -828,7 +828,7 @@ def process_set_as_link_property_ref(
                     assert isinstance(rvar, pgast.PathRangeVar)
                     if ptr_ids is None or rvar.schema_object_id in ptr_ids:
                         pathctx.put_path_source_rvar(
-                            subquery, orig_link_path_id, rvar, env=ctx.env
+                            subquery, orig_link_path_id, rvar
                         )
                         continue
                 # Spare get_path_var() from attempting to rebalance
@@ -937,7 +937,6 @@ def process_set_as_path_type_intersection(
                 ir_source.path_id,
                 source_rvar,
                 aspect=aspect,
-                env=ctx.env,
             )
 
             pathctx.put_path_rvar(
@@ -945,7 +944,6 @@ def process_set_as_path_type_intersection(
                 ir_set.path_id,
                 int_rvar,
                 aspect=aspect,
-                env=ctx.env,
             )
 
     return new_stmt_set_rvar(

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -79,7 +79,6 @@ def compile_SelectStmt(
                         path_id=iterator_set.path_id,
                         rvar=iterator_rvar,
                         aspect=aspect,
-                        env=ctx.env,
                     )
                 last_iterator = iterator_set
 

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -161,8 +161,7 @@ def compile_InsertStmt(
         )
 
         # Wrap up.
-        return dml.fini_dml_stmt(
-            stmt, ctx.rel, parts, ctx=ctx)
+        return dml.fini_dml_stmt(stmt, ctx.rel, parts, ctx=ctx)
 
 
 @dispatch.compile.register(irast.UpdateStmt)
@@ -190,8 +189,7 @@ def compile_UpdateStmt(
                 ctx=ctx,
             )
 
-        return dml.fini_dml_stmt(
-            stmt, ctx.rel, parts, ctx=ctx)
+        return dml.fini_dml_stmt(stmt, ctx.rel, parts, ctx=ctx)
 
 
 @dispatch.compile.register(irast.DeleteStmt)
@@ -217,5 +215,4 @@ def compile_DeleteStmt(
             )
 
         # Wrap up.
-        return dml.fini_dml_stmt(
-            stmt, ctx.rel, parts, ctx=ctx)
+        return dml.fini_dml_stmt(stmt, ctx.rel, parts, ctx=ctx)

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -146,7 +146,7 @@ def compile_InsertStmt(
     parent_ctx = ctx
     with parent_ctx.substmt() as ctx:
         # Common DML bootstrap.
-        parts = dml.init_dml_stmt(stmt, parent_ctx=parent_ctx, ctx=ctx)
+        parts = dml.init_dml_stmt(stmt, ctx=ctx)
 
         top_typeref = stmt.subject.typeref
         if top_typeref.material_type is not None:
@@ -163,7 +163,7 @@ def compile_InsertStmt(
 
         # Wrap up.
         return dml.fini_dml_stmt(
-            stmt, ctx.rel, parts, parent_ctx=parent_ctx, ctx=ctx)
+            stmt, ctx.rel, parts, ctx=ctx)
 
 
 @dispatch.compile.register(irast.UpdateStmt)
@@ -174,7 +174,7 @@ def compile_UpdateStmt(
     parent_ctx = ctx
     with parent_ctx.substmt() as ctx:
         # Common DML bootstrap.
-        parts = dml.init_dml_stmt(stmt, parent_ctx=parent_ctx, ctx=ctx)
+        parts = dml.init_dml_stmt(stmt, ctx=ctx)
         range_cte = parts.range_cte
         assert range_cte is not None
 
@@ -192,7 +192,7 @@ def compile_UpdateStmt(
             )
 
         return dml.fini_dml_stmt(
-            stmt, ctx.rel, parts, parent_ctx=parent_ctx, ctx=ctx)
+            stmt, ctx.rel, parts, ctx=ctx)
 
 
 @dispatch.compile.register(irast.DeleteStmt)
@@ -203,7 +203,7 @@ def compile_DeleteStmt(
     parent_ctx = ctx
     with parent_ctx.substmt() as ctx:
         # Common DML bootstrap
-        parts = dml.init_dml_stmt(stmt, parent_ctx=parent_ctx, ctx=ctx)
+        parts = dml.init_dml_stmt(stmt, ctx=ctx)
 
         range_cte = parts.range_cte
         assert range_cte is not None
@@ -213,11 +213,10 @@ def compile_DeleteStmt(
             dml.process_delete_body(
                 ir_stmt=stmt,
                 delete_cte=delete_cte,
-                dml_parts=parts,
                 typeref=typeref,
                 ctx=ctx,
             )
 
         # Wrap up.
         return dml.fini_dml_stmt(
-            stmt, ctx.rel, parts, parent_ctx=parent_ctx, ctx=ctx)
+            stmt, ctx.rel, parts, ctx=ctx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ zip-safe = false
 [tool.black]
 line-length = 79
 target-version = ["py310"]
+skip-string-normalization = true
 
 
 # ========================


### PR DESCRIPTION
- Refactor away unused function arguments
- Rename get_track_x into get_x_and_track
- Remove env arg of pgsql.pathctx.put_path_var
- Remove more env args from pathctx
- Remove env arg of pgsql.pathctx.put_path_rvar
- Remove env arg of pgsql.pathctx.get_path_rvar
- Remove env args from pgsql.pathctx
- darker

I suggest reviewing commits separately. This PR can also be split to make possible future reverting easier.
