### PR TITLE
Don't let "owned" affect how we calculate backlinks

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -593,19 +593,7 @@ class AlterLinkOwned(
     referrer_context_class=LinkSourceCommandContext,
     field='owned',
 ):
-    def _alter_begin(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-    ) -> s_schema.Schema:
-        schema = super()._alter_begin(schema, context)
-
-        # Ownership status can impact the details of how backlinks are compiled
-        if not context.canonical:
-            desc = self.get_friendly_description(schema=schema)
-            schema = self._propagate_if_expr_refs(schema, context, action=desc)
-
-        return schema
+    pass
 
 
 class SetTargetDeletePolicy(sd.Command):

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -192,7 +192,11 @@ class ObjectType(
             if (
                 lnk.get_shortname(schema).name == name
                 and not lnk.get_source_type(schema).is_view(schema)
-                and lnk.get_owned(schema)
+                # Only grab the "base" pointers
+                and all(
+                    b.generic(schema)
+                    for b in lnk.get_bases(schema).objects(schema)
+                )
                 and (not sources or lnk.get_source_type(schema) in sources)
             )
         }
@@ -204,7 +208,11 @@ class ObjectType(
                 if (
                     lnk.get_shortname(schema).name == name
                     and not lnk.get_source_type(schema).is_view(schema)
-                    and lnk.get_owned(schema)
+                    # Only grab the "base" pointers
+                    and all(
+                        b.generic(schema)
+                        for b in lnk.get_bases(schema).objects(schema)
+                    )
                     and (not sources or lnk.get_source_type(schema) in sources)
                 )
             )

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11412,6 +11412,21 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
 
         await self.migrate("")
 
+    async def test_edgeql_migration_backlink_overloaded(self):
+        await self.migrate(r'''
+            type Target {
+                multi link meta_sources := .<target[is MetaSource];
+            }
+            abstract type MetaSource {
+                link target -> Target;
+            }
+
+            type Source extending MetaSource;
+            type ExternalSource extending MetaSource {
+                overloaded link target -> Target;
+            }
+        ''')
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3226,6 +3226,23 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_get_migration_54(self):
+        schema = r'''
+            type Venue {
+                multi link meta_bookings := .<venue[is MetaBooking];
+            }
+            abstract type MetaBooking {
+                link venue -> Venue;
+            }
+
+            type Booking extending MetaBooking;
+            type ExternalBooking extending MetaBooking {
+                overloaded link venue -> Venue;
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different


### PR DESCRIPTION
Previously we would grab any "owned" pointer in getrptrs, when we really
did just want to grab the "root" ones. This caused a downstream problem
where this would cause trouble in how we computed `computed_backlink`.