### PR TITLE
Fix problems with dropping extensions

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2492,6 +2492,16 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         """
         return schema
 
+    def canonicalize_attributes_recursively(
+        self,
+        schema: s_schema.Schema,
+        context: CommandContext,
+    ) -> s_schema.Schema:
+        schema = self.canonicalize_attributes(schema, context)
+        for sub in self.get_subcommands(type=ObjectCommand):
+            schema = sub.canonicalize_attributes_recursively(schema, context)
+        return schema
+
     def update_field_status(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -385,6 +385,13 @@ class DeleteExtension(
             include_extensions=True,
             linearize_delta=True,
         )
-        self.update(delta.get_subcommands())
+        # delta_schemas claims everything is canonical, because all
+        # objects should be present, and its main audience is dumping
+        # it out as an AST. But the results will be filled with
+        # shells, which we need to get rid of in order for certain
+        # reflection things to work (annotations, for one).
+        for sub in delta.get_subcommands(type=sd.ObjectCommand):
+            schema = sub.canonicalize_attributes_recursively(schema, context)
+            self.add(sub)
 
         return schema

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -1023,6 +1023,8 @@ def write_meta_delete_object(
 
             parent_variables = {}
 
+            if not hasattr(target, 'id'):
+                breakpoint()
             parent_variables[f'__{target_link}'] = (
                 json.dumps(str(target.id))
             )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12357,6 +12357,19 @@ type default::Foo {
             };
         """)
 
+    async def test_edgeql_ddl_abstract_index_01(self):
+        for _ in range(2):
+            await self.con.execute('''
+                create abstract index test(
+                    named only lists: int64
+                ) {
+                    set code := ' ((__col__) NULLS FIRST)';
+                };
+            ''')
+            await self.con.execute('''
+                drop abstract index test;
+            ''')
+
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
             CREATE TYPE Err1 {
@@ -15775,6 +15788,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
           set sql_extensions := [];
           create module varchar;
           create scalar type varchar::varchar {
+            create annotation std::description := 'why are we doing this';
             set id := <uuid>'26dc1396-0196-11ee-a005-ad0eaed0df03';
             set sql_type := "varchar";
             set sql_type_scheme := "varchar({__arg_0__})";
@@ -15789,6 +15803,13 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             SET volatility := 'Immutable';
             USING SQL CAST;
           };
+
+          create abstract index varchar::with_param(
+              named only lists: int64
+          ) {
+              set code := ' ((__col__) NULLS FIRST)';
+          };
+
         };
         ''')
         try:


### PR DESCRIPTION
* abstract indexes need to clean up their parameters
 * we need to canonicalize the attributes in the delta we generated
   for dropping an extension; otherwise attribute values blow up
   because their reflection code needs an id, not a name