### PR TITLE
A link with only computables should not be considered as has user defined properties

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -139,7 +139,8 @@ class Link(
 
     def has_user_defined_properties(self, schema: s_schema.Schema) -> bool:
         return bool([p for p in self.get_pointers(schema).objects(schema)
-                     if not p.is_special_pointer(schema)])
+                     if not p.is_special_pointer(schema)
+                     and not p.is_pure_computable(schema)])
 
     def get_source(
         self,


### PR DESCRIPTION
Fixes #5358