### PR TITLE
'Fix' ISE for TypeExprs in function returns

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1079,13 +1079,13 @@ class CreateCallableObject(
         if hasattr(astnode, 'returning'):
             assert isinstance(astnode, (qlast.CreateOperator,
                                         qlast.CreateFunction))
-            assert isinstance(astnode.returning, qlast.TypeName)
             modaliases = context.modaliases
 
             return_type = utils.ast_to_type_shell(
                 astnode.returning,
                 metaclass=s_types.Type,
                 modaliases=modaliases,
+                module=cmd.classname.module,
                 schema=schema,
             )
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2340,6 +2340,22 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 );
         """)
 
+    async def test_edgeql_migration_function_06(self):
+        await self.migrate("""
+            type Foo;
+            type Bar;
+            type Baz {
+                optional link baz -> (Foo | Bar)
+            };
+            function getBaz(bar: Baz) -> optional (Foo | Bar)
+                using(bar.baz)
+        """)
+        await self.con.execute('insert test::Baz {}')
+        await self.assert_query_result(
+            "select test::getBaz((select test::Baz limit 1))",
+            [])
+        await self.con.execute("drop function test::getBaz(baz: test::Baz)")
+
     async def test_edgeql_migration_constraint_01(self):
         await self.migrate('''
             abstract constraint not_bad {


### PR DESCRIPTION
We are already happy to create a type shell from a TypeOp. Everything already
works...except that functions were not applying their qualfied namespace to any generated types. Fixing that makes it go.
