### PR TITLE
Make staeval more resilient to ops not being supported on a type

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -188,7 +188,13 @@ def evaluate_OperatorCall(
 
         args.append(arg_val)
 
-    value = eval_func(*args)
+    try:
+        value = eval_func(*args)
+    except TypeError:
+        raise UnsupportedExpressionError(
+            f'operator {opcall.func_shortname} not actually supported on '
+            f'input types',
+            context=opcall.context)
     qlconst: qlast.BaseConstant
     if isinstance(value, str):
         qlconst = qlast.StringConstant.from_python(value)

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -188,13 +188,7 @@ def evaluate_OperatorCall(
 
         args.append(arg_val)
 
-    try:
-        value = eval_func(*args)
-    except TypeError:
-        raise UnsupportedExpressionError(
-            f'operator {opcall.func_shortname} not actually supported on '
-            f'input types',
-            context=opcall.context)
+    value = eval_func(*args)
     qlconst: qlast.BaseConstant
     if isinstance(value, str):
         qlconst = qlast.StringConstant.from_python(value)

--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 from typing import *
 
+import functools
 import re
 import struct
 
@@ -41,6 +42,7 @@ class ScalarType:
         raise NotImplementedError
 
 
+@functools.total_ordering
 class Duration(ScalarType):
 
     _pg_simple_parser = re.compile(r'''
@@ -278,6 +280,9 @@ class Duration(ScalarType):
     def to_microseconds(self) -> int:
         return self._value
 
+    def __lt__(self, other: Duration) -> bool:
+        return self._value < other._value
+
     def to_iso8601(self) -> str:
         neg = '-' if self._value < 0 else ''
         seconds, usecs = divmod(abs(self._value), 1_000_000)
@@ -313,6 +318,7 @@ class Duration(ScalarType):
         return cls(microseconds=cls._codec.unpack(data)[0])
 
 
+@functools.total_ordering
 class ConfigMemory(ScalarType):
 
     PiB = 1024 * 1024 * 1024 * 1024 * 1024
@@ -368,6 +374,9 @@ class ConfigMemory(ScalarType):
         else:
             raise ValueError(
                 f"invalid ConfigMemory value: {type(val)}, expected int | str")
+
+    def __lt__(self, other: ConfigMemory) -> bool:
+        return self._value < other._value
 
     def to_nbytes(self) -> int:
         return self._value

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -347,3 +347,13 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
                 ['foo'],
                 use_http_post=use_http_post,
             )
+
+    def test_http_edgeql_query_duration_01(self):
+        Q = r"""select <duration>'15m' < <duration>'1h'"""
+
+        for use_http_post in [True, False]:
+            self.assert_edgeql_query_result(
+                Q,
+                [True],
+                use_http_post=use_http_post,
+            )

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -264,3 +264,12 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
             'create global foo -> int64',
         ])
         self.assertNotIn('error', results['results'][0])
+
+    def test_http_notebook_09(self):
+        results = self.run_queries([
+            '''
+            select <duration>'15m' < <duration>'1h';
+            ''',
+        ])
+
+        self.assertNotIn('error', results['results'][0])


### PR DESCRIPTION
staeval supports comparison operators (in order to check constraints
on config values in certain cases) and it supports durations (also for
config reasons). But our duration objects don't support comparison,
so doing a comparison of duration literals crashes in staeval.

This only really happens in the http/notebook protocols, because in
the binary protocol constant extraction breaks any hope of statically
evaluating things.