### PR TITLE
Fix migration that delete an link alias computed in a parent and child

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -801,21 +801,21 @@ class Pointer(referencing.NamedReferencedInheritingObject,
     def get_implicit_bases(self, schema: s_schema.Schema) -> List[Pointer]:
         bases = super().get_implicit_bases(schema)
 
-        # True implicit bases for pointers will have a different source.
-        my_source = self.get_source(schema)
+        # True implicit bases for pointers will have the same name
+        my_name = self.get_shortname(schema)
         return [
             b for b in bases
-            if b.get_source(schema) != my_source
+            if b.get_shortname(schema) == my_name
         ]
 
     def get_implicit_ancestors(self, schema: s_schema.Schema) -> List[Pointer]:
         ancestors = super().get_implicit_ancestors(schema)
 
-        # True implicit ancestors for pointers will have a different source.
-        my_source = self.get_source(schema)
+        # True implicit ancestors for pointers will have the same name
+        my_name = self.get_shortname(schema)
         return [
             b for b in ancestors
-            if b.get_source(schema) != my_source
+            if b.get_shortname(schema) == my_name
         ]
 
     def has_user_defined_properties(self, schema: s_schema.Schema) -> bool:

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -1349,7 +1349,7 @@ class RenameReferencedInheritingObject(
             # Distinguish between actual local name change and fully-qualified
             # name change due to structural parent rename.
             if orig_ref_lname != new_ref_lname:
-                implicit_bases = scls.get_implicit_bases(schema)
+                implicit_bases = scls.get_implicit_bases(orig_schema)
                 non_renamed_bases = {
                     x for x in implicit_bases if x not in context.renamed_objs}
                 # This object is inherited from one or more ancestors that

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7850,6 +7850,22 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             module foo { module bar { module baz {} } }
         """])
 
+    def test_schema_migrations_property_aliases(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type NamedObject {
+                    required property name: std::str;
+                };
+                type Person extending default::User;
+                type User extending default::NamedObject {
+                    multi link fav_users := (.favorites[is default::User]);
+                    multi link favorites: default::NamedObject;
+                };
+            """,
+            r"""
+            """,
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
Pointer.get_implicit_ancestors is supposed to only return "actual"
ancestors of the pointer, not ancestors that occur because of
computeds that directly reference another pointer.  The logic for this
didn't work right when there was another level of inheritance, though.

Fixes #4769.