### PR TITLE
Document mutation rewrites

### DIFF
--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -24,6 +24,7 @@ Schema
     access_policies
     functions
     triggers
+    mutation_rewrites
     inheritance
     extensions
     future

--- a/docs/datamodel/introspection/index.rst
+++ b/docs/datamodel/introspection/index.rst
@@ -35,6 +35,7 @@ information about EdgeDB types in a variety of human-readable formats.
     colltypes
     functions
     triggers
+    mutation_rewrites
     indexes
     constraints
     operators

--- a/docs/datamodel/introspection/mutation_rewrites.rst
+++ b/docs/datamodel/introspection/mutation_rewrites.rst
@@ -1,0 +1,173 @@
+.. versionadded:: 3.0
+
+.. _ref_datamodel_introspection_mutation_rewrites:
+
+=================
+Mutation rewrites
+=================
+
+This section describes introspection of :ref:`mutation rewrites
+<ref_datamodel_mutation_rewrites>`.
+
+Introspection of the ``schema::Rewrite``:
+
+.. code-block:: edgeql-repl
+
+    db> select schema::ObjectType {
+    ...   name,
+    ...   links: {
+    ...     name
+    ...   },
+    ...   properties: {
+    ...     name
+    ...   }
+    ... } filter .name = 'schema::Rewrite';
+    {
+      schema::ObjectType {
+        name: 'schema::Rewrite',
+        links: {
+          schema::Link {name: 'subject'},
+          schema::Link {name: '__type__'},
+          schema::Link {name: 'ancestors'},
+          schema::Link {name: 'bases'},
+          schema::Link {name: 'annotations'}
+        },
+        properties: {
+          schema::Property {name: 'inherited_fields'},
+          schema::Property {name: 'computed_fields'},
+          schema::Property {name: 'builtin'},
+          schema::Property {name: 'internal'},
+          schema::Property {name: 'name'},
+          schema::Property {name: 'id'},
+          schema::Property {name: 'abstract'},
+          schema::Property {name: 'is_abstract'},
+          schema::Property {name: 'final'},
+          schema::Property {name: 'is_final'},
+          schema::Property {name: 'kind'},
+          schema::Property {name: 'expr'},
+        },
+      },
+    }
+
+Introspection of all properties in the ``default`` schema with a mutation
+rewrite:
+
+.. code-block:: edgeql-repl
+
+    db> select schema::ObjectType {
+    ...   name,
+    ...   properties := (
+    ...     select .properties {
+    ...        name,
+    ...        rewrites: {
+    ...          kind
+    ...        }
+    ...     } filter exists .rewrites
+    ...   )
+    ... } filter .name ilike 'default::%'
+    ... and exists .properties.rewrites;
+    {
+      schema::ObjectType {
+        name: 'default::Post',
+        properties: {
+          schema::Property {
+            name: 'created',
+            rewrites: {
+              schema::Rewrite {
+                kind: Insert
+              }
+            }
+          },
+          schema::Property {
+            name: 'modified',
+            rewrites: {
+              schema::Rewrite {
+              kind: Insert
+              },
+              schema::Rewrite {
+                kind: Update
+              }
+            }
+          },
+        },
+      },
+    }
+
+Introspection of all rewrites, including the type of query (``kind``),
+rewrite expression, and the object and property they are on:
+
+.. code-block:: edgeql-repl
+
+    db> select schema::Rewrite {
+    ...   subject := (
+    ...     select .subject {
+    ...       name,
+    ...       source: {
+    ...         name
+    ...       }
+    ...     }
+    ...   ),
+    ...   kind,
+    ...   expr
+    ... };
+    {
+      schema::Rewrite {
+        subject: schema::Property {
+          name: 'created',
+          source: schema::ObjectType {
+            name: 'default::Post'
+          }
+        },
+        kind: Insert,
+        expr: 'std::datetime_of_statement()'
+      },
+      schema::Rewrite {
+        subject: schema::Property {
+          name: 'modified',
+          source: schema::ObjectType {
+            name: 'default::Post'
+          }
+        },
+        kind: Insert,
+        expr: 'std::datetime_of_statement()'
+      },
+      schema::Rewrite {
+        subject: schema::Property {
+          name: 'modified',
+          source: schema::ObjectType {
+            name: 'default::Post'
+          }
+        },
+        kind: Update,
+        expr: 'std::datetime_of_statement()'
+      },
+    }
+
+Introspection of all rewrites on a ``default::Post`` property named
+``modified``:
+
+.. code-block:: edgeql-repl
+
+    db> select schema::Rewrite {kind, expr}
+    ... filter .subject.source.name = 'default::Post'
+    ... and .subject.name = 'modified';
+    {
+      schema::Rewrite {
+        kind: Insert,
+        expr: 'std::datetime_of_statement()'
+      },
+      schema::Rewrite {
+        kind: Update,
+        expr: 'std::datetime_of_statement()'
+      }
+    }
+
+
+.. list-table::
+  :class: seealso
+
+  * - **See also**
+  * - :ref:`Schema > Mutation rewrites <ref_datamodel_mutation_rewrites>`
+  * - :ref:`SDL > Mutation rewrites <ref_eql_sdl_mutation_rewrites>`
+  * - :ref:`DDL > Mutation rewrites <ref_eql_ddl_mutation_rewrites>`
+

--- a/docs/datamodel/mutation_rewrites.rst
+++ b/docs/datamodel/mutation_rewrites.rst
@@ -111,11 +111,13 @@ Available variables
 
 Inside the rewrite rule's expression, you have access to a few special values:
 
-* ``__subject__`` refers to the object type with the new property and link values,
-* ``__specified__`` is a named tuple with a key for each property or link in the type
-  and a boolean value indicating whether this value was explicitly set in the
-  mutation
-* ``__old__`` refers to the object type with the previous property and link values (available for update-only mutation rewrites)
+* ``__subject__`` refers to the object type with the new property and link
+  values
+* ``__specified__`` is a named tuple with a key for each property or link in
+  the type and a boolean value indicating whether this value was explicitly set
+  in the mutation
+* ``__old__`` refers to the object type with the previous property and link
+  values (available for update-only mutation rewrites)
 
 Here are some examples of the special values in use. Maybe your blog hosts
 articles about particularly controversial topics. You could use ``__subject__``

--- a/docs/datamodel/mutation_rewrites.rst
+++ b/docs/datamodel/mutation_rewrites.rst
@@ -1,0 +1,267 @@
+.. versionadded:: 3.0
+
+.. _ref_datamodel_mutation_rewrites:
+
+=================
+Mutation rewrites
+=================
+
+Mutation rewrites allow you to intercept database mutations (i.e.,
+:ref:`inserts <ref_eql_insert>` and/or :ref:`updates <ref_eql_update>`) and set
+the value of a property or link to the result of an expression you define. They
+can be defined in your schema.
+
+Mutation rewrites are complementary to :ref:`triggers
+<ref_datamodel_triggers>`. While triggers are unable to modify the triggering
+object, mutation rewrites are built for that purpose.
+
+Here's an example of a mutation rewrite that updates a property of a ``Post``
+type to reflect the time of the most recent modification:
+
+.. code-block:: sdl
+
+    type Post {
+      ...
+      modified: datetime {
+        rewrite insert, update using (datetime_of_statement())
+      }
+    }
+
+
+Every time a ``Post`` is updated, the mutation rewrite will be triggered,
+updating the ``modified`` property:
+
+.. code-block:: edgeql-repl
+
+    db> insert Post {
+    ...   title := 'One wierd trick to fix all your spelling errors'
+    ... };
+    {default::Post {id: 19e024dc-d3b5-11ed-968c-37f5d0159e5f}}
+    db> select Post {title, modified};
+    {
+      default::Post {
+        title: 'One wierd trick to fix all your spelling errors',
+        modified: <datetime>'2023-04-05T13:23:49.488335Z',
+      },
+    }
+    db> update Post
+    ... filter .id = <uuid>'19e024dc-d3b5-11ed-968c-37f5d0159e5f'
+    ... set {title := 'One weird trick to fix all your spelling errors'};
+    {default::Post {id: 19e024dc-d3b5-11ed-968c-37f5d0159e5f}}
+    db> select Post {title, modified};
+    {
+      default::Post {
+        title: 'One weird trick to fix all your spelling errors',
+        modified: <datetime>'2023-04-05T13:25:04.119641Z',
+      },
+    }
+
+In some cases, you will want different rewrites depending on the type of query.
+Here, we will add an ``insert`` rewrite and an ``update`` rewrite:
+
+.. code-block:: sdl
+
+    type Post {
+      ...
+      created: datetime {
+        rewrite insert using (datetime_of_statement())
+      }
+      modified: datetime {
+        rewrite update using (datetime_of_statement())
+      }
+    }
+
+With this schema, inserts will set the ``Post`` object's ``created`` property
+while updates will set the ``modified`` property:
+
+.. code-block:: edgeql-repl
+
+    db> insert Post {
+    ...   title := 'One wierd trick to fix all your spelling errors'
+    ... };
+    {default::Post {id: 19e024dc-d3b5-11ed-968c-37f5d0159e5f}}
+    db> select Post {title, created, modified};
+    {
+      default::Post {
+        title: 'One wierd trick to fix all your spelling errors',
+        created: <datetime>'2023-04-05T13:23:49.488335Z',
+        modified: {},
+      },
+    }
+    db> update Post
+    ... filter .id = <uuid>'19e024dc-d3b5-11ed-968c-37f5d0159e5f'
+    ... set {title := 'One weird trick to fix all your spelling errors'};
+    {default::Post {id: 19e024dc-d3b5-11ed-968c-37f5d0159e5f}}
+    db> select Post {title, created, modified};
+    {
+      default::Post {
+        title: 'One weird trick to fix all your spelling errors',
+        created: <datetime>'2023-04-05T13:23:49.488335Z',
+        modified: <datetime>'2023-04-05T13:25:04.119641Z',
+      },
+    }
+
+.. note::
+
+    Each property may have a single ``insert`` and a single ``update`` mutation
+    rewrite rule, or they may have a single rule that covers both.
+
+Special values
+==============
+
+Inside the rewrite rule's expression, you have access to a few special values:
+
+* ``__subject__`` refers to the new value being set for the property
+* ``__specified__`` is a named tuple with a key for each pointer in the type
+  and a boolean value indicating whether this value was explicitly set in the
+  mutation
+* ``__old__`` refers to the previous value in update-only mutation rewrite
+  expressions
+
+Here are some examples of the special values in use. Maybe your blog hosts
+articles about particularly controversial topics. You could use ``__subject__``
+to enforce a "cooling off" period before publishing a blog post:
+
+.. code-block:: sdl
+
+    type Post {
+      ...
+      publish_time: datetime {
+        rewrite insert, update using (
+          __subject__.publish_time ?? datetime_of_statement() +
+          cal::to_relative_duration(days := 10)
+        )
+      }
+      ...
+    }
+
+Here we take the post's ``publish_time`` if set or the time the statement is
+executed and add 10 days to it. That should give our authors time to consider
+if they want to make any changes before a post goes live.
+
+You can omit ``__subject__`` in many cases and achieve the same thing:
+
+.. code-block:: sdl-diff
+
+      type Post {
+        ...
+        publish_time: datetime {
+          rewrite insert, update using (
+    -       __subject__.publish_time ?? datetime_of_statement() +
+    +       .publish_time ?? datetime_of_statement() +
+            cal::to_relative_duration(days := 10)
+          )
+        }
+        ...
+      }
+
+but only if the path prefix has not changed. In the following schema, for
+example, the ``__subject__`` in the rewrite rule is required since, in the
+context of the nested ``select`` query, the leading dot resolves from the
+``User`` path:
+
+.. code-block:: sdl
+
+    type Post {
+      ...
+      author_email: str;
+      author_name: str {
+        rewrite insert, update using (
+          (select User {name} filter .email = __subject__.author_email).name
+        )
+      }
+    }
+    type User {
+      name: str;
+      email: str;
+    }
+
+.. note::
+
+    Learn more about how this works in our documentation on :ref:`path
+    resolution <ref_eql_path_resolution>`.
+
+Using ``__specified__``, we can override ``modified`` with a specified value if
+the user provided one in the query while still using our default value
+(``datetime_of_statement()``) if they didn't:
+
+.. code-block:: sdl
+
+    type Post {
+      ...
+      modified: datetime {
+        rewrite update using (
+          datetime_of_statement()
+          if not __specified__.mtime
+          else .mtime
+        )
+      }
+      ...
+    }
+
+``__specified__.mtime`` will be ``true`` if that value was set as part of the
+update, and this rewrite mutation rule will allow the specified value to come
+through in the update in that case.
+
+Lastly, if we want to add an ``author`` property that can be set for each write
+and keep a history of all the authors, we can do this with the help of
+``__old__``:
+
+.. code-block:: sdl
+
+    type Post {
+      ...
+      author: str;
+      all_authors: array<str> {
+        default := <array<str>>[];
+        rewrite update using (
+          __old__.all_authors
+          ++ [__subject__.author]
+        );
+      }
+      ...
+    }
+
+On insert, our ``all_authors`` property will get initialized to an empty array
+of strings. We will rewrite updates to concatenate that array with an array
+containing the new author value.
+
+
+Mutation rewrite as cached computed
+===================================
+
+Mutation rewrites can be used to effectively create a cached computed value as
+demonstrated with the ``byline`` property in this schema:
+
+.. code-block:: sdl
+
+    type Post {
+      ...
+      author: str;
+      created: datetime {
+        rewrite insert using (datetime_of_statement())
+      }
+      byline: str {
+        rewrite insert, update using (
+          'by ' ++
+          __subject__.author ++
+          ' on ' ++
+          to_str(__subject__.created, 'Mon DD, YYYY')
+        )
+      }
+      ...
+    }
+
+The ``byline`` property will be updated on each insert or update, but the value
+will not need to be calculated at read time like a proper :ref:`computed
+propety <ref_datamodel_computed>`.
+
+
+.. list-table::
+  :class: seealso
+
+  * - **See also**
+  * - :ref:`SDL > Mutation rewrites <ref_eql_sdl_mutation_rewrites>`
+  * - :ref:`DDL > Mutation rewrites <ref_eql_ddl_mutation_rewrites>`
+  * - :ref:`Introspection > Mutation rewrites
+      <ref_datamodel_introspection_mutation_rewrites>`

--- a/docs/datamodel/mutation_rewrites.rst
+++ b/docs/datamodel/mutation_rewrites.rst
@@ -21,7 +21,8 @@ type to reflect the time of the most recent modification:
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       modified: datetime {
         rewrite insert, update using (datetime_of_statement())
       }
@@ -62,7 +63,8 @@ Here, we will add an ``insert`` rewrite and an ``update`` rewrite:
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       created: datetime {
         rewrite insert using (datetime_of_statement())
       }
@@ -126,14 +128,14 @@ to enforce a "cooling off" period before publishing a blog post:
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       publish_time: datetime {
         rewrite insert, update using (
           __subject__.publish_time ?? datetime_of_statement() +
           cal::to_relative_duration(days := 10)
         )
       }
-      ...
     }
 
 Here we take the post's ``publish_time`` if set or the time the statement is
@@ -145,7 +147,8 @@ You can omit ``__subject__`` in many cases and achieve the same thing:
 .. code-block:: sdl-diff
 
       type Post {
-        ...
+        required title: str;
+        required body: str;
         publish_time: datetime {
           rewrite insert, update using (
     -       __subject__.publish_time ?? datetime_of_statement() +
@@ -153,7 +156,6 @@ You can omit ``__subject__`` in many cases and achieve the same thing:
             cal::to_relative_duration(days := 10)
           )
         }
-        ...
       }
 
 but only if the path prefix has not changed. In the following schema, for
@@ -164,7 +166,8 @@ context of the nested ``select`` query, the leading dot resolves from the
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       author_email: str;
       author_name: str {
         rewrite insert, update using (
@@ -189,7 +192,8 @@ as in the ``title_modified`` property in this schema:
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       title_modified: datetime {
         rewrite update using (
           datetime_of_statement()
@@ -197,7 +201,6 @@ as in the ``title_modified`` property in this schema:
           else __old__.title_modified
         )
       }
-      ...
     }
 
 ``__specified__.title`` will be ``true`` if that value was set as part of the
@@ -209,7 +212,8 @@ Another way you might use this is to set a default value but allow overriding:
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       modified: datetime {
         rewrite update using (
           datetime_of_statement()
@@ -217,7 +221,6 @@ Another way you might use this is to set a default value but allow overriding:
           else .modified
         )
       }
-      ...
     }
 
 Here, we rewrite ``modified`` on updates to ``datetime_of_statment()`` unless
@@ -233,7 +236,8 @@ and keep a history of all the authors, we can do this with the help of
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       author: str;
       all_authors: array<str> {
         default := <array<str>>[];
@@ -242,7 +246,6 @@ and keep a history of all the authors, we can do this with the help of
           ++ [__subject__.author]
         );
       }
-      ...
     }
 
 On insert, our ``all_authors`` property will get initialized to an empty array
@@ -259,7 +262,8 @@ demonstrated with the ``byline`` property in this schema:
 .. code-block:: sdl
 
     type Post {
-      ...
+      required title: str;
+      required body: str;
       author: str;
       created: datetime {
         rewrite insert using (datetime_of_statement())
@@ -272,7 +276,6 @@ demonstrated with the ``byline`` property in this schema:
           to_str(__subject__.created, 'Mon DD, YYYY')
         )
       }
-      ...
     }
 
 The ``byline`` property will be updated on each insert or update, but the value

--- a/docs/datamodel/mutation_rewrites.rst
+++ b/docs/datamodel/mutation_rewrites.rst
@@ -106,17 +106,16 @@ while updates will set the ``modified`` property:
     Each property may have a single ``insert`` and a single ``update`` mutation
     rewrite rule, or they may have a single rule that covers both.
 
-Special values
-==============
+Available variables
+===================
 
 Inside the rewrite rule's expression, you have access to a few special values:
 
-* ``__subject__`` refers to the new value being set for the property
-* ``__specified__`` is a named tuple with a key for each pointer in the type
+* ``__subject__`` refers to the object type with the new property and link values,
+* ``__specified__`` is a named tuple with a key for each property or link in the type
   and a boolean value indicating whether this value was explicitly set in the
   mutation
-* ``__old__`` refers to the previous value in update-only mutation rewrite
-  expressions
+* ``__old__`` refers to the object type with the previous property and link values (available for update-only mutation rewrites)
 
 Here are some examples of the special values in use. Maybe your blog hosts
 articles about particularly controversial topics. You could use ``__subject__``
@@ -156,7 +155,7 @@ You can omit ``__subject__`` in many cases and achieve the same thing:
       }
 
 but only if the path prefix has not changed. In the following schema, for
-example, the ``__subject__`` in the rewrite rule is required since, in the
+example, the ``__subject__`` in the rewrite rule is required, because in the
 context of the nested ``select`` query, the leading dot resolves from the
 ``User`` path:
 

--- a/docs/datamodel/properties.rst
+++ b/docs/datamodel/properties.rst
@@ -100,6 +100,8 @@ particular order. If order is important, use an :ref:`array
 more involved discussion, see :ref:`EdgeQL > Sets
 <ref_eql_set_array_conversion>`.
 
+.. _ref_datamodel_props_default_values:
+
 Default values
 --------------
 

--- a/docs/reference/ddl/index.rst
+++ b/docs/reference/ddl/index.rst
@@ -20,6 +20,7 @@ DDL
     access_policies
     functions
     triggers
+    mutation_rewrites
     extensions
     future
     migrations

--- a/docs/reference/ddl/mutation_rewrites.rst
+++ b/docs/reference/ddl/mutation_rewrites.rst
@@ -26,8 +26,8 @@ When creating a new property or link:
       create { property | link } <prop-or-link-name> -> <type> "{"
         create rewrite {insert | update} [, ...]
           using <expr>
-      "}"
-    "}"
+      "}" ;
+    "}" ;
 
 When altering an existing property or link:
 
@@ -37,8 +37,8 @@ When altering an existing property or link:
       alter { property | link } <prop-or-link-name> "{"
         create rewrite {insert | update} [, ...]
           using <expr>
-      "}"
-    "}"
+      "}" ;
+    "}" ;
 
 
 Description
@@ -76,10 +76,10 @@ property on each update:
     alter type User {
       create property created -> datetime {
         create rewrite insert using (datetime_of_statement());
-      }
+      };
       create property modified -> datetime {
         create rewrite update using (datetime_of_statement());
-      }
+      };
     };
 
 
@@ -96,8 +96,8 @@ Remove a mutation rewrite.
     alter type <type-name> "{"
       alter property <prop-or-link-name> "{"
         drop rewrite {insert | update} ;
-      "}"
-    "}"
+      "}" ;
+    "}" ;
 
 
 Description
@@ -133,7 +133,7 @@ Remove the ``insert`` rewrite of the ``created`` property on the ``User`` type:
     alter type User {
       alter property created {
         drop rewrite insert;
-      }
+      };
     };
 
 

--- a/docs/reference/ddl/mutation_rewrites.rst
+++ b/docs/reference/ddl/mutation_rewrites.rst
@@ -1,0 +1,147 @@
+.. versionadded:: 3.0
+
+.. _ref_eql_ddl_mutation_rewrites:
+
+=================
+Mutation Rewrites
+=================
+
+This section describes the DDL commands pertaining to
+:ref:`mutation rewrites <ref_datamodel_mutation_rewrites>`.
+
+
+Create rewrite
+==============
+
+:eql-statement:
+
+
+:ref:`Define <ref_eql_sdl_mutation_rewrites>` a new mutation rewrite.
+
+When creating a new property or link:
+
+.. eql:synopsis::
+
+    {create | alter} type <type-name> "{"
+      create { property | link } <prop-or-link-name> -> <type> "{"
+        create rewrite {insert | update} [, ...]
+          using <expr>
+      "}"
+    "}"
+
+When altering an existing property or link:
+
+.. eql:synopsis::
+
+    {create | alter} type <type-name> "{"
+      alter { property | link } <prop-or-link-name> "{"
+        create rewrite {insert | update} [, ...]
+          using <expr>
+      "}"
+    "}"
+
+
+Description
+-----------
+
+The command ``create rewrite`` nested under ``create type`` or ``alter type``
+and then under ``create property/link`` or ``alter property/link`` defines a
+new mutation rewrite for the given property or link on the given object.
+
+
+Parameters
+----------
+
+:eql:synopsis:`<type-name>`
+    The name (optionally module-qualified) of the type containing the rewrite.
+
+:eql:synopsis:`<prop-or-link-name>`
+    The name (optionally module-qualified) of the property or link being
+    rewritten.
+
+:eql:synopsis:`insert | update [, ...]`
+    The query type (or types) that are rewritten. Separate multiple values with
+    commas to invoke the same rewrite for multiple types of queries.
+
+
+Examples
+--------
+
+Declare two mutation rewrites on new properties: one that sets a ``created``
+property when a new object is inserted and one that sets a ``modified``
+property on each update:
+
+.. code-block:: edgeql
+
+    alter type User {
+      create property created -> datetime {
+        create rewrite insert using (datetime_of_statement());
+      }
+      create property modified -> datetime {
+        create rewrite update using (datetime_of_statement());
+      }
+    };
+
+
+Drop rewrite
+============
+
+:eql-statement:
+
+
+Remove a mutation rewrite.
+
+.. eql:synopsis::
+
+    alter type <type-name> "{"
+      alter property <prop-or-link-name> "{"
+        drop rewrite {insert | update} ;
+      "}"
+    "}"
+
+
+Description
+-----------
+
+The command ``drop rewrite`` inside an ``alter type`` block and further inside
+an ``alter property`` block removes the definition of an existing mutation
+rewrite on the specified property or link of the specified type.
+
+
+Parameters
+----------
+
+:eql:synopsis:`<type-name>`
+    The name (optionally module-qualified) of the type containing the rewrite.
+
+:eql:synopsis:`<prop-or-link-name>`
+    The name (optionally module-qualified) of the property or link being
+    rewritten.
+
+:eql:synopsis:`insert | update [, ...]`
+    The query type (or types) that are rewritten. Separate multiple values with
+    commas to invoke the same rewrite for multiple types of queries.
+
+
+Example
+-------
+
+Remove the ``insert`` rewrite of the ``created`` property on the ``User`` type:
+
+.. code-block:: edgeql
+
+    alter type User {
+      alter property created {
+        drop rewrite insert;
+      }
+    };
+
+
+.. list-table::
+  :class: seealso
+
+  * - **See also**
+  * - :ref:`Schema > Mutation rewrites  <ref_datamodel_mutation_rewrites>`
+  * - :ref:`SDL > Mutation rewrites <ref_eql_sdl_mutation_rewrites>`
+  * - :ref:`Introspection > Mutation rewrites
+      <ref_datamodel_introspection_mutation_rewrites>`

--- a/docs/reference/sdl/index.rst
+++ b/docs/reference/sdl/index.rst
@@ -150,5 +150,6 @@ to the previous migration:
     access_policies
     functions
     triggers
+    mutation_rewrites
     extensions
     future

--- a/docs/reference/sdl/mutation_rewrites.rst
+++ b/docs/reference/sdl/mutation_rewrites.rst
@@ -62,4 +62,5 @@ This declaration defines a new trigger with the following options:
   * - **See also**
   * - :ref:`Schema > Mutation rewrites <ref_datamodel_mutation_rewrites>`
   * - :ref:`DDL > Mutation rewrites <ref_eql_ddl_mutation_rewrites>`
-  * - :ref:`Introspection > Mutation rewrites <ref_datamodel_introspection_mutation_rewrites>`
+  * - :ref:`Introspection > Mutation rewrites
+      <ref_datamodel_introspection_mutation_rewrites>`

--- a/docs/reference/sdl/mutation_rewrites.rst
+++ b/docs/reference/sdl/mutation_rewrites.rst
@@ -1,0 +1,65 @@
+.. versionadded:: 3.0
+
+.. _ref_eql_sdl_mutation_rewrites:
+
+=================
+Mutation rewrites
+=================
+
+This section describes the SDL declarations pertaining to
+:ref:`mutation rewrites <ref_datamodel_mutation_rewrites>`.
+
+
+Example
+-------
+
+Declare two mutation rewrites: one that sets a ``created`` property when a new
+object is inserted and one that sets a ``modified`` property on each update:
+
+.. code-block:: sdl
+
+    type User {
+      created: datetime {
+        rewrite insert using (datetime_of_statement());
+      }
+      modified: datetime {
+        rewrite update using (datetime_of_statement());
+      }
+    };
+
+.. _ref_eql_sdl_mutation_rewrites_syntax:
+
+Syntax
+------
+
+Define a new mutation rewrite corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_mutation_rewrites>`.
+
+.. sdl:synopsis::
+
+    rewrite {insert | update} [, ...]
+      using <expr>
+
+Mutation rewrites must be defined inside a property or link block.
+
+
+Description
+-----------
+
+This declaration defines a new trigger with the following options:
+
+:eql:synopsis:`insert | update [, ...]`
+    The query type (or types) the rewrite runs on. Separate multiple values
+    with commas to invoke the same rewrite for multiple types of queries.
+
+:eql:synopsis:`<expr>`
+    The expression to be evaluated to produce the new value of the property.
+
+
+.. list-table::
+  :class: seealso
+
+  * - **See also**
+  * - :ref:`Schema > Mutation rewrites <ref_datamodel_mutation_rewrites>`
+  * - :ref:`DDL > Mutation rewrites <ref_eql_ddl_mutation_rewrites>`
+  * - :ref:`Introspection > Mutation rewrites <ref_datamodel_introspection_mutation_rewrites>`


### PR DESCRIPTION
Creating this as a draft for now. I believe it is content-complete, but I plan to rebase it once [triggers](https://github.com/edgedb/edgedb/pull/5157) is merged and move the mutation rewrites introspection page into the new location established in the triggers PR. I will also link a reference to triggers in this documentation to the triggers documentation at that time.