### PR TITLE
Extend the patch system so we can backport extension package changes

### DIFF
--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -36,7 +36,8 @@ def get_version_key(num_patches: int):
     the key based on the number of schema layout patches that we can
     *see*, we still compute the right key.
     """
-    num_major = sum(p == 'edgeql+schema' for p, _ in PATCHES[:num_patches])
+    num_major = sum(
+        p.startswith('edgeql+schema') for p, _ in PATCHES[:num_patches])
     if num_major == 0:
         return ''
     else:
@@ -55,7 +56,7 @@ def _setup_patches(patches: list[tuple[str, str]]) -> list[tuple[str, str]]:
     npatches = []
     for kind, patch in patches:
         npatches.append((kind, patch))
-        if kind == 'edgeql+schema' and seen_repair:
+        if kind.startswith('edgeql+schema') and seen_repair:
             npatches.append(('repair', ''))
         seen_repair |= kind == 'repair'
     return npatches
@@ -66,6 +67,7 @@ The actual list of patches. The patches are (kind, script) pairs.
 
 There are currently 4 kinds:
  * sql - simply runs a SQL script
+ * metaschema-sql - create a function from metaschema
  * edgeql - runs an edgeql DDL command
  * edgeql+schema - runs an edgeql DDL command and updates the std schemas
  * repair - fix up inconsistencies in *user* schemas

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -253,7 +253,7 @@ class Field(struct.ProtoField, Generic[T]):
                  'allow_ddl_set', 'ddl_identity', 'special_ddl_syntax',
                  'aux_cmd_data', 'describe_visibility',
                  'weak_ref', 'reflection_method', 'reflection_proxy',
-                 'type_is_generic_self', 'is_reducible')
+                 'type_is_generic_self', 'is_reducible', 'patch_level')
 
     #: Name of the field on the target class; assigned by ObjectMeta
     name: str
@@ -310,6 +310,9 @@ class Field(struct.ProtoField, Generic[T]):
     #: this specifies a (ProxyType, linkname) pair of a proxy object type
     #: and the name of the link within that proxy type.
     reflection_proxy: Optional[Tuple[str, str]]
+    #: Which patch for the current major version this field was introduced in.
+    #: Ensures that the data tuples always get extended strictly at the end.
+    patch_level: int
 
     def __init__(
         self,
@@ -333,6 +336,7 @@ class Field(struct.ProtoField, Generic[T]):
         reflection_proxy: Optional[Tuple[str, str]] = None,
         name: Optional[str] = None,
         reflection_name: Optional[str] = None,
+        patch_level: int = -1,
         **kwargs: Any,
     ) -> None:
         """Schema item core attribute definition.
@@ -357,6 +361,7 @@ class Field(struct.ProtoField, Generic[T]):
         self.reflection_method = reflection_method
         self.reflection_proxy = reflection_proxy
         self.is_reducible = issubclass(type_, s_abc.Reducible)
+        self.patch_level = patch_level
 
         if name is not None:
             self.name = name
@@ -655,7 +660,8 @@ class ObjectMeta(type):
         cls._data_safe = data_safe
         cls._fields = fields
         cls._schema_fields = {
-            fn: f for fn, f in fields.items()
+            fn: f
+            for fn, f in sorted(fields.items(), key=lambda f: f[1].patch_level)
             if isinstance(f, SchemaField)
         }
         cls._hashable_fields = {

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -29,6 +29,7 @@ import itertools
 import immutables as immu
 
 from edb import errors
+from edb.common import adapter
 from edb.common import english
 
 from . import casts as s_casts
@@ -529,10 +530,10 @@ class FlatSchema(Schema):
                 Tuple[Type[so.Object], sn.Name],
                 FrozenSet[uuid.UUID]
             ]
-        ],
+        ] = None,
         globalname_to_id: Optional[
             immu.Map[Tuple[Type[so.Object], sn.Name], uuid.UUID]
-        ],
+        ] = None,
         refs_to: Optional[Refs_T] = None,
     ) -> FlatSchema:
         new = FlatSchema.__new__(FlatSchema)
@@ -1481,6 +1482,44 @@ class FlatSchema(Schema):
     def __repr__(self) -> str:
         return (
             f'<{type(self).__name__} gen:{self._generation} at {id(self):#x}>')
+
+
+def upgrade_schema(schema: FlatSchema) -> FlatSchema:
+    """Repair a schema object serialized by an older patch version
+
+    When an edgeql+schema patch adds fields to schema types, old
+    serialized schemas will be broken, since their tuples are missing
+    the fields.
+
+    In this situation, we run through all the data tuples and fill
+    them out. The upgraded version will then be cached.
+    """
+
+    cls_fields = {}
+    for py_cls in so.ObjectMeta.get_schema_metaclasses():
+        if isinstance(py_cls, adapter.Adapter):
+            continue
+
+        fields = py_cls._schema_fields.values()
+        cls_fields[py_cls] = sorted(fields, key=lambda f: f.index)
+
+    id_to_data = schema._id_to_data
+    fixes = {}
+    for id, typ_name in schema._id_to_type.items():
+        data = id_to_data[id]
+        obj = so.Object.schema_restore((typ_name, id))
+        typ = type(obj)
+
+        tfields = cls_fields[typ]
+        exp_len = len(tfields)
+        if len(data) < exp_len:
+            ldata = list(data)
+            for i in range(len(ldata), exp_len):
+                ldata.append(tfields[i].get_default())
+
+            fixes[id] = tuple(ldata)
+
+    return schema._replace(id_to_data=id_to_data.update(fixes))
 
 
 class SchemaIterator(Generic[so.Object_T]):


### PR DESCRIPTION
* Add a new patch mode, `metaschema-sql`, to recreate a function
  defined in metaschema. We need this to update a function whose
  contents are partially generated, but it's also just a much nicer
  way to update metaschema functions in general.
* Support modifying and regenerating the views for `sys` extension
  views.  To avoid just throwing every possible change into
  `edgeql+schema`, gate it on adding `+ext` to the patch type.
* Add a mechanism for repairing unpickled schemas. Schemas pickled and
  cached on old patch versions will have data tuples that are too
  short. When we load an old pickled schema, we need to fix it up. (We
  got away without this before because the only `edgeql+schema` patch
  we've done added a new type that obviously then couldn't appear in
  pickled schemas.)

With these changes, we can succesfully cherry-pick #5479 to 3.x and
patch it in.