### PR TITLE
migrations: add `is_object` type hints

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2363,7 +2363,9 @@ class SetPointerType(
                 placeholder=placeholder_name,
                 prompt=prompt,
                 old_type=str(old_type.get_name(schema)) if old_type else None,
+                old_type_is_object=old_type and old_type.is_object_type(),
                 new_type=str(new_type.get_name(schema)),
+                new_type_is_object=new_type.is_object_type(),
                 pointer_name=self.get_displayname(),
             ))
 


### PR DESCRIPTION
When `cast_expr` is needed for migration there are few options:

1. Scalar expression default must be `<new_type>.pointer_name`
2. Object expression default must be `.pointer_name[IS NewType]`

The mixed case is also possible, but we don't have a good default there. Perhaps empty set is fine for dev-mode.