### PR TITLE
Fix schema ordering bug when INSERTs appear in triggers

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3595,6 +3595,44 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_trigger_01(self):
+        schema = '''
+            type User {
+              trigger logInsert after insert for each do (
+                insert Log {
+                  user := __new__,
+                  action := 'Insert',
+                }
+              );
+            }
+
+            type Log {
+              required link user -> User;
+              required property action -> str;
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
+    def test_schema_trigger_02(self):
+        schema = '''
+            type User {
+              trigger logInsert after insert for each do (
+                update Log set {
+                  user := __new__,
+                  action := 'Insert',
+                }
+              );
+            }
+
+            type Log {
+              required link user -> User;
+              required property action -> str;
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_pointer_kind_infer_01(self):
         tschema = r'''
         type Bar;


### PR DESCRIPTION
The problem was that we didn't properly keep track of the path_prefix
when tracing an INSERT, so we didn't catch the dependencies correctly.

While fixing this I also made `alias_context` in the tracer
unconditionally copy the context. Previously we only copied it when
there were aliases, so the path_prefix setting code was modifying an
*outer* context, which is wrong.

Fixes #5481.