### PR TITLE
Fix pg_database for postgres 15

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5943,7 +5943,7 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
             datistemplate,
             datallowconn,
             datconnlimit,
-            datlastsysoid,
+            0::oid AS datlastsysoid,
             datfrozenxid,
             datminmxid,
             dattablespace,


### PR DESCRIPTION
Closes #5521

Postgres removed column pg_database.datlastsysoid
due to realization it is not used anywhere since
pg 9. This means that we can simply return 0
instead of correct value and not break anything,
while not erroring when running on pg 15.

https://www.postgresql.org/message-id/CA%2BTgmoa14%3DBRq0WEd0eevjEMn9EkghDB1FZEkBw7%2BUAb7tF49A%40mail.gmail.com
