### PR TITLE
Fix deleting a pointer with rewrites in a migration

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2130,7 +2130,8 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         # so sort by dependency order.
         objs_to_cmds = {}
         for delta, cmd, refdesc in context.affected_finalization.get(self, []):
-            objs_to_cmds[cmd.scls] = delta, cmd, refdesc
+            if schema.has_object(cmd.scls.id):
+                objs_to_cmds[cmd.scls] = delta, cmd, refdesc
         objs = sort_by_cross_refs(schema, objs_to_cmds.keys())
 
         for obj in reversed(objs):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7914,6 +7914,19 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             """,
         ])
 
+    def test_schema_migrations_rewrites_01(self):
+        self._assert_migration_equivalence([
+            r"""
+                type User {
+                    name: str {
+                        rewrite update, insert using (.name ++ "!")
+                    }
+                };
+            """,
+            r"""
+            """,
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
Currently it ISEs due to a bad interaction with affected_refs, where
we try to rework a rewrite that has been deleted.