### PR TITLE
Fix `pg_namespace` emulation

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5704,10 +5704,10 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
              WHERE pg_namespace.nspname = 'pg_catalog'::name
              AND pg_class.relname = 'pg_namespace'::name
              )                                  AS tableoid,
-            0                                   AS xmin,
-            0                                   AS cmin,
-            0                                   AS xmax,
-            0                                   AS cmax,
+            '0'::xid                            AS xmin,
+            '0'::cid                            AS cmin,
+            '0'::xid                            AS xmax,
+            '0'::cid                            AS cmax,
             NULL                                AS ctid
         FROM (
             SELECT DISTINCT schema_name, module_id

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5675,18 +5675,40 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
         dbops.View(
             name=("edgedbsql", "pg_namespace"),
             query="""
-        SELECT oid, nspname, nspowner, nspacl,
-            tableoid, xmin, cmin, xmax, cmax, ctid
+        SELECT
+            oid,
+            nspname,
+            nspowner,
+            nspacl,
+            tableoid,
+            xmin,
+            cmin,
+            xmax,
+            cmax,
+            ctid
         FROM pg_namespace
         WHERE nspname IN ('pg_catalog', 'pg_toast', 'information_schema',
                           'edgedb', 'edgedbstd')
         UNION ALL
         SELECT
-            edgedbsql.uuid_to_oid(t.module_id),
-            t.schema_name,
-            (SELECT oid FROM pg_roles WHERE rolname = CURRENT_USER LIMIT 1),
-            NULL,
-            NULL, NULL, NULL, NULL, NULL, NULL
+            edgedbsql.uuid_to_oid(t.module_id)  AS oid,
+            t.schema_name                       AS nspname,
+            (SELECT oid
+             FROM pg_roles
+             WHERE rolname = CURRENT_USER
+             LIMIT 1)                           AS nspowner,
+            NULL AS nspacl,
+            (SELECT pg_class.oid
+             FROM pg_class
+             JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
+             WHERE pg_namespace.nspname = 'pg_catalog'::name
+             AND pg_class.relname = 'pg_namespace'::name
+             )                                  AS tableoid,
+            0                                   AS xmin,
+            0                                   AS cmin,
+            0                                   AS xmax,
+            0                                   AS cmax,
+            NULL                                AS ctid
         FROM (
             SELECT DISTINCT schema_name, module_id
             FROM edgedbsql.virtual_tables


### PR DESCRIPTION
Current emulation of `pg_namespace` is somewhat broken because it
returns `NULL` for `tableoid` for synthesized schemes, which throws off
catalog map logic in `pg_dump` of PostgreSQL 15.  Emit OID of
`pg_namespace` correctly instead.  While at it, set `xmin`, `xmax`,
`cmin`, `cmax` to non-`NULL` values as well.  `ctid` is harder to
emulate correctly so leave it as `NULL`.
