### PR TITLE
Add /ready and /metrics to remote compiler

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -928,6 +928,10 @@ _compiler_options = [
         help="Directory to store UNIX domain socket file for IPC, a temporary "
              "directory will be used if not specified.",
     ),
+    click.option(
+        '--metrics-port', type=PortType(),
+        help=f'Port to listen on for metrics HTTP API.',
+    ),
 ]
 
 


### PR DESCRIPTION
HTTP endpoints are enabled with setting the listening port with --metrics-port option.

- [ ] Add test

Fixes #5302