### PR TITLE
Support a primitive form of parameterized types

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_06_06_00_00
+EDGEDB_CATALOG_VERSION = 2023_06_06_00_01
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -317,7 +317,7 @@ class TypeOf(TypeExpr):
 
 class TypeExprLiteral(TypeExpr):
     # Literal type exprs are used in enum declarations.
-    val: StringConstant
+    val: BaseConstant
 
 
 class TypeName(TypeExpr):

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1990,6 +1990,11 @@ class Subtype(Nonterm):
             val=kids[0].val,
         )
 
+    def reduce_BaseNumberConstant(self, *kids):
+        self.val = qlast.TypeExprLiteral(
+            val=kids[0].val,
+        )
+
 
 class SubtypeList(ListNonterm, element=Subtype, separator=tokens.T_COMMA):
     pass

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -326,7 +326,7 @@ def type_to_typeref(
         sql_type = None
         needs_custom_json_cast = False
         if isinstance(t, s_scalars.ScalarType):
-            sql_type = t.get_sql_type(schema)
+            sql_type = t.resolve_sql_type(schema)
             if material_typeref is None:
                 cast_name = s_casts.get_cast_fullname_from_names(
                     orig_name_hint or name_hint,

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -330,6 +330,7 @@ CREATE TYPE schema::ScalarType
 {
     CREATE PROPERTY default -> std::str;
     CREATE PROPERTY enum_values -> array<std::str>;
+    CREATE PROPERTY arg_values -> array<std::str>;
 };
 
 

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -118,10 +118,18 @@ def quote_type(type_: Tuple[str, ...] | str):
     if is_array:
         last = last[:-2]
 
+    param = None
+    if '(' in last:
+        last, param = last.split('(', 1)
+        param = '(' + param
+
     last = quote_ident(last)
 
     if is_rowtype:
         last += '%ROWTYPE'
+
+    if param:
+        last += param
 
     if is_array:
         last += '[]'

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -153,7 +153,7 @@ def get_scalar_base(
             # another domain.
             if base := base_type_name_map.get(ancestor.id):
                 pass
-            elif typstr := ancestor.get_sql_type(schema):
+            elif typstr := ancestor.resolve_sql_type(schema):
                 base = tuple(typstr.split('.'))
             else:
                 base = common.get_backend_name(
@@ -176,7 +176,7 @@ def pg_type_from_scalar(
     column_type = base_type_name_map.get(scalar.id)
     if column_type:
         pass
-    elif typstr := scalar.get_sql_type(schema):
+    elif typstr := scalar.resolve_sql_type(schema):
         column_type = tuple(typstr.split('.'))
     else:
         column_type = common.get_backend_name(schema, scalar, catenate=False)

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -478,18 +478,22 @@ def _build_object_mutation_shape(
                     f'<uuid>$__{var_prefix}id, '
                     f'{kind}, '
                     f'<uuid>$__{var_prefix}element_type, '
-                    f'<str>$__{var_prefix}sql_type), '
+                    f'<str>$__{var_prefix}sql_type2), '
                 )
             else:
                 assignments.append(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
                     f'<uuid>$__{var_prefix}id, {kind}, <uuid>{{}}, '
-                    f'<str>$__{var_prefix}sql_type), '
+                    f'<str>$__{var_prefix}sql_type2), '
                 )
+            sql_type = None
+            if isinstance(cmd.scls, s_scalars.ScalarType):
+                sql_type, _ = cmd.scls.resolve_sql_type_scheme(schema)
+
             variables[f'__{var_prefix}id'] = json.dumps(
                 str(cmd.get_attribute_value('id')))
-            variables[f'__{var_prefix}sql_type'] = json.dumps(
-                cmd.get_attribute_value('sql_type'))
+            variables[f'__{var_prefix}sql_type2'] = json.dumps(
+                sql_type)
 
     shape = ',\n'.join(assignments)
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -27,6 +27,8 @@ from edb.common import checked
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
+from edb.common.typeutils import downcast
+
 from . import abc as s_abc
 from . import annos as s_anno
 from . import casts as s_casts
@@ -60,7 +62,29 @@ class ScalarType(
     )
 
     sql_type = so.SchemaField(
-        str, default=None, compcoef=0.9)
+        str, default=None, inheritable=False, compcoef=0.9)
+
+    # A type scheme for supporting type mods in scalar types.
+    # If present, describes what the sql_type of children scalars
+    # should be, such as 'varchar({__arg_0__})'.
+    sql_type_scheme = so.SchemaField(
+        str, default=None, inheritable=False, compcoef=0.9)
+
+    # Param definitions for a parameterized type scheme.
+    # Array values notionally say what the type should be,
+    # but currently we only support integers.
+    params = so.SchemaField(
+        checked.FrozenCheckedList[str], default=None,
+        inheritable=False,
+        coerce=True, compcoef=0.8,
+    )
+
+    # Arguments to fill in a parent type's parameterized type scheme.
+    arg_values = so.SchemaField(
+        checked.FrozenCheckedList[str], default=None,
+        inheritable=False,
+        coerce=True, compcoef=0.8,
+    )
 
     @classmethod
     def get_schema_class_displayname(cls) -> str:
@@ -235,6 +259,37 @@ class ScalarType(
         dname = self.get_displayname(schema)
         return f"{clsname} '{dname}'"
 
+    def resolve_sql_type_scheme(
+        self, schema: s_schema.Schema,
+    ) -> tuple[Optional[str], Optional[str]]:
+        if sql := self.get_sql_type(schema):
+            return sql, None
+        if self.get_arg_values(schema) is None:
+            return None, None
+        bases = self.get_bases(schema).objects(schema)
+        if len(bases) != 1:
+            return None, None
+        if scheme := bases[0].get_sql_type_scheme(schema):
+            base_sql_type = bases[0].get_sql_type(schema)
+            assert base_sql_type is not None
+            return base_sql_type, scheme
+        return None, None
+
+    def resolve_sql_type(
+        self, schema: s_schema.Schema,
+    ) -> Optional[str]:
+        type, scheme = self.resolve_sql_type_scheme(schema)
+        if scheme:
+            return constraints.interpolate_errmessage(
+                scheme,
+                {
+                    f'__arg_{i}__': v
+                    for i, v in enumerate(self.get_arg_values(schema) or ())
+                },
+            )
+        else:
+            return type
+
     def as_alter_delta(
         self,
         other: ScalarType,
@@ -304,6 +359,35 @@ class ScalarTypeCommand(
     s_anno.AnnotationSubjectCommand[ScalarType],
     context_class=ScalarTypeCommandContext,
 ):
+    def validate_object(
+        self, schema: s_schema.Schema, context: sd.CommandContext
+    ) -> None:
+        if (
+            self.scls.resolve_sql_type_scheme(schema)[0]
+        ):
+            if len(self.scls.get_constraints(schema)):
+                raise errors.SchemaError(
+                    f'parameterized scalar types may not have constraints',
+                    context=self.source_context,
+                )
+
+        if args := self.scls.get_arg_values(schema):
+            base = self.scls.get_bases(schema).objects(schema)[0]
+            params = base.get_params(schema)
+            if not params:
+                raise errors.SchemaDefinitionError(
+                    f'base type {base.get_name(schema)} does not '
+                    f'accept parameters',
+                    context=self.source_context,
+                )
+            if len(params) != len(args):
+                raise errors.SchemaDefinitionError(
+                    f'incorrect number of arguments provided to base type '
+                    f'{base.get_name(schema)}: expected {len(params)} '
+                    f'but got {len(args)}',
+                    context=self.source_context,
+                )
+
     def validate_scalar_ancestors(
         self,
         ancestors: Sequence[so.SubclassableObject],
@@ -398,7 +482,8 @@ class CreateScalarType(
         astnode: qlast.DDLOperation,
         context: sd.CommandContext,
     ) -> sd.Command:
-        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        cmd = super()._cmd_tree_from_ast(
+            schema, astnode.replace(bases=None), context)
 
         if isinstance(cmd, sd.CommandGroup):
             for subcmd in cmd.get_subcommands():
@@ -419,6 +504,7 @@ class CreateScalarType(
                     metaclass=ScalarType,
                     modaliases=context.modaliases,
                     schema=schema,
+                    allow_generalized_bases=True,
                 )
                 for b in (astnode.bases or [])
             ]
@@ -479,6 +565,34 @@ class CreateScalarType(
                         collection_type=so.ObjectList,
                     )
                 )
+            else:
+                if any(b.extra_args for b in bases):
+                    if len(bases) > 1:
+                        raise errors.SchemaDefinitionError(
+                            'scalars with parameterized bases may '
+                            'only have one',
+                            context=astnode.bases[0].context,
+                        )
+                    base = bases[0]
+                    args = []
+                    for x in (base.extra_args or ()):
+                        if (
+                            not isinstance(x, qlast.TypeExprLiteral)
+                            or not isinstance(x.val, qlast.IntegerConstant)
+                        ):
+                            raise errors.SchemaDefinitionError(
+                                'invalid scalar type argument',
+                                context=x.context,
+                            )
+                        args.append(x.val.value)
+                    cmd.set_attribute_value('arg_values', args)
+
+                cmd.set_attribute_value(
+                    'bases',
+                    so.ObjectCollectionShell(
+                        bases, collection_type=so.ObjectList),
+                    # source_context=srcctx,
+                )
 
         return cmd
 
@@ -528,6 +642,16 @@ class CreateScalarType(
                 ]
             else:
                 super()._apply_field_ast(schema, context, node, op)
+                if arg_values := self.get_local_attribute_value('arg_values'):
+                    frags = [
+                        s_expr.Expression(text=x).qlast for x in arg_values]
+                    assert isinstance(node, qlast.BasedOnTuple)
+                    node.bases[0].subtypes = [
+                        qlast.TypeExprLiteral(
+                            val=downcast(qlast.BaseConstant, frag)
+                        )
+                        for frag in frags
+                    ]
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -70,13 +70,13 @@ class ScalarType(
     sql_type_scheme = so.SchemaField(
         str, default=None, inheritable=False, compcoef=0.9)
 
-    # Param definitions for a parameterized type scheme.
-    # Array values notionally say what the type should be,
-    # but currently we only support integers.
-    params = so.SchemaField(
-        checked.FrozenCheckedList[str], default=None,
+    # The number of parameters that the type takes. Currently all parameters
+    # must be integer literals.
+    # This is an internal API and might change.
+    num_params = so.SchemaField(
+        int, default=None,
         inheritable=False,
-        coerce=True, compcoef=0.8,
+        compcoef=0.8,
     )
 
     # Arguments to fill in a parent type's parameterized type scheme.
@@ -373,17 +373,17 @@ class ScalarTypeCommand(
 
         if args := self.scls.get_arg_values(schema):
             base = self.scls.get_bases(schema).objects(schema)[0]
-            params = base.get_params(schema)
-            if not params:
+            num_params = base.get_num_params(schema)
+            if not num_params:
                 raise errors.SchemaDefinitionError(
                     f'base type {base.get_name(schema)} does not '
                     f'accept parameters',
                     context=self.source_context,
                 )
-            if len(params) != len(args):
+            if num_params != len(args):
                 raise errors.SchemaDefinitionError(
                     f'incorrect number of arguments provided to base type '
-                    f'{base.get_name(schema)}: expected {len(params)} '
+                    f'{base.get_name(schema)}: expected {num_params} '
                     f'but got {len(args)}',
                     context=self.source_context,
                 )

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -571,6 +571,7 @@ class InheritingType(so.DerivableInheritingObject, QualifiedType):
 class TypeShell(so.ObjectShell[TypeT_co]):
 
     schemaclass: typing.Type[TypeT_co]
+    extra_args: tuple[qlast.Expr | qlast.TypeExpr, ...] | None
 
     def __init__(
         self,
@@ -581,6 +582,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         expr: Optional[str] = None,
         schemaclass: typing.Type[TypeT_co],
         sourcectx: Optional[parsing.ParserContext] = None,
+        extra_args: tuple[qlast.Expr] | None = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -591,6 +593,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         )
 
         self.expr = expr
+        self.extra_args = extra_args
 
     def resolve(self, schema: s_schema.Schema) -> TypeT_co:
         return schema.get(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15502,6 +15502,7 @@ DDLStatement);
 
 class TestDDLNonIsolated(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False
+    PARALLELISM_GRANULARITY = 'suite'
 
     async def test_edgeql_ddl_consecutive_create_migration_01(self):
         # A regression test for https://github.com/edgedb/edgedb/issues/2085.
@@ -15520,7 +15521,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         };
         ''')
 
-    async def _extension_test(self):
+    async def _extension_test_01(self):
         await self.con.execute('''
             create extension ltree
         ''')
@@ -15565,7 +15566,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             drop extension ltree;
         ''')
 
-    async def test_edgeql_ddl_extensions(self):
+    async def test_edgeql_ddl_extensions_01(self):
         # Make an extension that wraps a tiny bit of the ltree package.
         await self.con.execute('''
         create extension package ltree VERSION '1.0' {
@@ -15610,8 +15611,131 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         ''')
         try:
             async with self._run_and_rollback():
-                await self._extension_test()
+                await self._extension_test_01()
         finally:
             await self.con.execute('''
                 drop extension package ltree VERSION '1.0'
+            ''')
+
+    async def _extension_test_02(self):
+        await self.con.execute('''
+            create extension varchar
+        ''')
+
+        await self.con.execute('''
+            create scalar type vc5 extending varchar::varchar<5>;
+            create type X {
+                create property foo: vc5;
+            };
+        ''')
+
+        await self.assert_query_result(
+            '''
+                describe scalar type vc5;
+            ''',
+            ['create scalar type default::vc5 extending varchar::varchar<5>;'],
+        )
+        await self.assert_query_result(
+            '''
+                describe scalar type vc5 as sdl;
+            ''',
+            ['scalar type default::vc5 extending varchar::varchar<5>;'],
+        )
+
+        await self.assert_query_result(
+            '''
+                select schema::ScalarType { arg_values }
+                filter .name = 'default::vc5'
+            ''',
+            [{'arg_values': ['5']}],
+        )
+
+        await self.con.execute('''
+            insert X { foo := <vc5>"0123456789" }
+        ''')
+
+        await self.assert_query_result(
+            '''
+                select X.foo
+            ''',
+            ['01234'],
+            json_only=True,
+        )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaError,
+            "parameterized scalar types may not have constraints",
+        ):
+            await self.con.execute('''
+                alter scalar type vc5 create constraint expression on (true);
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "invalid scalar type argument",
+        ):
+            await self.con.execute('''
+                create scalar type fail extending varchar::varchar<foo>;
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "does not accept parameters",
+        ):
+            await self.con.execute('''
+                create scalar type yyy extending str<1, 2>;
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "incorrect number of arguments",
+        ):
+            await self.con.execute('''
+                create scalar type yyy extending varchar::varchar<1, 2>;
+            ''')
+
+        # If no params are specified, it just makes a normal scalar type
+        await self.con.execute('''
+            create scalar type vc extending varchar::varchar {
+                create constraint expression on (false);
+            };
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "invalid",
+        ):
+            await self.con.execute('''
+                select <str><vc>'a';
+            ''')
+
+    async def test_edgeql_ddl_extensions_02(self):
+        # Make an extension that wraps some of varchar
+        await self.con.execute('''
+        create extension package varchar VERSION '1.0' {
+          set ext_module := "varchar";
+          set sql_extensions := [];
+          create module varchar;
+          create scalar type varchar::varchar {
+            set id := <uuid>'26dc1396-0196-11ee-a005-ad0eaed0df03';
+            set sql_type := "varchar";
+            set sql_type_scheme := "varchar({__arg_0__})";
+            set params := ["num"];
+          };
+
+          create cast from varchar::varchar to std::str {
+            SET volatility := 'Immutable';
+            USING SQL CAST;
+          };
+          create cast from std::str to varchar::varchar {
+            SET volatility := 'Immutable';
+            USING SQL CAST;
+          };
+        };
+        ''')
+        try:
+            async with self._run_and_rollback():
+                await self._extension_test_02()
+        finally:
+            await self.con.execute('''
+                drop extension package varchar VERSION '1.0'
             ''')

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15719,7 +15719,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             set id := <uuid>'26dc1396-0196-11ee-a005-ad0eaed0df03';
             set sql_type := "varchar";
             set sql_type_scheme := "varchar({__arg_0__})";
-            set params := ["num"];
+            set num_params := 1;
           };
 
           create cast from varchar::varchar to std::str {


### PR DESCRIPTION
Types declared in extensions can declare a type scheme that allows
user-defined scalars that extend them to provide the argument value.
Eventually we may want to generalize this to work in arbitrary
situations, but we aren't there yet.

I may have built more generic of infrastructure than necessary: types
declare an array describing the parameters they take and a "type
scheme" that says how to format the modified type names.

But maybe that's just silly and it should just take a number of
parameters, which will need to be integers, and it will format them in
the obvious way?