### PR TITLE
Change to instance as CLI suggests

### DIFF
--- a/docs/reference/admin/configure.rst
+++ b/docs/reference/admin/configure.rst
@@ -72,13 +72,7 @@ Set the ``query_work_mem`` parameter for the duration of the session:
 
 .. code-block:: edgeql
 
-    configure session set query_work_mem := <cfg::memory>'4MiB';
-
-Set the same parameter, but for the current database:
-
-.. code-block:: edgeql
-
-    configure current database set query_work_mem := <cfg::memory>'4MiB';
+    configure instance set query_work_mem := <cfg::memory>'4MiB';
 
 Add a Trust authentication method for "my_user":
 


### PR DESCRIPTION
Just something I noticed today while looking for a good example command in a tutorial: both of these commands instruct the user to use `configure instance` for `query_work_mem`:

```
edgedb error: ConfigurationError: 'query_work_mem' is a system-level configuration parameter; use "CONFIGURE INSTANCE"
```