### PR TITLE
Fix minor TypeScript syntax error in docs

### DIFF
--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -458,7 +458,7 @@ like any good programming language.
   .. code-tab:: typescript
 
     const newMovie = e.insert({
-      title := "The Marvels"
+      title: "The Marvels"
     });
     const query = e.select(newMovie, () => ({
       id: true,

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -457,7 +457,7 @@ like any good programming language.
 
   .. code-tab:: typescript
 
-    const newMovie = e.insert({
+    const newMovie = e.insert(e.Movie, {
       title: "The Marvels"
     });
     const query = e.select(newMovie, () => ({


### PR DESCRIPTION
Which presumably was copied from the EdgeQL code sample