### PR TITLE
Enable compiling function arguments into subqueries for pgvector opt purposes

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_06_06_00_02
+EDGEDB_CATALOG_VERSION = 2023_06_06_00_03
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -556,6 +556,8 @@ def _infer_stmt_multiplicity(
             if (
                 irutils.get_path_root(flt_expr).path_id
                 == ctx.distinct_iterator
+                or irutils.get_path_root(irutils.unwrap_set(flt_expr)).path_id
+                == ctx.distinct_iterator
             ) and not infer_multiplicity(
                 flt_expr, scope_tree=scope_tree, ctx=ctx
             ).is_duplicate():

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -557,18 +557,19 @@ def compile_arg(
     typemod: ft.TypeModifier,
     *,
     in_conditional: bool=False,
+    prefer_subquery_args: bool=False,
     ctx: context.ContextLevel,
 ) -> irast.Set:
     fenced = typemod is ft.TypeModifier.SetOfType
     optional = typemod is ft.TypeModifier.OptionalType
 
-    # Create a a branch for OPTIONAL ones. The OPTIONAL branch is to
+    # Create a branch for OPTIONAL ones. The OPTIONAL branch is to
     # have a place to mark as optional in the scope tree.
     # For fenced arguments we instead wrap it in a SELECT below.
-    branched = optional
-
-    # XXX: Actually, always branch anything that isn't fenced.
-    branched |= not fenced
+    #
+    # We also put a branch when we are trying to compile the argument
+    # into a subquery, so that things it uses get bound locally.
+    branched = optional or (prefer_subquery_args and not fenced)
 
     new = ctx.newscope(fenced=False) if branched else ctx.new()
     with new as argctx:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -888,6 +888,11 @@ class Call(ImmutableExpr):
     # filter at the call site.
     impl_is_strict: bool = False
 
+    # Kind of a hack: indicates that when possible we should pass arguments
+    # to this function as a subquery-as-an-expression.
+    # See comment in schema/functions.py for more discussion.
+    prefer_subquery_args: bool = False
+
 
 class FunctionCall(Call):
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -131,7 +131,9 @@ def is_scalar_view_set(ir_expr: irast.Base) -> bool:
     )
 
 
-def is_implicit_wrapper(ir_expr: irast.Base) -> bool:
+def is_implicit_wrapper(
+    ir_expr: Optional[irast.Base]
+) -> TypeGuard[irast.SelectStmt]:
     """Return True if the given *ir_expr* expression is an implicit
        SELECT wrapper.
     """
@@ -162,7 +164,7 @@ def unwrap_set(ir_set: irast.Set) -> irast.Set:
        wrapped set.
     """
     if ir_set.expr is not None and is_implicit_wrapper(ir_set.expr):
-        return ir_set.expr.result  # type: ignore
+        return ir_set.expr.result
     else:
         return ir_set
 

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -522,6 +522,14 @@ def collapse_query(query: pgast.Query) -> pgast.BaseExpr:
         return query
 
     if (
+        isinstance(query, pgast.SelectStmt)
+        and len(query.target_list) == 1
+        and len(query.from_clause) == 0
+        and select_is_simple(query)
+    ):
+        return query.target_list[0].val
+
+    if (
         not isinstance(query, pgast.SelectStmt)
         or len(query.target_list) != 1
         or len(query.from_clause) != 1

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3156,15 +3156,15 @@ def _compile_call_args(
         # "push down" the subqueries from the top level, which is
         # important for things like hitting pgvector indexes in an
         # ORDER BY.
-        # XXX: Don't always do it?
-        can_make_subquery = (
-            typemod != qltypes.TypeModifier.SetOfType
+        make_subquery = (
+            expr.prefer_subquery_args
+            and typemod != qltypes.TypeModifier.SetOfType
             and ir_arg.cardinality.is_single()
             and ir_arg.expr.typeref.is_scalar
             and not _needs_arg_null_check(expr, ir_arg, typemod, ctx=ctx)
         )
 
-        if can_make_subquery:
+        if make_subquery:
             arg_ref = set_as_subquery(ir_arg.expr, as_value=True, ctx=ctx)
             arg_ref.nullable = ir_arg.cardinality.can_be_zero()
             arg_ref = astutils.collapse_query(arg_ref)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3102,21 +3102,31 @@ def _compile_func_epilogue(
     return new_stmt_set_rvar(ir_set, ctx.rel, aspects=aspects, ctx=ctx)
 
 
-def _compile_arg_null_check(
-    call_expr: irast.Call, ir_arg: irast.CallArg, arg_ref: pgast.BaseExpr,
+def _needs_arg_null_check(
+    call_expr: irast.Call, ir_arg: irast.CallArg,
     typemod: qltypes.TypeModifier, *,
     ctx: context.CompilerContextLevel
-) -> None:
-    if (
+) -> bool:
+    return (
         not call_expr.impl_is_strict
         and not ir_arg.is_default
-        and arg_ref.nullable
         and (
             (
                 typemod == qltypes.TypeModifier.SingletonType
                 and ir_arg.cardinality.can_be_zero()
             ) or typemod == qltypes.TypeModifier.SetOfType
         )
+    )
+
+
+def _compile_arg_null_check(
+    call_expr: irast.Call, ir_arg: irast.CallArg, arg_ref: pgast.BaseExpr,
+    typemod: qltypes.TypeModifier, *,
+    ctx: context.CompilerContextLevel
+) -> None:
+    if (
+        _needs_arg_null_check(call_expr, ir_arg, typemod, ctx=ctx)
+        and arg_ref.nullable
     ):
         ctx.rel.where_clause = astutils.extend_binop(
             ctx.rel.where_clause,
@@ -3141,8 +3151,27 @@ def _compile_call_args(
     for ir_arg, typemod in zip(expr.args, expr.params_typemods):
         assert ir_arg.multiplicity != qltypes.Multiplicity.UNKNOWN
 
-        arg_ref = dispatch.compile(ir_arg.expr, ctx=ctx)
-        args.append(output.output_as_value(arg_ref, env=ctx.env))
+        # Support a mode where we try to compile arguments as pure
+        # subqueries. This is occasionally valuable as it lets us
+        # "push down" the subqueries from the top level, which is
+        # important for things like hitting pgvector indexes in an
+        # ORDER BY.
+        # XXX: Don't always do it?
+        can_make_subquery = (
+            typemod != qltypes.TypeModifier.SetOfType
+            and ir_arg.cardinality.is_single()
+            and ir_arg.expr.typeref.is_scalar
+            and not _needs_arg_null_check(expr, ir_arg, typemod, ctx=ctx)
+        )
+
+        if can_make_subquery:
+            arg_ref = set_as_subquery(ir_arg.expr, as_value=True, ctx=ctx)
+            arg_ref.nullable = ir_arg.cardinality.can_be_zero()
+            arg_ref = astutils.collapse_query(arg_ref)
+        else:
+            arg_ref = dispatch.compile(ir_arg.expr, ctx=ctx)
+            arg_ref = output.output_as_value(arg_ref, env=ctx.env)
+        args.append(arg_ref)
         _compile_arg_null_check(expr, ir_arg, arg_ref, typemod, ctx=ctx)
 
         if (

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -774,6 +774,15 @@ class CallableObject(
     impl_is_strict = so.SchemaField(
         bool, default=True, compcoef=0.4)
 
+    # Kind of a hack: indicates that when possible we should pass arguments
+    # to this function as a subquery-as-an-expression. This is important for
+    # functions that see use in ORDER BY clauses that need indexes.
+    # The compilation strategy this asks for /should/ work in general,
+    # but I didn't want to make a major codegen change in an rc3.
+    # We should consider doing this a different way.
+    prefer_subquery_args = so.SchemaField(
+        bool, default=False, compcoef=0.9)
+
     def as_create_delta(
         self: CallableObjectT,
         schema: s_schema.Schema,

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -475,7 +475,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         UNIQUE
         """
 
-    def test_edgeql_ir_mult_inference_55(self):
+    def test_edgeql_ir_mult_inference_55a(self):
         """
         FOR x IN {'fire', 'water'}
         UNION (
@@ -486,7 +486,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         UNIQUE
         """
 
-    def test_edgeql_ir_mult_inference_55a(self):
+    def test_edgeql_ir_mult_inference_55b(self):
         """
         FOR letter IN {'I', 'B'}
         UNION (


### PR DESCRIPTION
postgres is finnicky about when it will use indexes for ORDER BY, and
won't do it if the ORDER BY is a subquery. We have machinery to try to
arrange for this to not happen in common cases like `ORDER BY .name`,
but for pgvector, where the clauses might be things like
`euclidean_distance(.embedding, <gpt_vec><str>$0)` or
`euclidean_distance(.embedding, Other.embedding)`,
things get trickier.

We want to generate code that looks approximatelylike
```
ORDER BY rel.embedding <-> (SELECT ...)
```
rather than what we would typically do, which is something like
```
ORDER BY (
    SELECT rel.embedding <-> q.foo
    FROM (SELECT ... as foo ...) as q
)
```

So we implement a compilation mode for function calls that will try to
put as much of the argument in a direct subquery expression as
possibly. This only works if the argument is actually single, and it
requires compiling the argument under a BRANCH (so that anything
referenced in it is bound in the *argument*, not at the enclosing
scope).

This works, and it passes the test suite.

But I'm wildly uncomfortable with making such a wide-reaching change
to our compilation strategy in 3.0 at such a late date, so I then made
it opt-in on the function level. We'll have the pgvector functions opt
in, and we can consider whether we could and should make this
universal after 3.0