### PR TITLE
3.0 beta changelog fixes

### DIFF
--- a/docs/changelog/3_x.rst
+++ b/docs/changelog/3_x.rst
@@ -14,7 +14,10 @@ community for reporting issues and contributing fixes. You are awesome! ❤️
 
 To play with the new features, install the CLI using `our installation guide
 <https://www.edgedb.com/install>`_, upgrade to the testing channel using
-``edgedb project upgrade --to-testing``, and initialize a new project.
+``edgedb cli upgrade --to-testing``, and initialize a new project.
+
+If the upgrade doesn't work, try updating to nightly first using
+``edgedb cli upgrade --to-nightly``
 
 .. code-block:: bash
 

--- a/docs/changelog/3_x.rst
+++ b/docs/changelog/3_x.rst
@@ -83,7 +83,7 @@ Alternatively, specify an instance name if you aren't using a project.
 
 .. code-block:: bash
 
-  $ edgedb project upgrade --to-testing -I my_instance
+  $ edgedb instance upgrade --to-testing -I my_instance
 
 **Hosted instances**
 

--- a/docs/changelog/3_x.rst
+++ b/docs/changelog/3_x.rst
@@ -14,7 +14,7 @@ community for reporting issues and contributing fixes. You are awesome! ❤️
 
 To play with the new features, install the CLI using `our installation guide
 <https://www.edgedb.com/install>`_, upgrade to the testing channel using
-``edgedb cli upgrade --to-testing``, and initialize a new project.
+``edgedb project upgrade --to-testing``, and initialize a new project.
 
 .. code-block:: bash
 
@@ -33,7 +33,7 @@ Upgrading
 
 **Local instances**
 
-To upgrade a local project, first upgrade your CLI using ``edgedb cli upgrade
+To upgrade a local project, first upgrade your CLI using ``edgedb project upgrade
 --to-testing``. Run an upgrade check to make sure your schema will migrate
 cleanly to 3.0.
 

--- a/docs/changelog/3_x.rst
+++ b/docs/changelog/3_x.rst
@@ -36,9 +36,10 @@ Upgrading
 
 **Local instances**
 
-To upgrade a local project, first upgrade your CLI using ``edgedb project upgrade
---to-testing``. Run an upgrade check to make sure your schema will migrate
-cleanly to 3.0.
+To upgrade a local project, first ensure that your CLI is up to date with
+``edgedb cli upgrade --to-testing`` (and ``edgedb cli upgrade --to-nightly``
+before that if the CLI doesn't recognize the command). Then run an upgrade
+check to make sure your schema will migrate cleanly to 3.0.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Three small changes to the changelog as I worked through the new commands and features today.

1: Upgrade a local project with `edgedb project`, not instance

2: Looks like nightly is needed to have the CLI recognize the --to-testing command in the first place. (Assumed at first this was a typo and `edgedb project` was the syntax, but it was a proper command that the non-nightly CLI didn't recognize. Another user on the Discord had this)

3. `edgedb project upgrade` to `edgedb instance upgrade` when not using a project.