### PR TITLE
Forbid ranges of user-defined scalars

### DIFF
--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -193,9 +193,8 @@ def pg_type_range(tp: Tuple[str, ...]) -> Tuple[str, ...]:
 
 
 def pg_type_from_object(
-        schema: s_schema.Schema,
-        obj: s_obj.Object,
-        persistent_tuples: bool=False) -> Tuple[str, ...]:
+    schema: s_schema.Schema, obj: s_obj.Object, persistent_tuples: bool = False
+) -> Tuple[str, ...]:
 
     if isinstance(obj, s_scalars.ScalarType):
         return pg_type_from_scalar(schema, obj)
@@ -341,8 +340,8 @@ class _PointerStorageInfo:
                                                       catenate=False)
             else:
                 column_type = pg_type_from_object(
-                    schema, pointer.get_target(schema),
-                    persistent_tuples=True)
+                    schema, pointer_target, persistent_tuples=True
+                )
         else:
             # The target may not be known in circular object-to-object
             # linking scenarios.

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2081,6 +2081,11 @@ class DerivableObject(QualifiedObject):
 
 
 class Shell:
+    """
+    Shells mimic objects, but are not part of the schema.
+    They are construced from AST and are used to hold object data
+    before it is commited to the schema.
+    """
 
     def resolve(self, schema: s_schema.Schema) -> Any:
         raise NotImplementedError

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -77,8 +77,9 @@ class ScalarType(
         schema: s_schema.Schema,
     ) -> bool:
         """Returns true of the type has only abstract bases"""
+        bases: Sequence[s_types.Type] = self.get_bases(schema).objects(schema)
         return all(
-            b.is_abstract() for b in self.get_bases(schema).objects(schema)
+            b.get_abstract(schema) for b in bases
         )
 
     def is_enum(self, schema: s_schema.Schema) -> bool:

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -72,6 +72,15 @@ class ScalarType(
             for base in self.get_bases(schema).objects(schema)
         )
 
+    def is_base_type(
+        self,
+        schema: s_schema.Schema,
+    ) -> bool:
+        """Returns true of the type has only abstract bases"""
+        return all(
+            b.is_abstract() for b in self.get_bases(schema).objects(schema)
+        )
+
     def is_enum(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_enum_values(schema))
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -78,9 +78,7 @@ class ScalarType(
     ) -> bool:
         """Returns true of the type has only abstract bases"""
         bases: Sequence[s_types.Type] = self.get_bases(schema).objects(schema)
-        return all(
-            b.get_abstract(schema) for b in bases
-        )
+        return all(b.get_abstract(schema) for b in bases)
 
     def is_enum(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_enum_values(schema))

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2286,7 +2286,7 @@ class Range(
         stype = subtypes[0]
         anypoint = schema.get('std::anypoint', type=Type)
 
-        if not stype.issubclass(schema, anypoint) or True:
+        if not stype.issubclass(schema, anypoint):
             raise errors.UnsupportedFeatureError(
                 f'unsupported range subtype: {stype.get_displayname(schema)}'
             )

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2286,9 +2286,10 @@ class Range(
         stype = subtypes[0]
         anypoint = schema.get('std::anypoint', type=Type)
 
-        if not stype.issubclass(schema, anypoint):
+        if not stype.issubclass(schema, anypoint) or True:
             raise errors.UnsupportedFeatureError(
-                f'unsupported range subtype: {stype.get_displayname(schema)}')
+                f'unsupported range subtype: {stype.get_displayname(schema)}'
+            )
 
         return cls.create(
             schema,
@@ -2694,6 +2695,23 @@ class CreateCollectionType(
         # might use it later.
         self.set_attribute_value('internal', False)
         return super().canonicalize_attributes(schema, context)
+
+    def validate_object(
+        self, schema: s_schema.Schema, context: sd.CommandContext
+    ):
+        super().validate_object(schema, context)
+
+        if isinstance(self.scls, Range):
+            from . import scalars as s_scalars
+
+            st = self.scls.get_subtypes(schema)[0]
+
+            if isinstance(st, s_scalars.ScalarType) and not st.is_base_type(
+                schema
+            ):
+                raise errors.UnsupportedFeatureError(
+                    f'unsupported range subtype: {st.get_displayname(schema)}'
+                )
 
 
 class AlterCollectionType(

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2698,7 +2698,7 @@ class CreateCollectionType(
 
     def validate_object(
         self, schema: s_schema.Schema, context: sd.CommandContext
-    ):
+    ) -> None:
         super().validate_object(schema, context)
 
         if isinstance(self.scls, Range):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5966,24 +5966,29 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
 
         async with self.assertRaisesRegexTx(
-                edgedb.SchemaError,
-                r'scalar type may not have a collection base type'):
-            await self.con.execute('''
+            edgedb.SchemaError,
+            r'scalar type may not have a collection base type',
+        ):
+            await self.con.execute(
+                '''
                 alter scalar type Foo {
                     drop extending str; extending array<str> last;
                 };
-            ''')
+            '''
+            )
 
     async def test_edgeql_ddl_scalar_14(self):
         async with self.assertRaisesRegexTx(
-                edgedb.UnsupportedFeatureError,
-                r'unsupported range subtype'):
-            await self.con.execute('''
+            edgedb.UnsupportedFeatureError, r'unsupported range subtype'
+        ):
+            await self.con.execute(
+                '''
                 create scalar type Age extending int16;
                 create type User {
                     create property age -> range<Age>;
                 };
-            ''')
+            '''
+            )
 
     async def test_edgeql_ddl_cast_01(self):
         await self.con.execute('''

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5974,6 +5974,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             ''')
 
+    async def test_edgeql_ddl_scalar_14(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.UnsupportedFeatureError,
+                r'unsupported range subtype'):
+            await self.con.execute('''
+                create scalar type Age extending int16;
+                create type User {
+                    create property age -> range<Age>;
+                };
+            ''')
+
     async def test_edgeql_ddl_cast_01(self):
         await self.con.execute('''
             CREATE SCALAR TYPE type_a EXTENDING std::str;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2127,12 +2127,11 @@ class TestSchema(tb.BaseSchemaLoadTest):
     )
     def test_schema_range_01(self):
         """
-            scalar type Age extending int64;
-            type Y {
-                property age_requirement -> range<Age>
-            }
+        scalar type Age extending int64;
+        type Y {
+            property age_requirement -> range<Age>
+        }
         """
-
 
 
 class TestGetMigration(tb.BaseSchemaLoadTest):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2121,6 +2121,19 @@ class TestSchema(tb.BaseSchemaLoadTest):
             alias val_i := {'alice', 'billie'} intersect User.name;
         """
 
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "unsupported range subtype: test::Age",
+    )
+    def test_schema_range_01(self):
+        """
+            scalar type Age extending int64;
+            type Y {
+                property age_requirement -> range<Age>
+            }
+        """
+
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.


### PR DESCRIPTION
This is the offending schema:

```
module default {
    type User {
        property age -> range<Age>;
    };

    scalar type Age extending int16 {
        constraint min_value(13);
        constraint max_value(99);
    };
} 
```

@msullivan, am I correct to assume that we should not allow this, with error:

```
unsupported range subtype: default::Age
```

In this specific case, we could allow it, by using a range of int64. 
