### PR TITLE
Add type annotations to `server.compiler.sertypes`

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -164,6 +164,7 @@ class Schema(abc.ABC):
         ] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Tuple[s_func.Function, ...]:
         raise NotImplementedError
 
@@ -176,6 +177,7 @@ class Schema(abc.ABC):
         ] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Tuple[s_oper.Operator, ...]:
         raise NotImplementedError
 
@@ -425,7 +427,11 @@ class Schema(abc.ABC):
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
         sourcectx: Optional[parsing.ParserContext],
+        disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
+        raise NotImplementedError
+
+    def _get_object_ids(self) -> Iterable[uuid.UUID]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -508,6 +514,9 @@ class FlatSchema(Schema):
         self._globalname_to_id = immu.Map()
         self._refs_to = immu.Map()
         self._generation = 0
+
+    def _get_object_ids(self) -> Iterable[uuid.UUID]:
+        return self._id_to_type.keys()
 
     def _replace(
         self,
@@ -1565,18 +1574,25 @@ class ChainedSchema(Schema):
 
     def __init__(
         self,
-        base_schema: FlatSchema,
-        top_schema: FlatSchema,
-        global_schema: FlatSchema
+        base_schema: Schema,
+        top_schema: Schema,
+        global_schema: Schema
     ) -> None:
         self._base_schema = base_schema
         self._top_schema = top_schema
         self._global_schema = global_schema
 
-    def get_top_schema(self) -> FlatSchema:
+    def _get_object_ids(self) -> Iterable[uuid.UUID]:
+        return itertools.chain(
+            self._base_schema._get_object_ids(),
+            self._top_schema._get_object_ids(),
+            self._global_schema._get_object_ids(),
+        )
+
+    def get_top_schema(self) -> Schema:
         return self._top_schema
 
-    def get_global_schema(self) -> FlatSchema:
+    def get_global_schema(self) -> Schema:
         return self._global_schema
 
     def add_raw(
@@ -1758,13 +1774,26 @@ class ChainedSchema(Schema):
         ] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Tuple[s_func.Function, ...]:
         objs = self._top_schema.get_functions(
-            name, module_aliases=module_aliases, default=())
+            name,
+            module_aliases=module_aliases,
+            default=(),
+            disallow_module=disallow_module,
+        )
         if not objs:
+            if disallow_module is not None:
+                dm = disallow_module
+                disallow_module = (
+                    lambda s: dm(s) or self._top_schema.has_module(s))
+            else:
+                disallow_module = self._top_schema.has_module
             objs = self._base_schema.get_functions(
-                name, default=default, module_aliases=module_aliases,
-                disallow_module=self._top_schema.has_module,
+                name,
+                default=default,
+                module_aliases=module_aliases,
+                disallow_module=disallow_module,
             )
         return objs
 
@@ -1776,13 +1805,26 @@ class ChainedSchema(Schema):
         ] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Tuple[s_oper.Operator, ...]:
         objs = self._top_schema.get_operators(
-            name, module_aliases=module_aliases, default=())
+            name,
+            module_aliases=module_aliases,
+            default=(),
+            disallow_module=disallow_module,
+        )
         if not objs:
+            if disallow_module is not None:
+                dm = disallow_module
+                disallow_module = (
+                    lambda s: dm(s) or self._top_schema.has_module(s))
+            else:
+                disallow_module = self._top_schema.has_module
             objs = self._base_schema.get_operators(
-                name, default=default, module_aliases=module_aliases,
-                disallow_module=self._top_schema.has_module,
+                name,
+                default=default,
+                module_aliases=module_aliases,
+                disallow_module=disallow_module,
             )
         return objs
 
@@ -1834,7 +1876,7 @@ class ChainedSchema(Schema):
         field_name: Optional[str] = None,
     ) -> FrozenSet[so.Object_T]:
         return (
-            self._base_schema.get_referrers(
+            self._base_schema.get_referrers(  # type: ignore [return-value]
                 scls,
                 scls_type=scls_type,
                 field_name=field_name,
@@ -1844,7 +1886,7 @@ class ChainedSchema(Schema):
                 scls_type=scls_type,
                 field_name=field_name,
             )
-            | self._global_schema.get_referrers(
+            | self._global_schema.get_referrers(  # type: ignore [operator]
                 scls,
                 scls_type=scls_type,
                 field_name=field_name,
@@ -1914,6 +1956,7 @@ class ChainedSchema(Schema):
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
         sourcectx: Optional[parsing.ParserContext],
+        disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
         obj = self._top_schema._get(
             name,
@@ -1923,8 +1966,15 @@ class ChainedSchema(Schema):
             condition=condition,
             label=label,
             sourcectx=sourcectx,
+            disallow_module=disallow_module,
         )
         if obj is None:
+            if disallow_module is not None:
+                dm = disallow_module
+                disallow_module = (
+                    lambda s: dm(s) or self._top_schema.has_module(s))
+            else:
+                disallow_module = self._top_schema.has_module
             return self._base_schema._get(
                 name,
                 default=default,
@@ -1933,7 +1983,7 @@ class ChainedSchema(Schema):
                 condition=condition,
                 label=label,
                 sourcectx=sourcectx,
-                disallow_module=self._top_schema.has_module,
+                disallow_module=disallow_module,
             )
         else:
             return obj
@@ -1972,11 +2022,7 @@ class ChainedSchema(Schema):
     ) -> SchemaIterator[so.Object_T]:
         return SchemaIterator[so.Object_T](
             self,
-            itertools.chain(
-                self._base_schema._id_to_type,
-                self._top_schema._id_to_type,
-                self._global_schema._id_to_type,
-            ),
+            self._get_object_ids(),
             exclude_global=exclude_global,
             exclude_stdlib=exclude_stdlib,
             exclude_internal=exclude_internal,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -530,8 +530,9 @@ class QualifiedType(so.QualifiedObject, Type):
 class InheritingType(so.DerivableInheritingObject, QualifiedType):
 
     def material_type(
-        self, schema: s_schema.Schema
-    ) -> typing.Tuple[s_schema.Schema, InheritingType]:
+        self: InheritingTypeT,
+        schema: s_schema.Schema_T,
+    ) -> typing.Tuple[s_schema.Schema_T, InheritingTypeT]:
         return schema, self.get_nearest_non_derived_parent(schema)
 
     def peel_view(self, schema: s_schema.Schema) -> Type:

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -722,9 +722,13 @@ class Transaction:
 
     def update_schema(self, new_schema: s_schema.Schema):
         assert isinstance(new_schema, s_schema.ChainedSchema)
+        user_schema = new_schema.get_top_schema()
+        assert isinstance(user_schema, s_schema.FlatSchema)
+        global_schema = new_schema.get_global_schema()
+        assert isinstance(global_schema, s_schema.FlatSchema)
         self._current = self._current._replace(
-            user_schema=new_schema.get_top_schema(),
-            global_schema=new_schema.get_global_schema(),
+            user_schema=user_schema,
+            global_schema=global_schema,
         )
 
     def update_modaliases(self, new_modaliases: immutables.Map):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ module = [
     "edb.server.pgcluster",
     "edb.server.pgconnparams",
     "edb.server.compiler.explain",
+    "edb.server.compiler.sertypes",
 ]
 # Equivalent of --strict on the command line,
 # but without disallow_untyped_calls:


### PR DESCRIPTION
This also taught `ChainedSchema` to chain any schemas, not just
`FlatSchema`.

Preparation for the sertypes reform.