### PR TITLE
release: Remove Debian Stretch and Ubuntu Xenial

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -316,7 +316,7 @@
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v5
+      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -1,15 +1,5 @@
 targets:
     linux:
-        - name: debian-stretch-x86_64
-          platform: debian
-          platform_version: stretch
-          family: debian
-          runs_on: [self-hosted, linux, x64]
-        - name: debian-stretch-aarch64
-          platform: debian
-          platform_version: stretch
-          family: debian
-          runs_on: [self-hosted, linux, arm64]
         - name: debian-buster-x86_64
           platform: debian
           platform_version: buster
@@ -30,16 +20,6 @@ targets:
         - name: debian-bullseye-aarch64
           platform: debian
           platform_version: bullseye
-          family: debian
-          runs_on: [self-hosted, linux, arm64]
-        - name: ubuntu-xenial-x86_64
-          platform: ubuntu
-          platform_version: xenial
-          family: debian
-          runs_on: [self-hosted, linux, x64]
-        - name: ubuntu-xenial-aarch64
-          platform: ubuntu
-          platform_version: xenial
           family: debian
           runs_on: [self-hosted, linux, arm64]
         - name: ubuntu-bionic-x86_64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,52 +26,6 @@ jobs:
 
 
 
-  build-debian-stretch-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        EXTRA_OPTIMIZATIONS: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-
-  build-debian-stretch-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        EXTRA_OPTIMIZATIONS: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-
   build-debian-buster-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
@@ -162,52 +116,6 @@ jobs:
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
-
-
-  build-ubuntu-xenial-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        EXTRA_OPTIMIZATIONS: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-
-  build-ubuntu-xenial-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        EXTRA_OPTIMIZATIONS: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
 
 
   build-ubuntu-bionic-x86_64:
@@ -615,52 +523,6 @@ jobs:
 
 
 
-  test-debian-stretch-x86_64:
-    needs: [build-debian-stretch-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-debian-stretch-aarch64:
-    needs: [build-debian-stretch-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
   test-debian-buster-x86_64:
     needs: [build-debian-buster-x86_64]
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -746,52 +608,6 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-ubuntu-xenial-x86_64:
-    needs: [build-ubuntu-xenial-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-ubuntu-xenial-aarch64:
-    needs: [build-ubuntu-xenial-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
         PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
@@ -1151,108 +967,6 @@ jobs:
 
 
 
-  publish-debian-stretch-x86_64:
-    needs: [test-debian-stretch-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-stretch-x86_64:
-    needs: [publish-debian-stretch-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-stretch
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-debian-stretch-aarch64:
-    needs: [test-debian-stretch-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-stretch-aarch64:
-    needs: [publish-debian-stretch-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-stretch
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
   publish-debian-buster-x86_64:
     needs: [test-debian-buster-x86_64]
     runs-on: ubuntu-latest
@@ -1448,108 +1162,6 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-ubuntu-xenial-x86_64:
-    needs: [test-ubuntu-xenial-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-xenial-x86_64:
-    needs: [publish-ubuntu-xenial-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-xenial
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-ubuntu-xenial-aarch64:
-    needs: [test-ubuntu-xenial-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-xenial-aarch64:
-    needs: [publish-ubuntu-xenial-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-xenial
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
         PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
@@ -2350,7 +1962,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v5
+      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,52 +21,6 @@ jobs:
 
 
 
-  build-debian-stretch-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-
-  build-debian-stretch-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-
   build-debian-buster-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
@@ -157,52 +111,6 @@ jobs:
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
-
-
-  build-ubuntu-xenial-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-
-  build-ubuntu-xenial-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
 
 
   build-ubuntu-bionic-x86_64:
@@ -610,50 +518,6 @@ jobs:
 
 
 
-  test-debian-stretch-x86_64:
-    needs: [build-debian-stretch-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-debian-stretch-aarch64:
-    needs: [build-debian-stretch-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
   test-debian-buster-x86_64:
     needs: [build-debian-buster-x86_64]
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -735,50 +599,6 @@ jobs:
       env:
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-ubuntu-xenial-x86_64:
-    needs: [build-ubuntu-xenial-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-ubuntu-xenial-aarch64:
-    needs: [build-ubuntu-xenial-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
         PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
@@ -1123,14 +943,10 @@ jobs:
 
   collect:
     needs:
-    - test-debian-stretch-x86_64
-    - test-debian-stretch-aarch64
     - test-debian-buster-x86_64
     - test-debian-buster-aarch64
     - test-debian-bullseye-x86_64
     - test-debian-bullseye-aarch64
-    - test-ubuntu-xenial-x86_64
-    - test-ubuntu-xenial-aarch64
     - test-ubuntu-bionic-x86_64
     - test-ubuntu-bionic-aarch64
     - test-ubuntu-focal-x86_64
@@ -1150,104 +966,6 @@ jobs:
     steps:
       - run: echo 'All build+tests passed, ready to publish now!'
 
-
-
-  publish-debian-stretch-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-stretch-x86_64:
-    needs: [publish-debian-stretch-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-stretch
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-debian-stretch-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-stretch-aarch64:
-    needs: [publish-debian-stretch-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-stretch
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
 
   publish-debian-buster-x86_64:
@@ -1437,104 +1155,6 @@ jobs:
         PKG_NAME: "${{ steps.describe.outputs.name }}"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-ubuntu-xenial-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-xenial-x86_64:
-    needs: [publish-ubuntu-xenial-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-xenial
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-ubuntu-xenial-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-xenial-aarch64:
-    needs: [publish-ubuntu-xenial-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-xenial
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
         PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
@@ -2307,7 +1927,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v5
+      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,54 +21,6 @@ jobs:
 
 
 
-  build-debian-stretch-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-
-  build-debian-stretch-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-
   build-debian-buster-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
@@ -163,54 +115,6 @@ jobs:
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
-
-
-  build-ubuntu-xenial-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-
-  build-ubuntu-xenial-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-
-
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
 
 
   build-ubuntu-bionic-x86_64:
@@ -633,52 +537,6 @@ jobs:
 
 
 
-  test-debian-stretch-x86_64:
-    needs: [build-debian-stretch-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-debian-stretch-aarch64:
-    needs: [build-debian-stretch-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
   test-debian-buster-x86_64:
     needs: [build-debian-buster-x86_64]
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -764,52 +622,6 @@ jobs:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-ubuntu-xenial-x86_64:
-    needs: [build-ubuntu-xenial-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-
-
-  test-ubuntu-xenial-aarch64:
-    needs: [build-ubuntu-xenial-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
         PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
@@ -1169,14 +981,10 @@ jobs:
 
   collect:
     needs:
-    - test-debian-stretch-x86_64
-    - test-debian-stretch-aarch64
     - test-debian-buster-x86_64
     - test-debian-buster-aarch64
     - test-debian-bullseye-x86_64
     - test-debian-bullseye-aarch64
-    - test-ubuntu-xenial-x86_64
-    - test-ubuntu-xenial-aarch64
     - test-ubuntu-bionic-x86_64
     - test-ubuntu-bionic-aarch64
     - test-ubuntu-focal-x86_64
@@ -1196,108 +1004,6 @@ jobs:
     steps:
       - run: echo 'All build+tests passed, ready to publish now!'
 
-
-
-  publish-debian-stretch-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-stretch-x86_64:
-    needs: [publish-debian-stretch-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-x86_64
-        path: artifacts/debian-stretch
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-stretch
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-debian-stretch-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-stretch-aarch64:
-    needs: [publish-debian-stretch-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-debian-stretch-aarch64
-        path: artifacts/debian-stretch
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-stretch
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
 
   publish-debian-buster-x86_64:
@@ -1495,108 +1201,6 @@ jobs:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-ubuntu-xenial-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-xenial-x86_64:
-    needs: [publish-ubuntu-xenial-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-x86_64
-        path: artifacts/ubuntu-xenial
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-xenial
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-
-  publish-ubuntu-xenial-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-xenial-aarch64:
-    needs: [publish-ubuntu-xenial-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-ubuntu-xenial-aarch64
-        path: artifacts/ubuntu-xenial
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-xenial
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
         PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
@@ -2397,7 +2001,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v5
+      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
These reached EOL upstream and are no longer supported.