### PR TITLE
Actually make CORS response cache effective

### DIFF
--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -307,6 +307,7 @@ cdef class HttpProtocol:
             if custom_headers:
                 data.append(b'Access-Control-Expose-Headers: ' + \
                     ', '.join(custom_headers.keys()).encode() + b'\r\n')
+            data.append(b'Access-Control-Max-Age: 86400\r\n')
 
         if close_connection:
             data.append(b'Connection: close\r\n')
@@ -471,7 +472,6 @@ cdef class HttpProtocol:
                     response.status = http.HTTPStatus.NO_CONTENT
                     response.custom_headers['Access-Control-Allow-Methods'] = \
                         'POST, OPTIONS'
-                    response.custom_headers['Access-Control-Max-Age'] = '86400'
                     return
 
                 if request.method == b'POST':
@@ -550,7 +550,6 @@ cdef class HttpProtocol:
                     response.status = http.HTTPStatus.NO_CONTENT
                     response.custom_headers['Access-Control-Allow-Methods'] = \
                         'GET, OPTIONS'
-                    response.custom_headers['Access-Control-Max-Age'] = '86400'
                     return
 
             # Authentication request


### PR DESCRIPTION
`Access-Control-Max-Age` should be present not just on the pre-flight
request, but on the actual request as well.
