### PR TITLE
Try to make the NOCREATEDB test suite pass

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Test
       env:
         EDGEDB_TEST_POSTGRES_VERSION: ${{ matrix.postgres-version }}
-      continue-on-error: ${{ matrix.single-mode == 'NOCREATEDB NOCREATEROLE' || matrix.postgres-version == 15 }}
+      continue-on-error: ${{ matrix.postgres-version == 15 }}
       run: |
         if [[ "${{ matrix.single-mode }}" ]]; then
           export EDGEDB_TEST_BACKEND_DSN=postgres://singles:test@localhost/singles

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -326,7 +326,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -499,7 +499,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -543,7 +543,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -746,7 +746,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -784,7 +784,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -955,7 +955,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -999,7 +999,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -1173,7 +1173,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -1218,7 +1218,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init
@@ -1399,7 +1399,7 @@ jobs:
           submodules: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
 
       - name: Initialize Terraform
         run: terraform init

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -498,7 +498,7 @@ jobs:
     - name: Test
       env:
         EDGEDB_TEST_POSTGRES_VERSION: ${{ matrix.postgres-version }}
-      continue-on-error: ${{ matrix.single-mode == 'NOCREATEDB NOCREATEROLE' || matrix.postgres-version == 15 }}
+      continue-on-error: ${{ matrix.postgres-version == 15 }}
       run: |
         if [[ "${{ matrix.single-mode }}" ]]; then
           export EDGEDB_TEST_BACKEND_DSN=postgres://singles:test@localhost/singles

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -801,21 +801,21 @@ class Pointer(referencing.NamedReferencedInheritingObject,
     def get_implicit_bases(self, schema: s_schema.Schema) -> List[Pointer]:
         bases = super().get_implicit_bases(schema)
 
-        # True implicit bases for pointers will have a different source.
-        my_source = self.get_source(schema)
+        # True implicit bases for pointers will have the same name
+        my_name = self.get_shortname(schema)
         return [
             b for b in bases
-            if b.get_source(schema) != my_source
+            if b.get_shortname(schema) == my_name
         ]
 
     def get_implicit_ancestors(self, schema: s_schema.Schema) -> List[Pointer]:
         ancestors = super().get_implicit_ancestors(schema)
 
-        # True implicit ancestors for pointers will have a different source.
-        my_source = self.get_source(schema)
+        # True implicit ancestors for pointers will have the same name
+        my_name = self.get_shortname(schema)
         return [
             b for b in ancestors
-            if b.get_source(schema) != my_source
+            if b.get_shortname(schema) == my_name
         ]
 
     def has_user_defined_properties(self, schema: s_schema.Schema) -> bool:

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -1349,7 +1349,7 @@ class RenameReferencedInheritingObject(
             # Distinguish between actual local name change and fully-qualified
             # name change due to structural parent rename.
             if orig_ref_lname != new_ref_lname:
-                implicit_bases = scls.get_implicit_bases(schema)
+                implicit_bases = scls.get_implicit_bases(orig_schema)
                 non_renamed_bases = {
                     x for x in implicit_bases if x not in context.renamed_objs}
                 # This object is inherited from one or more ancestors that

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -83,7 +83,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "actual_rows": 1,
                     "plan_rows": 1,
                     "plan_type": "IndexScan",
-                    "plan_width": 32,
                     "properties": tb.bag([
                         {
                             "important": False,
@@ -121,7 +120,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "type": "expr",
                         },
                     ]),
-                    "startup_cost": 0.28,
+                    "startup_cost": float,
                 }
             ],
             "subplans": [],
@@ -157,7 +156,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "actual_rows": 1,
                     "plan_rows": 1,
                     "plan_type": "SubqueryScan",
-                    "plan_width": 32,
                     "properties": tb.bag([
                         {
                             "important": False,
@@ -165,8 +163,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "type": "expr",
                         },
                     ]),
-                    "startup_cost": 278.1,
-                    "total_cost": 278.12,
+                    "startup_cost": float,
+                    "total_cost": float,
                 }
             ],
             "subplans": [
@@ -184,7 +182,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "actual_rows": 1,
                             "plan_rows": 1,
                             "plan_type": "Aggregate",
-                            "plan_width": 32,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -211,15 +208,14 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "value": "Simple",
                                 },
                             ]),
-                            "startup_cost": 8.3,
-                            "total_cost": 8.31,
+                            "startup_cost": float,
+                            "total_cost": float,
                         },
                         {
                             "actual_loops": 1,
                             "actual_rows": 1,
                             "plan_rows": 1,
                             "plan_type": "IndexScan",
-                            "plan_width": 16,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -269,8 +265,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "type": "expr",
                                 },
                             ]),
-                            "startup_cost": 0.28,
-                            "total_cost": 8.3,
+                            "startup_cost": float,
+                            "total_cost": float,
                         },
                     ],
                     "subplans": [],
@@ -289,7 +285,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "actual_rows": 1,
                             "plan_rows": 1,
                             "plan_type": "Aggregate",
-                            "plan_width": 32,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -316,15 +311,14 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "value": "Simple",
                                 },
                             ]),
-                            "startup_cost": 269.78,
-                            "total_cost": 269.79,
+                            "startup_cost": float,
+                            "total_cost": float,
                         },
                         {
                             "actual_loops": 1,
                             "actual_rows": 1,
                             "plan_rows": 5,
                             "plan_type": "SeqScan",
-                            "plan_width": 16,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -354,8 +348,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "type": "relation",
                                 },
                             ]),
-                            "startup_cost": 0.0,
-                            "total_cost": 269.76,
+                            "startup_cost": float,
+                            "total_cost": float,
                         },
                     ],
                     "subplans": [],
@@ -383,7 +377,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "actual_rows": 1,
                     "plan_rows": 1,
                     "plan_type": "IndexScan",
-                    "plan_width": 32,
                     "properties": tb.bag([
                         {
                             "important": False,
@@ -437,7 +430,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "actual_rows": 1,
                             "plan_rows": 1,
                             "plan_type": "Aggregate",
-                            "plan_width": 32,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -470,7 +462,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "actual_rows": 2,
                             "plan_rows": 2,
                             "plan_type": "NestedLoop",
-                            "plan_width": 32,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -495,7 +486,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "actual_rows": 2,
                                     "plan_rows": 2,
                                     "plan_type": "IndexOnlyScan",
-                                    "plan_width": 16,
                                     # This has property `heap_fetches`
                                     # that vary on github an locally.
                                     # So skip checking "properties"
@@ -510,7 +500,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "actual_rows": 1,
                                     "plan_rows": 1,
                                     "plan_type": "IndexScan",
-                                    "plan_width": 32,
                                     "properties": tb.bag([
                                         {
                                             "important": False,
@@ -592,7 +581,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "actual_rows": 1,
                     "plan_rows": 1,
                     "plan_type": "IndexScan",
-                    "plan_width": 32,
                     "properties": tb.bag([
                         {
                             "important": False,
@@ -630,8 +618,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "type": "expr",
                         },
                     ]),
-                    "startup_cost": 0.28,
-                    "total_cost": 16.69,
+                    "startup_cost": float,
+                    "total_cost": float,
                 }
             ],
             "subplans": [
@@ -656,7 +644,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "actual_rows": 1,
                             "plan_rows": 1,
                             "plan_type": "Aggregate",
-                            "plan_width": 32,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -683,15 +670,14 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "value": "Simple",
                                 },
                             ]),
-                            "startup_cost": 8.38,
-                            "total_cost": 8.39,
+                            "startup_cost": float,
+                            "total_cost": float,
                         },
                         {
                             "actual_loops": 1,
                             "actual_rows": 2,
                             "plan_rows": 5,
                             "plan_type": "Result",
-                            "plan_width": 32,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -706,15 +692,14 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "value": '("User~2".id = "User~2".id)',
                                 },
                             ]),
-                            "startup_cost": 0.28,
-                            "total_cost": 8.37,
+                            "startup_cost": float,
+                            "total_cost": float,
                         },
                         {
                             "actual_loops": 1,
                             "actual_rows": 2,
                             "plan_rows": 5,
                             "plan_type": "IndexScan",
-                            "plan_width": 32,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -757,8 +742,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "type": "expr",
                                 },
                             ]),
-                            "startup_cost": 0.28,
-                            "total_cost": 8.37,
+                            "startup_cost": float,
+                            "total_cost": float,
                         },
                     ],
                     "subplans": [],
@@ -785,16 +770,14 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "actual_loops": 1,
                     "plan_rows": 5001,
                     "plan_type": "Result",
-                    "plan_width": 32,
                     "properties": [],
-                    "startup_cost": 0.0,
+                    "startup_cost": float,
                 },
                 {
                     "actual_loops": 1,
                     "actual_rows": 5001,
                     "plan_rows": 5001,
                     "plan_type": "Append",
-                    "plan_width": 16,
                     "properties": tb.bag([
                         {
                             "important": False,
@@ -803,7 +786,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "value": "Outer",
                         }
                     ]),
-                    "startup_cost": 0.0,
+                    "startup_cost": float,
                 },
             ],
             # Order here can be arbitrary, unfortunately.
@@ -816,7 +799,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                         {
                             "actual_loops": 1,
                             "plan_type": "SeqScan",
-                            "plan_width": 16,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -841,7 +823,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "type": "relation",
                                 },
                             ]),
-                            "startup_cost": 0.0,
+                            "startup_cost": float,
                         }
                     ],
                     "subplans": [],
@@ -851,7 +833,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                         {
                             "actual_loops": 1,
                             "plan_type": "SeqScan",
-                            "plan_width": 16,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -876,7 +857,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "type": "relation",
                                 },
                             ]),
-                            "startup_cost": 0.0,
+                            "startup_cost": float,
                         }
                     ],
                     "subplans": [],
@@ -886,7 +867,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                         {
                             "actual_loops": 1,
                             "plan_type": "SeqScan",
-                            "plan_width": 16,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -911,7 +891,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "type": "relation",
                                 },
                             ]),
-                            "startup_cost": 0.0,
+                            "startup_cost": float,
                         }
                     ],
                     "subplans": [],
@@ -936,10 +916,9 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "actual_rows": 5001,
                     "plan_rows": 5001,
                     "plan_type": "Result",
-                    "plan_width": 32,
                     "properties": [],
-                    "startup_cost": 0.0,
-                    "total_cost": 41707.33,
+                    "startup_cost": float,
+                    "total_cost": float,
                 }
             ],
             "subplans": [
@@ -956,7 +935,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "actual_rows": 5001,
                             "plan_rows": 5001,
                             "plan_type": "Append",
-                            "plan_width": 20,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -965,8 +943,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "value": "Outer",
                                 }
                             ]),
-                            "startup_cost": 0.0,
-                            "total_cost": 149.02,
+                            "startup_cost": float,
+                            "total_cost": float,
                         }
                     ],
                     "subplans": tb.bag([
@@ -977,7 +955,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "actual_rows": 4999,
                                     "plan_rows": 4999,
                                     "plan_type": "SeqScan",
-                                    "plan_width": 20,
                                     "properties": tb.bag([
                                         {
                                             "important": False,
@@ -1003,8 +980,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                             "type": "relation",
                                         },
                                     ]),
-                                    "startup_cost": 0.0,
-                                    "total_cost": 121.99,
+                                    "startup_cost": float,
+                                    "total_cost": float,
                                 }
                             ],
                             "subplans": [],
@@ -1016,7 +993,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "actual_rows": 1,
                                     "plan_rows": 1,
                                     "plan_type": "SeqScan",
-                                    "plan_width": 38,
                                     "properties": tb.bag([
                                         {
                                             "important": False,
@@ -1042,8 +1018,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                             "type": "relation",
                                         },
                                     ]),
-                                    "startup_cost": 0.0,
-                                    "total_cost": 1.01,
+                                    "startup_cost": float,
+                                    "total_cost": float,
                                 }
                             ],
                             "subplans": [],
@@ -1055,7 +1031,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "actual_rows": 1,
                                     "plan_rows": 1,
                                     "plan_type": "SeqScan",
-                                    "plan_width": 45,
                                     "properties": tb.bag([
                                         {
                                             "important": False,
@@ -1081,8 +1056,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                             "type": "relation",
                                         },
                                     ]),
-                                    "startup_cost": 0.0,
-                                    "total_cost": 1.01,
+                                    "startup_cost": float,
+                                    "total_cost": float,
                                 }
                             ],
                             "subplans": [],
@@ -1104,7 +1079,6 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                             "actual_rows": 1,
                             "plan_rows": 1,
                             "plan_type": "IndexScan",
-                            "plan_width": 11,
                             "properties": tb.bag([
                                 {
                                     "important": False,
@@ -1156,8 +1130,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                     "type": "expr",
                                 },
                             ]),
-                            "startup_cost": 0.28,
-                            "total_cost": 8.3,
+                            "startup_cost": float,
+                            "total_cost": float,
                         }
                     ],
                     "subplans": [],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7850,6 +7850,22 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             module foo { module bar { module baz {} } }
         """])
 
+    def test_schema_migrations_property_aliases(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type NamedObject {
+                    required property name: std::str;
+                };
+                type Person extending default::User;
+                type User extending default::NamedObject {
+                    multi link fav_users := (.favorites[is default::User]);
+                    multi link favorites: default::NamedObject;
+                };
+            """,
+            r"""
+            """,
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
Refresh the connection to avoid a state mismatch after restoring from dump.

Fix the explain tests to not depend on a bunch of cost numbers that can't be relied on
(though that just came up on heroku, not in non-heroku NOCREATEDB).

Skip the SQL pg_dump tests.