### PR TITLE
config: Remove mandatory reliance on global config spec

### DIFF
--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -89,8 +89,11 @@ def lookup(
 
 def get_compilation_config(
     config: Mapping[str, SettingValue],
+    *,
+    spec: Optional[Spec] = None,
 ) -> immutables.Map[str, SettingValue]:
-    spec = get_settings()
+    if spec is None:
+        spec = get_settings()
     return immutables.Map((
         (k, v)
         for k, v in config.items()

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1204,13 +1204,15 @@ cdef class DatabaseIndex:
         await conn.sql_execute(block.to_string().encode())
 
     async def apply_system_config_op(self, conn, op):
-        op_value = op.get_setting(config.get_settings())
+        spec = config.get_settings()
+        op_value = op.get_setting(spec)
         if op.opcode is not None:
             allow_missing = (
                 op.opcode is config.OpCode.CONFIG_REM
                 or op.opcode is config.OpCode.CONFIG_RESET
             )
-            op_value = op.coerce_value(op_value, allow_missing=allow_missing)
+            op_value = op.coerce_value(
+                spec, op_value, allow_missing=allow_missing)
 
         # _save_system_overrides *must* happen before
         # the callbacks below, because certain config changes

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -86,7 +86,7 @@ testspec1 = spec.Spec(
     spec.Setting(
         'port',
         type=Port,
-        default=Port.from_pyvalue(make_port_value())),
+        default=Port(**make_port_value())),
 
     spec.Setting(
         'ints',
@@ -109,14 +109,6 @@ testspec1 = spec.Spec(
 
 
 class TestServerConfigUtils(unittest.TestCase):
-
-    def setUp(self):
-        self._cfgspec = config.get_settings()
-        config.set_settings(testspec1)
-
-    def tearDown(self):
-        config.set_settings(self._cfgspec)
-        self._cfgspec = None  # some settings cannot be pickled by runner.py
 
     def test_server_config_01(self):
         conf = immutables.Map({
@@ -207,8 +199,10 @@ class TestServerConfigUtils(unittest.TestCase):
         self.assertEqual(
             config.lookup('ports', storage2, spec=testspec1),
             {
-                Port.from_pyvalue(make_port_value(database='f1')),
-                Port.from_pyvalue(make_port_value(database='f2')),
+                Port.from_pyvalue(
+                    make_port_value(database='f1'), spec=testspec1),
+                Port.from_pyvalue(
+                    make_port_value(database='f2'), spec=testspec1),
             })
 
         j = ops.to_json(testspec1, storage2)
@@ -226,7 +220,8 @@ class TestServerConfigUtils(unittest.TestCase):
         self.assertEqual(
             config.lookup('ports', storage3, spec=testspec1),
             {
-                Port.from_pyvalue(make_port_value(database='f2')),
+                Port.from_pyvalue(
+                    make_port_value(database='f2'), spec=testspec1),
             })
 
         op = ops.Operation(
@@ -290,16 +285,22 @@ class TestServerConfigUtils(unittest.TestCase):
         op.apply(testspec1, storage)
 
         self.assertEqual(
-            Port.from_pyvalue(make_port_value(address='aaa')),
-            Port.from_pyvalue(make_port_value(address=['aaa'])))
+            Port.from_pyvalue(
+                make_port_value(address='aaa'), spec=testspec1),
+            Port.from_pyvalue(
+                make_port_value(address=['aaa']), spec=testspec1))
 
         self.assertEqual(
-            Port.from_pyvalue(make_port_value(address=['aaa', 'bbb'])),
-            Port.from_pyvalue(make_port_value(address=['bbb', 'aaa'])))
+            Port.from_pyvalue(
+                make_port_value(address=['aaa', 'bbb']), spec=testspec1),
+            Port.from_pyvalue(
+                make_port_value(address=['bbb', 'aaa']), spec=testspec1))
 
         self.assertNotEqual(
-            Port.from_pyvalue(make_port_value(address=['aaa', 'bbb'])),
-            Port.from_pyvalue(make_port_value(address=['bbb', 'aa1'])))
+            Port.from_pyvalue(
+                make_port_value(address=['aaa', 'bbb']), spec=testspec1),
+            Port.from_pyvalue(
+                make_port_value(address=['bbb', 'aa1']), spec=testspec1))
 
     def test_server_config_04(self):
         storage = immutables.Map()


### PR DESCRIPTION
Parts of config system innards are still exclusively reliant on global
`spec`.  Fix this and remove `config.set_settings()` from tests to avoid
concurrency issues.