### PR TITLE
Initial take on expanded extension package system

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_05_04_00_02
+EDGEDB_CATALOG_VERSION = 2023_05_23_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -127,6 +127,21 @@ def parse_migration_body_block(
     return parser.parse(tsource)
 
 
+def parse_extension_package_body_block(
+    source: str,
+) -> tuple[qlast.NestedQLBlock, list[qlast.SetField]]:
+    # For parser-internal technical reasons, we don't have a
+    # production that means "just the *inside* of a migration block
+    # (without braces)", so we just hack around this by adding braces.
+    # This is only really workable because we only use this in a place
+    # where the source contexts don't matter anyway.
+    source = '{' + source + '}'
+
+    tsource = qltokenizer.Source.from_string(source)
+    parser = qlparser.EdgeQLExtensionPackageBodyParser()
+    return parser.parse(tsource)
+
+
 def parse_sdl(expr: str):
     parser = qlparser.EdgeSDLParser()
     return parser.parse(expr)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -709,7 +709,7 @@ class CreateExtensionPackageBodyBlock(NestedQLBlock):
 
     @property
     def allowed_fields(self) -> typing.FrozenSet[str]:
-        return frozenset({'internal'})
+        return frozenset({'internal', 'ext_module', 'sql_extensions'})
 
     @property
     def result(self) -> typing.Any:

--- a/edb/edgeql/parser/grammar/extension_package_body.py
+++ b/edb/edgeql/parser/grammar/extension_package_body.py
@@ -1,0 +1,33 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+from .expressions import Nonterm
+from .precedence import *  # NOQA
+from .tokens import *  # NOQA
+from .statements import *  # NOQA
+from .ddl import *  # NOQA
+
+
+class CreateExtensionPackageBody(Nonterm):
+    "%start"
+
+    def reduce_CreateExtensionPackageCommandsBlock_EOF(self, *kids):
+        self.val = kids[0].val

--- a/edb/edgeql/parser/parser.py
+++ b/edb/edgeql/parser/parser.py
@@ -302,6 +302,12 @@ class EdgeQLMigrationBodyParser(EdgeQLParserBase):
         return migration_body
 
 
+class EdgeQLExtensionPackageBodyParser(EdgeQLParserBase):
+    def get_parser_spec_module(self):
+        from .grammar import extension_package_body
+        return extension_package_body
+
+
 class EdgeSDLParser(EdgeQLParserBase):
     def get_parser_spec_module(self):
         from .grammar import sdldocument

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -177,6 +177,8 @@ class TypeRef(ImmutableBase):
     is_opaque_union: bool = False
     # Does this need to call a custom json cast function
     needs_custom_json_cast: bool = False
+    # If this has a schema-configured backend type, what is it
+    sql_type: typing.Optional[str] = None
 
     def __repr__(self) -> str:
         return f'<ir.TypeRef \'{self.name_hint}\' at 0x{id(self):x}>'

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -175,6 +175,8 @@ class TypeRef(ImmutableBase):
     in_schema: bool = False
     # True, if this describes an opaque union type
     is_opaque_union: bool = False
+    # Does this need to call a custom json cast function
+    needs_custom_json_cast: bool = False
 
     def __repr__(self) -> str:
         return f'<ir.TypeRef \'{self.name_hint}\' at 0x{id(self):x}>'

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -25,6 +25,7 @@ import uuid
 
 from edb.edgeql import qltypes
 
+from edb.schema import casts as s_casts
 from edb.schema import links as s_links
 from edb.schema import name as s_name
 from edb.schema import properties as s_props
@@ -322,6 +323,16 @@ def type_to_typeref(
         else:
             ancestors = None
 
+        needs_custom_json_cast = False
+        if isinstance(t, s_scalars.ScalarType):
+            if material_typeref is None:
+                cast_name = s_casts.get_cast_fullname_from_names(
+                    orig_name_hint or name_hint,
+                    s_name.QualName('std', 'json'))
+                jcast = schema.get(cast_name, type=s_casts.Cast, default=None)
+                if jcast:
+                    needs_custom_json_cast = bool(jcast.get_code(schema))
+
         result = irast.TypeRef(
             id=t.id,
             name_hint=name_hint,
@@ -338,6 +349,7 @@ def type_to_typeref(
             is_abstract=t.get_abstract(schema),
             is_view=t.is_view(schema),
             is_opaque_union=t.get_is_opaque_union(schema),
+            needs_custom_json_cast=needs_custom_json_cast,
         )
     elif isinstance(t, s_types.Tuple) and t.is_named(schema):
         schema, material_type = t.material_type(schema)

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -323,8 +323,10 @@ def type_to_typeref(
         else:
             ancestors = None
 
+        sql_type = None
         needs_custom_json_cast = False
         if isinstance(t, s_scalars.ScalarType):
+            sql_type = t.get_sql_type(schema)
             if material_typeref is None:
                 cast_name = s_casts.get_cast_fullname_from_names(
                     orig_name_hint or name_hint,
@@ -350,6 +352,7 @@ def type_to_typeref(
             is_view=t.is_view(schema),
             is_opaque_union=t.get_is_opaque_union(schema),
             needs_custom_json_cast=needs_custom_json_cast,
+            sql_type=sql_type,
         )
     elif isinstance(t, s_types.Tuple) and t.is_named(schema):
         schema, material_type = t.material_type(schema)

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -25,6 +25,7 @@ from edb.ir import ast as irast
 from edb.edgeql import qltypes
 
 from edb.schema import casts as s_casts
+from edb.schema import name as sn
 
 from edb.pgsql import ast as pgast
 from edb.pgsql import common
@@ -534,7 +535,7 @@ def _compile_config_value(
             ],
         )
         cast_name = s_casts.get_cast_fullname_from_names(
-            'std', 'std::bytes', 'std::json')
+            sn.QualName('std', 'bytes'), sn.QualName('std', 'json'))
         val = pgast.FuncCall(
             name=common.get_cast_backend_name(cast_name, aspect='function'),
             args=[val],

--- a/edb/pgsql/dbops/extensions.py
+++ b/edb/pgsql/dbops/extensions.py
@@ -46,4 +46,19 @@ class CreateExtension(ddl.DDLOperation):
         self.opid = extension.name
 
     def code(self, block: base.PLBlock) -> str:
-        return self.extension.code(block)
+        ext = self.extension
+        name = qi(ext.get_extension_name())
+        schema = qi(ext.schema)
+        return f'CREATE EXTENSION {name} WITH SCHEMA {schema}'
+
+
+class DropExtension(ddl.DDLOperation):
+    def __init__(self, extension, *, conditions=None, neg_conditions=None):
+        super().__init__(conditions=conditions, neg_conditions=neg_conditions)
+        self.extension = extension
+        self.opid = extension.name
+
+    def code(self, block: base.PLBlock) -> str:
+        ext = self.extension
+        name = qi(ext.get_extension_name())
+        return f'DROP EXTENSION {name}'

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -28,7 +28,10 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 from edb.edgeql import parser as qlparser
 
+from edb.common import checked
+
 from . import annos as s_anno
+from . import casts as s_casts
 from . import delta as sd
 from . import name as sn
 from . import objects as so
@@ -51,6 +54,17 @@ class ExtensionPackage(
         str,
         compcoef=0.9,
     )
+
+    sql_extensions = so.SchemaField(
+        checked.FrozenCheckedSet[str],
+        default=so.DEFAULT_CONSTRUCTOR,
+        coerce=True,
+        inheritable=False,
+        compcoef=0.9,
+    )
+
+    ext_module = so.SchemaField(
+        str, default=None, coerce=True, compcoef=0.9)
 
     @classmethod
     def get_schema_class_displayname(cls) -> str:
@@ -119,6 +133,12 @@ class ExtensionPackageCommand(
         return super()._cmd_tree_from_ast(schema, astnode, context)
 
 
+# XXX: Trying to CREATE/DROP these from within a transaction managed
+# to get me stuck getting "Cannot serialize global DDL" errors.
+#
+# I'm haven't fully investigated whether it is actually sensible to do
+# this kind of global command in a transaction, but we currently allow
+# it and some tests do it.
 class CreateExtensionPackage(
     ExtensionPackageCommand,
     sd.CreateObject[ExtensionPackage],
@@ -197,6 +217,20 @@ class CreateExtension(
 ):
     astnode = qlast.CreateExtension
 
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        testmode = context.testmode
+        context.testmode = True
+
+        schema = super().apply(schema, context)
+
+        context.testmode = testmode
+
+        return schema
+
     @classmethod
     def _cmd_tree_from_ast(
         cls,
@@ -213,6 +247,26 @@ class CreateExtension(
             cmd.set_attribute_value('version', parsed_version)
 
         return cmd
+
+    def _create_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._create_begin(schema, context)
+
+        if not context.canonical:
+            package = self.scls.get_package(schema)
+            script = package.get_script(schema)
+            if script:
+                block, _ = qlparser.parse_extension_package_body_block(script)
+                for subastnode in block.commands:
+                    subcmd = sd.compile_ddl(
+                        schema, subastnode, context=context)
+                    if subcmd is not None:
+                        self.add(subcmd)
+
+        return schema
 
     def canonicalize_attributes(
         self,
@@ -255,6 +309,7 @@ class CreateExtension(
         self.set_attribute_value('package', pkgs[0])
         return schema
 
+    # XXX: I think this is wrong, but it might not matter ever.
     def _get_ast(
         self,
         schema: s_schema.Schema,
@@ -278,3 +333,57 @@ class DeleteExtension(
 ):
 
     astnode = qlast.DropExtension
+
+    def _delete_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        module = self.scls.get_package(schema).get_ext_module(schema)
+        schema = super()._delete_begin(schema, context)
+
+        if context.canonical or not module:
+            return schema
+
+        # If the extension included a module, delete everything in it.
+        from . import ddl as s_ddl
+
+        module_name = sn.UnqualName(module)
+
+        def _name_in_mod(name: sn.Name) -> bool:
+            return (
+                (isinstance(name, sn.QualName) and name.module == module)
+                or name == module_name
+            )
+
+        # Clean up the casts separately for annoying reasons
+        for obj in schema.get_objects(
+            included_modules=(sn.UnqualName('__derived__'),),
+            type=s_casts.Cast,
+        ):
+            if (
+                _name_in_mod(obj.get_from_type(schema).get_name(schema))
+                or _name_in_mod(obj.get_to_type(schema).get_name(schema))
+            ):
+                drop = obj.init_delta_command(
+                    schema,
+                    sd.DeleteObject,
+                )
+                self.add(drop)
+
+        def filt(schema: s_schema.Schema, obj: so.Object) -> bool:
+            return not _name_in_mod(obj.get_name(schema)) or obj == self.scls
+
+        # We handle deleting the module contents in a heavy-handed way:
+        # do a schema diff.
+        delta = s_ddl.delta_schemas(
+            schema, schema,
+            included_modules=[
+                sn.UnqualName(module),
+            ],
+            schema_b_filters=[filt],
+            linearize_delta=True,
+        )
+        self.update(delta.get_subcommands())
+
+        return schema

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -283,6 +283,7 @@ def generate_structure(
                 typeid: std::uuid,
                 kind: std::str,
                 elemid: OPTIONAL std::uuid,
+                sql_type: OPTIONAL std::str,
             ) -> std::int64 {
                 USING SQL FUNCTION 'edgedb.get_pg_type_for_edgedb_type';
                 SET volatility := 'STABLE';

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -477,15 +477,19 @@ def _build_object_mutation_shape(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
                     f'<uuid>$__{var_prefix}id, '
                     f'{kind}, '
-                    f'<uuid>$__{var_prefix}element_type)'
+                    f'<uuid>$__{var_prefix}element_type, '
+                    f'<str>$__{var_prefix}sql_type), '
                 )
             else:
                 assignments.append(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
-                    f'<uuid>$__{var_prefix}id, {kind}, <uuid>{{}})'
+                    f'<uuid>$__{var_prefix}id, {kind}, <uuid>{{}}, '
+                    f'<str>$__{var_prefix}sql_type), '
                 )
             variables[f'__{var_prefix}id'] = json.dumps(
                 str(cmd.get_attribute_value('id')))
+            variables[f'__{var_prefix}sql_type'] = json.dumps(
+                cmd.get_attribute_value('sql_type'))
 
     shape = ',\n'.join(assignments)
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -59,6 +59,9 @@ class ScalarType(
         coerce=True, compcoef=0.8,
     )
 
+    sql_type = so.SchemaField(
+        str, default=None, compcoef=0.9)
+
     @classmethod
     def get_schema_class_displayname(cls) -> str:
         return 'scalar type'
@@ -337,6 +340,7 @@ class ScalarTypeCommand(
             and not context.stdmode
             and not abstract
             and not enum
+            and not self.get_attribute_value('sql_type')
         ):
             if not ancestors:
                 hint = (

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1351,7 +1351,8 @@ async def _init_stdlib(
                 backend_id := sys::_get_pg_type_for_edgedb_type(
                     .id,
                     .__type__.name,
-                    <uuid>{}
+                    <uuid>{},
+                    <str>{},
                 )
             }
             ''',
@@ -1372,6 +1373,7 @@ async def _init_stdlib(
                     .id,
                     .__type__.name,
                     .element_type.id,
+                    <str>{},
                 )
             }
             ''',

--- a/setup.py
+++ b/setup.py
@@ -786,6 +786,7 @@ class build_parsers(setuptools.Command):
         "edb.edgeql.parser.grammar.fragment",
         "edb.edgeql.parser.grammar.sdldocument",
         "edb.edgeql.parser.grammar.migration_body",
+        "edb.edgeql.parser.grammar.extension_package_body",
     ]
 
     def initialize_options(self):


### PR DESCRIPTION
This should support enough machinery to allow defining opt-in extension
packages that wrap postgres types that come from extensions.

The major changes are:
* Extension packages have an optional list of postgres extensions to
  create
* Extension packages get an optional module name for things to go
* Actually run the script associated with a package when creating
  an extension
* Support specifying the name of an underlying SQL type for a scalar
  in DDL instead of needing to hardcode it in the compiler.
  (We could probably move all the hardcoding into the schema now,
  but I haven't yet.)
* Delete everything in the relevant module when deleting an extension

There are still some open questions:
* Currently I create a postgres schema with the name of the
  extension. This won't work on heroku, but do we care?
* How will we deal with exposing binary encodings to clients?
* Do we need to expose a mechanism for running some raw SQL,
  or at least for defining helper functions?

I've tested this by writing a very minimal extension package that wraps the
"ltree" extension that ships with postgres.

Work towards #5478.