### PR TITLE
Improve the docs for `array_unpack`

### DIFF
--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -289,11 +289,16 @@ Reference
     .. note::
 
         The ordering of the returned set is not guaranteed.
+        However, if it is wrapped in a call to :eql:func:`enumerate`,
+        the assigned indexes are guaranteed to match the array.
 
     .. code-block:: edgeql-repl
 
         db> select array_unpack([2, 3, 5]);
         {3, 2, 5}
+
+        db> select enumerate(array_unpack([2, 3, 5]));
+        {(1, 3), (0, 2), (2, 5)}
 
 
 ----------
@@ -322,7 +327,7 @@ Reference
 
     Returns an array of the specified size, filled with the provided value.
 
-    Create anarray of size *n* where every element has the value *val*.
+    Create an array of size *n* where every element has the value *val*.
 
     .. code-block:: edgeql-repl
 


### PR DESCRIPTION
array_unpack's docs correctly call out that the order of the returned
set is not guaranteed (though in practice is probably is for non
objects). Note in the docs that wrapping the call in enumerate will
preserve the indexes.