### PR TITLE
Work around mysterious Digital Ocean crashes

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -79,7 +79,7 @@ from . import status
 from . import ddl
 
 if TYPE_CHECKING:
-    from edb.server import pgcon
+    from edb.server import metaschema
 
 
 EMPTY_MAP = immutables.Map()
@@ -225,7 +225,7 @@ def new_compiler(
     ))
 
 
-async def new_compiler_from_pg(con: pgcon.PGConnection) -> Compiler:
+async def new_compiler_from_pg(con: metaschema.PGConnection) -> Compiler:
     num_patches = await get_patch_count(con)
 
     return new_compiler(
@@ -290,7 +290,7 @@ def new_compiler_context(
     return ctx
 
 
-async def get_patch_count(backend_conn: pgcon.PGConnection) -> int:
+async def get_patch_count(backend_conn: metaschema.PGConnection) -> int:
     """Get the number of applied patches."""
     num_patches = await backend_conn.sql_fetch_val(
         b'''
@@ -303,7 +303,7 @@ async def get_patch_count(backend_conn: pgcon.PGConnection) -> int:
 
 
 async def load_cached_schema(
-    backend_conn: pgcon.PGConnection,
+    backend_conn: metaschema.PGConnection,
     patches: int,
     key: str,
 ) -> s_schema.Schema:
@@ -323,14 +323,14 @@ async def load_cached_schema(
 
 
 async def load_std_schema(
-    backend_conn: pgcon.PGConnection,
+    backend_conn: metaschema.PGConnection,
     patches: int,
 ) -> s_schema.Schema:
     return await load_cached_schema(backend_conn, patches, 'stdschema')
 
 
 async def load_schema_intro_query(
-    backend_conn: pgcon.PGConnection,
+    backend_conn: metaschema.PGConnection,
     patches: int,
     kind: str,
 ) -> str:
@@ -345,7 +345,7 @@ async def load_schema_intro_query(
 
 
 async def load_schema_class_layout(
-    backend_conn: pgcon.PGConnection,
+    backend_conn: metaschema.PGConnection,
     patches: int,
 ) -> s_refl.SchemaClassLayout:
     key = f'classlayout{pg_patches.get_version_key(patches)}'


### PR DESCRIPTION
When bootstrapping against managed Digital Ocean databases, the
postgres occasionally has a server process crash. This only seems to
happen if we keep our main connection open while initializing the
template DB (!).

So don't do that, I guess.

With this change I've managed 100+ bootstraps in a row without a
failure, so I am pretty confident this is a fix, even though I don't
have a satisfactory explanation of it.