### PR TITLE
Refactor pg types

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -374,7 +374,7 @@ def get_index_backend_name(id, module_name, catenate=True, *, aspect=None):
     return convert_name(name, aspect, catenate)
 
 
-def get_tuple_backend_name(id, catenate=True, *, aspect=None):
+def get_tuple_backend_name(id, catenate=True, *, aspect=None) -> Tuple[str, ...]:
 
     name = s_name.QualName(module='edgedb', name=f'{id}_t')
     return convert_name(name, aspect, catenate)

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -374,7 +374,9 @@ def get_index_backend_name(id, module_name, catenate=True, *, aspect=None):
     return convert_name(name, aspect, catenate)
 
 
-def get_tuple_backend_name(id, catenate=True, *, aspect=None) -> Tuple[str, ...]:
+def get_tuple_backend_name(
+    id, catenate=True, *, aspect=None
+) -> Tuple[str, ...]:
 
     name = s_name.QualName(module='edgedb', name=f'{id}_t')
     return convert_name(name, aspect, catenate)

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -539,9 +539,6 @@ def _get_ptrref_storage_info(
         table_type = 'ObjectType'
         col_name = ptrref.shortname.name
 
-    elif isinstance(ptrref, irast.TypeIntersectionPointerRef):
-        raise NotImplementedError()
-
     elif ptrref.source_ptr is not None:
         # link property
         assert isinstance(ptrref, irast.PointerRef)

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -604,7 +604,7 @@ def _get_ptrref_storage_info(
     return PointerStorageInfo(
         table_name=table,
         table_type=table_type,
-        column_name=col_name,
+        column_name=col_name,  # type: ignore
         column_type=column_type,  # type: ignore
     )
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 #
 # This source file is part of the EdgeDB open source project.
 #
@@ -22,6 +20,7 @@
 from __future__ import annotations
 
 import functools
+import dataclasses
 from typing import *
 
 from edb.ir import ast as irast
@@ -33,6 +32,8 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import name as sn
 from edb.schema import objects as s_obj
 from edb.schema import schema as s_schema
+from edb.schema import types as s_types
+from edb.schema import pointers as s_pointers
 
 from . import common
 
@@ -128,16 +129,18 @@ base_type_name_map_r = {
 }
 
 
-def is_builtin_scalar(schema, scalar):
+def is_builtin_scalar(
+    schema: s_schema.Schema, scalar: s_scalars.ScalarType
+) -> bool:
     return scalar.id in base_type_name_map
 
 
-def type_has_stable_oid(typ):
+def type_has_stable_oid(typ: s_types.Type) -> bool:
     pg_type = base_type_name_map.get(typ.id)
     return pg_type is not None and len(pg_type) == 1
 
 
-def get_scalar_base(schema, scalar) -> Tuple[str, ...]:
+def get_scalar_base(schema: s_schema.Schema, scalar: s_scalars.ScalarType) -> Tuple[str, ...]:
     base = base_type_name_map.get(scalar.id)
     if base is not None:
         return base
@@ -153,6 +156,7 @@ def get_scalar_base(schema, scalar) -> Tuple[str, ...]:
             else:
                 base = common.get_backend_name(
                     schema, ancestor, catenate=False)
+                assert base
 
             return base
 
@@ -161,8 +165,9 @@ def get_scalar_base(schema, scalar) -> Tuple[str, ...]:
 
 
 def pg_type_from_scalar(
-        schema: s_schema.Schema,
-        scalar: s_scalars.ScalarType) -> Tuple[str, ...]:
+    schema: s_schema.Schema,
+    scalar: s_scalars.ScalarType
+) -> Tuple[str, ...]:
 
     if scalar.is_polymorphic(schema):
         return ('anynonarray',)
@@ -174,6 +179,7 @@ def pg_type_from_scalar(
         column_type = tuple(typstr.split('.'))
     else:
         column_type = common.get_backend_name(schema, scalar, catenate=False)
+    assert column_type
 
     return column_type
 
@@ -196,7 +202,7 @@ def pg_type_from_object(
     if isinstance(obj, s_scalars.ScalarType):
         return pg_type_from_scalar(schema, obj)
 
-    elif obj.is_type() and obj.is_anytuple(schema):
+    elif isinstance(obj, s_types.Type) and obj.is_anytuple(schema):
         return ('record',)
 
     elif isinstance(obj, s_abc.Tuple):
@@ -205,7 +211,7 @@ def pg_type_from_object(
         else:
             return ('record',)
 
-    elif isinstance(obj, s_abc.Array):
+    elif isinstance(obj, s_types.Array):
         if obj.is_polymorphic(schema):
             return ('anyarray',)
         else:
@@ -214,7 +220,7 @@ def pg_type_from_object(
                 persistent_tuples=persistent_tuples)
             return pg_type_array(tp)
 
-    elif isinstance(obj, s_abc.Range):
+    elif isinstance(obj, s_types.Range):
         if obj.is_polymorphic(schema):
             return ('anyrange',)
         else:
@@ -226,7 +232,7 @@ def pg_type_from_object(
     elif isinstance(obj, s_objtypes.ObjectType):
         return ('uuid',)
 
-    elif obj.is_type() and obj.is_any(schema):
+    elif isinstance(obj, s_types.Type) and obj.is_any(schema):
         return ('anyelement',)
 
     else:
@@ -298,6 +304,7 @@ def pg_type_from_ir_typeref(
             pg_type = base_type_name_map.get(material.id)
             if pg_type is None:
                 real_name_hint = material.orig_name_hint or material.name_hint
+                assert isinstance(real_name_hint, sn.QualName)
                 # User-defined scalar type
                 pg_type = common.get_scalar_backend_name(
                     material.id, real_name_hint.module, catenate=False)
@@ -305,131 +312,70 @@ def pg_type_from_ir_typeref(
             return pg_type
 
 
-class _PointerStorageInfo:
-    @classmethod
-    def _source_table_info(cls, schema, pointer):
-        table = common.get_backend_name(
-            schema, pointer.get_source(schema), catenate=False)
-        ptr_name = pointer.get_shortname(schema).name
-        if ptr_name.startswith('__') or ptr_name == 'id':
-            col_name = ptr_name
-        else:
-            col_name = str(pointer.id)
-        table_type = 'ObjectType'
+TableInfo = Tuple[
+    Tuple[str, ...],
+    str,
+    str
+]
 
-        return table, table_type, col_name
 
-    @classmethod
-    def _pointer_table_info(cls, schema, pointer):
-        table = common.get_backend_name(
-            schema, pointer, catenate=False)
-        col_name = 'target'
-        table_type = 'link'
+def _source_table_info(schema: s_schema.Schema, pointer: s_pointers.Pointer) -> TableInfo:
+    table = common.get_backend_name(
+        schema, pointer.get_source(schema), catenate=False)
+    ptr_name = pointer.get_shortname(schema).name
+    if ptr_name.startswith('__') or ptr_name == 'id':
+        col_name = ptr_name
+    else:
+        col_name = str(pointer.id)
+    table_type = 'ObjectType'
 
-        return table, table_type, col_name
+    return table, table_type, col_name
 
-    @classmethod
-    def _resolve_type(cls, schema, pointer):
-        pointer_target = pointer.get_target(schema)
-        if pointer_target is not None:
-            if pointer_target.is_object_type():
-                column_type = ('uuid',)
-            elif pointer_target.is_tuple(schema):
-                column_type = common.get_backend_name(schema, pointer_target,
-                                                      catenate=False)
-            else:
-                column_type = pg_type_from_object(
-                    schema, pointer_target, persistent_tuples=True
-                )
-        else:
-            # The target may not be known in circular object-to-object
-            # linking scenarios.
+
+def _pointer_table_info(schema: s_schema.Schema, pointer: s_pointers.Pointer) -> TableInfo:
+    table = common.get_backend_name(
+        schema, pointer, catenate=False)
+    col_name = 'target'
+    table_type = 'link'
+
+    return table, table_type, col_name
+
+
+def _resolve_type(schema: s_schema.Schema, pointer: s_pointers.Pointer) -> Tuple[str, ...]:
+    column_type: Tuple[str, ...]
+
+    pointer_target = pointer.get_target(schema)
+    if pointer_target is not None:
+        if pointer_target.is_object_type():
             column_type = ('uuid',)
-
-        return column_type
-
-    @classmethod
-    def _storable_in_source(cls, schema, pointer):
-        return pointer.singular(schema)
-
-    @classmethod
-    def _storable_in_pointer(cls, schema, pointer):
-        return (
-            not pointer.singular(schema) or
-            pointer.has_user_defined_properties(schema))
-
-    def __new__(cls, schema, pointer, source=None, resolve_type=True,
-                link_bias=False):
-
-        if source is None:
-            source = pointer.get_source(schema)
-
-        is_lprop = pointer.is_link_property(schema)
-
-        if resolve_type and schema is None:
-            msg = 'PointerStorageInfo needs a schema to resolve column_type'
-            raise ValueError(msg)
-
-        if is_lprop and pointer.issubclass(schema, schema.get('std::target')):
-            # Normalize link@target to link
-            pointer = source
-            is_lprop = False
-
-        if isinstance(pointer, irast.TupleIndirectionLink):
-            table = None
-            table_type = 'ObjectType'
-            col_name = pointer.get_shortname(schema).name
-        elif is_lprop:
-            table = common.get_backend_name(
-                schema, source, catenate=False)
-            table_type = 'link'
-            if pointer.get_shortname(schema).name == 'source':
-                col_name = 'source'
-            else:
-                col_name = str(pointer.id)
+        elif pointer_target.is_tuple(schema):
+            column_type = common.get_backend_name(schema, pointer_target,
+                                                    catenate=False)
         else:
-            if isinstance(source, s_scalars.ScalarType):
-                # This is a pseudo-link on an scalar (__type__)
-                table = None
-                table_type = 'ObjectType'
-                col_name = None
-            elif cls._storable_in_source(schema, pointer) and not link_bias:
-                table, table_type, col_name = cls._source_table_info(
-                    schema, pointer)
-            elif cls._storable_in_pointer(schema, pointer):
-                table, table_type, col_name = cls._pointer_table_info(
-                    schema, pointer)
-            else:
-                return None
+            column_type = pg_type_from_object(
+                schema, pointer_target, persistent_tuples=True
+            )
+    else:
+        # The target may not be known in circular object-to-object
+        # linking scenarios.
+        column_type = ('uuid',)
 
-        if resolve_type:
-            column_type = cls._resolve_type(schema, pointer)
-        else:
-            column_type = None
+    return column_type
 
-        result = super().__new__(cls)
 
-        result.table_name = table
-        result.table_type = table_type
-        result.column_name = col_name
-        result.column_type = column_type
+def _pointer_storable_in_source(schema: s_schema.Schema, pointer: s_pointers.Pointer) -> bool:
+    return pointer.singular(schema)
 
-        return result
 
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __repr__(self):
-        return \
-            '<{} (table_name={}, table_type={}, column_name={}, ' \
-            'column_type={}) at 0x{:x}>'.format(
-                self.__class__.__name__, '.'.join(self.table_name),
-                self.table_type, self.column_name, self.column_type, id(self))
+def _pointer_storable_in_pointer(schema: s_schema.Schema, pointer: s_pointers.Pointer) -> bool:
+    return (
+        not pointer.singular(schema) or
+        pointer.has_user_defined_properties(schema))
 
 
 @functools.lru_cache()
 def get_pointer_storage_info(
-    pointer, *, schema, source=None, resolve_type=True, link_bias=False
+    pointer: s_pointers.Pointer, *, schema: s_schema.Schema, source: Optional[s_obj.InheritingObject]=None, resolve_type: bool=True, link_bias: bool=False
 ) -> PointerStorageInfo:
     assert not pointer.generic(
         schema
@@ -440,17 +386,76 @@ def get_pointer_storage_info(
         schema, material_ptrcls = pointer.material_type(schema)
     if material_ptrcls is not None:
         pointer = material_ptrcls
-    return _PointerStorageInfo(
-        schema, pointer, source=source, resolve_type=resolve_type,
-        link_bias=link_bias)
+
+    if source is None:
+        source = pointer.get_source(schema)
+
+    is_lprop = pointer.is_link_property(schema)
+
+    if resolve_type and schema is None:
+        msg = 'PointerStorageInfo needs a schema to resolve column_type'
+        raise ValueError(msg)
+
+    if is_lprop and pointer.issubclass(schema, schema.get('std::target', type=s_obj.SubclassableObject)):
+        # Normalize link@target to link
+        assert isinstance(source, s_pointers.Pointer)
+        pointer = source
+        is_lprop = False
+
+    if isinstance(pointer, irast.TupleIndirectionLink):
+        table = None
+        table_type = 'ObjectType'
+        col_name = pointer.get_shortname(schema).name
+    elif is_lprop:
+        table = common.get_backend_name(
+            schema, source, catenate=False)
+        table_type = 'link'
+        if pointer.get_shortname(schema).name == 'source':
+            col_name = 'source'
+        else:
+            col_name = str(pointer.id)
+    else:
+        if isinstance(source, s_scalars.ScalarType):
+            # This is a pseudo-link on an scalar (__type__)
+            table = None
+            table_type = 'ObjectType'
+            col_name = None
+        elif _pointer_storable_in_source(schema, pointer) and not link_bias:
+            table, table_type, col_name = _source_table_info(
+                schema, pointer)
+        elif _pointer_storable_in_pointer(schema, pointer):
+            table, table_type, col_name = _pointer_table_info(
+                schema, pointer)
+        else:
+            return None  # type: ignore
+
+    if resolve_type:
+        column_type = _resolve_type(schema, pointer)
+    else:
+        column_type = None
+
+    return PointerStorageInfo(
+        table_name=table,
+        table_type=table_type,
+        column_name=col_name,  # type: ignore
+        column_type=column_type,  # type: ignore
+    )
 
 
-class PointerStorageInfo(NamedTuple):
+@dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
+class PointerStorageInfo:
 
     table_name: Optional[Tuple[str, str]]
     table_type: str
     column_name: str
     column_type: Tuple[str, str]
+
+    def __repr__(self) -> str:
+        return \
+            '<{} (table_name={}, table_type={}, column_name={}, ' \
+            'column_type={}) at 0x{:x}>'.format(
+                self.__class__.__name__, '.'.join(self.table_name or ()),
+                self.table_type, self.column_name, self.column_type, id(self))
 
 
 @overload
@@ -475,8 +480,8 @@ def get_ptrref_storage_info(  # NoQA: F811
 
 def get_ptrref_storage_info(  # NoQA: F811
         ptrref: irast.BasePointerRef, *,
-        resolve_type=True, link_bias=False,
-        allow_missing=False) -> Optional[PointerStorageInfo]:
+        resolve_type: bool=True, link_bias: bool=False,
+        allow_missing: bool=False) -> Optional[PointerStorageInfo]:
     # We wrap the real version because of bad mypy interactions
     # with lru_cache.
     return _get_ptrref_storage_info(
@@ -490,8 +495,8 @@ def get_ptrref_storage_info(  # NoQA: F811
 @functools.lru_cache()
 def _get_ptrref_storage_info(
         ptrref: irast.BasePointerRef, *,
-        resolve_type=True, link_bias=False,
-        allow_missing=False) -> Optional[PointerStorageInfo]:
+        resolve_type: bool=True, link_bias: bool=False,
+        allow_missing: bool=False) -> Optional[PointerStorageInfo]:
 
     if ptrref.material_ptr:
         ptrref = ptrref.material_ptr
@@ -503,13 +508,6 @@ def _get_ptrref_storage_info(
             f'cannot determine backend storage parameters for the '
             f'{ptrref.name!r} pointer: the cardinality is not known')
 
-    is_lprop = ptrref.source_ptr is not None
-
-    if is_lprop:
-        source = ptrref.source_ptr
-    else:
-        source = ptrref.out_source
-
     target = ptrref.out_target
 
     if isinstance(ptrref, irast.TupleIndirectionPointerRef):
@@ -517,24 +515,36 @@ def _get_ptrref_storage_info(
         table_type = 'ObjectType'
         col_name = ptrref.shortname.name
 
-    elif is_lprop:
+    elif isinstance(ptrref, irast.TypeIntersectionPointerRef):
+        raise NotImplementedError()
+
+    elif ptrref.source_ptr is not None:
+        # link property
+        assert isinstance(ptrref, irast.PointerRef)
+        source_ptr = ptrref.source_ptr
+
         table = common.get_pointer_backend_name(
-            source.id, source.name.module, catenate=False)
+            source_ptr.id, source_ptr.name.module, catenate=False)
         table_type = 'link'
         if ptrref.shortname.name in ('source', 'target'):
             col_name = ptrref.shortname.name
         else:
             col_name = str(ptrref.id)
     else:
+        assert isinstance(ptrref, irast.PointerRef)
+        source = ptrref.out_source
+
         if irtyputils.is_scalar(source):
             # This is a pseudo-link on an scalar (__type__)
             table = None
             table_type = 'ObjectType'
             col_name = None
 
-        elif _storable_in_source(ptrref) and not link_bias:
+        elif _ptrref_storable_in_source(ptrref) and not link_bias:
+            assert isinstance(source.name_hint, sn.QualName)
             table = common.get_objtype_backend_name(
-                source.id, source.name_hint.module, catenate=False)
+                source.id, source.name_hint.module, catenate=False
+            )
             ptrname = ptrref.shortname.name
             if ptrname.startswith('__') or ptrname == 'id':
                 col_name = ptrname
@@ -542,7 +552,7 @@ def _get_ptrref_storage_info(
                 col_name = str(ptrref.id)
             table_type = 'ObjectType'
 
-        elif _storable_in_pointer(ptrref):
+        elif _ptrref_storable_in_pointer(ptrref):
             table = common.get_pointer_backend_name(
                 ptrref.id, ptrref.name.module, catenate=False)
             col_name = 'target'
@@ -556,6 +566,7 @@ def _get_ptrref_storage_info(
         else:
             return None
 
+    column_type: Tuple[str, ...] | None
     if resolve_type:
         if irtyputils.is_object(target):
             column_type = ('uuid',)
@@ -567,17 +578,17 @@ def _get_ptrref_storage_info(
 
     return PointerStorageInfo(
         table_name=table, table_type=table_type,
-        column_name=col_name, column_type=column_type
+        column_name=col_name, column_type=column_type  # type: ignore
     )
 
 
-def _storable_in_source(ptrref: irast.PointerRef) -> bool:
+def _ptrref_storable_in_source(ptrref: irast.BasePointerRef) -> bool:
     return ptrref.out_cardinality.is_single()
 
 
-def _storable_in_pointer(ptrref: irast.PointerRef) -> bool:
+def _ptrref_storable_in_pointer(ptrref: irast.BasePointerRef) -> bool:
     if ptrref.union_components:
-        return all(_storable_in_pointer(c) for c in ptrref.union_components)
+        return all(_ptrref_storable_in_pointer(c) for c in ptrref.union_components)
     else:
         return (
             ptrref.out_cardinality.is_multi()

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -454,26 +454,13 @@ def get_pointer_storage_info(
     )
 
 
-@dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
+@dataclasses.dataclass(kw_only=True, eq=False, slots=True)
 class PointerStorageInfo:
 
     table_name: Optional[Tuple[str, str]]
     table_type: str
     column_name: str
     column_type: Tuple[str, str]
-
-    def __repr__(self) -> str:
-        return (
-            '<{} (table_name={}, table_type={}, column_name={}, '
-            'column_type={}) at 0x{:x}>'.format(
-                self.__class__.__name__,
-                '.'.join(self.table_name or ()),
-                self.table_type,
-                self.column_name,
-                self.column_type,
-                id(self),
-            )
-        )
 
 
 @overload

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1224,9 +1224,6 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
 
         return schema.update_obj(self, updates)
 
-    def is_type(self) -> bool:
-        return False
-
     def hash_criteria(
         self: Object_T, schema: s_schema.Schema
     ) -> FrozenSet[HashCriterion]:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -225,9 +225,6 @@ class Type(
 
         return schema, derived
 
-    def is_type(self) -> bool:
-        return True
-
     def is_object_type(self) -> bool:
         return False
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -481,9 +481,9 @@ def typeref_to_ast(
 
     result: qlast.TypeExpr
 
-    if t.is_type() and cast(s_types.Type, t).is_any(schema):
+    if isinstance(t, s_types.Type) and t.is_any(schema):
         result = qlast.TypeName(name=_name, maintype=qlast.AnyType())
-    elif t.is_type() and cast(s_types.Type, t).is_anytuple(schema):
+    elif isinstance(t, s_types.Type) and t.is_anytuple(schema):
         result = qlast.TypeName(name=_name, maintype=qlast.AnyTuple())
     elif isinstance(t, s_types.Tuple) and t.is_named(schema):
         result = qlast.TypeName(
@@ -511,9 +511,8 @@ def typeref_to_ast(
                 for st in t.get_subtypes(schema)
             ]
         )
-    elif t.is_type() and cast(s_types.Type, t).is_union_type(schema):
-        object_set: Optional[so.ObjectSet[s_types.Type]] = \
-            cast(s_types.Type, t).get_union_of(schema)
+    elif isinstance(t, s_types.Type) and t.is_union_type(schema):
+        object_set = t.get_union_of(schema)
         assert object_set is not None
 
         component_objects = tuple(object_set.objects(schema))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ module = [
     "edb.ir.*",
     "edb.pgsql.metaschema",
     "edb.pgsql.codegen",
+    "edb.pgsql.types",
     "edb.pgsql.compiler.*",
     "edb.repl.*",
     "edb.schema.*",


### PR DESCRIPTION
Add type annotations to `edb/pgsql/types.py`

Remove `_PointerStorageInfo` class that only has classmethods and pretends to be another class, in favor of `PointerStorageInfo`, which I converted from extending a NamedTuple into a dataclass.