### PR TITLE
Clarification that backlinks are multi by default

### DIFF
--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -48,6 +48,31 @@ link.
       multi friends: Person;
     }
 
+On the other hand, backlinks work in reverse to find objects that link to the
+object, and thus assume  ``multi`` as a default. Use the ``single`` keyword 
+to declare a "to-one" backlink.
+
+.. code-block:: sdl
+    :version-lt: 3.0
+
+    type Author {
+      link posts := .<authors[is Article];
+    }
+
+    type CompanyEmployee {
+      single link company := .<employees[is Company];
+    }
+
+.. code-block:: sdl
+
+    type Author {
+      link posts := .<authors[is Article];
+    }
+
+    type CompanyEmployee {
+      single link company := .<employees[is Company];
+    }
+
 Required links
 --------------
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -53,17 +53,6 @@ object, and thus assume  ``multi`` as a default. Use the ``single`` keyword
 to declare a "to-one" backlink.
 
 .. code-block:: sdl
-    :version-lt: 3.0
-
-    type Author {
-      link posts := .<authors[is Article];
-    }
-
-    type CompanyEmployee {
-      single link company := .<employees[is Company];
-    }
-
-.. code-block:: sdl
 
     type Author {
       link posts := .<authors[is Article];


### PR DESCRIPTION
Noticed today that backlinks are multi by default. This seems like the best page to inform the user of this.