### PR TITLE
analyze: nicer translation of relation names

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1389,7 +1389,8 @@ def _compile_ql_explain(
     )
 
     config_vals = _get_compilation_config_vals(ctx)
-    explain_data = (config_vals, args)
+    modaliases = ctx.state.current_tx().get_modaliases()
+    explain_data = (config_vals, args, modaliases)
 
     query = _compile_ql_query(
         ctx, ql.query, script_info=script_info,

--- a/edb/server/compiler/explain/ir_analyze.py
+++ b/edb/server/compiler/explain/ir_analyze.py
@@ -26,11 +26,11 @@ from edb.common import debug
 from edb.edgeql import ast as qlast
 
 from edb.ir import ast as irast
-from edb.schema import schema as s_schema
 
 from edb.pgsql import ast as pgast
 from edb.pgsql.compiler import astutils
 
+from edb.server.compiler import explain
 from edb.server.compiler.explain import to_json
 
 
@@ -123,8 +123,10 @@ class VisitShapes(ast.NodeVisitor):
 # info than we actually consume, since we are still in a somewhat
 # exploratory phase.
 def analyze_queries(
-    ql: qlast.Base, ir: irast.Statement, pg: pgast.Base,
-    *, schema: s_schema.Schema,
+    ql: qlast.Base,
+    ir: irast.Statement,
+    pg: pgast.Base,
+    ctx: explain.AnalyzeContext,
 ) -> AnalysisInfo:
     debug_spew = debug.flags.edgeql_explain
 


### PR DESCRIPTION
This uses defined aliases to translate namespaces according to module aliases. Particularly:

1. `default::` is removed (or whatever default module in the current state)
2. Aliases are translated. This will be particularly important with installable packages as they might have long names like this: `ext::company_name::package_name::Type`
3. Pointer relations are transformed to human-readable form

Relevant part of analyze output before this patch:
```
                   │ Time    Cost Loops Rows Width │ Relations
root               │  0.0 1133.29   1.0  0.0    32 │ default::Movie
├─ .avg_rating     │  0.0    82.1   0.0  0.0     8 │ default::Review
├─ .directors      │  0.0   16.85   0.0  0.0    32 │ default::__|directors@default|Movie, default::Person
├─ .cast           │  0.0  774.79   0.0  0.0    32 │ default::Person, default::__|cast@default|Movie
│   ╰─ .starred_in │  0.0    98.3   0.0  0.0     8 │ default::Movie, default::__|directors@default|Movie, default::__|cast@default|Movie
╰─ .reviews        │  0.0  251.23   0.0  0.0    32 │ default::User, default::Review
    ╰─ .author     │  0.0   81.79   0.0  0.0    78 │
```

Analyze after this patch:
```
                   │ Time    Cost Loops Rows Width │ Relations
root               │  0.0 1133.29   1.0  0.0    32 │ Movie
├─ .avg_rating     │  0.0    82.1   0.0  0.0     8 │ Review
├─ .directors      │  0.0   16.85   0.0  0.0    32 │ Movie.directors, Person
├─ .cast           │  0.0  774.79   0.0  0.0    32 │ Movie.cast, Person
│   ╰─ .starred_in │  0.0    98.3   0.0  0.0     8 │ Movie.directors, Movie.cast, Movie
╰─ .reviews        │  0.0  251.23   0.0  0.0    32 │ User, Review
    ╰─ .author     │  0.0   81.79   0.0  0.0    78 │
```