### PR TITLE
Don't ICE on free shape in insert

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -264,6 +264,11 @@ class SimpleInsert(Nonterm):
         unless_conflict = kids[2].val
 
         if isinstance(subj, qlast.Shape):
+            if not subj.expr:
+                raise errors.EdgeQLSyntaxError(
+                    "insert shape expressions must have a type name",
+                    context=subj.context
+                )
             subj_path = subj.expr
             shape = subj.elements
         else:

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3165,6 +3165,12 @@ aa';
         );
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError)
+    def test_edgeql_syntex_insert_23(self):
+        """
+        INSERT { oops := "uhoh" };
+        """
+
     def test_edgeql_syntax_delete_01(self):
         """
         DELETE Foo;


### PR DESCRIPTION
We were parsing

```
insert { whoops := "uhoh" }
```

as a free shape, because the INSERT parsing logic looks for an Expr, rather than
something more specific. Forbid free shapes in insert statements and add a test.

Fixes #5438.
