### PR TITLE
Fix constraints without any refs

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -690,7 +690,7 @@ class ComputableInfo(typing.NamedTuple):
 
 class Statement(Command):
 
-    expr: typing.Union[Set, Expr]
+    expr: Set
     views: typing.Dict[sn.Name, s_types.Type]
     params: typing.List[Param]
     globals: typing.List[Global]

--- a/edb/pgsql/dbops/constraints.py
+++ b/edb/pgsql/dbops/constraints.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+import typing
+
 from .. import common
 from . import base
 
@@ -45,11 +47,11 @@ class Constraint(base.DBObject):
             self.constraint_name(), self.get_subject_type(),
             self.get_subject_name())
 
-    def constraint_name(self, quote=True):
+    def constraint_name(self, quote=True) -> str:
         if quote and self._constraint_name:
             return common.quote_ident(self._constraint_name)
         else:
             return self._constraint_name
 
-    def constraint_code(self, block: base.PLBlock) -> str:
+    def constraint_code(self, block: base.PLBlock) -> str | typing.List[str]:
         raise NotImplementedError

--- a/edb/pgsql/dbops/tables.py
+++ b/edb/pgsql/dbops/tables.py
@@ -508,7 +508,7 @@ class TableConstraintExists(base.Condition):
 
 
 class AlterTableAddConstraint(AlterTableFragment, TableConstraintCommand):
-    def __init__(self, constraint):
+    def __init__(self, constraint: TableConstraint):
         assert not isinstance(constraint, list)
         self.constraint = constraint
 
@@ -519,6 +519,7 @@ class AlterTableAddConstraint(AlterTableFragment, TableConstraintCommand):
             code += f'CONSTRAINT {name} '
 
         constr_code = self.constraint.constraint_code(block)
+        assert isinstance(constr_code, str)
 
         if not isinstance(constr_code, base.PLExpression):
             # Static declaration

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2092,11 +2092,9 @@ class ConstraintCommand(MetaCommand):
                 and not context.is_deleting(base)
             ):
                 subject = base.get_subject(schema)
-                schemac_to_backendc = \
-                    schemamech.ConstraintMech.\
-                    schema_constraint_to_backend_constraint
-                bconstr = schemac_to_backendc(
-                    subject, base, schema, context, source_context)
+                bconstr = schemamech.compile_constraint(
+                    subject, base, schema, source_context
+                )
                 op.add_command(bconstr.alter_ops(
                     bconstr, only_modify_enabled=True))
 
@@ -2110,12 +2108,9 @@ class ConstraintCommand(MetaCommand):
             subject = constraint.get_subject(schema)
 
             if subject is not None:
-                schemac_to_backendc = \
-                    schemamech.ConstraintMech.\
-                    schema_constraint_to_backend_constraint
-                bconstr = schemac_to_backendc(
-                    subject, constraint, schema, context,
-                    source_context)
+                bconstr = schemamech.compile_constraint(
+                    subject, constraint, schema, source_context
+                )
 
                 op.add_command(bconstr.create_ops())
 
@@ -2129,12 +2124,9 @@ class ConstraintCommand(MetaCommand):
             subject = constraint.get_subject(schema)
 
             if subject is not None:
-                schemac_to_backendc = \
-                    schemamech.ConstraintMech.\
-                    schema_constraint_to_backend_constraint
-                bconstr = schemac_to_backendc(
-                    subject, constraint, schema, context,
-                    source_context)
+                bconstr = schemamech.compile_constraint(
+                    subject, constraint, schema, source_context
+                )
 
                 op.add_command(bconstr.delete_ops())
 
@@ -2148,12 +2140,9 @@ class ConstraintCommand(MetaCommand):
             subject = constraint.get_subject(schema)
 
             if subject is not None:
-                schemac_to_backendc = \
-                    schemamech.ConstraintMech.\
-                    schema_constraint_to_backend_constraint
-                bconstr = schemac_to_backendc(
-                    subject, constraint, schema, context,
-                    source_context)
+                bconstr = schemamech.compile_constraint(
+                    subject, constraint, schema, source_context
+                )
 
                 return bconstr.enforce_ops()
         else:
@@ -2233,18 +2222,14 @@ class AlterConstraint(
             return schema
 
         if subject is not None:
-            schemac_to_backendc = \
-                schemamech.ConstraintMech.\
-                schema_constraint_to_backend_constraint
+            bconstr = schemamech.compile_constraint(
+                subject, constraint, schema, self.source_context
+            )
 
-            bconstr = schemac_to_backendc(
-                subject, constraint, schema, context, self.source_context)
-
-            orig_bconstr = schemac_to_backendc(
+            orig_bconstr = schemamech.compile_constraint(
                 constraint.get_subject(orig_schema),
                 constraint,
                 orig_schema,
-                context,
                 self.source_context,
             )
 
@@ -2254,18 +2239,16 @@ class AlterConstraint(
 
                 # XXX: I don't think any of this logic is needed??
                 for child in constraint.children(schema):
-                    orig_cbconstr = schemac_to_backendc(
+                    orig_cbconstr = schemamech.compile_constraint(
                         child.get_subject(orig_schema),
                         child,
                         orig_schema,
-                        context,
                         self.source_context,
                     )
-                    cbconstr = schemac_to_backendc(
+                    cbconstr = schemamech.compile_constraint(
                         child.get_subject(schema),
                         child,
                         schema,
-                        context,
                         self.source_context,
                     )
                     op.add_command(cbconstr.alter_ops(orig_cbconstr))
@@ -2273,18 +2256,16 @@ class AlterConstraint(
                 op.add_command(bconstr.alter_ops(orig_bconstr))
 
                 for child in constraint.children(schema):
-                    orig_cbconstr = schemac_to_backendc(
+                    orig_cbconstr = schemamech.compile_constraint(
                         child.get_subject(orig_schema),
                         child,
                         orig_schema,
-                        context,
                         self.source_context,
                     )
-                    cbconstr = schemac_to_backendc(
+                    cbconstr = schemamech.compile_constraint(
                         child.get_subject(schema),
                         child,
                         schema,
-                        context,
                         self.source_context,
                     )
                     op.add_command(cbconstr.alter_ops(orig_cbconstr))
@@ -3176,7 +3157,7 @@ class CompositeMetaCommand(MetaCommand):
         if pg_schema is not None:
             inhview_name = (pg_schema, inhview_name[1])
 
-        ptrs = {}
+        ptrs: Dict[sn.UnqualName, Tuple[str, Tuple[str, ...]]] = {}
 
         if isinstance(obj, s_sources.Source):
             pointers = list(obj.get_pointers(schema).items(schema))
@@ -3204,7 +3185,7 @@ class CompositeMetaCommand(MetaCommand):
 
         else:
             # MULTI PROPERTY
-            ptrs[sn.UnqualName('source')] = ('source', 'uuid')
+            ptrs[sn.UnqualName('source')] = ('source', ('uuid',))
             lp_info = types.get_pointer_storage_info(
                 obj,
                 link_bias=True,
@@ -3944,6 +3925,7 @@ class PointerMetaCommand(
         if isinstance(source_op, sd.CreateObject):
             return
 
+        assert ptr_stor_info.table_name
         tab = q(*ptr_stor_info.table_name)
         target_col = ptr_stor_info.column_name
         source = ptr.get_source(orig_schema)
@@ -4143,6 +4125,7 @@ class PointerMetaCommand(
 
         if fill_expr is not None:
 
+            assert ptr_stor_info.table_name
             tab = q(*ptr_stor_info.table_name)
             target_col = ptr_stor_info.column_name
             source = ptr.get_source(orig_schema)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4703,7 +4703,7 @@ def ptr_col_name(
 ) -> str:
     prop = obj.getptr(schema, s_name.UnqualName(propname))
     psi = types.get_pointer_storage_info(prop, schema=schema)
-    return psi.column_name  # type: ignore[no-any-return]
+    return psi.column_name
 
 
 def format_fields(

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -279,8 +279,15 @@ def compile_constraint(
         subject_db_name, info = next(iter(ref_tables.items()))
         table_type = info[0][3].table_type
     else:
+        # the expression does don't have any refs: default to the subject table
+
+        if isinstance(subject, s_pointers.Pointer):
+            subject_table = subject.get_source(schema)
+        else:
+            subject_table = subject
+
         subject_db_name = common.get_backend_name(
-            schema, subject, catenate=False
+            schema, subject_table, catenate=False
         )
         table_type = 'ObjectType'
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import *
 
 import itertools
+import dataclasses
 
 from edb import errors
 
@@ -40,8 +41,10 @@ from edb.schema import utils as s_utils
 from edb.schema import types as s_types
 from edb.schema import constraints as s_constraints
 from edb.schema import schema as s_schema
+from edb.schema import sources as s_sources
 
 from edb.common import ast
+from edb.common import parsing
 
 from . import ast as pg_ast
 from . import dbops
@@ -50,361 +53,405 @@ from . import common
 from . import types
 from . import compiler
 from . import codegen
+from .common import qname as qn
 
 
-class ConstraintMech:
+def _get_exclusive_refs(tree: irast.Statement) -> Sequence[irast.Base] | None:
+    # Check if the expression is
+    #   std::_is_exclusive(<arg>) [and std::_is_exclusive(<arg>)...]
 
-    @classmethod
-    def _get_exclusive_refs(cls, tree):
-        # Check if the expression is
-        #   std::_is_exclusive(<arg>) [and std::_is_exclusive(<arg>)...]
-        expr = tree.expr.expr.result
+    assert isinstance(tree.expr.expr, irast.SelectStmt)
+    expr = tree.expr.expr.result
 
-        astexpr = irastexpr.DistinctConjunctionExpr()
-        refs = astexpr.match(expr)
+    astexpr = irastexpr.DistinctConjunctionExpr()  # type: ignore
+    refs = astexpr.match(expr)
 
-        if refs is None:
-            return refs
-        else:
-            all_refs = []
-            for ref in refs:
-                # Unnest sequences in refs
-                all_refs.append(ref)
-
-            return all_refs
-
-    @classmethod
-    def _edgeql_tree_to_exprdata(cls, sql_expr, is_multicol=False, refs=None):
-        if refs is None:
-            refs = set(ast.find_children(
-                sql_expr, pg_ast.ColumnRef, lambda n: len(n.name) == 1))
-
-        plain_expr = codegen.SQLSourceGenerator.to_source(sql_expr)
-
-        if is_multicol:
-            chunks = []
-
-            for elem in sql_expr.args:
-                chunks.append(codegen.SQLSourceGenerator.to_source(elem))
-        else:
-            chunks = [plain_expr]
-
-        if isinstance(sql_expr, pg_ast.ColumnRef):
-            refs.add(sql_expr)
-
+    if refs is None:
+        return refs
+    else:
+        all_refs = []
         for ref in refs:
-            ref.name.insert(0, 'NEW')
-        new_expr = codegen.SQLSourceGenerator.to_source(sql_expr)
+            # Unnest sequences in refs
+            all_refs.append(ref)
 
-        for ref in refs:
-            ref.name[0] = 'OLD'
-        old_expr = codegen.SQLSourceGenerator.to_source(sql_expr)
+        return all_refs
 
-        return dict(
-            plain=plain_expr, new=new_expr, old=old_expr, plain_chunks=chunks)
 
-    @classmethod
-    def _edgeql_ref_to_pg_constr(cls, subject, origin_subject, tree, schema):
-        sql_tree, _ = compiler.compile_ir_to_sql_tree(
-            tree, singleton_mode=True)
+@dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
+class PGConstrData:
+    subject_db_name: Optional[Tuple[str, str]]
+    expressions: List[ExprData]
+    origin_expressions: List[ExprData]
+    table_type: str
+    except_data: Optional[ExprDataSources]
 
-        if isinstance(sql_tree, pg_ast.SelectStmt):
-            # XXX: use ast pattern matcher for this
-            sql_expr = sql_tree.from_clause[0].relation\
-                .query.target_list[0].val
-        else:
-            sql_expr = sql_tree
+    scope: Optional[str] = None
+    type: Optional[str] = None
 
-        if isinstance(tree, irast.Statement):
-            tree = tree.expr
 
-        if isinstance(tree.expr, irast.SelectStmt):
-            tree = tree.expr.result
+@dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
+class ExprData:
+    exprdata: ExprDataSources
+    is_multicol: bool
+    is_trivial: bool
+    origin_subject_db_name: Optional[Tuple[str, str]] = None
+    origin_except_data: Optional[ExprDataSources] = None
 
-        is_multicol = isinstance(sql_expr, (
-            pg_ast.RowExpr, pg_ast.ImplicitRowExpr))
 
-        # Determine if the sequence of references are all simple refs, not
-        # expressions.  This influences the type of Postgres constraint used.
-        #
-        is_trivial = (
-            isinstance(sql_expr, pg_ast.ColumnRef) or (
-                is_multicol and all(
-                    isinstance(el, pg_ast.ColumnRef)
-                    for el in sql_expr.args)))
+@dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
+class ExprDataSources:
+    plain: str
+    new: str
+    old: str
+    plain_chunks: Sequence[str]
 
-        # Find all field references
-        #
+
+def _edgeql_tree_to_expr_data(
+    sql_expr: pg_ast.Base, refs: Optional[Set[pg_ast.ColumnRef]] = None
+) -> ExprDataSources:
+    if refs is None:
         refs = set(ast.find_children(
             sql_expr, pg_ast.ColumnRef, lambda n: len(n.name) == 1))
 
-        if isinstance(subject, s_scalars.ScalarType):
-            # Domain constraint, replace <scalar_name> with VALUE
+    plain_expr = codegen.SQLSourceGenerator.to_source(sql_expr)
 
-            subj_pgname = common.edgedb_name_to_pg_name(str(subject.id))
-            orgsubj_pgname = common.edgedb_name_to_pg_name(
-                str(origin_subject.id))
+    if isinstance(sql_expr, (pg_ast.RowExpr, pg_ast.ImplicitRowExpr)):
+        chunks = []
 
-            for ref in refs:
-                if ref.name != [subj_pgname] and ref.name != [orgsubj_pgname]:
-                    raise ValueError(
-                        f'unexpected node reference in '
-                        f'ScalarType constraint: {".".join(ref.name)}'
-                    )
+        for elem in sql_expr.args:
+            chunks.append(codegen.SQLSourceGenerator.to_source(elem))
+    else:
+        chunks = [plain_expr]
 
-                # work around the immutability check
-                object.__setattr__(ref, 'name', ['VALUE'])
+    if isinstance(sql_expr, pg_ast.ColumnRef):
+        refs.add(sql_expr)
 
-        exprdata = cls._edgeql_tree_to_exprdata(
-            sql_expr, is_multicol=is_multicol, refs=refs)
+    for ref in refs:
+        assert isinstance(ref.name, List)
+        ref.name.insert(0, 'NEW')
+    new_expr = codegen.SQLSourceGenerator.to_source(sql_expr)
 
-        # Scalar constraints shouldn't ever fail on NULL
-        if isinstance(subject, s_scalars.ScalarType):
-            exprdata['plain'] = f"VALUE IS NULL OR ({exprdata['plain']})"
+    for ref in refs:
+        assert isinstance(ref.name, List)
+        ref.name[0] = 'OLD'
+    old_expr = codegen.SQLSourceGenerator.to_source(sql_expr)
 
-        return dict(
-            exprdata=exprdata, is_multicol=is_multicol, is_trivial=is_trivial)
+    return ExprDataSources(
+        plain=plain_expr, new=new_expr, old=old_expr, plain_chunks=chunks
+    )
 
-    @classmethod
-    def schema_constraint_to_backend_constraint(
-        cls,
-        subject: s_types.Type,
-        constraint: s_constraints.Constraint,
-        schema: s_schema.Schema,
-        context,
-        source_context,
-    ) -> SchemaDomainConstraint | SchemaTableConstraint:
-        assert constraint.get_subject(schema) is not None
 
-        constraint_origins = constraint.get_constraint_origins(schema)
-        first_subject = constraint_origins[0].get_subject(schema)
+def _edgeql_ref_to_pg_constr(
+    subject: s_types.Type,
+    origin_subject: s_types.Type | s_pointers.Pointer | None,
+    tree: irast.Base,
+) -> ExprData:
+    sql_tree, _ = compiler.compile_ir_to_sql_tree(tree, singleton_mode=True)
 
-        TypeOrPointer = s_types.Type | s_pointers.Pointer
-        is_optional = (
-            isinstance(first_subject, s_pointers.Pointer)
-            and not first_subject.get_required(schema)
+    sql_expr: pg_ast.Base
+    if isinstance(sql_tree, pg_ast.SelectStmt):
+        # XXX: use ast pattern matcher for this
+        from_clause = sql_tree.from_clause[0]
+        assert isinstance(from_clause, pg_ast.RelRangeVar)
+        assert isinstance(from_clause.relation, pg_ast.CommonTableExpr)
+        sql_expr = from_clause.relation.query.target_list[0].val
+    else:
+        sql_expr = sql_tree
+
+    if isinstance(tree, irast.Statement):
+        tree = tree.expr
+
+    if isinstance(tree, irast.Set) and isinstance(tree.expr, irast.SelectStmt):
+        tree = tree.expr.result
+
+    is_multicol = isinstance(sql_expr, (pg_ast.RowExpr, pg_ast.ImplicitRowExpr))
+
+    # Determine if the sequence of references are all simple refs, not
+    # expressions.  This influences the type of Postgres constraint used.
+    #
+    is_trivial = isinstance(sql_expr, pg_ast.ColumnRef) or (
+        isinstance(sql_expr, (pg_ast.RowExpr, pg_ast.ImplicitRowExpr))
+        and all(isinstance(el, pg_ast.ColumnRef) for el in sql_expr.args)
+    )
+
+    # Find all field references
+    #
+    refs = set(
+        ast.find_children(
+            sql_expr, pg_ast.ColumnRef, lambda n: len(n.name) == 1
         )
-        singletons: Collection[tuple[TypeOrPointer, bool]] = (
-            frozenset({(subject, is_optional)}))
+    )
 
-        options = qlcompiler.CompilerOptions(
-            anchors={qlast.Subject().name: subject},
-            path_prefix_anchor=qlast.Subject().name,
-            apply_query_rewrites=False,
-            singletons=singletons,
-            schema_object_context=type(constraint),
-            # Remap the constraint origin to the subject, so that if
-            # we have B <: A, and the constraint references A.foo, it
-            # gets rewritten in the subtype to B.foo. It's OK to only
-            # look at one constraint origin, because if there were
-            # multiple different origins, they couldn't get away with
-            # referring to the type explicitly.
-            type_remaps={first_subject: subject},
-        )
+    if isinstance(subject, s_scalars.ScalarType):
+        # Domain constraint, replace <scalar_name> with VALUE
+        assert origin_subject
 
-        final_expr = constraint.get_finalexpr(schema)
-        assert final_expr is not None and final_expr.qlast is not None
-        ir = qlcompiler.compile_ast_to_ir(
-            final_expr.qlast,
+        subj_pgname = common.edgedb_name_to_pg_name(str(subject.id))
+        orgsubj_pgname = common.edgedb_name_to_pg_name(str(origin_subject.id))
+
+        for ref in refs:
+            if ref.name != [subj_pgname] and ref.name != [orgsubj_pgname]:
+                raise ValueError(
+                    f'unexpected node reference in '
+                    f'ScalarType constraint: {qn(*ref.name)}'
+                )
+
+            # work around the immutability check
+            object.__setattr__(ref, 'name', ['VALUE'])
+
+    exprdata = _edgeql_tree_to_expr_data(sql_expr, refs=refs)
+
+    # Scalar constraints shouldn't ever fail on NULL
+    if isinstance(subject, s_scalars.ScalarType):
+        exprdata.plain = f"VALUE IS NULL OR ({exprdata.plain})"
+
+    return ExprData(
+        exprdata=exprdata, is_multicol=is_multicol, is_trivial=is_trivial
+    )
+
+
+def compile_constraint(
+    subject: s_types.Type,
+    constraint: s_constraints.Constraint,
+    schema: s_schema.Schema,
+    source_context: Optional[parsing.ParserContext],
+) -> SchemaDomainConstraint | SchemaTableConstraint:
+    assert constraint.get_subject(schema) is not None
+    TypeOrPointer = s_types.Type | s_pointers.Pointer
+
+    constraint_origins = constraint.get_constraint_origins(schema)
+    first_subject = constraint_origins[0].get_subject(schema)
+
+    is_optional = isinstance(
+        first_subject, s_pointers.Pointer
+    ) and not first_subject.get_required(schema)
+    singletons: Collection[Tuple[TypeOrPointer, bool]] = frozenset(
+        {(subject, is_optional)}
+    )
+    options = qlcompiler.CompilerOptions(
+        anchors={qlast.Subject().name: subject},
+        path_prefix_anchor=qlast.Subject().name,
+        apply_query_rewrites=False,
+        singletons=singletons,
+        schema_object_context=type(constraint),
+        # Remap the constraint origin to the subject, so that if
+        # we have B <: A, and the constraint references A.foo, it
+        # gets rewritten in the subtype to B.foo. It's OK to only
+        # look at one constraint origin, because if there were
+        # multiple different origins, they couldn't get away with
+        # referring to the type explicitly.
+        type_remaps={first_subject: subject},
+    )
+
+    final_expr = constraint.get_finalexpr(schema)
+    assert final_expr is not None and final_expr.qlast is not None
+    ir = qlcompiler.compile_ast_to_ir(
+        final_expr.qlast,
+        schema,
+        options=options,
+    )
+    assert isinstance(ir, irast.Statement)
+    assert isinstance(ir.expr.expr, irast.SelectStmt)
+
+    except_data = None
+    if except_expr := constraint.get_except_expr(schema):
+        except_ir = qlcompiler.compile_ast_to_ir(
+            except_expr.qlast,
             schema,
             options=options,
         )
+        except_sql, _ = compiler.compile_ir_to_sql_tree(
+            except_ir, singleton_mode=True
+        )
+        except_data = _edgeql_tree_to_expr_data(except_sql)
 
-        except_data = None
-        if (except_expr := constraint.get_except_expr(schema)):
+    terminal_refs = ir_utils.get_longest_paths(ir.expr.expr.result)
+    ref_tables = get_ref_storage_info(ir.schema, terminal_refs)
+
+    if len(ref_tables) > 1:
+        raise errors.InvalidConstraintDefinitionError(
+            f'Constraint {constraint.get_displayname(schema)} on '
+            f'{subject.get_displayname(schema)} is not supported '
+            f'because it would depend on multiple objects',
+            context=source_context,
+        )
+    elif ref_tables:
+        subject_db_name, info = next(iter(ref_tables.items()))
+        table_type = info[0][3].table_type
+    else:
+        subject_db_name = common.get_backend_name(
+            schema, subject, catenate=False
+        )
+        table_type = 'ObjectType'
+
+    exclusive_expr_refs = _get_exclusive_refs(ir)
+
+    pg_constr_data = PGConstrData(
+        subject_db_name=subject_db_name,
+        expressions=[],
+        origin_expressions=[],
+        table_type=table_type,
+        except_data=except_data,
+    )
+
+    different_origins = [
+        origin for origin in constraint_origins if origin != constraint
+    ]
+
+    per_origin_parts = []
+    for constraint_origin in different_origins:
+        sub = constraint_origin.get_subject(schema)
+        assert isinstance(sub, (s_types.Type, s_pointers.Pointer))
+        origin_subject: s_types.Type | s_pointers.Pointer = sub
+
+        origin_path_prefix_anchor = (
+            qlast.Subject().name
+            if isinstance(origin_subject, s_types.Type)
+            else None
+        )
+        singletons = frozenset({(origin_subject, is_optional)})
+
+        origin_options = qlcompiler.CompilerOptions(
+            anchors={qlast.Subject().name: origin_subject},
+            path_prefix_anchor=origin_path_prefix_anchor,
+            apply_query_rewrites=False,
+            singletons=singletons,
+            schema_object_context=type(constraint),
+        )
+
+        final_expr = constraint_origin.get_finalexpr(schema)
+        assert final_expr is not None and final_expr.qlast is not None
+        origin_ir = qlcompiler.compile_ast_to_ir(
+            final_expr.qlast,
+            schema,
+            options=origin_options,
+        )
+
+        origin_terminal_refs = ir_utils.get_longest_paths(
+            origin_ir.expr.expr.result
+        )
+        origin_ref_tables = get_ref_storage_info(
+            origin_ir.schema, origin_terminal_refs
+        )
+
+        if origin_ref_tables:
+            origin_subject_db_name, _ = next(iter(origin_ref_tables.items()))
+        else:
+            origin_subject_db_name = common.get_backend_name(
+                schema,
+                origin_subject,
+                catenate=False,
+            )
+
+        origin_except_data = None
+        if except_expr := constraint_origin.get_except_expr(schema):
             except_ir = qlcompiler.compile_ast_to_ir(
                 except_expr.qlast,
                 schema,
-                options=options,
+                options=origin_options,
             )
             except_sql, _ = compiler.compile_ir_to_sql_tree(
                 except_ir, singleton_mode=True)
-            except_data = cls._edgeql_tree_to_exprdata(except_sql)
+            origin_except_data = _edgeql_tree_to_expr_data(except_sql)
 
-        terminal_refs = ir_utils.get_longest_paths(ir.expr.expr.result)
-        ref_tables = get_ref_storage_info(ir.schema, terminal_refs)
-
-        if len(ref_tables) > 1:
-            raise errors.InvalidConstraintDefinitionError(
-                f'Constraint {constraint.get_displayname(schema)} on '
-                f'{subject.get_displayname(schema)} is not supported '
-                f'because it would depend on multiple objects',
-                context=source_context,
-            )
-        elif ref_tables:
-            subject_db_name, info = next(iter(ref_tables.items()))
-            table_type = info[0][3].table_type
-        else:
-            subject_db_name = common.get_backend_name(
-                schema, subject, catenate=False)
-            table_type = 'ObjectType'
-
-        exclusive_expr_refs = cls._get_exclusive_refs(ir)
-
-        pg_constr_data = {
-            'subject_db_name': subject_db_name,
-            'expressions': [],
-            'origin_expressions': [],
-            'table_type': table_type,
-            'except_data': except_data,
-        }
-
-        different_origins = [
-            origin for origin in constraint_origins
-            if origin != constraint
-        ]
-
-        per_origin_parts = []
-        for constraint_origin in different_origins:
-            sub = constraint_origin.get_subject(schema)
-            assert isinstance(sub, (s_types.Type, s_pointers.Pointer))
-            origin_subject: s_types.Type | s_pointers.Pointer = sub
-
-            origin_path_prefix_anchor = (
-                qlast.Subject().name
-                if isinstance(origin_subject, s_types.Type) else None
-            )
-            singletons = frozenset({(origin_subject, is_optional)})
-
-            origin_options = qlcompiler.CompilerOptions(
-                anchors={qlast.Subject().name: origin_subject},
-                path_prefix_anchor=origin_path_prefix_anchor,
-                apply_query_rewrites=False,
-                singletons=singletons,
-                schema_object_context=type(constraint),
-            )
-
-            final_expr = constraint_origin.get_finalexpr(schema)
-            assert final_expr is not None and final_expr.qlast is not None
-            origin_ir = qlcompiler.compile_ast_to_ir(
-                final_expr.qlast,
-                schema,
-                options=origin_options,
-            )
-
-            origin_terminal_refs = ir_utils.get_longest_paths(
-                origin_ir.expr.expr.result)
-            origin_ref_tables = get_ref_storage_info(
-                origin_ir.schema, origin_terminal_refs)
-
-            if origin_ref_tables:
-                origin_subject_db_name, _ = (
-                    next(iter(origin_ref_tables.items()))
-                )
-            else:
-                origin_subject_db_name = common.get_backend_name(
-                    schema, origin_subject, catenate=False,
-                )
-
-            origin_except_data = None
-            if (except_expr := constraint_origin.get_except_expr(schema)):
-                except_ir = qlcompiler.compile_ast_to_ir(
-                    except_expr.qlast,
-                    schema,
-                    options=origin_options,
-                )
-                except_sql, _ = compiler.compile_ir_to_sql_tree(
-                    except_ir, singleton_mode=True)
-                origin_except_data = cls._edgeql_tree_to_exprdata(except_sql)
-
-            origin_exclusive_expr_refs = cls._get_exclusive_refs(origin_ir)
-            per_origin_parts.append((
+        origin_exclusive_expr_refs = _get_exclusive_refs(origin_ir)
+        per_origin_parts.append(
+            (
                 origin_subject,
                 origin_exclusive_expr_refs,
                 origin_subject_db_name,
                 origin_except_data,
-            ))
+            )
+        )
 
-        if not per_origin_parts:
-            origin_subject = subject
-            origin_subject_db_name = subject_db_name
-            origin_except_data = except_data
-            per_origin_parts.append((
+    if not per_origin_parts:
+        origin_subject = subject
+        origin_subject_db_name = subject_db_name
+        origin_except_data = except_data
+        per_origin_parts.append(
+            (
                 origin_subject,
                 None,
                 origin_subject_db_name,
                 origin_except_data,
-            ))
-
-        if exclusive_expr_refs:
-            exprdatas = []
-            for ref in exclusive_expr_refs:
-                exprdata = cls._edgeql_ref_to_pg_constr(
-                    subject, None, ref, schema)
-                exprdata.update(
-                    origin_subject_db_name=subject_db_name,
-                    origin_except_data=except_data,
-                )
-                exprdatas.append(exprdata)
-
-            pg_constr_data['expressions'].extend(exprdatas)
-
-        else:
-            assert len(constraint_origins) == 1
-            exprdata = cls._edgeql_ref_to_pg_constr(
-                subject, origin_subject, ir, schema)
-            exprdata.update(
-                origin_subject_db_name=origin_subject_db_name,
-                origin_except_data=origin_except_data,
             )
-            pg_constr_data['expressions'].append(exprdata)
+        )
 
-        for (
-            origin_subject,
-            origin_exclusive_expr_refs,
-            origin_subject_db_name,
-            origin_except_data
-        ) in per_origin_parts:
-            if not exclusive_expr_refs:
-                continue
+    if exclusive_expr_refs:
+        exprdatas: List[ExprData] = []
+        for ref in exclusive_expr_refs:
+            exprdata = _edgeql_ref_to_pg_constr(subject, None, ref)
+            exprdata.origin_subject_db_name = subject_db_name
+            exprdata.origin_except_data = except_data
+            exprdatas.append(exprdata)
 
-            if origin_exclusive_expr_refs:
-                for ref in origin_exclusive_expr_refs:
-                    exprdata = cls._edgeql_ref_to_pg_constr(
-                        subject, origin_subject, ref, schema)
-                    exprdata.update(
-                        origin_subject_db_name=origin_subject_db_name,
-                        origin_except_data=origin_except_data,
-                    )
-                    pg_constr_data['origin_expressions'].append(exprdata)
-            else:
-                pg_constr_data['origin_expressions'].extend(exprdatas)
+        pg_constr_data.expressions.extend(exprdatas)
 
-        if exclusive_expr_refs:
-            pg_constr_data['scope'] = 'relation'
-            pg_constr_data['type'] = 'unique'
+    else:
+        assert len(constraint_origins) == 1
+        exprdata = _edgeql_ref_to_pg_constr(subject, origin_subject, ir)
+        exprdata.origin_subject_db_name = origin_subject_db_name
+        exprdata.origin_except_data = origin_except_data
+
+        pg_constr_data.expressions.append(exprdata)
+
+    for (
+        origin_subject,
+        origin_exclusive_expr_refs,
+        origin_subject_db_name,
+        origin_except_data,
+    ) in per_origin_parts:
+        if not exclusive_expr_refs:
+            continue
+
+        if origin_exclusive_expr_refs:
+            for ref in origin_exclusive_expr_refs:
+                exprdata = _edgeql_ref_to_pg_constr(
+                    subject, origin_subject, ref
+                )
+                exprdata.origin_subject_db_name = origin_subject_db_name
+                exprdata.origin_except_data = origin_except_data
+                pg_constr_data.origin_expressions.append(exprdata)
         else:
-            pg_constr_data['scope'] = 'row'
-            pg_constr_data['type'] = 'check'
+            pg_constr_data.origin_expressions.extend(exprdatas)
 
-        if isinstance(constraint.get_subject(schema), s_scalars.ScalarType):
-            return SchemaDomainConstraint(
-                subject=subject, constraint=constraint,
-                pg_constr_data=pg_constr_data,
-                schema=schema)
-        else:
-            return SchemaTableConstraint(
-                subject=subject, constraint=constraint,
-                pg_constr_data=pg_constr_data,
-                schema=schema)
+    if exclusive_expr_refs:
+        pg_constr_data.scope = 'relation'
+        pg_constr_data.type = 'unique'
+    else:
+        pg_constr_data.scope = 'row'
+        pg_constr_data.type = 'check'
+
+    if isinstance(constraint.get_subject(schema), s_scalars.ScalarType):
+        return SchemaDomainConstraint(
+            subject=subject,
+            constraint=constraint,
+            pg_constr_data=pg_constr_data,
+            schema=schema,
+        )
+    else:
+        return SchemaTableConstraint(
+            subject=subject,
+            constraint=constraint,
+            pg_constr_data=pg_constr_data,
+            schema=schema,
+        )
 
 
+@dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
 class SchemaDomainConstraint:
-    def __init__(self, subject, constraint, pg_constr_data, schema):
-        self._subject = subject
-        self._constraint = constraint
-        self._pg_constr_data = pg_constr_data
-        self._schema = schema
+    subject: s_types.Type
+    constraint: s_constraints.Constraint
+    pg_constr_data: PGConstrData
+    schema: s_schema.Schema
 
-    def _domain_constraint(self, constr):
-        domain_name = constr._pg_constr_data['subject_db_name']
-        expressions = constr._pg_constr_data['expressions']
+    def _domain_constraint(self, constr: SchemaConstraint):
+        domain_name = constr.pg_constr_data.subject_db_name
+        expressions = constr.pg_constr_data.expressions
 
-        constr = deltadbops.SchemaConstraintDomainConstraint(
-            domain_name, constr._constraint, expressions,
-            schema=self._schema)
-
-        return constr
+        return deltadbops.SchemaConstraintDomainConstraint(
+            domain_name, constr.constraint, expressions, schema=self.schema
+        )
 
     def create_ops(self):
         ops = dbops.CommandGroup()
@@ -417,7 +464,9 @@ class SchemaDomainConstraint:
 
         return ops
 
-    def alter_ops(self, orig_constr, only_modify_enabled=False):
+    def alter_ops(
+        self, orig_constr: SchemaConstraint, only_modify_enabled: bool = False
+    ):
         ops = dbops.CommandGroup()
         return ops
 
@@ -437,32 +486,32 @@ class SchemaDomainConstraint:
         return ops
 
 
+@dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
 class SchemaTableConstraint:
-    def __init__(self, subject, constraint, pg_constr_data, schema):
-        self._subject = subject
-        self._constraint = constraint
-        self._pg_constr_data = pg_constr_data
-        self._schema = schema
+    subject: s_types.Type
+    constraint: s_constraints.Constraint
+    pg_constr_data: PGConstrData
+    schema: s_schema.Schema
 
-    def _table_constraint(self, constr):
-        pg_c = constr._pg_constr_data
+    def _table_constraint(
+        self, constr: SchemaConstraint
+    ) -> deltadbops.SchemaConstraintTableConstraint:
+        pg_c = constr.pg_constr_data
 
-        table_name = pg_c['subject_db_name']
-        expressions = pg_c['expressions']
-        origin_expressions = pg_c['origin_expressions']
+        table_name = pg_c.subject_db_name
+        expressions = pg_c.expressions
+        origin_expressions = pg_c.origin_expressions
 
-        constr = deltadbops.SchemaConstraintTableConstraint(
+        return deltadbops.SchemaConstraintTableConstraint(
             table_name,
-            constraint=constr._constraint,
+            constraint=constr.constraint,
             exprdata=expressions,
             origin_exprdata=origin_expressions,
-            except_data=pg_c['except_data'],
-            scope=pg_c['scope'],
-            type=pg_c['type'],
-            schema=constr._schema,
+            except_data=pg_c.except_data,
+            scope=pg_c.scope,
+            type=pg_c.type,
+            schema=constr.schema,
         )
-
-        return constr
 
     def create_ops(self):
         ops = dbops.CommandGroup()
@@ -475,7 +524,9 @@ class SchemaTableConstraint:
 
         return ops
 
-    def alter_ops(self, orig_constr, only_modify_enabled=False):
+    def alter_ops(
+        self, orig_constr: SchemaConstraint, only_modify_enabled=False
+    ):
         ops = dbops.CommandGroup()
 
         tabconstr = self._table_constraint(self)
@@ -513,35 +564,35 @@ class SchemaTableConstraint:
             itertools.cycle(tabconstr._exprdata),
             tabconstr._origin_exprdata
         ):
-            exprdata = expr['exprdata']
-            origin_exprdata = origin_expr['exprdata']
-            old_expr = origin_exprdata['old']
-            new_expr = exprdata['new']
+            exprdata = expr.exprdata
+            origin_exprdata = origin_expr.exprdata
+            old_expr = origin_exprdata.old
+            new_expr = exprdata.new
 
-            schemaname, tablename = origin_expr['origin_subject_db_name']
+            schemaname, tablename = origin_expr.origin_subject_db_name
             real_tablename = tabconstr.get_subject_name(quote=False)
 
             errmsg = 'duplicate key value violates unique ' \
                      'constraint {constr}'.format(constr=constr_name)
             detail = common.quote_literal(
-                f"Key ({origin_exprdata['plain']}) already exists."
+                f"Key ({origin_exprdata.plain}) already exists."
             )
 
             if (
-                isinstance(self._subject, s_pointers.Pointer)
-                and self._pg_constr_data['table_type'] == 'link'
+                isinstance(self.subject, s_pointers.Pointer)
+                and self.pg_constr_data.table_type == 'link'
             ):
                 key = "source"
             else:
                 key = "id"
 
             except_data = tabconstr._except_data
-            origin_except_data = origin_expr['origin_except_data']
+            origin_except_data = origin_expr.origin_except_data
 
             if except_data:
                 except_part = f'''
-                    AND ({origin_except_data['old']} is not true)
-                    AND ({except_data['new']} is not true)
+                    AND ({origin_except_data.old} is not true)
+                    AND ({except_data.new} is not true)
                 '''
             else:
                 except_part = ''
@@ -568,6 +619,9 @@ class SchemaTableConstraint:
             ops.add_command(check)
 
         return ops
+
+
+SchemaConstraint = SchemaDomainConstraint | SchemaTableConstraint
 
 
 def ptr_default_to_col_default(schema, ptr, expr):
@@ -602,19 +656,39 @@ def ptr_default_to_col_default(schema, ptr, expr):
     return sql_text
 
 
-def get_ref_storage_info(schema, refs):
-    link_biased = {}
-    objtype_biased = {}
+RefTables = Dict[
+    Optional[Tuple[str, str]],
+    List[
+        Tuple[
+            irast.Set,
+            s_pointers.PointerLike,
+            s_pointers.PointerLike | s_types.Type,
+            types.PointerStorageInfo,
+        ]
+    ],
+]
 
-    ref_ptrs = {}
+
+def get_ref_storage_info(
+    schema: s_schema.Schema, refs: Collection[irast.Set]
+) -> RefTables:
+    link_biased: Dict[irast.Set, types.PointerStorageInfo] = {}
+    objtype_biased: Dict[irast.Set, types.PointerStorageInfo] = {}
+
+    RefPtr = Tuple[
+        s_pointers.PointerLike, s_types.Type | s_pointers.PointerLike
+    ]
+    ref_ptrs: Dict[irast.Set, RefPtr] = {}
     refs = list(refs)
     for ref in refs:
-        rptr = ref.rptr
-        if rptr is None:
+        ptr: s_pointers.PointerLike
+        src: s_types.Type | s_pointers.PointerLike
+        if ref.rptr is None:
             source_typeref = ref.typeref
             if not irtyputils.is_object(source_typeref):
                 continue
             schema, t = irtyputils.ir_typeref_to_type(schema, ref.typeref)
+            assert isinstance(t, s_sources.Source)
             ptr = t.getptr(schema, s_name.UnqualName('id'))
         else:
             ptrref = ref.rptr.ptrref
@@ -622,6 +696,7 @@ def get_ref_storage_info(schema, refs):
             source_typeref = ref.rptr.source.typeref
 
         if ptr.is_link_property(schema):
+            assert ref.rptr and ref.rptr.source and ref.rptr.source.rptr
             srcref = ref.rptr.source.rptr.ptrref
             schema, src = irtyputils.ptrcls_from_ptrref(
                 srcref, schema=schema)
@@ -630,9 +705,11 @@ def get_ref_storage_info(schema, refs):
                 # for the purposes of constraint expr compilation.
                 src = src.get_bases(schema).first(schema)
         elif ptr.is_tuple_indirection():
+            assert ref.rptr
             refs.append(ref.rptr.source)
             continue
         elif ptr.is_type_intersection():
+            assert ref.rptr
             refs.append(ref.rptr.source)
             continue
         else:
@@ -664,7 +741,7 @@ def get_ref_storage_info(schema, refs):
                 link_biased[ref] = ptr_info
                 objtype_biased.pop(ref)
 
-    ref_tables = {}
+    ref_tables: RefTables = {}
 
     for ref, ptr_info in itertools.chain(
             objtype_biased.items(), link_biased.items()):

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -429,10 +429,11 @@ class _PointerStorageInfo:
 
 @functools.lru_cache()
 def get_pointer_storage_info(
-        pointer, *, schema, source=None, resolve_type=True,
-        link_bias=False):
-    assert not pointer.generic(schema), \
-        "only specialized pointers can be stored"
+    pointer, *, schema, source=None, resolve_type=True, link_bias=False
+) -> PointerStorageInfo:
+    assert not pointer.generic(
+        schema
+    ), "only specialized pointers can be stored"
     if pointer.get_computable(schema):
         material_ptrcls = None
     else:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1742,3 +1742,14 @@ class TestConstraintsDDL(tb.DDLTestCase):
                 };
             """
             )
+
+    async def test_constraints_no_refs(self):
+        await self.con.execute(
+            """
+            create type X {
+                create property name -> str {
+                    create constraint std::expression on (true);
+                };
+            };
+        """
+        )


### PR DESCRIPTION
Closes #5530

Vast majority of changes here are:
- type annotations for pgsql/schemamech.py and friends,
- refactors schemamech.ConstraintMech into plain functions,
- refactor many `Dict[str, Any]` into data classes (which are better with type checking and will be fasterrr in Python 11)