### PR TITLE
backport: Add support for JWT allowlist and revocation list (#5226)

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -200,6 +200,8 @@ class ServerConfig(NamedTuple):
     jws_key_file: pathlib.Path
     jwe_key_file: pathlib.Path
     jose_key_mode: JOSEKeyMode
+    jwt_sub_allowlist_file: Optional[pathlib.Path]
+    jwt_revocation_list_file: Optional[pathlib.Path]
 
     default_auth_method: ServerAuthMethods
     security: ServerSecurityMode
@@ -815,6 +817,26 @@ _server_options = [
              '--runstate-dir.\n\nThe default is "require_file" when the '
              '--security option is set to "strict", and "generate" when the '
              '--security option is set to "insecure_dev_mode"'),
+    click.option(
+        '--jwt-sub-allowlist-file',
+        type=PathPath(),
+        envvar="EDGEDB_SERVER_JWT_SUB_ALLOWLIST_FILE",
+        hidden=True,
+        help='A file where the server can obtain a list of all JWT subjects '
+             'that are allowed to access this instance. '
+             'The file must contain one JWT "sub" claim value per line. '
+             'Applies only to the JWT authentication method.'
+    ),
+    click.option(
+        '--jwt-revocation-list-file',
+        type=PathPath(),
+        envvar="EDGEDB_SERVER_JWT_REVOCATION_LIST_FILE",
+        hidden=True,
+        help='A file where the server can obtain a list of all JWT ids '
+             'that are allowed to access this instance. '
+             'The file must contain one JWT "jti" claim value per line. '
+             'Applies only to the JWT authentication method.'
+    ),
     click.option(
         "--default-auth-method",
         envvar="EDGEDB_SERVER_DEFAULT_AUTH_METHOD", cls=EnvvarResolver,

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -237,8 +237,10 @@ async def _run_server(
         ss.init_jwcrypto(
             args.jws_key_file,
             args.jwe_key_file,
-            jws_keys_newly_generated,
+            args.jwt_sub_allowlist_file,
+            args.jwt_revocation_list_file,
             jwe_keys_newly_generated,
+            jws_keys_newly_generated,
         )
 
         def load_configuration(_signum):
@@ -247,7 +249,12 @@ async def _run_server(
                 if args.readiness_state_file:
                     ss.reload_readiness_state(args.readiness_state_file)
                 ss.reload_tls(args.tls_cert_file, args.tls_key_file)
-                ss.load_jwcrypto(args.jws_key_file, args.jwe_key_file)
+                ss.load_jwcrypto(
+                    args.jws_key_file,
+                    args.jwe_key_file,
+                    args.jwt_sub_allowlist_file,
+                    args.jwt_revocation_list_file,
+                )
             except Exception:
                 logger.critical(
                     "Unexpected error occurred during reload configuration; "

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -690,6 +690,9 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         self._check_jwt_authz(claims, token_version, user)
 
     def _check_jwt_authz(self, claims, token_version, user):
+        # Check general key validity (e.g. whether it's a revoked key)
+        self.server.check_jwt(claims)
+
         token_instances = None
         token_roles = None
         token_databases = None

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -45,6 +45,7 @@ from edb import errors
 
 from edb.common import devmode
 from edb.common import retryloop
+from edb.common import secretkey
 from edb.common import taskgroup
 from edb.common import windowedsum
 
@@ -258,6 +259,8 @@ class Server(ha_base.ClusterProtocol):
         self._jwe_key: jwk.JWK | None = None
         self._jws_keys_newly_generated = False
         self._jwe_keys_newly_generated = False
+        self._jwt_sub_allowlist: frozenset[str] | None = None
+        self._jwt_revocation_list: frozenset[str] | None = None
 
         self._default_auth_method = default_auth_method
         self._binary_endpoint_security = binary_endpoint_security
@@ -2006,20 +2009,35 @@ class Server(ha_base.ClusterProtocol):
         self,
         jws_key_file: pathlib.Path,
         jwe_key_file: pathlib.Path,
+        jwt_sub_allowlist_file: Optional[pathlib.Path],
+        jwt_revocation_list_file: Optional[pathlib.Path],
     ) -> None:
         try:
-            with open(jws_key_file, 'rb') as kf:
-                self._jws_key = jwk.JWK.from_pem(kf.read())
-        except Exception as e:
-            raise StartupError(f"cannot load JWS key: {e}") from e
+            self._jws_key = secretkey.load_secret_key(jws_key_file)
+        except secretkey.SecretKeyReadError as e:
+            raise StartupError(e.args[0]) from e
 
-        if (
-            not self._jws_key.has_public
-            or self._jws_key['kty'] not in {"RSA", "EC"}
-        ):
-            raise StartupError(
-                f"the provided JWS key file does not "
-                f"contain a valid RSA or EC public key")
+        if jwt_sub_allowlist_file is not None:
+            logger.info("(re-)loading JWT subject allowlist from "
+                        f"\"{jwt_sub_allowlist_file}\"")
+            try:
+                self._jwt_sub_allowlist = frozenset(
+                    jwt_sub_allowlist_file.read_text().splitlines(),
+                )
+            except Exception as e:
+                raise StartupError(
+                    f"cannot load JWT sub allowlist: {e}") from e
+
+        if jwt_revocation_list_file is not None:
+            logger.info("(re-)loading JWT revocation list from "
+                        f"\"{jwt_revocation_list_file}\"")
+            try:
+                self._jwt_revocation_list = frozenset(
+                    jwt_revocation_list_file.read_text().splitlines(),
+                )
+            except Exception as e:
+                raise StartupError(
+                    f"cannot load JWT revocation list: {e}") from e
 
         try:
             with open(jwe_key_file, 'rb') as kf:
@@ -2039,10 +2057,17 @@ class Server(ha_base.ClusterProtocol):
         self,
         jws_key_file: pathlib.Path,
         jwe_key_file: pathlib.Path,
+        jwt_sub_allowlist_file: Optional[pathlib.Path],
+        jwt_revocation_list_file: Optional[pathlib.Path],
         jws_keys_newly_generated: bool,
         jwe_keys_newly_generated: bool,
     ) -> None:
-        self.load_jwcrypto(jws_key_file, jwe_key_file)
+        self.load_jwcrypto(
+            jws_key_file,
+            jwe_key_file,
+            jwt_sub_allowlist_file,
+            jwt_revocation_list_file,
+        )
         self._jws_keys_newly_generated = jws_keys_newly_generated
         self._jwe_keys_newly_generated = jwe_keys_newly_generated
 
@@ -2051,6 +2076,29 @@ class Server(ha_base.ClusterProtocol):
 
     def get_jwe_key(self) -> jwk.JWK | None:
         return self._jwe_key
+
+    def check_jwt(self, claims: dict[str, Any]) -> None:
+        """Check JWT for validity"""
+
+        if self._jwt_sub_allowlist is not None:
+            subject = claims.get("sub")
+            if not subject:
+                raise errors.AuthenticationError(
+                    "authentication failed: "
+                    "JWT does not contain a valid subject claim")
+            if subject not in self._jwt_sub_allowlist:
+                raise errors.AuthenticationError(
+                    "authentication failed: unauthorized subject")
+
+        if self._jwt_revocation_list is not None:
+            key_id = claims.get("jti")
+            if not key_id:
+                raise errors.AuthenticationError(
+                    "authentication failed: "
+                    "JWT does not contain a valid key id")
+            if key_id in self._jwt_revocation_list:
+                raise errors.AuthenticationError(
+                    "authentication failed: revoked key")
 
     async def _stop_servers(self, servers):
         async with taskgroup.TaskGroup() as g:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1573,6 +1573,9 @@ class _EdgeDBServer:
         tls_key_file: Optional[os.PathLike] = None,
         tls_cert_mode: edgedb_args.ServerTlsCertMode = (
             edgedb_args.ServerTlsCertMode.SelfSigned),
+        jws_key_file: Optional[os.PathLike] = None,
+        jwt_sub_allowlist_file: Optional[os.PathLike] = None,
+        jwt_revocation_list_file: Optional[os.PathLike] = None,
         env: Optional[Dict[str, str]] = None,
     ) -> None:
         self.bind_addrs = bind_addrs
@@ -1600,6 +1603,9 @@ class _EdgeDBServer:
         self.tls_cert_file = tls_cert_file
         self.tls_key_file = tls_key_file
         self.tls_cert_mode = tls_cert_mode
+        self.jws_key_file = jws_key_file
+        self.jwt_sub_allowlist_file = jwt_sub_allowlist_file
+        self.jwt_revocation_list_file = jwt_revocation_list_file
         self.env = env
 
     async def wait_for_server_readiness(self, stream: asyncio.StreamReader):
@@ -1747,8 +1753,18 @@ class _EdgeDBServer:
         if self.tls_key_file:
             cmd += ['--tls-key-file', self.tls_key_file]
 
-        if self.readiness_state_file is not None:
+        if self.readiness_state_file:
             cmd += ['--readiness-state-file', self.readiness_state_file]
+
+        if self.jws_key_file:
+            cmd += ['--jws-key-file', self.jws_key_file]
+
+        if self.jwt_sub_allowlist_file:
+            cmd += ['--jwt-sub-allowlist-file', self.jwt_sub_allowlist_file]
+
+        if self.jwt_revocation_list_file:
+            cmd += ['--jwt-revocation-list-file',
+                    self.jwt_revocation_list_file]
 
         if self.debug:
             print(
@@ -1870,6 +1886,9 @@ def start_edgedb_server(
     tls_key_file: Optional[os.PathLike] = None,
     tls_cert_mode: edgedb_args.ServerTlsCertMode = (
         edgedb_args.ServerTlsCertMode.SelfSigned),
+    jws_key_file: Optional[os.PathLike] = None,
+    jwt_sub_allowlist_file: Optional[os.PathLike] = None,
+    jwt_revocation_list_file: Optional[os.PathLike] = None,
     env: Optional[Dict[str, str]] = None,
 ):
     if not devmode.is_in_dev_mode() and not runstate_dir:
@@ -1916,6 +1935,9 @@ def start_edgedb_server(
         tls_cert_file=tls_cert_file,
         tls_key_file=tls_key_file,
         tls_cert_mode=tls_cert_mode,
+        jws_key_file=jws_key_file,
+        jwt_sub_allowlist_file=jwt_sub_allowlist_file,
+        jwt_revocation_list_file=jwt_revocation_list_file,
         env=env,
     )
 


### PR DESCRIPTION
The new `--jwt-sub-allowlist-file` server argument allows providing a
list of subjects whose keys are authorized, and the new
`--jwt-revocation-list-file` server argument allows providing a list of
key ids that are explicitly revoked.