### PR TITLE
More cleanups in sertypes

### DIFF
--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -41,7 +41,7 @@ class Setting:
     name: str
     type: type
     default: Any
-    s_type: Any = None
+    schema_type_name: Optional[sn.QualName] = None
     set_of: bool = False
     system: bool = False
     internal: bool = False
@@ -169,7 +169,7 @@ def load_spec_from_schema(schema):
         setting = Setting(
             pn,
             type=pytype,
-            s_type=ptype,
+            schema_type_name=ptype.get_name(schema),
             set_of=set_of,
             internal=attributes.get(sn.QualName('cfg', 'internal'), False),
             system=attributes.get(sn.QualName('cfg', 'system'), False),


### PR DESCRIPTION
Use helpers to encode strings and descriptor references, add comments,
and clean things up a bit.