### PR TITLE
Pass context through ScopeTreeNode.fuse_subtree

### DIFF
--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -511,7 +511,10 @@ class ScopeTreeNode:
                 descendant.optional = desc_optional
                 descendant.strip_path_namespace(dns | vns)
                 visible.fuse_subtree(
-                    descendant, self_fenced=False, node_fenced=desc_fenced)
+                    descendant,
+                    self_fenced=False,
+                    node_fenced=desc_fenced,
+                    context=context)
 
             elif descendant.parent_fence is node:
                 # Unfenced path.
@@ -563,7 +566,8 @@ class ScopeTreeNode:
                     existing.fuse_subtree(
                         current,
                         self_fenced=existing_fenced,
-                        node_fenced=node_fenced)
+                        node_fenced=node_fenced,
+                        context=context)
 
                     current = existing
 
@@ -668,6 +672,7 @@ class ScopeTreeNode:
         node: ScopeTreeNode,
         self_fenced: bool=False,
         node_fenced: bool=False,
+        context: Optional[pctx.ParserContext]=None,
     ) -> None:
         node.remove()
 
@@ -684,7 +689,7 @@ class ScopeTreeNode:
         else:
             subtree = node
 
-        self.attach_subtree(subtree, was_fenced=self_fenced)
+        self.attach_subtree(subtree, was_fenced=self_fenced, context=context)
 
     def remove_subtree(self, node: ScopeTreeNode) -> None:
         """Remove the given subtree from this node."""

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -96,3 +96,11 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             )
         """
         # This one is fine now, since it is a property
+
+    @tb.must_fail(errors.InvalidReferenceError,
+                  "cannot reference correlated set 'User' here",
+                  line=2, col=45)
+    def test_edgeql_ir_scope_tree_bad_06(self):
+        """
+        UPDATE User SET { avatar := (UPDATE .avatar SET { text := "foo" }) }
+        """


### PR DESCRIPTION
Since `ScopeTreeNode.fuse_subtree` is both called from and calls
`ScopeTreeNode.attach_subtree`, calls through `fuse_subtree` that later re-enter
`attach_subtree` will lose context information for any thrown errors.

Fixes #5019.
