### PR TITLE
Make extensions work properly with the migration system

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -452,11 +452,22 @@ def sdl_to_ddl(
         for decl_ast in declarations:
             trace_dependencies(decl_ast, ctx=tracectx)
 
-    # Before sorting normalize all ordering, to make sure that errors
-    # are consistent.
     for ddlentry in ddlgraph.values():
-        ddlentry.deps = OrderedSet(sorted(ddlentry.deps))
-        ddlentry.weak_deps = OrderedSet(sorted(ddlentry.weak_deps))
+        # Filter out deps that are in the schema but not in ctx.objects.
+        # Deps that are in neither get left in, so that we catch the bug.
+        deps = {
+            x for x in ddlentry.deps
+            if x in ctx.objects or not schema.get(x, default=None)
+        }
+        weak_deps = {
+            x for x in ddlentry.weak_deps
+            if x in ctx.objects or not schema.get(x, default=None)
+        }
+
+        # Before sorting normalize all ordering, to make sure that errors
+        # are consistent.
+        ddlentry.deps = OrderedSet(sorted(deps))
+        ddlentry.weak_deps = OrderedSet(sorted(weak_deps))
 
     try:
         ordered = topological.sort(ddlgraph, allow_unresolved=False)

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -382,6 +382,7 @@ class DeleteExtension(
                 sn.UnqualName(module),
             ],
             schema_b_filters=[filt],
+            include_extensions=True,
             linearize_delta=True,
         )
         self.update(delta.get_subcommands())

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -816,6 +816,10 @@ class CreateInheritingObject(
                             ],
                         )
                     )
+            else:
+                if isinstance(node, qlast.CreateObject):
+                    if isinstance(node, qlast.BasedOnTuple):
+                        node.bases = []
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -483,7 +483,7 @@ class CreateScalarType(
         context: sd.CommandContext,
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(
-            schema, astnode.replace(bases=None), context)
+            schema, astnode.replace(bases=[]), context)
 
         if isinstance(cmd, sd.CommandGroup):
             for subcmd in cmd.get_subcommands():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9440,9 +9440,9 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             'DESCRIBE SCHEMA AS DDL',
 
             """
+            CREATE EXTENSION NOTEBOOK VERSION '1.0';
             CREATE MODULE default IF NOT EXISTS;
             CREATE MODULE test IF NOT EXISTS;
-            CREATE EXTENSION NOTEBOOK VERSION '1.0';
             CREATE TYPE default::Foo;
             CREATE TYPE test::Bar {
                 CREATE LINK foo: default::Foo;


### PR DESCRIPTION
* Load extensions first, before running declarative
 * Properly sort CREATE EXTENSION and DROP EXTENSION
 * Don't try to duplicate the extension package commands in
   generated migrations