### PR TITLE
Parameterize schema for pg extension (uuid-ossp)

### DIFF
--- a/.github/heroku-postgres/main.tf
+++ b/.github/heroku-postgres/main.tf
@@ -1,29 +1,21 @@
 terraform {
   required_providers {
     heroku = {
-      source = "heroku/heroku"
+      source  = "heroku/heroku"
       version = "~> 4.0"
     }
   }
 }
 
-//resource "heroku_app" "default" {
-//  name = "edgedb-heroku-ci"
-//  region = "us"
-//
-//  organization {
-//    name = "edgedb"
-//  }
-//}
-
 resource "heroku_addon" "database" {
-//  app = heroku_app.default.name
-  app = "edgedb-heroku-ci"
-  plan = "heroku-postgresql:hobby-basic"
-  config = {}
+  app  = "edgedb-heroku-ci"
+  plan = "heroku-postgresql:mini"
+  config = {
+    version = "14"
+  }
 }
 
 output "heroku_postgres_dsn" {
-  value = heroku_addon.database.config_var_values.DATABASE_URL
+  value     = heroku_addon.database.config_var_values.DATABASE_URL
   sensitive = true
 }

--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -410,7 +410,7 @@
         submodules: false
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
     - name: Initialize Terraform
       run: terraform init

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_03_30_00_01
+EDGEDB_CATALOG_VERSION = 2023_05_03_00_01
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/lib/std/30-uuidfuncs.edgeql
+++ b/edb/lib/std/30-uuidfuncs.edgeql
@@ -24,7 +24,7 @@ CREATE FUNCTION
 std::uuid_generate_v1mc() -> std::uuid {
     CREATE ANNOTATION std::description := 'Return a version 1 UUID.';
     SET volatility := 'Volatile';
-    USING SQL FUNCTION 'edgedbext.uuid_generate_v1mc';
+    USING SQL FUNCTION 'edgedb.uuid_generate_v1mc';
 };
 
 
@@ -32,7 +32,7 @@ CREATE FUNCTION
 std::uuid_generate_v4() -> std::uuid {
     CREATE ANNOTATION std::description := 'Return a version 4 UUID.';
     SET volatility := 'Volatile';
-    USING SQL FUNCTION 'edgedbext.uuid_generate_v4';
+    USING SQL FUNCTION 'edgedb.uuid_generate_v4';
 };
 
 

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -412,10 +412,7 @@ def _rewrite_config_insert(
 
     overwrite_query = pgast.SelectStmt()
     id_expr = pgast.FuncCall(
-        name=(
-            ctx.env.backend_runtime_params.instance_params.ext_schema,
-            'uuid_generate_v1mc',
-        ),
+        name=('edgedb', 'uuid_generate_v1mc'),
         args=[],
     )
     pathctx.put_path_identity_var(

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -412,7 +412,10 @@ def _rewrite_config_insert(
 
     overwrite_query = pgast.SelectStmt()
     id_expr = pgast.FuncCall(
-        name=('edgedbext', 'uuid_generate_v1mc',),
+        name=(
+            ctx.env.backend_runtime_params.instance_params.ext_schema,
+            'uuid_generate_v1mc',
+        ),
         args=[],
     )
     pathctx.put_path_identity_var(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -445,7 +445,11 @@ def new_free_object_rvar(
         qry = subctx.rel
 
         id_expr = pgast.FuncCall(
-            name=('edgedbext', 'uuid_generate_v4',), args=[]
+            name=(
+                ctx.env.backend_runtime_params.instance_params.ext_schema,
+                'uuid_generate_v4',
+            ),
+            args=[],
         )
 
         pathctx.put_path_identity_var(qry, path_id, id_expr)
@@ -753,7 +757,10 @@ def ensure_transient_identity_for_path(
 ) -> None:
 
     id_expr = pgast.FuncCall(
-        name=('edgedbext', 'uuid_generate_v4',),
+        name=(
+            ctx.env.backend_runtime_params.instance_params.ext_schema,
+            'uuid_generate_v4',
+        ),
         args=[],
     )
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -445,10 +445,7 @@ def new_free_object_rvar(
         qry = subctx.rel
 
         id_expr = pgast.FuncCall(
-            name=(
-                ctx.env.backend_runtime_params.instance_params.ext_schema,
-                'uuid_generate_v4',
-            ),
+            name=('edgedb', 'uuid_generate_v4'),
             args=[],
         )
 
@@ -757,10 +754,7 @@ def ensure_transient_identity_for_path(
 ) -> None:
 
     id_expr = pgast.FuncCall(
-        name=(
-            ctx.env.backend_runtime_params.instance_params.ext_schema,
-            'uuid_generate_v4',
-        ),
+        name=('edgedb', 'uuid_generate_v4'),
         args=[],
     )
 

--- a/edb/pgsql/dbops/schemas.py
+++ b/edb/pgsql/dbops/schemas.py
@@ -44,13 +44,17 @@ class SchemaExists(base.Condition):
 
 
 class CreateSchema(ddl.DDLOperation):
-    def __init__(self, name, *, conditions=None, neg_conditions=None):
+    def __init__(
+        self, name, *, conditions=None, neg_conditions=None, conditional=False
+    ):
         super().__init__(conditions=conditions, neg_conditions=neg_conditions)
         self.name = name
         self.opid = name
+        self.conditional = conditional
 
     def code(self, block: base.PLBlock) -> str:
-        return f'CREATE SCHEMA {qi(self.name)}'
+        condition = "IF NOT EXISTS " if self.conditional else ''
+        return f'CREATE SCHEMA {condition}{qi(self.name)}'
 
     def __repr__(self):
         return '<edb.sync.%s %s>' % (self.__class__.__name__, self.name)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -6620,7 +6620,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 name=proc_name, text=proc_text, volatility='volatile',
                 returns='trigger', language='plpgsql')
 
-            self.pgops.add(dbops.CreateOrReplaceFunction(trig_func))
+            self.pgops.add(dbops.CreateFunction(trig_func, or_replace=True))
 
             self.pgops.add(dbops.CreateTrigger(
                 trigger, neg_conditions=[dbops.TriggerExists(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1340,7 +1340,9 @@ class FunctionCommand(MetaCommand):
                 explicit_top_cast=irtyputils.type_to_typeref(  # note: no cache
                     schema, func.get_return_type(schema)),
                 output_format=compiler.OutputFormat.NATIVE,
-                use_named_params=True)
+                use_named_params=True,
+                backend_runtime_params=context.backend_runtime_params,
+            )
 
         return self.make_function(func, body, schema), replace
 

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -467,7 +467,7 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
             language='plpgsql',
         )
 
-        return [dbops.CreateOrReplaceFunction(func)]
+        return [dbops.CreateFunction(func, or_replace=True)]
 
     def drop_constr_trigger_function(self, proc_name: Tuple[str, ...]):
         return [dbops.DropFunction(name=proc_name, args=())]

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4409,6 +4409,66 @@ class FormatTypeFunction(dbops.Function):
         )
 
 
+class UuidGenerateV1mcFunction(dbops.Function):
+    text = f'''
+    DECLARE
+        ext_schema text;
+        value uuid;
+    BEGIN
+        SELECT
+            json ->> 'ext_schema'
+        FROM
+            edgedbinstdata.instdata
+        WHERE
+            key = 'backend_instance_params'
+        INTO
+            ext_schema;
+        EXECUTE 'SELECT ' || ext_schema || '.uuid_generate_v1mc()' INTO value;
+        RETURN value;
+    END;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'uuid_generate_v1mc'),
+            args=[],
+            returns=('uuid',),
+            volatility='stable',
+            language='plpgsql',
+            text=self.text,
+        )
+
+
+class UuidGenerateV4(dbops.Function):
+    text = f'''
+    DECLARE
+        ext_schema text;
+        value uuid;
+    BEGIN
+        SELECT
+            json ->> 'ext_schema'
+        FROM
+            edgedbinstdata.instdata
+        WHERE
+            key = 'backend_instance_params'
+        INTO
+            ext_schema;
+        EXECUTE 'SELECT ' || ext_schema || '.uuid_generate_v4()' INTO value;
+        RETURN value;
+    END;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'uuid_generate_v4'),
+            args=[],
+            returns=('uuid',),
+            volatility='stable',
+            language='plpgsql',
+            text=self.text,
+        )
+
+
 async def bootstrap(
     conn: pgcon.PGConnection,
     config_spec: edbconfig.Spec
@@ -4423,6 +4483,8 @@ async def bootstrap(
         dbops.CreateTable(DBConfigTable()),
         dbops.CreateTable(DMLDummyTable()),
         dbops.Query(DMLDummyTable.SETUP_QUERY),
+        dbops.CreateFunction(UuidGenerateV1mcFunction()),
+        dbops.CreateFunction(UuidGenerateV4()),
         dbops.CreateFunction(IntervalToMillisecondsFunction()),
         dbops.CreateFunction(SafeIntervalCastFunction()),
         dbops.CreateFunction(QuoteIdentFunction()),

--- a/edb/pgsql/params.py
+++ b/edb/pgsql/params.py
@@ -59,6 +59,7 @@ class BackendInstanceParams(NamedTuple):
     base_superuser: Optional[str] = None
     max_connections: int = 500
     reserved_connections: int = 0
+    ext_schema: str = "edgedbext"
 
 
 class BackendRuntimeParams(NamedTuple):

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -829,11 +829,13 @@ async def _make_stdlib(
         schema_class_layout=reflection.class_layout,  # type: ignore
     )
 
+    backend_runtime_params = ctx.cluster.get_runtime_params()
     compilerctx = edbcompiler.new_compiler_context(
         compiler_state=compiler.state,
         user_schema=reflschema.get_top_schema(),
         global_schema=schema.get_global_schema(),
         bootstrap_mode=True,
+        backend_runtime_params=backend_runtime_params,
     )
 
     for std_plan in std_plans:
@@ -849,6 +851,7 @@ async def _make_stdlib(
         global_schema=schema.get_global_schema(),
         bootstrap_mode=True,
         internal_schema_mode=True,
+        backend_runtime_params=backend_runtime_params,
     )
     edbcompiler.compile_schema_storage_in_delta(
         ctx=compilerctx,
@@ -1009,7 +1012,7 @@ async def _init_stdlib(
         stdlib = await _make_stdlib(ctx, in_dev_mode or testmode, global_ids)
 
     logger.info('Creating the necessary PostgreSQL extensions...')
-    await metaschema.create_pg_extensions(conn)
+    await metaschema.create_pg_extensions(conn, cluster.get_runtime_params())
 
     config_spec = config.load_spec_from_schema(stdlib.stdschema)
     config.set_settings(config_spec)

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -259,6 +259,8 @@ def new_compiler_context(
     bootstrap_mode: bool = False,
     internal_schema_mode: bool = False,
     protocol_version: Tuple[int, int] = defines.CURRENT_PROTOCOL,
+    backend_runtime_params: pg_params.BackendRuntimeParams = (
+        pg_params.get_default_runtime_params()),
 ) -> CompileContext:
     """Create and return an ad-hoc compiler context."""
 
@@ -282,6 +284,7 @@ def new_compiler_context(
         bootstrap_mode=bootstrap_mode,
         internal_schema_mode=internal_schema_mode,
         protocol_version=protocol_version,
+        backend_runtime_params=backend_runtime_params,
     )
 
     return ctx
@@ -1231,6 +1234,7 @@ def _compile_schema_storage_stmt(
             expected_cardinality_one=False,
             bootstrap_mode=ctx.bootstrap_mode,
             protocol_version=ctx.protocol_version,
+            backend_runtime_params=ctx.backend_runtime_params,
         )
 
         source = edgeql.Source.from_string(eql)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -857,16 +857,17 @@ class Server(ha_base.ClusterProtocol):
             return
 
         try:
-            extensions = await self._introspect_extensions(conn)
             assert self._dbindex is not None
-            self._dbindex.register_db(
-                dbname,
-                user_schema=None,
-                db_config=None,
-                reflection_cache=None,
-                backend_ids=None,
-                extensions=extensions,
-            )
+            if not self._dbindex.has_db(dbname):
+                extensions = await self._introspect_extensions(conn)
+                self._dbindex.register_db(
+                    dbname,
+                    user_schema=None,
+                    db_config=None,
+                    reflection_cache=None,
+                    backend_ids=None,
+                    extensions=extensions,
+                )
         finally:
             self.release_pgcon(dbname, conn)
 


### PR DESCRIPTION
This supports the latest Heroku where extensions must be created under the schema "heroku_ext" instead of our preferred "edgedbext".