### PR TITLE
Fix some obscure optional bugs in the presence of tuple projections

### DIFF
--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -484,10 +484,13 @@ class ScopeTreeNode:
 
             path_id = descendant.path_id.strip_namespace(dns)
             visible, visible_finfo, vns = self.find_visible_ex(path_id)
-            desc_optional = (
-                descendant.is_optional_upto(node.parent) or self.optional)
 
             if visible is not None:
+                desc_optional = (
+                    descendant.is_optional_upto(node.parent)
+                    or self.is_optional_upto(visible.parent)
+                )
+
                 if visible_finfo is not None and visible_finfo.factoring_fence:
                     # This node is already present in the surrounding
                     # scope and cannot be factored out, such as
@@ -530,6 +533,12 @@ class ScopeTreeNode:
                 current = descendant
                 if factorable_nodes:
                     descendant.strip_path_namespace(dns)
+                    desc_optional = (
+                        descendant.is_optional_upto(node.parent)
+                        # Check if there is an optional branch between here
+                        # and the *highest* factoring point.
+                        or self.is_optional_upto(factorable_nodes[-1][1])
+                    )
                     if desc_optional:
                         descendant.mark_as_optional()
 

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -811,6 +811,83 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+        await self.assert_query_result(
+            r'''
+                WITH
+                    I := (
+                        SELECT Issue
+                        FILTER Issue.status.name = 'Open'
+                    )
+                # `I.time_estimate` is now a LCP
+                SELECT I.time_estimate ?= (I.time_estimate,).0;
+            ''',
+            [
+                True,
+            ],
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH
+                    I := (
+                        SELECT Issue
+                        FILTER Issue.status.name = 'Open'
+                    )
+                # `I.time_estimate` is now a LCP
+                SELECT (I.time_estimate,).0 ?= (I.time_estimate,).0;
+            ''',
+            [
+                True,
+            ],
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH
+                    I := (
+                        SELECT Issue
+                        FILTER Issue.status.name = 'Open'
+                    )
+                # `I.time_estimate` is now a LCP
+                SELECT ((I.time_estimate,).0,).0 ?= (I.time_estimate,).0;
+            ''',
+            [
+                True,
+            ],
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH
+                    I := (
+                        SELECT Issue
+                        FILTER Issue.status.name = 'Open'
+                    )
+                # `I.time_estimate` is now a LCP
+                SELECT
+                  ({I.time_estimate} = 0) ?=
+                  (({I.time_estimate} = 0) = (I.time_estimate = 0));
+            ''',
+            [
+                True,
+            ],
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH
+                    I := (
+                        SELECT Issue
+                        FILTER Issue.status.name = 'Open'
+                    )
+                # `I.time_estimate` is now a LCP
+                SELECT {I.time_estimate} ?= (I.time_estimate,).0;
+            ''',
+            [
+                True,
+            ],
+        )
+
     async def test_edgeql_coalesce_dependent_21(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
When attaching a path in the scope tree, the detection of whether the
*target* node was optional was insufficient. It only checked the node
itself, but needs to check all the way to the factoring point.
I think that logic had forgotten about BRANCHes that weren't FENCEs.

This came up in a branch where I was experimenting with always
BRANCHing function arguments as a way to validate *sometimes*
branching function arguments to produce code that hits ORDER BY
indexes in complex pgvector cases.