### PR TITLE
Use base schema for migration name lookups

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -448,7 +448,7 @@ def apply_sdl(
     for decl in sdl_document.declarations:
         collect(decl, None)
 
-    ddl_stmts = s_decl.sdl_to_ddl(current_schema, documents)
+    ddl_stmts = s_decl.sdl_to_ddl(base_schema, documents)
     context = sd.CommandContext(
         modaliases={},
         schema=base_schema,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12117,6 +12117,18 @@ class TestEdgeQLMigrationRewrite(EdgeQLMigrationRewriteTestCase):
             {'script': 'CREATE TYPE default::A;\nCREATE TYPE default::B;'},
         ])
 
+    async def test_edgeql_migration_preexisting_01(self):
+        await self.con.execute("create type Foo;")
+        with self.assertRaisesRegex(
+            edgedb.InvalidReferenceError,
+            r"type 'default::Foo' does not exist"
+        ):
+            await self.start_migration("""
+                type Bar {
+                    baz: Foo
+                }
+            """, module='default')
+
 
 class TestEdgeQLMigrationRewriteNonisolated(TestEdgeQLMigrationRewrite):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
We used to use the existing schema for lookups when doing initial ddl type
calculations. This meant that if you referenced a type that existed in the
current schema, but which you intended NOT to exist post-migration, we would get
the bookkeeping wrong. We really want to use the schema for stdlib stuff
anyways. Just use the base.

Fixes #5559.
