### PR TITLE
Use 1-based indexing for EdgeDBErrors when talking to psql

### DIFF
--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -408,7 +408,8 @@ cdef class PgConnection(frontend.FrontendConnection):
             if exc.line >= 0:
                 args['L'] = str(exc.line)
             if exc.position >= 0:
-                args['P'] = str(exc.position)
+                # pg uses 1 based indexes for showing errors.
+                args['P'] = str(exc.position + 1)
             exc = pgerror.new(
                 exc.pgext_code or pgerror.ERROR_INTERNAL_ERROR,
                 str(exc),


### PR DESCRIPTION
I noticed while working on another PR that psql uses 1-based indexing for
showing error positions. Our pgsql parser uses 0-based location information.

This yields stuff like:
```
edgedb=# select 1 + "foo";
ERROR:  cannot find column `foo`
LINE 1: select 1 + "foo";
                  ^
```
With this change, we now more correctly show:
```
edgedb=# select 1 + "foo";
ERROR:  cannot find column `foo`
LINE 1: select 1 + "foo";
                   ^
```