### PR TITLE
Type unions should not appear when computing the source of a back link

### DIFF
--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -192,6 +192,7 @@ class ObjectType(
             if (
                 lnk.get_shortname(schema).name == name
                 and not lnk.get_source_type(schema).is_view(schema)
+                and not lnk.get_source_type(schema).is_union_type(schema)
                 # Only grab the "base" pointers
                 and all(
                     b.generic(schema)

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -186,29 +186,19 @@ class ObjectType(
         if sn.is_qualified(name):
             raise ValueError(
                 'references to concrete pointers must not be qualified')
-        ptrs = {
-            lnk for lnk in schema.get_referrers(self, scls_type=links.Link,
-                                                field_name='target')
-            if (
-                lnk.get_shortname(schema).name == name
-                and not lnk.get_source_type(schema).is_view(schema)
-                and not lnk.get_source_type(schema).is_union_type(schema)
-                # Only grab the "base" pointers
-                and all(
-                    b.generic(schema)
-                    for b in lnk.get_bases(schema).objects(schema)
-                )
-                and (not sources or lnk.get_source_type(schema) in sources)
-            )
-        }
 
-        for obj in self.get_ancestors(schema).objects(schema):
+        ptrs: Set[links.Link] = set()
+
+        ancestor_objects = self.get_ancestors(schema).objects(schema)
+
+        for obj in (self,) + ancestor_objects:
             ptrs.update(
                 lnk for lnk in schema.get_referrers(obj, scls_type=links.Link,
                                                     field_name='target')
                 if (
                     lnk.get_shortname(schema).name == name
                     and not lnk.get_source_type(schema).is_view(schema)
+                    and not lnk.get_source_type(schema).is_union_type(schema)
                     # Only grab the "base" pointers
                     and all(
                         b.generic(schema)

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1580,3 +1580,20 @@ class TestIntrospection(tb.QueryTestCase):
             ''',
             [True],
         )
+
+    async def test_edgeql_schema_inheritance_computed_backlinks_01(self):
+        await self.assert_query_result(
+            r'''WITH MODULE schema
+            SELECT InheritingObject {
+                children := .<bases[IS Type],
+                descendants := .<ancestors[IS Type]
+            } LIMIT 2''',
+            [
+                {'children': [],
+                 'descendants': []
+                 },
+                {'children': [],
+                 'descendants': []
+                 },
+            ]
+        )


### PR DESCRIPTION
Fix #5500