### PR TITLE
Implement a schema repair mechanism

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -475,19 +475,6 @@ def apply_sdl(
     return target_schema
 
 
-def apply_ddl(
-    ddl_stmt: qlast.DDLCommand,
-    *,
-    schema: s_schema.Schema,
-    modaliases: Mapping[Optional[str], str],
-    stdmode: bool=False,
-    testmode: bool=False,
-) -> s_schema.Schema:
-    schema, _ = _delta_from_ddl(ddl_stmt, schema=schema, modaliases=modaliases,
-                                stdmode=stdmode, testmode=testmode)
-    return schema
-
-
 def apply_ddl_script(
     ddl_text: str,
     *,
@@ -516,6 +503,11 @@ def apply_ddl_script_ex(
     stdmode: bool = False,
     internal_schema_mode: bool = False,
     testmode: bool = False,
+    allow_dml_in_functions: bool=False,
+    schema_object_ids: Optional[
+        Mapping[Tuple[sn.Name, Optional[str]], uuid.UUID]
+    ]=None,
+    compat_ver: Optional[verutils.Version] = None,
 ) -> Tuple[s_schema.Schema, sd.DeltaRoot]:
 
     delta = sd.DeltaRoot()
@@ -533,6 +525,9 @@ def apply_ddl_script_ex(
             stdmode=stdmode,
             internal_schema_mode=internal_schema_mode,
             testmode=testmode,
+            allow_dml_in_functions=allow_dml_in_functions,
+            schema_object_ids=schema_object_ids,
+            compat_ver=compat_ver,
         )
 
         delta.add(cmd)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1577,6 +1577,12 @@ class DeltaRoot(CommandGroup, context_class=DeltaRootContext):
 
         return schema
 
+    def is_data_safe(self) -> bool:
+        return all(
+            subcmd.is_data_safe()
+            for subcmd in self.get_subcommands()
+        )
+
 
 class Query(Command):
     """A special delta command representing a non-DDL query.

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2247,7 +2247,9 @@ class SetPointerType(
         return 'alter the type of'
 
     def is_data_safe(self) -> bool:
-        return False
+        # A computed target means this must be an inferred computed
+        # property, so it is data safe.
+        return self.is_attribute_computed('target')
 
     def record_diff_annotations(
         self, *,
@@ -2568,6 +2570,11 @@ class AlterPointerUpperCardinality(
         )
 
     def is_data_safe(self) -> bool:
+        # A computed target means this must be an inferred computed
+        # property, so it is data safe.
+        if self.is_attribute_computed('cardinality'):
+            return True
+
         old_val = self.get_orig_attribute_value('cardinality')
         new_val = self.get_attribute_value('cardinality')
         if (

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -29,6 +29,7 @@ from .dbstate import QueryUnit, QueryUnitGroup
 from .enums import Capability, Cardinality
 from .enums import InputFormat, OutputFormat
 from .explain import analyze_explain_output
+from .ddl import repair_schema
 
 __all__ = (
     'Cardinality',
@@ -48,4 +49,5 @@ __all__ = (
     'new_compiler_context',
     'compile',
     'compile_schema_storage_in_delta',
+    'repair_schema',
 )

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1432,6 +1432,8 @@ def _compile_ql_administer(
                 context=ql.expr.context,
             )
         sql = (b'ANALYZE',)
+    elif ql.expr.func == 'repair_schema':
+        return ddl.administer_repair_schema(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -977,9 +977,14 @@ class Server(ha_base.ClusterProtocol):
     async def _maybe_patch_db(self, dbname, patches):
         logger.info("applying patches to database '%s'", dbname)
 
-        if dbname != defines.EDGEDB_SYSTEM_DB:
+        try:
             async with self._direct_pgcon(dbname) as conn:
                 await self._maybe_apply_patches(dbname, conn, patches)
+        except Exception as e:
+            raise errors.InternalServerError(
+                f'Could not apply patches for minor version upgrade to '
+                f'database {dbname}'
+            ) from e
 
     async def _maybe_patch(self):
         """Apply patches to all the databases"""

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -681,13 +681,13 @@ class Server(ha_base.ClusterProtocol):
         self._dbindex.update_global_schema(new_global_schema)
         self._fetch_roles()
 
-    async def introspect_user_schema(self, conn):
+    async def introspect_user_schema(self, conn, global_schema=None):
         json_data = await conn.sql_fetch_val(self._local_intro_query)
 
         base_schema = s_schema.ChainedSchema(
             self._std_schema,
             s_schema.FlatSchema(),
-            self.get_global_schema(),
+            global_schema or self.get_global_schema(),
         )
 
         return s_refl.parse_into(
@@ -922,7 +922,7 @@ class Server(ha_base.ClusterProtocol):
                     conn, f'patch_log_{idx}', pickle.dumps(entry))
 
             patches[num] = entry
-            _, _, updates = entry
+            _, _, updates, _ = entry
             if 'stdschema' in updates:
                 self._std_schema = updates['stdschema']
             if 'reflschema' in updates:
@@ -939,13 +939,40 @@ class Server(ha_base.ClusterProtocol):
     async def _maybe_apply_patches(self, dbname, conn, patches, sys=False):
         """Apply any un-applied patches to the database."""
         num_patches = await self.get_patch_count(conn)
-        for num, (sql, syssql, _) in patches.items():
+        for num, (sql, syssql, _, repair) in patches.items():
             if num_patches <= num:
                 if sys:
                     sql += syssql
                 logger.info("applying patch %d to database '%s'", num, dbname)
                 sql = tuple(x.encode('utf-8') for x in sql)
-                await conn.sql_fetch(sql)
+
+                # Only do repairs when they are the *last* pending
+                # repair in the patch queue. We make sure that every
+                # patch that changes the user schema is followed by a
+                # repair, so this allows us to only ever have to do
+                # repairs on up-to-date std schemas.
+                last_repair = repair and not any(
+                    patches[i][3] for i in range(num + 1, len(patches))
+                )
+                if last_repair:
+                    from . import bootstrap
+
+                    global_schema = await self.introspect_global_schema(conn)
+                    user_schema = await self.introspect_user_schema(
+                        conn, global_schema)
+                    config = await self.introspect_db_config(conn)
+                    sql += bootstrap.prepare_repair_patch(
+                        self._std_schema,
+                        self._refl_schema,
+                        user_schema,
+                        global_schema,
+                        self._schema_class_layout,
+                        self.get_backend_runtime_params(),
+                        config,
+                    )
+
+                if sql:
+                    await conn.sql_fetch(sql)
 
     async def _maybe_patch_db(self, dbname, patches):
         logger.info("applying patches to database '%s'", dbname)


### PR DESCRIPTION
As discussed in #5321, certain changes and bugfixes can result in the
schema state being inconsistent, with inferred attributes that do not
match what would be created if the schema was created freshly.

Implement a repair system that works by serializing the current schema
to DDL, generating a fresh schema from that, then comparing the
current schema to this new target and applying the delta.
For safety, we refuse if the change is not data-safe.

This mechanism is exposed as a new "patch kind" for the patch mechanism,
and as a test-mode ADMINISTER function.

I tested this manually using #5180 and #5329. When we add 'repair'
patches to stable branches we should endeavor to make sure that it
actually gets exercised by the old versions CI job.
Also tested with an edgeql+schema patch made after it.

Fixes #5321.