### PR TITLE
Fix references to single links on `__old__` in triggers

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1126,6 +1126,14 @@ def process_set_as_path(
             # If this is a link that is stored inline, make sure
             # the source aspect is actually accessible (not just value).
             src_rvar = ensure_source_rvar(ir_source, stmt, ctx=ctx)
+            # In case the source is visible (so the codepath below
+            # that uses the current statement doesn't trigger) but the
+            # source aspect wasn't available, make sure we include it
+            # in our return. This can come up with __old__ in triggers.
+            if source_is_visible:
+                rvars.append(SetRVar(
+                    src_rvar, path_id=ir_source.path_id, aspects=['source']
+                ))
         else:
             aspects = ['value', 'source']
             src_rvar = get_set_rvar(ir_source, ctx=ctx)


### PR DESCRIPTION
The issue was a subtle condition in path compilation where if a path
was visible, but didn't have a source aspect (like `__old__`), *and*
wasn't in the path_scope (which `__old__` isn't, but also it gets
cleared in DML anyway), then the source rvar we create with
ensure_source_rvar would get lost.

Fixes #5384.