### PR TITLE
Add more detailed Cloud usage instructions

### DIFF
--- a/docs/cli/edgedb_cloud/edgedb_cloud_login.rst
+++ b/docs/cli/edgedb_cloud/edgedb_cloud_login.rst
@@ -5,6 +5,10 @@
 edgedb cloud login
 ==================
 
+.. note::
+
+    This CLI command requires CLI version 3.0 or later.
+
 Authenticate to the EdgeDB Cloud and remember the secret key locally
 
 .. cli:synopsis::

--- a/docs/cli/edgedb_cloud/edgedb_cloud_logout.rst
+++ b/docs/cli/edgedb_cloud/edgedb_cloud_logout.rst
@@ -5,6 +5,10 @@
 edgedb cloud logout
 ===================
 
+.. note::
+
+    This CLI command requires CLI version 3.0 or later.
+
 Forget the stored access token
 
 .. cli:synopsis::

--- a/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/edgedb_cloud_secretkey_create.rst
+++ b/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/edgedb_cloud_secretkey_create.rst
@@ -5,6 +5,10 @@
 edgedb cloud secretkey create
 =============================
 
+.. note::
+
+    This CLI command requires CLI version 3.0 or later.
+
 Create a new secret key
 
 .. cli:synopsis::

--- a/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/edgedb_cloud_secretkey_list.rst
+++ b/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/edgedb_cloud_secretkey_list.rst
@@ -5,6 +5,10 @@
 edgedb cloud secretkey list
 ===========================
 
+.. note::
+
+    This CLI command requires CLI version 3.0 or later.
+
 List existing secret keys
 
 .. cli:synopsis::

--- a/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/edgedb_cloud_secretkey_revoke.rst
+++ b/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/edgedb_cloud_secretkey_revoke.rst
@@ -5,6 +5,10 @@
 edgedb cloud secretkey revoke
 =============================
 
+.. note::
+
+    This CLI command requires CLI version 3.0 or later.
+
 Revoke a secret key
 
 .. cli:synopsis::

--- a/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/index.rst
+++ b/docs/cli/edgedb_cloud/edgedb_cloud_secretkey/index.rst
@@ -5,6 +5,10 @@
 edgedb cloud secretkey
 ======================
 
+.. note::
+
+    These CLI commands require CLI version 3.0 or later.
+
 Manage your secret keys
 
 .. toctree::

--- a/docs/cli/edgedb_cloud/index.rst
+++ b/docs/cli/edgedb_cloud/index.rst
@@ -70,6 +70,10 @@ these commands:
       $ edgedb project init \
         --server-instance <github-username>/<instance-name>
 
+  Alternatively, you can run ``edgedb project init`` *without* the
+  ``--server-instance`` option and enter an instance name in the
+  ``<github-username>/<instance-name>`` format when prompted interactively.
+
 
 3. Configure your application
 -----------------------------

--- a/docs/cli/edgedb_cloud/index.rst
+++ b/docs/cli/edgedb_cloud/index.rst
@@ -74,8 +74,8 @@ these commands:
 -----------------------------
 
 For your production deployment, generate a dedicated secret key for your
-instance with :ref:`ref_edgedb_cloud_secretkey_create`. Create two environment
-variables accessible to your production application:
+instance with :ref:`ref_cli_edgedb_cloud_secretkey_create`. Create two
+environment variables accessible to your production application:
 
 * ``EDGEDB_SECRET_KEY``- contains the secret key you generated
 * ``EDGEDB_INSTANCE``- the name of your EdgeDB Cloud instance

--- a/docs/cli/edgedb_cloud/index.rst
+++ b/docs/cli/edgedb_cloud/index.rst
@@ -16,8 +16,23 @@ offers tools to manage your instances running on our EdgeDB Cloud.
     edgedb_cloud_logout
     edgedb_cloud_secretkey/index
 
+.. list-table::
+    :class: funcoptable
+
+    * - :ref:`ref_cli_edgedb_cloud_login`
+      - Authenticate to the EdgeDB Cloud and remember the access token locally
+    * - :ref:`ref_cli_edgedb_cloud_logout`
+      - Forget the stored access token
+    * - :ref:`ref_cli_edgedb_cloud_secretkey`
+      - Manage your secret keys
+
+
 Usage
 =====
+
+
+1. Log in
+---------
 
 To use the CLI with EdgeDB Cloud, start by running
 :ref:`ref_cli_edgedb_cloud_login`. This will open a browser and allow you to
@@ -28,15 +43,36 @@ log in to EdgeDB Cloud.
     During the Cloud beta, you will only be able to successfully complete
     authentication if you have been invited to the beta.
 
+
+2. Create an instance
+---------------------
+
 Once your login is complete, you may use the other CLI commands to create and
-interact with Cloud instances.
+interact with Cloud instances. To create an Cloud instance, you can use one of
+these commands:
 
-.. list-table::
-    :class: funcoptable
+* :ref:`ref_cli_edgedb_instance_create` with an instance name of
+  ``<github-username>/<instance-name>``.
 
-    * - :ref:`ref_cli_edgedb_cloud_login`
-      - Authenticate to the EdgeDB Cloud and remember the access token locally
-    * - :ref:`ref_cli_edgedb_cloud_logout`
-      - Forget the stored access token
-    * - :ref:`ref_cli_edgedb_cloud_secretkey`
-      - Manage your secret keys
+  .. code-block:: bash
+
+      edgedb instance create <github-username>/<instance-name>
+
+* :ref:`ref_cli_edgedb_project_init` with the ``--server-instance`` option. Set
+  the server instance name to ``<github-username>/<instance-name>``.
+
+  .. code-block:: bash
+
+      edgedb project init --server-instance <github-username>/<instance-name>
+
+
+3. Configure your application
+-----------------------------
+
+For your production deployment, generate a dedicated secret key for your
+instance with :ref:`ref_edgedb_cloud_secretkey_create`. Create two environment
+variables accessible to your production application:
+
+* ``EDGEDB_SECRET_KEY``- contains the secret key you generated
+* ``EDGEDB_INSTANCE``- the name of your EdgeDB Cloud instance
+  (``<github-username>/<instance-name>``)

--- a/docs/cli/edgedb_cloud/index.rst
+++ b/docs/cli/edgedb_cloud/index.rst
@@ -60,14 +60,15 @@ these commands:
 
   .. code-block:: bash
 
-      edgedb instance create <github-username>/<instance-name>
+      $ edgedb instance create <github-username>/<instance-name>
 
 * :ref:`ref_cli_edgedb_project_init` with the ``--server-instance`` option. Set
   the server instance name to ``<github-username>/<instance-name>``.
 
   .. code-block:: bash
 
-      edgedb project init --server-instance <github-username>/<instance-name>
+      $ edgedb project init \
+        --server-instance <github-username>/<instance-name>
 
 
 3. Configure your application

--- a/docs/cli/edgedb_cloud/index.rst
+++ b/docs/cli/edgedb_cloud/index.rst
@@ -5,6 +5,10 @@
 edgedb cloud
 ============
 
+.. note::
+
+    These CLI commands require CLI version 3.0 or later.
+
 In addition to managing your own local and remote instances, the EdgeDB CLI
 offers tools to manage your instances running on our EdgeDB Cloud.
 

--- a/docs/cli/edgedb_instance/edgedb_instance_create.rst
+++ b/docs/cli/edgedb_instance/edgedb_instance_create.rst
@@ -27,6 +27,10 @@ EdgeDB Cloud
 .. TODO: Cloud release
 .. Update this after Cloud has released
 
+.. note::
+
+    Creating a Cloud instance requires CLI version 3.0 or later.
+
 Users with access to the EdgeDB Cloud beta may use this command to create a
 Cloud instance after logging in using :ref:`ref_cli_edgedb_cloud_login`.
 

--- a/docs/cli/edgedb_project/edgedb_project_init.rst
+++ b/docs/cli/edgedb_project/edgedb_project_init.rst
@@ -28,6 +28,10 @@ EdgeDB Cloud
 .. TODO: Cloud release
 .. Update this after Cloud has released
 
+.. note::
+
+    Creating a Cloud instance requires CLI version 3.0 or later.
+
 Users with access to the EdgeDB Cloud beta may use this command to create a
 Cloud instance after logging in using :ref:`ref_cli_edgedb_cloud_login`.
 


### PR DESCRIPTION
Is this good for user-facing instructions for Cloud? I also suspect this (or something very similar) needs to be somewhere else in our documentation to make it more visible. Do you think it makes sense to have a new top-level section for Cloud? I think, with this addition, we probably have everything in the regular docs that we need (aside from maybe something about the Cloud UI), but it might be nice to surface everything that's Cloud-related somewhere else in addition to inside the CLI docs.