### PR TITLE
Add more 3.0 dump tests and fix reflected name of triggers

### DIFF
--- a/docs/datamodel/introspection/triggers.rst
+++ b/docs/datamodel/introspection/triggers.rst
@@ -68,10 +68,10 @@ Introspection of a trigger named ``log_insert`` on the ``User`` type:
     ...   subject: {
     ...     name
     ...   }
-    ... } filter .name = '__::log_insert';
+    ... } filter .name = 'log_insert';
     {
       schema::Trigger {
-        name: '__::log_insert',
+        name: 'log_insert',
         kinds: {Insert},
         timing: After,
         scope: Each,
@@ -90,4 +90,3 @@ Introspection of a trigger named ``log_insert`` on the ``User`` type:
   * - :ref:`Schema > Triggers <ref_datamodel_triggers>`
   * - :ref:`SDL > Triggers <ref_eql_sdl_triggers>`
   * - :ref:`DDL > Triggers <ref_eql_ddl_triggers>`
-

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_05_04_00_01
+EDGEDB_CATALOG_VERSION = 2023_05_04_00_02
 EDGEDB_MAJOR_VERSION = 3
 
 

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -38,7 +38,7 @@ from . import types as s_types
 
 
 class Rewrite(
-    referencing.ReferencedInheritingObject,
+    referencing.NamedReferencedInheritingObject,
     so.InheritingObject,  # Help reflection figure out the right db MRO
     s_anno.AnnotationSubject,
     qlkind=qltypes.SchemaObjectClass.REWRITE,
@@ -89,7 +89,7 @@ class RewriteSubjectCommand(
 
 
 class RewriteCommand(
-    referencing.ReferencedInheritingObjectCommand[Rewrite],
+    referencing.NamedReferencedInheritingObjectCommand[Rewrite],
     s_anno.AnnotationSubjectCommand[Rewrite],
     context_class=RewriteCommandContext,
     referrer_context_class=RewriteSubjectCommandContext,

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 
 class Trigger(
-    referencing.ReferencedInheritingObject,
+    referencing.NamedReferencedInheritingObject,
     so.InheritingObject,  # Help reflection figure out the right db MRO
     qlkind=qltypes.SchemaObjectClass.TRIGGER,
     data_safe=True,

--- a/tests/schemas/dump_v3_setup.edgeql
+++ b/tests/schemas/dump_v3_setup.edgeql
@@ -24,3 +24,23 @@ ONTO m1nnh3uhlwn5vfe7dfhyyxxjafsxniljyuzov6avzqeyddw2qpkw7q {
 };
 
 CREATE TYPE default::Test2;
+
+create type Log {
+    create property message -> str;
+    create property timestamp -> float64 {
+        create rewrite insert, update using (random())
+    };
+    create access policy whatever allow all;
+    create access policy whatever_no deny insert using (false) {
+        set errmessage := "aaaaaa";
+    };
+};
+
+create type Foo {
+    create property name -> str;
+    create trigger log after insert for each do (
+        insert Log {
+            message := __new__.name
+        }
+    );
+};

--- a/tests/test_dump_v3.py
+++ b/tests/test_dump_v3.py
@@ -59,12 +59,48 @@ class DumpTestCaseMixin:
             r'''
             select schema::Migration { script, message, generated_by }
             order by exists .parents then exists .parents.parents
+            limit 3
             ''',
             [
                 {"message": None, "generated_by": None},
                 {"message": "test", "generated_by": None},
                 {"message": None, "generated_by": "DDLStatement"},
             ],
+        )
+
+        await self.assert_query_result(
+            r'''
+            select schema::Trigger {
+                name, scope, kinds, sname := .subject.name
+            };
+            ''',
+            [
+                {
+                    "name": "log",
+                    "scope": "Each",
+                    "kinds": ["Insert"],
+                    "sname": "default::Foo"
+                }
+            ]
+        )
+        await self.assert_query_result(
+            r'''
+            select schema::Rewrite {
+                sname := .subject.source.name ++ "." ++ .subject.name,
+                name,
+            };
+            ''',
+            tb.bag([
+                {"sname": "default::Log.timestamp", "name": "Insert"},
+                {"sname": "default::Log.timestamp", "name": "Update"},
+            ]),
+        )
+        await self.assert_query_result(
+            r'''
+            select schema::AccessPolicy { name, errmessage }
+            filter .name = 'whatever_no';
+            ''',
+            [{"name": "whatever_no", "errmessage": "aaaaaa"}],
         )
 
 


### PR DESCRIPTION
The *first* instance of triggers in the schema got it right, and then
d4a5a1676e5c927c5df51110b582c72e8734169f factored out duplicated name
handling but forgot to use the factored out macinery in triggers!