### PR TITLE
Allow `ADMINISTER repair_schema()` outside of test mode

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1424,18 +1424,19 @@ def _compile_ql_administer(
     *,
     script_info: Optional[irast.ScriptInfo] = None,
 ) -> dbstate.BaseQuery:
-    if not _is_dev_instance(ctx):
-        raise errors.QueryError(
-            'ADMINISTER can only be executed in test mode',
-            context=ql.context)
-
     if ql.expr.func == 'statistics_update':
+        if not _is_dev_instance(ctx):
+            raise errors.QueryError(
+                'statistics_update() can only be executed in test mode',
+                context=ql.context)
+
         if ql.expr.args or ql.expr.kwargs:
             raise errors.QueryError(
                 'statistics_update() does not take arguments',
                 context=ql.expr.context,
             )
-        sql = (b'ANALYZE',)
+
+        return dbstate.MaintenanceQuery(sql=(b'ANALYZE',))
     elif ql.expr.func == 'repair_schema':
         return ddl.administer_repair_schema(ctx, ql)
     else:
@@ -1443,10 +1444,6 @@ def _compile_ql_administer(
             'Unknown ADMINISTER function',
             context=ql.expr.context,
         )
-
-    return dbstate.MaintenanceQuery(
-        sql=sql,
-    )
 
 
 def _compile_ql_query(

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1241,6 +1241,12 @@ def administer_repair_schema(
     ctx: compiler.CompileContext,
     ql: qlast.AdministerStmt,
 ) -> dbstate.BaseQuery:
+    if ql.expr.args or ql.expr.kwargs:
+        raise errors.QueryError(
+            'repair_schema() does not take arguments',
+            context=ql.expr.context,
+        )
+
     current_tx = ctx.state.current_tx()
 
     res = repair_schema(ctx)


### PR DESCRIPTION
Originally "all" ADMINISTER commands (really just ANALYZE) were hidden
behind test mode, but we need to make case-by-case decisions.

I feel pretty strongly that we need to allow `repair_schema()`, though
I would refrain from *documenting* it yet.
One main use case is if we ship a point relase that uses a "repair"
patch, a user takes it and upgrades, and then runs into trouble and
needs to downgrade. Now their schema might be out of sync, and doing
a repair to undo the first repair would solve the problem.

And, importantly, we can't just wait until we've seen users encounter
this problem before doing something, because at that point it would be
too late: they would need the feature present in an *older* version.

But we can skip documenting it until it seems like it is coming up.