### PR TITLE
Fix cardinality of derived __tname__ and __tid__ pointers

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2091,6 +2091,9 @@ def _inline_type_computable(
                 ctx=scopectx
             )
 
+        ctx.env.schema = ptr.set_field_value(
+            ctx.env.schema, 'cardinality', qltypes.SchemaCardinality.One)
+
     view_shape = ctx.env.view_shapes[stype]
     view_shape_ptrs = {p for p, _ in view_shape}
     if ptr not in view_shape_ptrs:

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -125,6 +125,32 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             ])
         )
 
+    async def test_edgeql_group_simple_04(self):
+        await self.assert_query_result(
+            r'''
+            WITH snapshots := cards::Card
+            GROUP snapshots {} BY .element;
+            ''',
+            tb.bag([
+                {
+                    "elements": tb.bag([{}, {}]),
+                    "key": {"element": "Water"}
+                },
+                {
+                    "elements": tb.bag([{}, {}]),
+                    "key": {"element": "Fire"}
+                },
+                {
+                    "elements": tb.bag([{}, {}]),
+                    "key": {"element": "Earth"}
+                },
+                {
+                    "elements": tb.bag([{}, {}, {}]),
+                    "key": {"element": "Air"}
+                }
+            ])
+        )
+
     async def test_edgeql_group_simple_no_id_output_01(self):
         # the implicitly injected id was making it into the output
         # in native mode at one point


### PR DESCRIPTION
Closes #4719

This might not be the best place to set the cardinality, but it works. Also not sure why this matters only for `group` and not for plain `select`s.