### PR TITLE
Update desc of `EDGEDB_SERVER_BOOTSTRAP_COMMAND`

### DIFF
--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -248,6 +248,7 @@ Determines the log verbosity level in the entrypoint script. Valid levels are
 ``trace``, ``debug``, ``info``, ``warning``, and ``error``.  The default is
 ``info``.
 
+.. _ref_guide_deployment_docker_custom_bootstrap_scripts:
 
 Custom scripts in ``/edgedb-bootstrap.d/`` and ``/edgedb-bootstrap-late.d``
 ...........................................................................

--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -261,6 +261,12 @@ executed *before* any schema migrations are applied, and parts in
 ``/edgedb-bootstrap-late.d`` are executed *after* the schema migration have
 been applied.
 
+.. note::
+
+    Best practice for naming your script files when you will have multiple
+    script files to run on bootstrap is to prepend the filenames with ``01-``,
+    ``02-``, and so on to indicate your desired order of execution.
+
 Health Checks
 =============
 

--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -29,8 +29,23 @@ Supported variables
 EDGEDB_SERVER_BOOTSTRAP_COMMAND
 ...............................
 
-Useful to fine-tune initial user and database creation, and other initial
-setup.
+Useful to fine-tune initial user creation and other initial setup.
+
+.. note::
+
+    A :eql:stmt:`create database` statement cannot be combined in a block with
+    any other statements. Since all statements in
+    ``EDGEDB_SERVER_BOOTSTRAP_COMMAND`` run in a single block, it cannot be
+    used to create a database and, for example, create a user for that
+    database.
+
+    For Docker deployments, you can instead write :ref:`custom scripts to run
+    before migrations <ref_guide_deployment_docker_custom_bootstrap_scripts>`.
+    These are placed in ``/edgedb-bootstrap.d/``. By writing your ``create
+    database`` statements in one ``.edgeql`` file each placed in
+    ``/edgedb-bootstrap.d/`` and other statements in their own file, you can
+    create databases and still run other EdgeQL statements to bootstrap your
+    instance.
 
 Maps directly to the ``edgedb-server`` flag ``--default-auth-method``. The
 ``*_FILE`` and ``*_ENV`` variants are also supported.


### PR DESCRIPTION
Current description says you can use it to create a database and users. Database creation via this mechanism blocks any other statements from running since it cannot run in the same block as anything else. This removes that from the description and offers an alternative for users who want to create a database and run other statements.

@elprans This change is based on the guidance you gave a Discord user here: https://discord.com/channels/841451783728529451/1110848080619769876/1110848120788631633

Questions:
1. What determines the order of the bootstrap scripts? Are the executed alphabetically by file name? I would like to add this to the documentation of `/edgedb-bootstrap.d/`.
2. Should we also offer guidance for other types of deployments besides Docker? What should that guidance be?