### PR TITLE
Fix coalesce with type intersection

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1018,7 +1018,7 @@ def _get_rel_path_output(
             ptrref = actual_ptrref
 
     ptr_info = None
-    if ptrref:
+    if ptrref and not isinstance(ptrref, irast.TypeIntersectionPointerRef):
         ptr_info = pg_types.get_ptrref_storage_info(
             ptrref, resolve_type=False, link_bias=False)
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -512,9 +512,6 @@ def _get_ptrref_storage_info(
 
     target = ptrref.out_target
 
-    if isinstance(ptrref, irast.TypeIntersectionPointerRef):
-        return None
-
     if isinstance(ptrref, irast.TupleIndirectionPointerRef):
         table = None
         table_type = 'ObjectType'

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -512,6 +512,9 @@ def _get_ptrref_storage_info(
 
     target = ptrref.out_target
 
+    if isinstance(ptrref, irast.TypeIntersectionPointerRef):
+        return None
+
     if isinstance(ptrref, irast.TupleIndirectionPointerRef):
         table = None
         table_type = 'ObjectType'

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -7313,6 +7313,12 @@ aa \
                 SELECT Object.id[IS uuid];
             ''')
 
+    async def test_edgeql_expr_type_intersection_04(self):
+        await self.con.execute('''\
+            SELECT Named[IS Issue].id
+                ?? <uuid>'00000000-0000-0000-0000-000000000000';
+        ''')
+
     async def test_edgeql_expr_comparison_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,


### PR DESCRIPTION
Closes #5474

The problem was a specific codepath, that was trying to
get_rel_path_output out of a NullRelation for a type intersection
path.

The fix is basically saying "this path does not have storage info",
so the codepath can hit the handler for NullRelation.

This fix was easy write, very hard to find.
