### PR TITLE
Fix adding certain computed links to a type with an alias

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -513,6 +513,8 @@ def _elide_derived_ancestors(
     expose any ephemeral derived objects, as these wouldn't be
     present in the schema outside of the compilation context.
     """
+    # if isinstance(obj, s_pointers.Pointer):
+    #     return
 
     pbase = obj.get_bases(ctx.env.schema).first(ctx.env.schema)
     if pbase.get_is_derived(ctx.env.schema):

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1082,6 +1082,9 @@ def _get_rel_path_output(
                 name=[ptr_info.column_name],
                 nullable=not ptrref.required)
 
+        # if '@s1' in str(path_id):
+        #     breakpoint()
+
     _put_path_output_var(rel, path_id, aspect, result, flavor=flavor)
     return result
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -605,7 +605,15 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         """
         ptrcls = self
         while (
-            ptrcls.get_is_derived(schema)
+            (
+                ptrcls.get_is_derived(schema)
+                # Link properties on computed links need to go up to
+                # the real place too, but aren't marked derived
+                or (
+                    isinstance((src := ptrcls.get_source(schema)), Pointer)
+                    and src.get_expr(schema)
+                )
+            )
             and not ptrcls.get_defined_here(schema)
             # schema defined computeds don't have the ephemeral defined_here
             # set, but they do have expr set, so we check that also.
@@ -1173,10 +1181,6 @@ class PointerCommandOrFragment(
         if base is not None:
             self.set_attribute_value(
                 'bases', so.ObjectList.create(schema, [base]),
-            )
-
-            self.set_attribute_value(
-                'is_derived', True
             )
 
             if context.declarative:

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11427,6 +11427,58 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         ''')
 
+    async def test_edgeql_migration_alias_new_computed_01(self):
+        await self.migrate(r'''
+            global a_id -> str;
+            global current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+            }
+        ''')
+
+        await self.migrate(r'''
+            global a_id -> str;
+            global current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+              required property a_id := .x_id;
+            }
+        ''')
+
+    async def test_edgeql_migration_alias_new_computed_02(self):
+        await self.migrate(r'''
+            global a_id -> str;
+            alias current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+            }
+        ''')
+
+        await self.migrate(r'''
+            global a_id -> str;
+            alias current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+              required property a_id := .x_id;
+            }
+        ''')
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
Pointers that are a direct alias for another pointer were being marked
as `is_derived`, which is mostly supposed to mean things that are
*automatically* derived in a view or some such.

When a type with such a computed pointer had an alias created of it,
`_elide_derived_ancestors` in the edgeql compiler was marking the base
of the pointer in the view subclass as being the aliased pointer in
the base class, which is inconsistent with what happened when an ALTER
was emitted.

Downside of this fix is that it cherry-picking it is dodgy, since it
changes how things are stored after a simple CREATE.