### PR TITLE
Type descriptor parsing cleanups

### DIFF
--- a/edb/common/binwrapper.py
+++ b/edb/common/binwrapper.py
@@ -118,3 +118,6 @@ class BinWrapper:
             return None
         else:
             return self.read_bytes(size)
+
+    def tell(self) -> int:
+        return self.buf.tell()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ module = [
     "edb.common.struct",
     "edb.common.topological",
     "edb.common.uuidgen",
+    "edb.common.value_dispatch",
 ]
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = true


### PR DESCRIPTION
Apply the same treatment as for the marshalling side: use dispatch to
parse, add context, and add helpers for common patterns.