### PR TITLE
SQL parsing fix ROW

### DIFF
--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -682,11 +682,16 @@ def _build_sub_link(n: Node, c: Context) -> pgast.SubLink:
     )
 
 
-def _build_row_expr(n: Node, c: Context) -> pgast.ImplicitRowExpr:
-    return pgast.ImplicitRowExpr(
-        args=_list(n, c, "args", _build_base_expr),
-        context=_build_context(n, c),
+def _build_row_expr(n: Node, c: Context) -> pgast.BaseExpr:
+    args: List[pgast.BaseExpr] = (
+        _maybe_list(n, c, "args", _build_base_expr) or []
     )
+
+    format = n.get('row_format', None)
+    if format in {'COERCE_EXPLICIT_CALL', 'COERCE_EXPLICIT_CAST'}:
+        return pgast.RowExpr(args=args, context=_build_context(n, c))
+    else:
+        return pgast.ImplicitRowExpr(args=args, context=_build_context(n, c))
 
 
 def _build_boolean_test(n: Node, c: Context) -> pgast.BooleanTest:

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -622,52 +622,6 @@ class TestEdgeQLSelect(tb.BaseDocTest):
         WHERE ((x = y) OR x = ANY ((SELECT * FROM table_two)))
         """
 
-    def test_sql_parse_query_00(self):
-        """
-        SELECT * FROM
-        (VALUES (1, 'one'), (2, 'two')) AS t(num, letter)
-        """
-
-    @test.xerror("unsupported")
-    def test_sql_parse_query_01(self):
-        """
-        SELECT * FROM my_table ORDER BY field ASC NULLS LAST USING @>
-        """
-
-    @test.xfail("unsupported")
-    def test_sql_parse_query_02(self):
-        """
-        SELECT m.* FROM mytable AS m FOR UPDATE
-        """
-
-    @test.xfail("unsupported")
-    def test_sql_parse_query_03(self):
-        """
-        SELECT m.* FROM mytable m FOR SHARE of m nowait
-        """
-
-    def test_sql_parse_query_04(self):
-        """
-        SELECT * FROM unnest(ARRAY['a', 'b', 'c', 'd', 'e', 'f'])
-        """
-
-    @test.xerror("unsupported")
-    def test_sql_parse_query_06(self):
-        """
-        SELECT ?
-        """
-
-    @test.xerror("unsupported")
-    def test_sql_parse_query_07(self):
-        """
-        SELECT * FROM x WHERE y = ?
-        """
-
-    def test_sql_parse_query_08(self):
-        """
-        SELECT * FROM x WHERE y = ANY ($1)
-        """
-
     def test_sql_parse_transaction_00(self):
         """
         BEGIN
@@ -827,6 +781,52 @@ class TestEdgeQLSelect(tb.BaseDocTest):
         SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE
         """
 
+    def test_sql_parse_query_00(self):
+        """
+        SELECT * FROM
+        (VALUES (1, 'one'), (2, 'two')) AS t(num, letter)
+        """
+
+    @test.xerror("unsupported")
+    def test_sql_parse_query_01(self):
+        """
+        SELECT * FROM my_table ORDER BY field ASC NULLS LAST USING @>
+        """
+
+    @test.xfail("unsupported")
+    def test_sql_parse_query_02(self):
+        """
+        SELECT m.* FROM mytable AS m FOR UPDATE
+        """
+
+    @test.xfail("unsupported")
+    def test_sql_parse_query_03(self):
+        """
+        SELECT m.* FROM mytable m FOR SHARE of m nowait
+        """
+
+    def test_sql_parse_query_04(self):
+        """
+        SELECT * FROM unnest(ARRAY['a', 'b', 'c', 'd', 'e', 'f'])
+        """
+
+    @test.xerror("unsupported")
+    def test_sql_parse_query_06(self):
+        """
+        SELECT ?
+        """
+
+    @test.xerror("unsupported")
+    def test_sql_parse_query_07(self):
+        """
+        SELECT * FROM x WHERE y = ?
+        """
+
+    def test_sql_parse_query_08(self):
+        """
+        SELECT * FROM x WHERE y = ANY ($1)
+        """
+
     def test_sql_parse_query_09(self):
         """
         PREPARE fooplan (int, text, bool, numeric) AS (SELECT $1, $2, $3, $4)
@@ -863,6 +863,11 @@ class TestEdgeQLSelect(tb.BaseDocTest):
     def test_sql_parse_query_14(self):
         """
         VACUUM FULL my_table
+        """
+
+    def test_sql_parse_query_15(self):
+        """
+        SELECT (pg_column_size(ROW()))::text
         """
 
     @test.xerror("unsupported")


### PR DESCRIPTION
A minor fix of how we parse `SELECT ROW()` and `SELECT ()`.