### PR TITLE
Type descriptor reform

### DIFF
--- a/docs/reference/protocol/index.rst
+++ b/docs/reference/protocol/index.rst
@@ -15,6 +15,7 @@ clients and servers.  The protocol is supported over TCP/IP.
     messages
     errors
     typedesc
+    typedesc_1_0
     dataformats
 
 

--- a/docs/reference/protocol/typedesc_1_0.rst
+++ b/docs/reference/protocol/typedesc_1_0.rst
@@ -1,0 +1,378 @@
+.. _ref_proto_typedesc_1_0:
+
+============================================
+Type descriptors (Protocol v1.0 and earlier)
+============================================
+
+This section describes how type information for query input and results
+is encoded.  Specifically, this is needed to decode the server response to
+the :ref:`ref_protocol_msg_command_data_description` message.
+
+The type descriptor is essentially a list of type information *blocks*:
+
+* each *block* encodes one type;
+
+* *blocks* can reference other *blocks*.
+
+While parsing the *blocks*, a database driver can assemble an
+*encoder* or a *decoder* of the EdgeDB binary data.
+
+An *encoder* is used to encode objects, native to the driver's runtime,
+to binary data that EdegDB can decode and work with.
+
+A *decoder* is used to decode data from EdgeDB native format to
+data types native to the driver.
+
+There is one special type with *type id* of zero:
+``00000000-0000-0000-0000-000000000000``. The describe result of this type
+contains zero *blocks*. It's used when a statement returns no meaningful
+results, e.g. the ``CREATE DATABASE example`` statement.  It is also used
+to represent the input descriptor when a query does not receive any arguments,
+or the state descriptor for an empty/default state.
+
+
+Set Descriptor
+==============
+
+.. code-block:: c
+
+    struct SetDescriptor {
+        // Indicates that this is a Set value descriptor.
+        uint8   type = 0;
+
+        // Descriptor ID.
+        uuid    id;
+
+        // Set element type descriptor index.
+        uint16  type_pos;
+    };
+
+Set values are encoded on the wire as
+:ref:`single-dimensional arrays <ref_protocol_fmt_array>`.
+
+
+Object Shape Descriptor
+=======================
+
+.. code-block:: c
+
+    struct ObjectShapeDescriptor {
+        // Indicates that this is an
+        // Object Shape descriptor.
+        uint8           type = 1;
+
+        // Descriptor ID.
+        uuid            id;
+
+        // Number of elements in shape.
+        uint16          element_count;
+
+        ShapeElement    elements[element_count];
+    };
+
+    struct ShapeElement {
+        // Field flags:
+        //   1 << 0: the field is implicit
+        //   1 << 1: the field is a link property
+        //   1 << 2: the field is a link
+        uint32          flags;
+
+        uint8<Cardinality> cardinality;
+
+        // Field name.
+        string          name;
+
+        // Field type descriptor index.
+        uint16          type_pos;
+    };
+
+.. eql:struct:: edb.protocol.enums.Cardinality
+
+Objects are encoded on the wire as :ref:`tuples <ref_protocol_fmt_tuple>`.
+
+
+Base Scalar Type Descriptor
+===========================
+
+.. code-block:: c
+
+    struct BaseScalarTypeDescriptor {
+        // Indicates that this is an
+        // Base Scalar Type descriptor.
+        uint8           type = 2;
+
+        // Descriptor ID.
+        uuid            id;
+    };
+
+
+The descriptor IDs for base scalar types are constant.
+The following table lists all EdgeDB base types descriptor IDs:
+
+.. list-table::
+   :header-rows: 1
+
+   * - ID
+     - Type
+
+   * - ``00000000-0000-0000-0000-000000000100``
+     - :ref:`std::uuid <ref_protocol_fmt_uuid>`
+
+   * - ``00000000-0000-0000-0000-000000000101``
+     - :ref:`std::str <ref_protocol_fmt_str>`
+
+   * - ``00000000-0000-0000-0000-000000000102``
+     - :ref:`std::bytes <ref_protocol_fmt_bytes>`
+
+   * - ``00000000-0000-0000-0000-000000000103``
+     - :ref:`std::int16 <ref_protocol_fmt_int16>`
+
+   * - ``00000000-0000-0000-0000-000000000104``
+     - :ref:`std::int32 <ref_protocol_fmt_int32>`
+
+   * - ``00000000-0000-0000-0000-000000000105``
+     - :ref:`std::int64 <ref_protocol_fmt_int64>`
+
+   * - ``00000000-0000-0000-0000-000000000106``
+     - :ref:`std::float32 <ref_protocol_fmt_float32>`
+
+   * - ``00000000-0000-0000-0000-000000000107``
+     - :ref:`std::float64 <ref_protocol_fmt_float64>`
+
+   * - ``00000000-0000-0000-0000-000000000108``
+     - :ref:`std::decimal <ref_protocol_fmt_decimal>`
+
+   * - ``00000000-0000-0000-0000-000000000109``
+     - :ref:`std::bool <ref_protocol_fmt_bool>`
+
+   * - ``00000000-0000-0000-0000-00000000010A``
+     - :ref:`std::datetime <ref_protocol_fmt_datetime>`
+
+   * - ``00000000-0000-0000-0000-00000000010E``
+     - :ref:`std::duration <ref_protocol_fmt_duration>`
+
+   * - ``00000000-0000-0000-0000-00000000010F``
+     - :ref:`std::json <ref_protocol_fmt_json>`
+
+   * - ``00000000-0000-0000-0000-00000000010B``
+     - :ref:`cal::local_datetime <ref_protocol_fmt_local_datetime>`
+
+   * - ``00000000-0000-0000-0000-00000000010C``
+     - :ref:`cal::local_date <ref_protocol_fmt_local_date>`
+
+   * - ``00000000-0000-0000-0000-00000000010D``
+     - :ref:`cal::local_time <ref_protocol_fmt_local_time>`
+
+   * - ``00000000-0000-0000-0000-000000000110``
+     - :ref:`std::bigint <ref_protocol_fmt_bigint>`
+
+   * - ``00000000-0000-0000-0000-000000000111``
+     - :ref:`cal::relative_duration <ref_protocol_fmt_relative_duration>`
+
+   * - ``00000000-0000-0000-0000-000000000112``
+     - :ref:`cal::date_duration <ref_protocol_fmt_date_duration>`
+
+   * - ``00000000-0000-0000-0000-000000000130``
+     - :ref:`cfg::memory <ref_protocol_fmt_memory>`
+
+Scalar Type Descriptor
+======================
+
+.. code-block:: c
+
+    struct ScalarTypeDescriptor {
+        // Indicates that this is a
+        // Scalar Type descriptor.
+        uint8           type = 3;
+
+        // Descriptor ID.
+        uuid            id;
+
+        // Parent type descriptor index.
+        uint16          base_type_pos;
+    };
+
+
+Tuple Type Descriptor
+=====================
+
+.. code-block:: c
+
+    struct TupleTypeDescriptor {
+        // Indicates that this is a
+        // Tuple Type descriptor.
+        uint8     type = 4;
+
+        // Descriptor ID.
+        uuid      id;
+
+        // The number of elements in tuple.
+        uint16    element_count;
+
+        // Indexes of element type descriptors.
+        uint16    element_types[element_count];
+    };
+
+An empty tuple type descriptor has an ID of
+``00000000-0000-0000-0000-0000000000FF``.
+
+
+Named Tuple Type Descriptor
+===========================
+
+.. code-block:: c
+
+    struct NamedTupleTypeDescriptor {
+        // Indicates that this is a
+        // Named Tuple Type descriptor.
+        uint8        type = 5;
+
+        // Descriptor ID.
+        uuid         id;
+
+        // The number of elements in tuple.
+        uint16       element_count;
+
+        // Indexes of element type descriptors.
+        TupleElement elements[element_count];
+    };
+
+    struct TupleElement {
+        // Field name.
+        string  name;
+
+        // Field type descriptor index.
+        int16   type_pos;
+    };
+
+
+Array Type Descriptor
+=====================
+
+.. code-block:: c
+
+    struct ArrayTypeDescriptor {
+        // Indicates that this is an
+        // Array Type descriptor.
+        uint8        type = 6;
+
+        // Descriptor ID.
+        uuid         id;
+
+        // Element type descriptor index.
+        uint16       type_pos;
+
+        // The number of array dimensions, at least 1.
+        uint16       dimension_count;
+
+        // Sizes of array dimensions, -1 indicates
+        // unbound dimension.
+        uint32       dimensions[dimension_count];
+    };
+
+
+Enumeration Type Descriptor
+===========================
+
+.. code-block:: c
+
+    struct EnumerationTypeDescriptor {
+        // Indicates that this is an
+        // Enumeration Type descriptor.
+        uint8        type = 7;
+
+        // Descriptor ID.
+        uuid         id;
+
+        // The number of enumeration members.
+        uint16       member_count;
+
+        // Names of enumeration members.
+        string       members[member_count];
+    };
+
+
+
+Input Shape Descriptor
+======================
+
+.. code-block:: c
+
+    struct InputShapeDescriptor {
+        // Indicates that this is an
+        // Object Shape descriptor.
+        uint8           type = 8;
+
+        // Descriptor ID.
+        uuid            id;
+
+        // Number of elements in shape.
+        uint16          element_count;
+
+        ShapeElement    elements[element_count];
+    };
+
+Input objects are encoded on the wire as
+:ref:`sparse objects <ref_protocol_fmt_sparse_obj>`.
+
+
+Range Type Descriptor
+===========================
+
+.. code-block:: c
+
+    struct RangeTypeDescriptor {
+        // Indicates that this is a
+        // Range Type descriptor.
+        uint8        type = 9;
+
+        // Descriptor ID.
+        uuid         id;
+
+        // Range type descriptor index.
+        uint16       type_pos;
+    };
+
+Ranges are encoded on the wire as :ref:`ranges <ref_protocol_fmt_range>`.
+
+
+Scalar Type Name Annotation
+===========================
+
+Part of the type descriptor when the :ref:`ref_protocol_msg_execute`
+client message has the ``INLINE_TYPENAMES`` header set.  Every non-builtin
+base scalar type and all enum types would have their full schema name
+provided via this annotation.
+
+.. code-block:: c
+
+    struct TypeAnnotationDescriptor {
+        uint8        type = 0xff;
+
+        // ID of the scalar type.
+        uuid         id;
+
+        // Type name.
+        string       type_name;
+    };
+
+
+Type Annotation Descriptor
+==========================
+
+Drivers must ignore unknown type annotations.
+
+.. code-block:: c
+
+    struct TypeAnnotationDescriptor {
+        // Indicates that this is an
+        // Type Annotation descriptor.
+        uint8        type = 0x80..0xfe;
+
+        // ID of the descriptor the
+        // annotation is for.
+        uuid         id;
+
+        // Annotation text.
+        string       annotation;
+    };

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_06_14_00_00
+EDGEDB_CATALOG_VERSION = 2023_06_28_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+from typing import *
 
 from edb import buildmeta
 from edb.schema import defines as s_def
@@ -73,11 +74,13 @@ HTTP_PORT_QUERY_CACHE_SIZE = 1000
 # to the system database after the connection was broken during runtime.
 SYSTEM_DB_RECONNECT_INTERVAL = 1
 
-MIN_PROTOCOL = (1, 0)
-CURRENT_PROTOCOL = (1, 0)
+ProtocolVersion: TypeAlias = tuple[int, int]
 
-MIN_LEGACY_PROTOCOL = (0, 13)
-MAX_LEGACY_PROTOCOL = (0, 14)
+MIN_PROTOCOL: ProtocolVersion = (1, 0)
+CURRENT_PROTOCOL: ProtocolVersion = (2, 0)
+
+MIN_LEGACY_PROTOCOL: ProtocolVersion = (0, 13)
+MAX_LEGACY_PROTOCOL: ProtocolVersion = (0, 14)
 
 MIN_SUGGESTED_CLIENT_POOL_SIZE = 10
 MAX_SUGGESTED_CLIENT_POOL_SIZE = 100

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -97,7 +97,7 @@ cdef object FMT_JSON_ELEMENTS = compiler.OutputFormat.JSON_ELEMENTS
 cdef object FMT_NONE = compiler.OutputFormat.NONE
 
 cdef tuple DUMP_VER_MIN = (0, 7)
-cdef tuple DUMP_VER_MAX = (1, 0)
+cdef tuple DUMP_VER_MAX = edbdef.CURRENT_PROTOCOL
 
 cdef tuple MIN_PROTOCOL = edbdef.MIN_PROTOCOL
 cdef tuple MAX_LEGACY_PROTOCOL = edbdef.MAX_LEGACY_PROTOCOL
@@ -155,7 +155,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         *,
         auth_data: bytes,
         conn_params: dict[str, str] | None,
-        protocol_version: tuple[int, int] = CURRENT_PROTOCOL,
+        protocol_version: edbdef.ProtocolVersion = CURRENT_PROTOCOL,
         **kwargs,
     ):
         super().__init__(server, **kwargs)
@@ -326,7 +326,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         )
         self.write_status(
             b'system_config',
-            self.server.get_report_config_data()
+            self.server.get_report_config_data(self.protocol_version),
         )
 
         self.write(self.sync_status())
@@ -1778,7 +1778,7 @@ async def eval_buffer(
     database: str,
     data: bytes,
     conn_params: dict[str, str],
-    protocol_version: tuple[int, int],
+    protocol_version: edbdef.ProtocolVersion,
     auth_data: bytes,
     transport: srvargs.ServerConnTransport,
 ):
@@ -1826,7 +1826,7 @@ def new_edge_connection(
     transport: srvargs.ServerConnTransport = (
         srvargs.ServerConnTransport.TCP),
     auth_data: bytes = b'',
-    protocol_version: tuple[int, int] = edbdef.CURRENT_PROTOCOL,
+    protocol_version: edbdef.ProtocolVersion = edbdef.CURRENT_PROTOCOL,
     conn_params: dict[str, str] | None = None,
 ):
     return EdgeConnectionBackwardsCompatible(

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -867,6 +867,10 @@ class ConnectedTestCaseMixin:
     def _run_and_rollback(self):
         return RollbackChanges(self)
 
+    def assert_data_shape(self, data, shape, message=None):
+        assert_data_shape.assert_data_shape(
+            data, shape, self.fail, message=message)
+
     async def assert_query_result(self, query,
                                   exp_result_json,
                                   exp_result_binary=...,

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -57,7 +57,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
             'SELECT "AAAA"',
         ])
 
-        self.assertEqual(
+        self.assert_data_shape(
             results,
             {
                 'kind': 'results',
@@ -65,19 +65,19 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
                     {
                         'kind': 'data',
                         'data': [
-                            'AAAAAAAAAAAAAAAAAAABBQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQU=',
+                            str,
+                            str,
                             'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
-                            'U0VMRUNU'
+                            str,
                         ]
                     },
                     {
                         'kind': 'data',
                         'data': [
-                            'AAAAAAAAAAAAAAAAAAABAQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQE=',
+                            str,
+                            str,
                             'RAAAAA4AAQAAAARBQUFB',
-                            'U0VMRUNU'
+                            str,
                         ]
                     },
                 ]
@@ -91,7 +91,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
             'SELECT 55',
         ])
 
-        self.assertEqual(
+        self.assert_data_shape(
             results,
             {
                 'kind': 'results',
@@ -99,10 +99,10 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
                     {
                         'kind': 'data',
                         'data': [
-                            'AAAAAAAAAAAAAAAAAAABBQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQU=',
+                            str,
+                            str,
                             'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
-                            'U0VMRUNU'
+                            str,
                         ]
                     },
                     {
@@ -172,7 +172,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
             'SELECT 2'
         ])
 
-        self.assertEqual(
+        self.assert_data_shape(
             results,
             {
                 'kind': 'results',
@@ -180,10 +180,10 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
                     {
                         'kind': 'data',
                         'data': [
-                            'AAAAAAAAAAAAAAAAAAABBQ==',
-                            'AgAAAAAAAAAAAAAAAAAAAQU=',
+                            str,
+                            str,
                             'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
-                            'U0VMRUNU'
+                            str,
                         ]
                     },
                     {
@@ -222,15 +222,15 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
 
         self.assertNotIn('error', results['results'][0])
 
-        self.assertEqual(
+        self.assert_data_shape(
             results['results'][1],
             {
                 'kind': 'data',
                 'data': [
-                    'AAAAAAAAAAAAAAAAAAABBQ==',
-                    'AgAAAAAAAAAAAAAAAAAAAQU=',
+                    str,
+                    str,
                     'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
-                    'U0VMRUNU'
+                    str,
                 ]
             },
         )
@@ -245,15 +245,15 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
         self.assertNotIn('error', results['results'][0])
         self.assertNotIn('error', results['results'][1])
 
-        self.assertEqual(
+        self.assert_data_shape(
             results['results'][2],
             {
                 'kind': 'data',
                 'data': [
-                    'AAAAAAAAAAAAAAAAAAABBQ==',
-                    'AgAAAAAAAAAAAAAAAAAAAQU=',
+                    str,
+                    str,
                     'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
-                    'U0VMRUNU'
+                    str,
                 ]
             },
         )

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2293,19 +2293,13 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                         )
 
                         self.assertEqual(status, http.HTTPStatus.OK)
-                        self.assertEqual(
+                        self.assert_data_shape(
                             response,
                             {
                                 'kind': 'results',
                                 'results': [
                                     {
                                         'kind': 'data',
-                                        'data': [
-                                            'AAAAAAAAAAAAAAAAAAABBQ==',
-                                            'AgAAAAAAAAAAAAAAAAAAAQU=',
-                                            'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
-                                            'U0VMRUNU'
-                                        ]
                                     },
                                 ],
                             },
@@ -2324,19 +2318,13 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                         )
 
                         self.assertEqual(status, http.HTTPStatus.OK)
-                        self.assertEqual(
+                        self.assert_data_shape(
                             response,
                             {
                                 'kind': 'results',
                                 'results': [
                                     {
                                         'kind': 'data',
-                                        'data': [
-                                            'AAAAAAAAAAAAAAAAAAABBQ==',
-                                            'AgAAAAAAAAAAAAAAAAAAAQU=',
-                                            'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
-                                            'U0VMRUNU'
-                                        ]
                                     },
                                 ],
                             },


### PR DESCRIPTION
This changes the type descriptor protocol to include more schema type information for the benefit of introspection and code generation.

Supercedes: #4800