### PR TITLE
Fix schema introspection with computed backlinks test case

### DIFF
--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1587,13 +1587,6 @@ class TestIntrospection(tb.QueryTestCase):
             SELECT InheritingObject {
                 children := .<bases[IS Type],
                 descendants := .<ancestors[IS Type]
-            } LIMIT 2''',
-            [
-                {'children': [],
-                 'descendants': []
-                 },
-                {'children': [],
-                 'descendants': []
-                 },
-            ]
+            } LIMIT 0''',
+            []
         )


### PR DESCRIPTION
Apparently schema changes have broke this test case. The idea of the test case is not to inspect the actual schema, but to make sure backlinks wouldn't cause SQL errors.