### PR TITLE
Allow configuring abstract index code in the indexes themselves

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_06_06_00_01
+EDGEDB_CATALOG_VERSION = 2023_06_06_00_02
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/lib/fts.edgeql
+++ b/edb/lib/fts.edgeql
@@ -22,6 +22,7 @@ CREATE MODULE fts;
 CREATE ABSTRACT INDEX fts::textsearch(named only language: std::str) {
     CREATE ANNOTATION std::description :=
         "Full-text search index based on the Postgres's GIN index.";
+    SET code := 'gin (to_tsvector(__kw_language__, __col__))';
 };
 
 ## Functions

--- a/edb/lib/pg.edgeql
+++ b/edb/lib/pg.edgeql
@@ -22,32 +22,38 @@ CREATE MODULE pg;
 CREATE ABSTRACT INDEX pg::hash {
     CREATE ANNOTATION std::description :=
         'Index based on a 32-bit hash derived from the indexed value.';
+    SET code := 'hash ((__col__))';
 };
 
 CREATE ABSTRACT INDEX pg::btree {
     CREATE ANNOTATION std::description :=
         'B-tree index can be used to retrieve data in sorted order.';
+    SET code := 'btree ((__col__) NULLS FIRST)';
 };
 
-CREATE ABSTRACT INDEX pg::gin{
+CREATE ABSTRACT INDEX pg::gin {
     CREATE ANNOTATION std::description :=
         'GIN is an "inverted index" appropriate for data values that \
         contain multiple elements, such as arrays and JSON.';
+    SET code := 'gin ((__col__))';
 };
 
-CREATE ABSTRACT INDEX pg::gist{
+CREATE ABSTRACT INDEX pg::gist {
     CREATE ANNOTATION std::description :=
         'GIST index can be used to optimize searches involving ranges.';
+    SET code := 'gist ((__col__))';
 };
 
-CREATE ABSTRACT INDEX pg::spgist{
+CREATE ABSTRACT INDEX pg::spgist {
     CREATE ANNOTATION std::description :=
         'SP-GIST index can be used to optimize searches involving ranges \
         and strings.';
+    SET code := 'spgist ((__col__))';
 };
 
-CREATE ABSTRACT INDEX pg::brin{
+CREATE ABSTRACT INDEX pg::brin {
     CREATE ANNOTATION std::description :=
         'BRIN (Block Range INdex) index works with summaries about the values \
         stored in consecutive physical block ranges in the database.';
+    SET code := 'brin ((__col__))';
 };

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3485,9 +3485,11 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
         orig_name = sn.shortname_from_fullname(index.get_name(schema))
         if orig_name == s_indexes.DEFAULT_INDEX:
             root_name = orig_name
+            root_code = None
         else:
             root = index.get_root(schema)
             root_name = root.get_name(schema)
+            root_code = root.get_code(schema)
 
             kwargs = index.get_concrete_kwargs(schema)
             # Get all the concrete kwargs compiled (they are expected to be
@@ -3523,13 +3525,16 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
         index_name = common.get_index_backend_name(
             index.id, module_name, catenate=False)
 
+        if root_code is None:
+            root_code = get_index_code(root_name)
+
         pg_index = dbops.Index(
             name=index_name[1], table_name=table_name, exprs=sql_exprs,
             unique=False, inherit=True,
             predicate=except_src,
             metadata={
                 'schemaname': str(index.get_name(schema)),
-                'code': get_index_code(root_name),
+                'code': root_code,
                 'kwargs': sql_kwarg_exprs,
             }
         )

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -140,6 +140,15 @@ class Index(
         inheritable=False,
     )
 
+    # Appears in base abstract index definitions and defines how the index
+    # is represented in postgres.
+    code = so.SchemaField(
+        str,
+        default=None,
+        compcoef=None,
+        inheritable=False,
+    )
+
     # These can appear in abstract indexes extending an existing one in order
     # to override exisitng parameters. Also they can appear in concrete
     # indexes.

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12347,6 +12347,16 @@ type default::Foo {
             [{"indexes": [{"except_expr": ".exclude", "expr": ".name"}]}]
         )
 
+    async def test_edgeql_ddl_index_07(self):
+        # Unfortunately we don't really have a way to test that this
+        # actually works, but I looked at the SQL DDL.
+        await self.con.execute(r"""
+            create type Foo {
+                create property fields -> array<str>;
+                create index pg::gin on (.fields);
+            };
+        """)
+
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
             CREATE TYPE Err1 {


### PR DESCRIPTION
Add a `code` field to `Index` and get rid of `get_index_code`.
Main immediate goal of this is making it so we don't need to
hardcode things for pgvector.

I am going to cherry-pick just the first commit in this PR to 3.0, and
leave `get_index_code` as a fallback there.