### PR TITLE
Don't claim that making a pointer computed is data-safe

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2192,6 +2192,14 @@ class AlterPointer(
             computed=pointer.field_is_computed(schema, 'target'),
         )
 
+    def is_data_safe(self) -> bool:
+        # HACK: expr ought to be managed by AlterSpecialObjectField
+        # the way that target/required/cardinality are.
+        return super().is_data_safe() and not (
+            self.get_attribute_value('expr') is not None
+            and self.get_orig_attribute_value('expr') is None
+        )
+
 
 class DeletePointer(
     referencing.DeleteReferencedInheritingObject[Pointer_T],

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -9802,6 +9802,38 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             ]
         )
 
+        # And changing a property to computed is NOT!
+        await self.start_migration('''
+            type Obj11 {
+                single property name := "test";
+            }
+        ''')
+
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'proposed': {
+                'data_safe': False,
+            },
+        })
+
+        await self.fast_forward_describe_migration()
+
+        # But just changing a computed is
+        await self.start_migration('''
+            type Obj11 {
+                single property name := "fffff";
+            }
+        ''')
+
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'proposed': {
+                'data_safe': True,
+            },
+        })
+
+        await self.fast_forward_describe_migration()
+
     async def test_edgeql_migration_prompt_id_01(self):
         await self.start_migration('''
             type Bar { link spam -> Spam };


### PR DESCRIPTION
The right way to do this is to use the AlterSpecialObjectField
machinery, but that's a more involved change and I'm all about quick
fixes this week.

Fixes #5408.