### PR TITLE
Fix nightly build by removing typing_inspect dependency

### DIFF
--- a/edb/common/_typing_inspect.py
+++ b/edb/common/_typing_inspect.py
@@ -29,7 +29,7 @@ relies on that only works on Python 3.9+.
 from __future__ import annotations
 
 import collections
-from types import GenericAlias  # type: ignore
+from types import GenericAlias, UnionType  # type: ignore
 from typing import _GenericAlias  # type: ignore
 from typing import Any, ClassVar, Generic, Optional, Tuple, TypeVar, Union
 
@@ -66,7 +66,11 @@ def is_generic_type(t) -> bool:
 
 
 def is_union_type(t) -> bool:
-    return t is Union or _is_genericalias(t) and t.__origin__ is Union
+    return (
+        t is Union
+        or (_is_genericalias(t) and t.__origin__ is Union)
+        or isinstance(t, UnionType)
+    )
 
 
 def is_tuple_type(t) -> bool:
@@ -83,7 +87,7 @@ def is_tuple_type(t) -> bool:
 def get_args(t, evaluate: bool = True) -> Any:
     if evaluate is not None and not evaluate:
         raise ValueError("evaluate can only be True in Python >= 3.7")
-    if _is_genericalias(t):
+    if _is_genericalias(t) or isinstance(t, UnionType):
         res = t.__args__
         if (
             get_origin(t) is collections.abc.Callable

--- a/edb/tools/gen_rust_ast.py
+++ b/edb/tools/gen_rust_ast.py
@@ -1,6 +1,5 @@
 import itertools
 import typing
-import typing_inspect
 import dataclasses
 import textwrap
 from itertools import chain
@@ -9,6 +8,7 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 from edb.common.ast import base as ast
 from edb.common import enum as s_enum
+from edb.common import typing_inspect
 from edb.tools.edb import edbcommands
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ test = [
     'types-pkg-resources~=0.1.3',
     'types-typed-ast~=1.4.2',
     'types-requests~=2.25.6',
-    'typing_inspect~=0.8.0',
 
     'prometheus_client~=0.11.0',
 


### PR DESCRIPTION
Nightlies are failing because:
 * gen_rust_ast.py uses typing_inspect, which is a test dependency
 * The nightly tests run `edb.tool`, which imports all the tools
 * Test dependencies aren't included in the built artifacts
   (tests that use test dependencies are all written to be skipped
   if the dep is missing)

There are a bunch of ways to fix this but the one that I apparently
chose was to make gen_rust_ast instead use the custom simplified
version of typing_inspect that we have for some reason. (Maybe just to
avoid the dependency.) This required fixing it to understand unions
created with `|`.