### PR TITLE
Document rounding for float to int casts

### DIFF
--- a/docs/reference/edgeql/casts.csv
+++ b/docs/reference/edgeql/casts.csv
@@ -1,8 +1,8 @@
 from \\ to,:eql:type:`json <std::json>`,:eql:type:`str <std::str>`,:eql:type:`float32 <std::float32>`,:eql:type:`float64 <std::float64>`,:eql:type:`int16 <std::int16>`,:eql:type:`int32 <std::int32>`,:eql:type:`int64 <std::int64>`,:eql:type:`bigint <std::bigint>`,:eql:type:`decimal <std::decimal>`,:eql:type:`bool <std::bool>`,:eql:type:`bytes <std::bytes>`,:eql:type:`uuid <std::uuid>`,:eql:type:`datetime <std::datetime>`,:eql:type:`duration <std::duration>`,:eql:type:`local_date <cal::local_date>`,:eql:type:`local_datetime <cal::local_datetime>`,:eql:type:`local_time <cal::local_time>`,object
 :eql:type:`json <std::json>`,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,
 :eql:type:`str <std::str>`,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,,``<>``,``<>``,``<>``,``<>``,``<>``,``<>``,
-:eql:type:`float32 <std::float32>`,``<>``,``<>``,,impl,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,,
-:eql:type:`float64 <std::float64>`,``<>``,``<>``,``:=``,,``<>``,``<>``,``<>``,``<>``,``<>``,,,,,,,,,
+:eql:type:`float32 <std::float32>`,``<>``,``<>``,,impl,``<>``,``<>*``,``<>*``,``<>``,``<>``,,,,,,,,,
+:eql:type:`float64 <std::float64>`,``<>``,``<>``,``:=``,,``<>``,``<>*``,``<>*``,``<>``,``<>``,,,,,,,,,
 :eql:type:`int16 <std::int16>`,``<>``,``<>``,impl,impl,,impl,impl,impl,impl,,,,,,,,,
 :eql:type:`int32 <std::int32>`,``<>``,``<>``,,impl,``<>``,,impl,impl,impl,,,,,,,,,
 :eql:type:`int64 <std::int64>`,``<>``,``<>``,``:=``,impl,``:=``,``:=``,,impl,impl,,,,,,,,,

--- a/docs/reference/edgeql/casts.rst
+++ b/docs/reference/edgeql/casts.rst
@@ -148,4 +148,8 @@ Casting Table
 
 - ``<>`` - can be cast explicitly
 - ``:=`` - assignment cast is supported
-- "impl" - implicit cast is supported
+- ``impl`` - implicit cast is supported
+- ``*``- When casting a float type to an integer type, the fractional value
+  naturally cannot be preserved after the cast. When executing this cast, we
+  round to the nearest integer, rounding ties to the nearest even (e.g., 1.5 is
+  rounded up to 2; 2.5 is also rounded to 2).


### PR DESCRIPTION
Addresses a question posed by @msullivan on Slack a while back (while I was focused on 3.0 docs).