### PR TITLE
Translate generated pgsql error locations to input text

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -243,7 +243,10 @@ class AST:
     def __copy__(self):
         copied = self.__class__()
         for field, value in iter_fields(self, include_meta=False):
-            object.__setattr__(copied, field, value)
+            try:
+                object.__setattr__(copied, field, value)
+            except AttributeError:
+                continue
         return copied
 
     def __deepcopy__(self, memo):

--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -246,6 +246,7 @@ class AST:
             try:
                 object.__setattr__(copied, field, value)
             except AttributeError:
+                # don't mind not setting getter_only attrs.
                 continue
         return copied
 

--- a/edb/common/ast/codegen.py
+++ b/edb/common/ast/codegen.py
@@ -60,7 +60,7 @@ class SourceGenerator(NodeVisitor):
         if indent:
             self.new_lines = 1
             self.char_indentation += 1
-        res = super().visit(node)
+        res = self.visit(node)
         if indent:
             self.char_indentation -= 1
         if nest:

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -669,8 +669,9 @@ class Expr(ImmutableBaseExpr):
 class BaseConstant(ImmutableBaseExpr):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if not isinstance(self, NullConstant) and self.val is None:
-            raise ValueError('cannot create a pgast.Constant without a value')
+        '''if not isinstance(self, NullConstant) and self.val is None:
+            raise ValueError('cannot create a pgast.Constant without a
+            value')'''
 
 
 class StringConstant(BaseConstant):

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -667,11 +667,7 @@ class Expr(ImmutableBaseExpr):
 
 
 class BaseConstant(ImmutableBaseExpr):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        '''if not isinstance(self, NullConstant) and self.val is None:
-            raise ValueError('cannot create a pgast.Constant without a
-            value')'''
+    pass
 
 
 class StringConstant(BaseConstant):

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -82,11 +82,34 @@ class SQLSourceGeneratorError(errors.InternalServerError):
             ctx = SQLSourceGeneratorContext(node)
             exceptions.add_context(self, ctx)
 
+class SQLSourceGeneratorTranslationData:
+    source_start: int
+    source_end: int
+    output_start: int
+    output_end: int
+    children: List[SQLSourceGeneratorTranslationData]
+
+    def __init__(
+        self,
+        *,
+        source_start: int,
+        source_end: int,
+        output_start: int,
+    ):
+        self.source_start = source_start
+        self.source_end = source_end
+        self.output_start = output_start
+        self.output_end = -1
+        self.children = []
+
 
 class SQLSourceGenerator(codegen.SourceGenerator):
-    def __init__(self, *args, reordered=False, **kwargs):  # type: ignore
+    def __init__(self, *args, reordered=False, with_translation_data=False, **kwargs):  # type: ignore
         super().__init__(*args, **kwargs)
         self.param_index: dict[object, int] = {}
+        self.with_translation_data: bool = with_translation_data
+        self.write_index: int = 0
+        self.translation_data: Optional[SQLSourceGeneratorTranslationData] = None
         self.reordered = reordered
 
     @classmethod
@@ -116,6 +139,59 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         generator = cls()
         generator.gen_ctes(ctes)
         return ''.join(generator.result)
+
+    @classmethod
+    def to_source_with_translation(
+        cls,
+        node: pgast.Base,
+        indent_with: str = ' ' * 4,
+        add_line_information: bool = False,
+        pretty: bool = True,
+        reordered: bool = True,
+    ) -> Tuple[str, SQLSourceGeneratorTranslationData]:
+        try:
+            generator = cls(
+                indent_with=indent_with,
+                add_line_information=add_line_information,
+                pretty=pretty,
+                reordered=reordered,
+                with_translation_data=True,
+            )
+            generator.visit(node)
+            assert generator.translation_data
+            return ''.join(generator.result), generator.translation_data
+        except SQLSourceGeneratorError as e:
+            ctx = SQLSourceGeneratorContext(node)
+            exceptions.add_context(e, ctx)
+            raise
+
+    def write(
+        self,
+        *x: str,
+        delimiter: Optional[str] = None,
+    ) -> None:
+        start = len(self.result)
+        super().write(*x, delimiter=delimiter)
+        for new in range(start, len(self.result)):
+            self.write_index += len(self.result[new])
+
+
+    def visit(self, node): # type: ignore
+        if self.with_translation_data:
+            translation_data = SQLSourceGeneratorTranslationData(
+                source_start = node.context.start,
+                source_end = node.context.end,
+                output_start = self.write_index,
+            )
+            old_top = self.translation_data
+            self.translation_data = translation_data
+        super().visit(node)
+        if self.with_translation_data:
+            assert self.translation_data == translation_data
+            self.translation_data.output_end = self.write_index
+            if old_top:
+                old_top.children.append(self.translation_data)
+                self.translation_data = old_top
 
     def generic_visit(self, node):  # type: ignore
         raise SQLSourceGeneratorError(
@@ -1172,3 +1248,5 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
 
 generate_source = SQLSourceGenerator.to_source
+generate_source_with_translation_data = \
+    SQLSourceGenerator.to_source_with_translation

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -100,6 +100,16 @@ class SQLSourceGeneratorTranslationData:
         self.output_end = -1
         self.children = []
 
+    def translate(self, pos: int) -> int:
+        bu = None
+        for u in self.children:
+            if u.output_start >= pos:
+                break
+            bu = u
+        if bu and bu.output_end > pos:
+            return bu.translate(pos)
+        return self.source_start
+
 
 class SQLSourceGenerator(codegen.SourceGenerator):
     def __init__(  # type: ignore
@@ -1251,5 +1261,5 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
 
 generate_source = SQLSourceGenerator.to_source
-generate_source_with_translation_data = \
-    SQLSourceGenerator.to_source_with_translation
+generate_source_with_translation_data = (SQLSourceGenerator.
+                                         to_source_with_translation)

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -82,6 +82,7 @@ class SQLSourceGeneratorError(errors.InternalServerError):
             ctx = SQLSourceGeneratorContext(node)
             exceptions.add_context(self, ctx)
 
+
 class SQLSourceGeneratorTranslationData:
     source_start: int
     output_start: int
@@ -101,12 +102,19 @@ class SQLSourceGeneratorTranslationData:
 
 
 class SQLSourceGenerator(codegen.SourceGenerator):
-    def __init__(self, *args, reordered=False, with_translation_data=False, **kwargs):  # type: ignore
+    def __init__(  # type: ignore
+        self,
+        *args,
+        reordered=False,
+        with_translation_data=False,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self.param_index: dict[object, int] = {}
         self.with_translation_data: bool = with_translation_data
         self.write_index: int = 0
-        self.translation_data: Optional[SQLSourceGeneratorTranslationData] = None
+        self.translation_data: Optional[
+            SQLSourceGeneratorTranslationData] = None
         self.reordered = reordered
 
     @classmethod
@@ -172,12 +180,11 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         for new in range(start, len(self.result)):
             self.write_index += len(self.result[new])
 
-
-    def visit(self, node): # type: ignore
+    def visit(self, node):  # type: ignore
         if self.with_translation_data:
             translation_data = SQLSourceGeneratorTranslationData(
-                source_start = node.context.start if node.context else 0,
-                output_start = self.write_index,
+                source_start=node.context.start if node.context else 0,
+                output_start=self.write_index,
             )
             old_top = self.translation_data
             self.translation_data = translation_data

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -152,7 +152,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         indent_with: str = ' ' * 4,
         add_line_information: bool = False,
         pretty: bool = True,
-        reordered: bool = True,
+        reordered: bool = False,
     ) -> Tuple[str, SQLSourceGeneratorTranslationData]:
         try:
             generator = cls(

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -84,7 +84,6 @@ class SQLSourceGeneratorError(errors.InternalServerError):
 
 class SQLSourceGeneratorTranslationData:
     source_start: int
-    source_end: int
     output_start: int
     output_end: int
     children: List[SQLSourceGeneratorTranslationData]
@@ -93,11 +92,9 @@ class SQLSourceGeneratorTranslationData:
         self,
         *,
         source_start: int,
-        source_end: int,
         output_start: int,
     ):
         self.source_start = source_start
-        self.source_end = source_end
         self.output_start = output_start
         self.output_end = -1
         self.children = []
@@ -179,8 +176,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
     def visit(self, node): # type: ignore
         if self.with_translation_data:
             translation_data = SQLSourceGeneratorTranslationData(
-                source_start = node.context.start,
-                source_end = node.context.end,
+                source_start = node.context.start if node.context else 0,
                 output_start = self.write_index,
             )
             old_top = self.translation_data

--- a/edb/pgsql/resolver/dispatch.py
+++ b/edb/pgsql/resolver/dispatch.py
@@ -39,7 +39,7 @@ def _resolve(
 
 def resolve(ir: Base_T, *, ctx: context.ResolverContextLevel) -> Base_T:
     res = _resolve(ir, ctx=ctx)
-    return typing.cast(Base_T, res)
+    return typing.cast(Base_T, res.replace(context=ir.context))
 
 
 def resolve_opt(
@@ -77,7 +77,7 @@ def resolve_relation(
     ir: BaseRelation_T, *, ctx: context.ResolverContextLevel
 ) -> typing.Tuple[BaseRelation_T, context.Table]:
     res, tab = _resolve_relation(ir, ctx=ctx)
-    return typing.cast(BaseRelation_T, res), tab
+    return typing.cast(BaseRelation_T, res.replace(context=ir.context)), tab
 
 
 @_resolve.register

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -86,7 +86,11 @@ def resolve_ResTarget(
         alias = static.name_in_pg_catalog(res_target.val.name)
 
     col = context.Column(name=alias, reference_as=alias)
-    return (pgast.ResTarget(val=val, name=alias),), (col,)
+    new_target = pgast.ResTarget(
+        val=val,
+        name=alias,
+        context=res_target.context)
+    return (new_target,), (col,)
 
 
 @dispatch._resolve.register

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -52,6 +52,7 @@ def resolve_BaseRangeVar(
 
     # general case
     node, table = _resolve_range_var(range_var, alias, ctx=ctx)
+    node.context = range_var.context
 
     # infer public name and internal alias
     table.alias = range_var.alias.aliasname
@@ -242,6 +243,7 @@ def resolve_CommonTableExpr(
 
     node = pgast.CommonTableExpr(
         name=cte.name,
+        context=cte.context,
         aliascolnames=reference_as,
         query=query,
         recursive=cte.recursive,

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -52,7 +52,7 @@ def resolve_BaseRangeVar(
 
     # general case
     node, table = _resolve_range_var(range_var, alias, ctx=ctx)
-    node.context = range_var.context
+    node = node.replace(context=range_var.context)
 
     # infer public name and internal alias
     table.alias = range_var.alias.aliasname

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -668,10 +668,11 @@ class Compiler:
                     **args
                 )
                 resolved = pg_resolver.resolve(stmt, schema, options)
-                source, tl_data = \
+                source, tl_data = (
                     pg_codegen.generate_source_with_translation_data(
                         resolved
-                    )
+                    ))
+
                 unit = dbstate.SQLQueryUnit(
                     query=source,
                     input_query=query_str,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -675,7 +675,6 @@ class Compiler:
 
                 unit = dbstate.SQLQueryUnit(
                     query=source,
-                    input_query=query_str,
                     translation_data=tl_data)
 
             tx_state.apply(unit)

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -668,8 +668,14 @@ class Compiler:
                     **args
                 )
                 resolved = pg_resolver.resolve(stmt, schema, options)
-                source = pg_codegen.generate_source(resolved)
-                unit = dbstate.SQLQueryUnit(query=source)
+                source, tl_data = \
+                    pg_codegen.generate_source_with_translation_data(
+                        resolved
+                    )
+                unit = dbstate.SQLQueryUnit(
+                    query=source,
+                    input_query=query_str,
+                    translation_data=tl_data)
 
             tx_state.apply(unit)
             unit.stmt_name = b"s" + hashlib.sha1(

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -39,6 +39,8 @@ from edb.schema import schema as s_schema
 
 from edb.server import config
 
+from edb.pgsql.codegen import SQLSourceGeneratorTranslationData
+
 from . import enums
 from . import sertypes
 
@@ -394,6 +396,8 @@ class QueryUnitGroup:
 @dataclasses.dataclass
 class SQLQueryUnit:
     query: str
+    input_query: Optional[str] = None
+    translation_data: Optional[SQLSourceGeneratorTranslationData] = None
 
     tx_action: Optional[TxAction] = None
     tx_chain: bool = False

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -396,7 +396,6 @@ class QueryUnitGroup:
 @dataclasses.dataclass
 class SQLQueryUnit:
     query: str
-    input_query: Optional[str] = None
     translation_data: Optional[SQLSourceGeneratorTranslationData] = None
 
     tx_action: Optional[TxAction] = None

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1672,19 +1672,10 @@ cdef class PGConnection:
                                 pos_bytes = self.buffer.read_null_str()
                                 if unit.translation_data:
                                     pos = int(pos_bytes.decode('utf8'))
-                                    def best_unit(tl_unit):
-                                        bu = None
-                                        for u in tl_unit.children:
-                                            if u.output_start >= pos:
-                                                break
-                                            bu = u
-                                        if bu and bu.output_end > pos:
-                                            return best_unit(bu)
-                                        return tl_unit
-                                    pos = best_unit(unit.translation_data).source_start
-
+                                    pos = unit.translation_data.translate(pos)
                                     # pg uses 1-based indexes
-                                    pos_bytes = str(pos + 1).encode('utf8')
+                                    pos += 1
+                                    pos_bytes = str(pos).encode('utf8')
                                 msg_buf.write_bytestring(pos_bytes)
                             else:
                                 msg_buf.write_byte(field_type)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -57,6 +57,7 @@ from edb.pgsql import common as pgcommon
 from edb.pgsql.common import quote_ident as pg_qi
 from edb.pgsql.common import quote_literal as pg_ql
 from edb.pgsql import params as pg_params
+from edb.pgsql.codegen import SQLSourceGeneratorTranslationData
 
 from edb.server.pgproto cimport hton
 from edb.server.pgproto cimport pgproto
@@ -1666,17 +1667,12 @@ cdef class PGConnection:
                         while True:
                             field_type = self.buffer.read_byte()
                             if field_type == b'P':  # Position
-                                msg_buf.write_byte(b'q')  # Internal query
-                                msg_buf.write_bytestring(unit.input_query.encode('utf8'))
-                                msg_buf.write_byte(b'p')  # Internal position
-                                pos_bytes = self.buffer.read_null_str()
-                                if unit.translation_data:
-                                    pos = int(pos_bytes.decode('utf8'))
-                                    pos = unit.translation_data.translate(pos)
-                                    # pg uses 1-based indexes
-                                    pos += 1
-                                    pos_bytes = str(pos).encode('utf8')
-                                msg_buf.write_bytestring(pos_bytes)
+                                self._write_error_position(
+                                    msg_buf,
+                                    query,
+                                    self.buffer.read_null_str(),
+                                    unit.translation_data
+                                )
                             else:
                                 msg_buf.write_byte(field_type)
                                 if field_type == b'\0':
@@ -2062,6 +2058,26 @@ cdef class PGConnection:
             fe_conn.write(buf)
         return rv
 
+    def _write_error_position(
+        self,
+        msg_buf: WriteBuffer,
+        query: bytes,
+        pos_bytes: bytes,
+        translation_data: Optional[SQLSourceGeneratorTranslationData]
+    ):
+        if translation_data:
+            pos = int(pos_bytes.decode('utf8'))
+            pos = translation_data.translate(pos)
+            # pg uses 1-based indexes
+            pos += 1
+            pos_bytes = str(pos).encode('utf8')
+            msg_buf.write_byte(b'P') # Position
+        else:
+            msg_buf.write_byte(b'q')  # Internal query
+            msg_buf.write_bytestring(query)
+            msg_buf.write_byte(b'p')  # Internal position
+        msg_buf.write_bytestring(pos_bytes)
+
     cdef _rewrite_sql_error_response(self, PGMessage action, WriteBuffer buf):
         cdef WriteBuffer msg_buf
 
@@ -2070,12 +2086,15 @@ cdef class PGConnection:
             while True:
                 field_type = self.buffer.read_byte()
                 if field_type == b'P':  # Position
-                    # Internal query
-                    msg_buf.write_byte(b'q')
-                    # Compiled SQL
-                    msg_buf.write_bytestring(action.args[0])
-                    # Internal position
-                    msg_buf.write_byte(b'p')
+                    qu = (action.query_unit.translation_data
+                          if action.query_unit else None)
+                    self._write_error_position(
+                        msg_buf,
+                        action.args[0],
+                        self.buffer.read_null_str(),
+                        qu
+                    )
+                    continue
                 else:
                     msg_buf.write_byte(field_type)
                     if field_type == b'\0':
@@ -2108,6 +2127,15 @@ cdef class PGConnection:
                     msg_buf.write_byte(field_type)
                     msg_buf.write_bytestring(
                         message.encode('utf-8')
+                    )
+                elif field_type == b'P':
+                    qu = (action.query_unit.translation_data
+                          if action.query_unit else None)
+                    self._write_error_position(
+                        msg_buf,
+                        action.args[0],
+                        self.buffer.read_null_str(),
+                        qu
                     )
                 else:
                     msg_buf.write_byte(field_type)

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -392,7 +392,7 @@ cdef class PgConnection(frontend.FrontendConnection):
             exc = pgerror.new(
                 pgerror.ERROR_SYNTAX_ERROR,
                 str(exc),
-                L=str(exc.lineno),
+                L=str(69420),
                 P=str(exc.cursorpos),
             )
         elif isinstance(exc, errors.AuthenticationError):

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -392,7 +392,7 @@ cdef class PgConnection(frontend.FrontendConnection):
             exc = pgerror.new(
                 pgerror.ERROR_SYNTAX_ERROR,
                 str(exc),
-                L=str(69420),
+                L=str(exc.lineno),
                 P=str(exc.cursorpos),
             )
         elif isinstance(exc, errors.AuthenticationError):

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -880,3 +880,46 @@ class TestSQL(tb.SQLQueryTestCase):
         out = io.StringIO(out.getvalue().decode("utf-8"))
         names = set(row[6] for row in csv.reader(out, delimiter="\t"))
         self.assertEqual(names, {"Forrest Gump", "Saving Private Ryan"})
+
+    async def test_sql_query_error_01(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            internal_position="12"
+        ):
+            await self.scon.execute("SELECT 1 + 'foo'")
+
+    async def test_sql_query_error_02(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            internal_position="10"
+        ):
+            await self.scon.execute("SELECT 1+'foo'")
+
+    async def test_sql_query_error_03(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            internal_position="28"
+        ):
+            await self.scon.execute("""SELECT 1 +
+                'foo'""")
+
+    async def test_sql_query_error_04(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            internal_position="12"
+        ):
+            await self.scon.execute(
+                '''SELECT 1 + 'foo' FROM "Movie" ORDER BY id''')
+
+    async def test_sql_query_error_05(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            internal_position="28"
+        ):
+            await self.scon.execute('''SELECT 1 +
+                'foo' FROM "Movie" ORDER BY id''')

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -885,7 +885,7 @@ class TestSQL(tb.SQLQueryTestCase):
         with self.assertRaisesRegex(
             asyncpg.InvalidTextRepresentationError,
             "type integer",
-            internal_position="12"
+            position="12"
         ):
             await self.scon.execute("SELECT 1 + 'foo'")
 
@@ -893,7 +893,7 @@ class TestSQL(tb.SQLQueryTestCase):
         with self.assertRaisesRegex(
             asyncpg.InvalidTextRepresentationError,
             "type integer",
-            internal_position="10"
+            position="10"
         ):
             await self.scon.execute("SELECT 1+'foo'")
 
@@ -901,7 +901,7 @@ class TestSQL(tb.SQLQueryTestCase):
         with self.assertRaisesRegex(
             asyncpg.InvalidTextRepresentationError,
             "type integer",
-            internal_position="28"
+            position="28"
         ):
             await self.scon.execute("""SELECT 1 +
                 'foo'""")
@@ -910,7 +910,7 @@ class TestSQL(tb.SQLQueryTestCase):
         with self.assertRaisesRegex(
             asyncpg.InvalidTextRepresentationError,
             "type integer",
-            internal_position="12"
+            position="12"
         ):
             await self.scon.execute(
                 '''SELECT 1 + 'foo' FROM "Movie" ORDER BY id''')
@@ -919,7 +919,50 @@ class TestSQL(tb.SQLQueryTestCase):
         with self.assertRaisesRegex(
             asyncpg.InvalidTextRepresentationError,
             "type integer",
-            internal_position="28"
+            position="28"
         ):
             await self.scon.execute('''SELECT 1 +
+                'foo' FROM "Movie" ORDER BY id''')
+
+    async def test_sql_query_error_06(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            position="12"
+        ):
+            await self.scon.fetch("SELECT 1 + 'foo'")
+
+    async def test_sql_query_error_07(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            position="10"
+        ):
+            await self.scon.fetch("SELECT 1+'foo'")
+
+    async def test_sql_query_error_08(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            position="28"
+        ):
+            await self.scon.fetch("""SELECT 1 +
+                'foo'""")
+
+    async def test_sql_query_error_09(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            position="12"
+        ):
+            await self.scon.fetch(
+                '''SELECT 1 + 'foo' FROM "Movie" ORDER BY id''')
+
+    async def test_sql_query_error_10(self):
+        with self.assertRaisesRegex(
+            asyncpg.InvalidTextRepresentationError,
+            "type integer",
+            position="28"
+        ):
+            await self.scon.fetch('''SELECT 1 +
                 'foo' FROM "Movie" ORDER BY id''')


### PR DESCRIPTION
When a user writes some error-ful query into psql, we are currently returning
errors in terms of the generated query. This is unsightly and hard to follow:

```
edgedb=# select 1 + 'goo';
ERROR:  invalid input syntax for type integer: "goo"
LINE 2:     (1 + 'goo')
                 ^
QUERY:  SELECT/*<pg.SelectStmt at 0x1213e37c0>*/
    (1 + 'goo')
```

Instead, return error locations against the input query. This yields:

```
edgedb=# select 1 + 'goo';
ERROR:  invalid input syntax for type integer: "goo"
LINE 1: select 1 + 'goo';
                   ^
QUERY:  select 1 + 'goo';
```

Much better.
