### PR TITLE
Enable GraphQL support for type unions.

### DIFF
--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -173,3 +173,10 @@ function id_func(s: str) -> str using (s);
 alias FuncTest := {
     fstr := id_func('test'),
 };
+
+type Combo {
+    required property name -> str;
+    # Test type union, Setting and Profile share some inherited fields as well
+    # as non-inherited ones.
+    link data -> Setting | Profile;
+};

--- a/tests/schemas/graphql_schema.esdl
+++ b/tests/schemas/graphql_schema.esdl
@@ -63,6 +63,12 @@ alias SettingAliasAugmented := Setting {
 
 type Person extending User;
 
+type Combo {
+    # Test type union, Setting and Profile share some inherited fields as well
+    # as non-inherited ones.
+    link data -> Setting | Profile;
+}
+
 scalar type positive_int_t extending int64 {
     constraint min_value(0);
 }

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -186,3 +186,19 @@ INSERT LinkedList {
         LIMIT 1
     )
 };
+
+INSERT Combo {
+    name := 'combo 0',
+};
+
+INSERT Combo {
+    name := 'combo 1',
+    data := assert_single((
+        SELECT Setting FILTER .name = 'template' AND .value = 'blue'
+    )),
+};
+
+INSERT Combo {
+    name := 'combo 2',
+    data := assert_single((SELECT Profile FILTER .name = 'Alice profile')),
+};

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -3183,6 +3183,130 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             "User": [orig_data]
         })
 
+    def test_graphql_mutation_update_link_06(self):
+        # updating a single link targeting a type union
+        orig_data = {
+            'name': 'combo 0',
+            'data': None,
+        }
+        data1 = {
+            'name': 'combo 0',
+            'data': {
+                "__typename": "Setting_Type",
+                "name": "perks",
+            },
+        }
+        data2 = {
+            'name': 'combo 0',
+            'data': {
+                "__typename": "Profile_Type",
+                "name": "Bob profile",
+            },
+        }
+
+        validation_query = r"""
+            query {
+                Combo(
+                    filter: {name: {eq: "combo 0"}}
+                ) {
+                    name
+                    data {
+                        __typename
+                        name
+                    }
+                }
+            }
+        """
+
+        self.assert_graphql_query_result(validation_query, {
+            "Combo": [orig_data]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation update_Combo {
+                update_Combo(
+                    data: {
+                        data: {
+                            set: {
+                                filter: {name: {eq: "perks"}}
+                            }
+                        }
+                    },
+                    filter: {
+                        name: {eq: "combo 0"}
+                    }
+                ) {
+                    name
+                    data {
+                        __typename
+                        name
+                    }
+                }
+            }
+        """, {
+            "update_Combo": [data1]
+        })
+
+        self.assert_graphql_query_result(validation_query, {
+            "Combo": [data1]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation update_Combo {
+                update_Combo(
+                    data: {
+                        data: {
+                            set: {
+                                filter: {name: {eq: "Bob profile"}}
+                            }
+                        }
+                    },
+                    filter: {
+                        name: {eq: "combo 0"}
+                    }
+                ) {
+                    name
+                    data {
+                        __typename
+                        name
+                    }
+                }
+            }
+        """, {
+            "update_Combo": [data2]
+        })
+
+        self.assert_graphql_query_result(validation_query, {
+            "Combo": [data2]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation update_Combo {
+                update_Combo(
+                    data: {
+                        data: {
+                            clear: true
+                        }
+                    },
+                    filter: {
+                        name: {eq: "combo 0"}
+                    }
+                ) {
+                    name
+                    data {
+                        __typename
+                        name
+                    }
+                }
+            }
+        """, {
+            "update_Combo": [orig_data]
+        })
+
+        self.assert_graphql_query_result(validation_query, {
+            "Combo": [orig_data]
+        })
+
     def test_graphql_mutation_update_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -4092,6 +4092,49 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             ]
         })
 
+    def test_graphql_functional_type_union_01(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                Combo(
+                    order: {name: {dir: ASC}}
+                ) {
+                    name
+                    data {
+                        __typename
+                        name
+                        value
+                        ... on Profile {
+                            tags
+                        }
+                    }
+                }
+            }
+        """, {
+            "Combo": [
+                {
+                    "name": "combo 0",
+                    "data": None,
+                },
+                {
+                    "name": "combo 1",
+                    "data": {
+                        "__typename": "Setting_Type",
+                        "name": "template",
+                        "value": "blue",
+                    },
+                },
+                {
+                    "name": "combo 2",
+                    "data": {
+                        "__typename": "Profile_Type",
+                        "name": "Alice profile",
+                        "value": "special",
+                        "tags": ['1st', '2nd'],
+                    },
+                },
+            ]
+        })
+
     def test_graphql_globals_01(self):
         Q = r'''query { GlobalTest { gstr, garray, gid, gdef, gdef2 } }'''
 

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -1274,6 +1274,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                 "name": "Profile",
                                 "kind": "INTERFACE"
                             },
+                            {
+                                "__typename": "__Type",
+                                "name": "Profile_OR_Setting",
+                                "kind": "INTERFACE"
+                            },
                         ],
                         "possibleTypes": None,
                         "enumValues": None,
@@ -1352,6 +1357,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             {
                                 "__typename": "__Type",
                                 "name": "Object",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Profile_OR_Setting",
                                 "kind": "INTERFACE"
                             },
                             {
@@ -2495,6 +2505,404 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             }
         })
 
+    def test_graphql_schema_type_20(self):
+        # make sure the union type got reflected
+        self.assert_graphql_query_result(r"""
+        query {
+            __type(name: "Profile_OR_Setting") {
+                __typename
+                name
+                kind
+                fields {
+                    __typename
+                    name
+                    description
+                    args {
+                        name
+                        description
+                        type {
+                            __typename
+                            name
+                            kind
+                            ofType {
+                                __typename
+                                name
+                                kind
+                            }
+                        }
+                        defaultValue
+                    }
+                    type {
+                        __typename
+                        name
+                        kind
+                        fields {name}
+                        ofType {
+                            name
+                            kind
+                            fields {name}
+                        }
+                    }
+                    isDeprecated
+                    deprecationReason
+                }
+                possibleTypes {
+                    name
+                }
+            }
+        }
+        """, {
+            "__type": {
+                "__typename": "__Type",
+                "name": "Profile_OR_Setting",
+                "kind": "INTERFACE",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "id",
+                        "description": None,
+                        "args": [],
+                        "type": {
+                            "__typename": "__Type",
+                            "name": None,
+                            "kind": "NON_NULL",
+                            "fields": None,
+                            "ofType": {
+                                "name": "ID",
+                                "kind": "SCALAR",
+                                "fields": None
+                            }
+                        },
+                        "isDeprecated": False,
+                        "deprecationReason": None
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "name",
+                        "description": None,
+                        "args": [],
+                        "type": {
+                            "__typename": "__Type",
+                            "name": None,
+                            "kind": "NON_NULL",
+                            "fields": None,
+                            "ofType": {
+                                "name": "String",
+                                "kind": "SCALAR",
+                                "fields": None
+                            }
+                        },
+                        "isDeprecated": False,
+                        "deprecationReason": None
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "value",
+                        "description": None,
+                        "args": [],
+                        "type": {
+                            "__typename": "__Type",
+                            "name": None,
+                            "kind": "NON_NULL",
+                            "fields": None,
+                            "ofType": {
+                                "name": "String",
+                                "kind": "SCALAR",
+                                "fields": None
+                            }
+                        },
+                        "isDeprecated": False,
+                        "deprecationReason": None
+                    },
+                ],
+                "possibleTypes": [
+                    {"name": "Profile_Type"},
+                    {"name": "Setting_Type"},
+                ],
+            }
+        }, sort={
+            'fields': {
+                '.': lambda x: x['name'],
+                'args': lambda x: x['name'],
+            }
+        })
+
+    def test_graphql_schema_type_21(self):
+        # make sure that the union type supports filtering
+        self.assert_graphql_query_result(r"""
+            fragment _t on __Type {
+                name
+                kind
+            }
+
+            query {
+                __type(name: "FilterProfile_OR_Setting") {
+                    __typename
+                    ..._t
+                    inputFields {
+                        name
+                        type {
+                            ..._t
+                            ofType {
+                                ..._t
+                                ofType {
+                                    ..._t
+                                    ofType {
+                                        ..._t
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """, {
+            "__type": {
+                "__typename": "__Type",
+                "name": "FilterProfile_OR_Setting",
+                "kind": "INPUT_OBJECT",
+                "inputFields": [
+                    {
+                        "name": "and",
+                        "type": {
+                            "name": None,
+                            "kind": "LIST",
+                            "ofType": {
+                                "name": None,
+                                "kind": "NON_NULL",
+                                "ofType": {
+                                    "name": "FilterProfile_OR_Setting",
+                                    "kind": "INPUT_OBJECT",
+                                    "ofType": None
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "type": {
+                            "name": "FilterID",
+                            "kind": "INPUT_OBJECT",
+                            "ofType": None
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "type": {
+                            "name": "FilterString",
+                            "kind": "INPUT_OBJECT",
+                            "ofType": None
+                        }
+                    },
+                    {
+                        "name": "not",
+                        "type": {
+                            "name": "FilterProfile_OR_Setting",
+                            "kind": "INPUT_OBJECT",
+                            "ofType": None
+                        }
+                    },
+                    {
+                        "name": "or",
+                        "type": {
+                            "name": None,
+                            "kind": "LIST",
+                            "ofType": {
+                                "name": None,
+                                "kind": "NON_NULL",
+                                "ofType": {
+                                    "name": "FilterProfile_OR_Setting",
+                                    "kind": "INPUT_OBJECT",
+                                    "ofType": None
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "name": "value",
+                        "type": {
+                            "name": "FilterString",
+                            "kind": "INPUT_OBJECT",
+                            "ofType": None
+                        }
+                    },
+                ]
+            }
+        }, sort={
+            'inputFields': lambda x: x['name'],
+        })
+
+    def test_graphql_schema_type_22(self):
+        # make sure the union type is used as link target
+        self.assert_graphql_query_result(r"""
+        query {
+            __type(name: "Combo") {
+                __typename
+                name
+                kind
+                fields {
+                    __typename
+                    name
+                    description
+                    args {
+                        name
+                        description
+                        type {
+                            __typename
+                            name
+                            kind
+                            ofType {
+                                __typename
+                                name
+                                kind
+                            }
+                        }
+                        defaultValue
+                    }
+                    type {
+                        __typename
+                        name
+                        kind
+                        fields {name}
+                        ofType {
+                            name
+                            kind
+                            fields {name}
+                        }
+                    }
+                    isDeprecated
+                    deprecationReason
+                }
+            }
+        }
+        """, {
+            "__type": {
+
+                "__typename": "__Type",
+                "kind": "INTERFACE",
+                "name": "Combo",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "data",
+                        "description": None,
+                        "args": [
+                            {
+                                "name": "after",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": None,
+                                    "__typename": "__Type"
+                                },
+                                "description": None,
+                                "defaultValue": None
+                            },
+                            {
+                                "name": "before",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": None,
+                                    "__typename": "__Type"
+                                },
+                                "description": None,
+                                "defaultValue": None
+                            },
+                            {
+                                "name": "filter",
+                                "type": {
+                                    "kind": "INPUT_OBJECT",
+                                    "name": "FilterProfile_OR_Setting",
+                                    "ofType": None,
+                                    "__typename": "__Type"
+                                },
+                                "description": None,
+                                "defaultValue": None
+                            },
+                            {
+                                "name": "first",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": None,
+                                    "__typename": "__Type"
+                                },
+                                "description": None,
+                                "defaultValue": None
+                            },
+                            {
+                                "name": "last",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": None,
+                                    "__typename": "__Type"
+                                },
+                                "description": None,
+                                "defaultValue": None
+                            },
+                            {
+                                "name": "order",
+                                "type": {
+                                    "kind": "INPUT_OBJECT",
+                                    "name": "OrderProfile_OR_Setting",
+                                    "ofType": None,
+                                    "__typename": "__Type"
+                                },
+                                "description": None,
+                                "defaultValue": None
+                            },
+                        ],
+                        "type": {
+                            "kind": "INTERFACE",
+                            "name": "Profile_OR_Setting",
+                            "fields": [
+                                {
+                                    "name": "id"
+                                },
+                                {
+                                    "name": "name"
+                                },
+                                {
+                                    "name": "value"
+                                }
+                            ],
+                            "ofType": None,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": False,
+                        "deprecationReason": None
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "id",
+                        "description": None,
+                        "args": [],
+                        "type": {
+                            "__typename": "__Type",
+                            "name": None,
+                            "kind": "NON_NULL",
+                            "fields": None,
+                            "ofType": {
+                                "name": "ID",
+                                "kind": "SCALAR",
+                                "fields": None
+                            }
+                        },
+                        "isDeprecated": False,
+                        "deprecationReason": None
+                    },
+                ],
+
+            }
+        }, sort={
+            'fields': {
+                '.': lambda x: x['name'],
+                'args': lambda x: x['name'],
+            }
+        })
+
     def test_graphql_reflection_01(self):
         # Make sure that FreeObject is not reflected.
         result = self.graphql_query(r"""
@@ -2562,3 +2970,40 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                 bad,
                 [t['name'] for t in result['up']['inputFields']]
             )
+
+    def test_graphql_reflection_03(self):
+        # Make sure that union type `Profile | Setting` is not reflected at
+        # the root of Query or Mutation.
+        result = self.graphql_query(r"""
+            query {
+                __schema {
+                    queryType {
+                        fields {
+                            name
+                        }
+                    }
+                    mutationType {
+                        fields {
+                            name
+                        }
+                    }
+                }
+            }
+        """)
+
+        self.assertNotIn(
+            'Profile_OR_Setting',
+            [t['name'] for t in result['__schema']['queryType']['fields']]
+        )
+        self.assertNotIn(
+            'delete_Profile_OR_Setting',
+            [t['name'] for t in result['__schema']['mutationType']['fields']]
+        )
+        self.assertNotIn(
+            'update_Profile_OR_Setting',
+            [t['name'] for t in result['__schema']['mutationType']['fields']]
+        )
+        self.assertNotIn(
+            'insert_Profile_OR_Setting',
+            [t['name'] for t in result['__schema']['mutationType']['fields']]
+        )


### PR DESCRIPTION
In EdgeDB a type union includes all the common fields of the individual member types. This is different from a GraphQL union type which has no fields at all. Therefore it's more accurate to use GraphQL interfaces to reflect type unions from EdgeDB.

Fixes #3851