### PR TITLE
Prehibit directly modifying stdlib objects

### DIFF
--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -94,6 +94,12 @@ class GlobalCompilerOptions:
     #: Is the compiler running in testmode
     testmode: bool = False
 
+    # Is the compiler running in the server's schema reflection mode
+    schema_reflection_mode: bool = False
+
+    # are we invoking the compiler from inside a CONFIGURE?
+    in_server_config_op: bool = False
+
 
 @dataclass
 class CompilerOptions(GlobalCompilerOptions):

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1334,6 +1334,7 @@ def _get_compile_options(
         ) or is_explain,
         testmode=_get_config_val(ctx, '__internal_testmode'),
         devmode=_is_dev_instance(ctx),
+        schema_reflection_mode=ctx.schema_reflection_mode
     )
 
 
@@ -1763,6 +1764,7 @@ def _compile_ql_config_op(ctx: CompileContext, ql: qlast.Base):
         schema=schema,
         options=qlcompiler.CompilerOptions(
             modaliases=modaliases,
+            in_server_config_op=True
         ),
     )
 

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -71,6 +71,23 @@ class TestDelete(tb.QueryTestCase):
                 DELETE std::FreeObject
             ''')
 
+    async def test_edgeql_delete_bad_03(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r'delete standard library type',
+        ):
+            await self.con.execute('''\
+                DELETE schema::Object;
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r'delete standard library type',
+        ):
+            await self.con.execute('''\
+                DELETE {default::LinkingType, schema::Object};
+            ''')
+
     async def test_edgeql_delete_simple_01(self):
         # ensure a clean slate, not part of functionality testing
         await self.con.execute(r"""

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -95,6 +95,15 @@ class TestInsert(tb.QueryTestCase):
                 INSERT Person { name := .name };
             ''')
 
+    async def test_edgeql_insert_fail_7(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            r"insert standard library type",
+        ):
+            await self.con.execute('''
+                INSERT schema::Migration { script := 'foo' };
+            ''')
+
     async def test_edgeql_insert_simple_01(self):
         await self.con.execute(r"""
             INSERT InsertTest {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -541,6 +541,15 @@ class TestUpdate(tb.QueryTestCase):
                 UPDATE foo SET { bar := 2 };
             ''')
 
+    async def test_edgeql_update_bad_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r'update standard library type',
+        ):
+            await self.con.execute('''\
+                UPDATE schema::Migration SET { script := 'foo'};
+            ''')
+
     async def test_edgeql_update_filter_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Prohibit `INSERT` `UPDATE` and `DELETE` operations on objects in stdlib modules.

Fixes #4212.
