### PR TITLE
Make `_reconnect_sys_pgcon` more resilient

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1722,7 +1722,7 @@ class Server(ha_base.ClusterProtocol):
                 try:
                     conn = await self._pg_connect(defines.EDGEDB_SYSTEM_DB)
                     break
-                except (ConnectionError, TimeoutError):
+                except OSError:
                     # Keep retrying as far as:
                     #   1. The EdgeDB server is still serving,
                     #   2. We still cannot connect to the Postgres cluster, or


### PR DESCRIPTION
Currently, `_reconnect_sys_pgcon` will give up on `EHOSTUNREACH` ("No
route to host"), leaving the server in a broken state when the old
Postgres host goes away completely during failover.  Rather than playing
the `errno` whack-a-mole, retry on all OSErrors.
