### PR TITLE
SQL privileges functions

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -1159,7 +1159,7 @@ class SQLValueFunctionOP(enum.IntEnum):
 
 class SQLValueFunction(BaseExpr):
     op: SQLValueFunctionOP
-    arg: typing.Optional[BaseExpr]
+    arg: typing.Optional[BaseExpr] = None
 
 
 class CreateStmt(Statement):


### PR DESCRIPTION
Support for `has_any_column_privilege`, `has_column_privilege`, `has_database_privilege`, `has_foreign_data_wrapper_privilege`, `has_function_privilege`, `has_language_privilege`, `has_parameter_privilege`, `has_schema_privilege`, `has_sequence_privilege`, `has_server_privilege`, `has_table_privilege`, `has_tablespace_privilege`, `has_type_privilege`, `pg_has_role`, `row_security_active` in our SQL connector.

