### PR TITLE
Fix adding certain computed links to a type with an alias

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -507,6 +507,7 @@ def _get_nearest_non_source_derived_parent(
     obj: s_obj.DerivableInheritingObjectT,
     ctx: context.ContextLevel
 ) -> s_obj.DerivableInheritingObjectT:
+    """Find the nearest ancestor of obj whose "root source" is not derived"""
     schema = ctx.env.schema
     while (
         (src := s_pointers.get_root_source(obj, schema))

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -503,6 +503,20 @@ def _fixup_schema_view(
                 )
 
 
+def _get_nearest_non_source_derived_parent(
+    obj: s_obj.DerivableInheritingObjectT,
+    ctx: context.ContextLevel
+) -> s_obj.DerivableInheritingObjectT:
+    schema = ctx.env.schema
+    while (
+        (src := s_pointers.get_root_source(obj, schema))
+        and isinstance(src, s_obj.DerivableInheritingObject)
+        and src.get_is_derived(schema)
+    ):
+        obj = obj.get_bases(schema).first(schema)
+    return obj
+
+
 def _elide_derived_ancestors(
     obj: Union[s_types.InheritingType, s_pointers.Pointer], *,
     ctx: context.ContextLevel
@@ -515,12 +529,12 @@ def _elide_derived_ancestors(
     """
 
     pbase = obj.get_bases(ctx.env.schema).first(ctx.env.schema)
-    if pbase.get_is_derived(ctx.env.schema):
-        pbase = pbase.get_nearest_non_derived_parent(ctx.env.schema)
+    new_pbase = _get_nearest_non_source_derived_parent(pbase, ctx)
+    if pbase != new_pbase:
         ctx.env.schema = obj.set_field_value(
             ctx.env.schema,
             'bases',
-            s_obj.ObjectList.create(ctx.env.schema, [pbase]),
+            s_obj.ObjectList.create(ctx.env.schema, [new_pbase]),
         )
 
         ctx.env.schema = obj.set_field_value(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11427,6 +11427,58 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         ''')
 
+    async def test_edgeql_migration_alias_new_computed_01(self):
+        await self.migrate(r'''
+            global a_id -> str;
+            global current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+            }
+        ''')
+
+        await self.migrate(r'''
+            global a_id -> str;
+            global current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+              required property a_id := .x_id;
+            }
+        ''')
+
+    async def test_edgeql_migration_alias_new_computed_02(self):
+        await self.migrate(r'''
+            global a_id -> str;
+            alias current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+            }
+        ''')
+
+        await self.migrate(r'''
+            global a_id -> str;
+            alias current_user := (
+              select User filter .x_id = global a_id);
+
+            type User {
+                required property x_id -> str {
+                  constraint exclusive;
+              }
+              required property a_id := .x_id;
+            }
+        ''')
+
 
 class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
     TRANSACTION_ISOLATION = False

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15350,6 +15350,22 @@ DDLStatement);
             alter type X { create link bar := .foo };
         """)
 
+    async def test_edgeql_ddl_computed_intersection_lprop_01(self):
+        await self.con.execute(r"""
+            create type Pointer;
+            create type Property extending Pointer;
+            create type Link extending Pointer;
+            create type ObjectType {
+                create multi link pointers -> Pointer {
+                    create property owned -> bool;
+                };
+                create link links := .pointers[is Link];
+            };
+        """)
+        await self.con.query(r"""
+            select ObjectType {links: {@owned}};
+        """)
+
     async def test_edgeql_ddl_rebase_views_01(self):
         await self.con.execute(r"""
             CREATE TYPE default::Foo {


### PR DESCRIPTION
When a type with such a computed pointer that was an alias of another
pointer had an alias created of it, `_elide_derived_ancestors` in the
edgeql compiler was marking the base of the pointer in the view
subclass as being the aliased pointer in the base class, which is
inconsistent with what happened when an ALTER was emitted.

Fix this by having `_elide_derived_ancestors` be more careful about
what it skips over.

Downside of this fix is that it cherry-picking it is dodgy, since it
changes how things are stored after a simple CREATE.