### PR TITLE
Fix 3 more bugs in state sync

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -767,8 +767,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             else:
                 assert query_unit.tx_rollback
                 _dbview.abort_tx()
-            if not _dbview.in_tx():
-                conn.last_state = _dbview.serialize_state()
         finally:
             self.maybe_release_pgcon(conn)
 

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -165,13 +165,15 @@ async def execute(
         side_effects = dbv.on_success(query_unit, new_types)
         if side_effects:
             signal_side_effects(dbv, side_effects)
-        if not dbv.in_tx():
+        if not dbv.in_tx() and not query_unit.tx_rollback:
             state = dbv.serialize_state()
             if state is not orig_state:
                 # In 3 cases the state is changed:
                 #   1. The non-tx query changed the state
                 #   2. The state is synced with dbview (orig_state is None)
                 #   3. We came out from a transaction (orig_state is None)
+                # Excluding one special case when the state is NOT changed:
+                #   1. An orphan ROLLBACK command without a paring start tx
                 be_conn.last_state = state
     finally:
         if query_unit.drop_db:


### PR DESCRIPTION
1. Orphan ROLLBACK should not set last_state
2. State not in sync when ISE happens in a tx without breaking pgcon (refix #4953)
3. Similar as (2) but in legacy protocol