### PR TITLE
Adjust error messages for GraphQL.

### DIFF
--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -41,6 +41,9 @@ from edb.server import compiler
 from edb.server import defines as edbdef
 from edb.server.pgcon import errors as pgerrors
 from edb.server.protocol import execute
+from edb.server.compiler import errormech
+
+from edb.schema import schema as s_schema
 
 from edb.common import debug
 from edb.common import markup
@@ -174,10 +177,28 @@ async def handle_request(
             markup.dump(ex)
 
         ex_type = type(ex)
-        if issubclass(ex_type, (gql_errors.GraphQLError,
-                                pgerrors.BackendError)):
+        if issubclass(ex_type, gql_errors.GraphQLError):
             # XXX Fix this when LSP "location" objects are implemented
             ex_type = errors.QueryError
+        elif issubclass(ex_type, pgerrors.BackendError):
+            static_exc = errormech.static_interpret_backend_error(
+                ex.fields, from_graphql=True)
+
+            # only use the backend if schema is required
+            if static_exc is errormech.SchemaRequired:
+                ex = errormech.interpret_backend_error(
+                    s_schema.ChainedSchema(
+                        server._std_schema,
+                        db.user_schema,
+                        server.get_global_schema(),
+                    ),
+                    ex.fields,
+                    from_graphql=True,
+                )
+            else:
+                ex = static_exc
+
+            ex_type = type(ex)
 
         err_dct = {
             'message': f'{ex_type.__name__}: {ex}',

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1183,15 +1183,23 @@ class GraphQLTranslator:
                 card = ptype.get_field_cardinality(fname)
                 if card is qltypes.SchemaCardinality.Many:
                     # Need to wrap the set into an "assert_distinct()".
+                    msg = f'objects provided for {fname!r} are not distinct'
                     compexpr = qlast.FunctionCall(
                         func='assert_distinct',
                         args=[compexpr],
+                        kwargs={
+                            'message': qlast.StringConstant.from_python(msg)
+                        }
                     )
                 else:
                     # Singleton object values need to be verified.
+                    msg = f'more than one object provided for {fname!r}'
                     compexpr = qlast.FunctionCall(
                         func='assert_single',
                         args=[compexpr],
+                        kwargs={
+                            'message': qlast.StringConstant.from_python(msg)
+                        }
                     )
 
             # Object types need to be wrapped in a DETACHED in

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -395,7 +395,8 @@ class GQLCoreSchema:
     def graphql_schema(self) -> GraphQLSchema:
         return self._gql_schema
 
-    def get_gql_name(self, name: s_name.QualName) -> str:
+    @classmethod
+    def get_gql_name(cls, name: s_name.QualName) -> str:
         module, shortname = name.module, name.name
 
         # Adjust the shortname.
@@ -412,7 +413,7 @@ class GQLCoreSchema:
             names = []
             for part in shortname[1:-1].split(' | '):
                 names.append(
-                    self.get_gql_name(s_name.QualName(*part.split(':', 1))))
+                    cls.get_gql_name(s_name.QualName(*part.split(':', 1))))
             shortname = '_OR_'.join(names)
 
         if module in {'default', 'std'}:

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -108,7 +108,7 @@ INSERT Foo {
 
 INSERT ScalarTest {
     p_bool := True,
-    p_str := 'Hello',
+    p_str := 'Hello world',
     p_datetime := <datetime>'2018-05-07T20:01:22.306916+00:00',
     p_local_datetime := <cal::local_datetime>'2018-05-07T20:01:22.306916',
     p_local_date := <cal::local_date>'2018-05-07',
@@ -132,6 +132,8 @@ INSERT ScalarTest {
 
     p_tuple := (123, 'test'),
     p_array_tuple := [('hello', true), ('world', false)],
+
+    p_short_str := 'hello',
 };
 
 # Inheritance tests
@@ -201,4 +203,9 @@ INSERT Combo {
 INSERT Combo {
     name := 'combo 2',
     data := assert_single((SELECT Profile FILTER .name = 'Alice profile')),
+};
+
+INSERT ErrorTest {
+    text := ')error(',
+    val := 0,
 };

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -1413,11 +1413,11 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
 
     def test_graphql_functional_arguments_22(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError,
+                edgedb.InvalidValueError,
                 # this error message is subpar, but this is what we get
                 # from postgres, because we transfer bigint values to postgres
                 # as strings
-                r'invalid input syntax for type bigint: "aaaaa"',
+                r'invalid input syntax for type Int64: "aaaaa"',
                 # _line=5, _col=32,
         ):
             self.graphql_query(r"""
@@ -2545,7 +2545,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         """, {
             "ScalarTest": [{
                 'p_bool': True,
-                'p_str': 'Hello',
+                'p_str': 'Hello world',
                 'p_datetime': '2018-05-07T20:01:22.306916+00:00',
                 'p_local_datetime': '2018-05-07T20:01:22.306916',
                 'p_local_date': '2018-05-07',
@@ -3268,8 +3268,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
 
     def test_graphql_functional_variables_33(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'expected JSON string'):
+                edgedb.InvalidValueError,
+                r'expected JSON string or null; got JSON number'):
 
             self.graphql_query(
                 r"""
@@ -3407,7 +3407,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     # error message expressed in terms of GraphQL types.
     def test_graphql_functional_variables_39(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError,
+                edgedb.InvalidValueError,
                 r'expected JSON number.+got JSON string'):
             self.graphql_query(
                 r"""
@@ -4134,6 +4134,58 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 },
             ]
         })
+
+    def test_graphql_functional_edgedb_errors_01(self):
+        with self.assertRaisesRegex(
+            edgedb.DivisionByZeroError,
+            r"division by zero"
+        ):
+            self.graphql_query(r"""
+                query {
+                    ErrorTest {
+                        div_by_val
+                    }
+                }
+            """)
+
+    def test_graphql_functional_edgedb_errors_02(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            r"LIMIT must not be negative"
+        ):
+            self.graphql_query(r"""
+                query {
+                    ErrorTest(first: -2) {
+                        text
+                    }
+                }
+            """)
+
+    def test_graphql_functional_edgedb_errors_03(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            r"OFFSET must not be negative"
+        ):
+            self.graphql_query(r"""
+                query {
+                    ErrorTest(after: "-2") {
+                        text
+                    }
+                }
+            """)
+
+    def test_graphql_functional_edgedb_errors_04(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            r"invalid regular expression"
+        ):
+            self.graphql_query(r"""
+                query {
+                    ErrorTest {
+                        re_text
+                    }
+                }
+            """)
 
     def test_graphql_globals_01(self):
         Q = r'''query { GlobalTest { gstr, garray, gid, gdef, gdef2 } }'''


### PR DESCRIPTION
In GraphQL mode the error messages should refer to various types by their exposed names (as opposed to SQL names or EdgeDB names) wherever possible. Custom scalars are an exception to this rule since they get exposed as their underlying base types instead.

Fixes #3816