### PR TITLE
Fix making pointer non-computed and giving it an abstract base at the same time

### DIFF
--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -224,7 +224,7 @@ def reconstruct_tree(
             isinstance(op, sd.DeleteObject)
             or (
                 isinstance(op, sd.AlterObject)
-                and op.get_nonattr_special_subcommand_count() == 0
+                and op.get_nonattr_subcommand_count() == 0
             )
         ):
             return False
@@ -248,6 +248,7 @@ def reconstruct_tree(
                 isinstance(parents[op], sd.DeltaRoot)
                 != isinstance(parents[alter_op], sd.DeltaRoot)
             )
+            or bool(alter_op.get_subcommands(type=sd.RenameObject))
         ):
             return False
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1584,6 +1584,22 @@ class PointerCommand(
 
         is_computable = scls.is_pure_computable(schema)
         is_owned = scls.get_owned(schema)
+
+        if is_computable:
+            if any(
+                b.generic(schema)
+                and not str(b.get_name(schema)) in (
+                    'std::link', 'std::property')
+                for b in scls.get_bases(schema).objects(schema)
+            ):
+                raise errors.SchemaDefinitionError(
+                    f'it is illegal for the computed '
+                    f'{scls.get_verbosename(schema, with_parent=True)} '
+                    f'to extend an abstract '
+                    f'{scls.get_schema_class_displayname()}',
+                    context=self.source_context,
+                )
+
         # Get the non-generic, explicitly declared ancestors as the
         # limitations on computables apply to explicitly declared
         # pointers, not just a long chain of inherited ones.

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2209,6 +2209,15 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             },
         })
 
+    async def test_edgeql_migration_abs_ptr_01(self):
+        await self.migrate(r"""
+            type T { multi link following := T; }
+        """)
+        await self.migrate(r"""
+            abstract link abs { property foo: str };
+            type T { multi link following extending abs -> T; }
+        """)
+
     async def test_edgeql_migration_describe_function_01(self):
         await self.migrate('''
             function foo(x: str) -> str using (SELECT <str>random());
@@ -5922,7 +5931,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         await self.interact([
             "did you create object type 'test::HasContent'?",
             "did you alter object type 'test::Post'?",
-            "did you alter object type 'test::Post'?",
+            "did you alter property 'content' of object type 'test::Post'?",
             "did you create object type 'test::Reply'?",
         ])
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -341,6 +341,16 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
         """
 
+    @tb.must_fail(
+        errors.SchemaDefinitionError,
+        "illegal for the computed link.*to extend an abstract link",
+    )
+    def test_schema_bad_link_06(self):
+        """
+            abstract link abs { property foo: str };
+            type T { multi link following extending abs -> T {using (T)} }
+        """
+
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
                   "or a scalar collection, got object type 'test::Object'",


### PR DESCRIPTION
Some obscure details of how reconstruction worked was preventing the alter
from getting joined with the rebase, since the alter had a
`RESET OPTIONALITY` in it. Removed that limitation, and then had to
fix some knock-on effects from that.

Also prohibit having a computed pointer with an abstract base, since
it doesn't work. That check would move this bug up from a migration
time ISE to a real error, though of course we also fixed the bug.

Fixes #5390.