### PR TITLE
Backport pgvector to 3.x

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -359,7 +359,7 @@ class TypeOf(TypeExpr):
 
 class TypeExprLiteral(TypeExpr):
     # Literal type exprs are used in enum declarations.
-    val: StringConstant
+    val: BaseConstant
 
 
 class TypeName(TypeExpr):

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -556,6 +556,8 @@ def _infer_stmt_multiplicity(
             if (
                 irutils.get_path_root(flt_expr).path_id
                 == ctx.distinct_iterator
+                or irutils.get_path_root(irutils.unwrap_set(flt_expr)).path_id
+                == ctx.distinct_iterator
             ) and not infer_multiplicity(
                 flt_expr, scope_tree=scope_tree, ctx=ctx
             ).is_duplicate():

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -452,11 +452,22 @@ def sdl_to_ddl(
         for decl_ast in declarations:
             trace_dependencies(decl_ast, ctx=tracectx)
 
-    # Before sorting normalize all ordering, to make sure that errors
-    # are consistent.
     for ddlentry in ddlgraph.values():
-        ddlentry.deps = OrderedSet(sorted(ddlentry.deps))
-        ddlentry.weak_deps = OrderedSet(sorted(ddlentry.weak_deps))
+        # Filter out deps that are in the schema but not in ctx.objects.
+        # Deps that are in neither get left in, so that we catch the bug.
+        deps = {
+            x for x in ddlentry.deps
+            if x in ctx.objects or not schema.get(x, default=None)
+        }
+        weak_deps = {
+            x for x in ddlentry.weak_deps
+            if x in ctx.objects or not schema.get(x, default=None)
+        }
+
+        # Before sorting normalize all ordering, to make sure that errors
+        # are consistent.
+        ddlentry.deps = OrderedSet(sorted(deps))
+        ddlentry.weak_deps = OrderedSet(sorted(weak_deps))
 
     try:
         ordered = topological.sort(ddlgraph, allow_unresolved=False)

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -127,6 +127,21 @@ def parse_migration_body_block(
     return parser.parse(tsource)
 
 
+def parse_extension_package_body_block(
+    source: str,
+) -> tuple[qlast.NestedQLBlock, list[qlast.SetField]]:
+    # For parser-internal technical reasons, we don't have a
+    # production that means "just the *inside* of a migration block
+    # (without braces)", so we just hack around this by adding braces.
+    # This is only really workable because we only use this in a place
+    # where the source contexts don't matter anyway.
+    source = '{' + source + '}'
+
+    tsource = qltokenizer.Source.from_string(source)
+    parser = qlparser.EdgeQLExtensionPackageBodyParser()
+    return parser.parse(tsource)
+
+
 def parse_sdl(expr: str):
     parser = qlparser.EdgeSDLParser()
     return parser.parse(expr)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -709,7 +709,7 @@ class CreateExtensionPackageBodyBlock(NestedQLBlock):
 
     @property
     def allowed_fields(self) -> typing.FrozenSet[str]:
-        return frozenset({'internal'})
+        return frozenset({'internal', 'ext_module', 'sql_extensions'})
 
     @property
     def result(self) -> typing.Any:

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1990,6 +1990,11 @@ class Subtype(Nonterm):
             val=kids[0].val,
         )
 
+    def reduce_BaseNumberConstant(self, *kids):
+        self.val = qlast.TypeExprLiteral(
+            val=kids[0].val,
+        )
+
 
 class SubtypeList(ListNonterm, element=Subtype, separator=tokens.T_COMMA):
     pass

--- a/edb/edgeql/parser/grammar/extension_package_body.py
+++ b/edb/edgeql/parser/grammar/extension_package_body.py
@@ -1,0 +1,33 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+from .expressions import Nonterm
+from .precedence import *  # NOQA
+from .tokens import *  # NOQA
+from .statements import *  # NOQA
+from .ddl import *  # NOQA
+
+
+class CreateExtensionPackageBody(Nonterm):
+    "%start"
+
+    def reduce_CreateExtensionPackageCommandsBlock_EOF(self, *kids):
+        self.val = kids[0].val

--- a/edb/edgeql/parser/parser.py
+++ b/edb/edgeql/parser/parser.py
@@ -302,6 +302,12 @@ class EdgeQLMigrationBodyParser(EdgeQLParserBase):
         return migration_body
 
 
+class EdgeQLExtensionPackageBodyParser(EdgeQLParserBase):
+    def get_parser_spec_module(self):
+        from .grammar import extension_package_body
+        return extension_package_body
+
+
 class EdgeSDLParser(EdgeQLParserBase):
     def get_parser_spec_module(self):
         from .grammar import sdldocument

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -888,6 +888,11 @@ class Call(ImmutableExpr):
     # filter at the call site.
     impl_is_strict: bool = False
 
+    # Kind of a hack: indicates that when possible we should pass arguments
+    # to this function as a subquery-as-an-expression.
+    # See comment in schema/functions.py for more discussion.
+    prefer_subquery_args: bool = False
+
 
 class FunctionCall(Call):
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -175,6 +175,10 @@ class TypeRef(ImmutableBase):
     in_schema: bool = False
     # True, if this describes an opaque union type
     is_opaque_union: bool = False
+    # Does this need to call a custom json cast function
+    needs_custom_json_cast: bool = False
+    # If this has a schema-configured backend type, what is it
+    sql_type: typing.Optional[str] = None
 
     def __repr__(self) -> str:
         return f'<ir.TypeRef \'{self.name_hint}\' at 0x{id(self):x}>'

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -326,7 +326,7 @@ def type_to_typeref(
         sql_type = None
         needs_custom_json_cast = False
         if isinstance(t, s_scalars.ScalarType):
-            sql_type = t.get_sql_type(schema)
+            sql_type = t.resolve_sql_type(schema)
             if material_typeref is None:
                 cast_name = s_casts.get_cast_fullname_from_names(
                     orig_name_hint or name_hint,

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -131,7 +131,9 @@ def is_scalar_view_set(ir_expr: irast.Base) -> bool:
     )
 
 
-def is_implicit_wrapper(ir_expr: irast.Base) -> bool:
+def is_implicit_wrapper(
+    ir_expr: Optional[irast.Base]
+) -> TypeGuard[irast.SelectStmt]:
     """Return True if the given *ir_expr* expression is an implicit
        SELECT wrapper.
     """
@@ -162,7 +164,7 @@ def unwrap_set(ir_set: irast.Set) -> irast.Set:
        wrapped set.
     """
     if ir_set.expr is not None and is_implicit_wrapper(ir_set.expr):
-        return ir_set.expr.result  # type: ignore
+        return ir_set.expr.result
     else:
         return ir_set
 

--- a/edb/lib/ext/vector.edgeql
+++ b/edb/lib/ext/vector.edgeql
@@ -1,0 +1,153 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+create extension package vector version '1.0' {
+    set ext_module := "vector";
+    set sql_extensions := ["vector"];
+
+    create module vector;
+
+    create scalar type vector::vector extending std::anyscalar {
+        set id := <uuid>"9565dd88-04f5-11ee-a691-0b6ebe179825";
+        set sql_type := "vector";
+        set sql_type_scheme := "vector({__arg_0__})";
+        set num_params := 1;
+    };
+
+    create cast from vector::vector to std::str {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create cast from std::str to vector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create cast from vector::vector to std::json {
+        set volatility := 'Immutable';
+        using sql 'SELECT val::text::jsonb';
+    };
+
+    create cast from std::json to vector::vector {
+        set volatility := 'Immutable';
+        using sql $$
+        SELECT (
+            CASE WHEN nullif(val, 'null'::jsonb) IS NULL THEN NULL
+            ELSE
+                (SELECT COALESCE(array_agg(j), ARRAY[]::jsonb[])
+                FROM jsonb_array_elements(val) as j)
+            END
+        )::float[]::vector
+        $$;
+    };
+
+    create function vector::euclidean_distance(
+        a: vector::vector,
+        b: vector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <-> b';
+    };
+
+    create function vector::inner_product(
+        a: vector::vector,
+        b: vector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT -(a <#> b)';
+    };
+
+    create function vector::cosine_distance(
+        a: vector::vector,
+        b: vector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <=> b';
+    };
+
+    create function vector::len(a: vector::vector) -> std::int64 {
+        using sql function 'vector_dims';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function vector::euclidean_norm(
+        a: vector::vector
+    ) -> std::float64 {
+        using sql function 'vector_norm';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function vector::mean(
+        a: set of vector::vector
+    ) -> vector::vector {
+        using sql function 'avg';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function vector::set_probes(num: std::int64) -> std::int64 {
+	using sql $$
+            select num from (
+	        select set_config('ivfflat.probes', num::text, true)
+            ) as dummy;
+	$$;
+    };
+
+    create function vector::_get_probes() -> optional std::int64 {
+        using sql $$
+          select nullif(current_setting('ivfflat.probes'), '')::int8
+        $$;
+    };
+
+    create abstract index vector::ivfflat_euclidean(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for euclidean distance.';
+        set code :=
+            'ivfflat (__col__ vector_l2_ops) WITH (lists = __kw_lists__)';
+    };
+
+    create abstract index vector::ivfflat_ip(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for inner product.';
+        set code :=
+            'ivfflat (__col__ vector_ip_ops) WITH (lists = __kw_lists__)';
+    };
+
+    create abstract index vector::ivfflat_cosine(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for cosine distance.';
+        set code :=
+            'ivfflat (__col__ vector_cosine_ops) WITH (lists = __kw_lists__)';
+    };
+};

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -330,6 +330,7 @@ CREATE TYPE schema::ScalarType
 {
     CREATE PROPERTY default -> std::str;
     CREATE PROPERTY enum_values -> array<std::str>;
+    CREATE PROPERTY arg_values -> array<std::str>;
 };
 
 

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -611,6 +611,92 @@ std::find(haystack: array<anytype>, needle: anytype,
 # ----------------------------
 
 CREATE INFIX OPERATOR
+std::`=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'eq';
+    CREATE ANNOTATION std::description := 'Compare two values for equality.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
+    USING SQL OPERATOR r'=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`?=` (l: OPTIONAL anyscalar, r: OPTIONAL anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_eq';
+    CREATE ANNOTATION std::description :=
+        'Compare two (potentially empty) values for equality.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
+std::`!=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'neq';
+    CREATE ANNOTATION std::description := 'Compare two values for inequality.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
+    USING SQL OPERATOR r'<>';
+};
+
+
+CREATE INFIX OPERATOR
+std::`?!=` (l: OPTIONAL anyscalar, r: OPTIONAL anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_neq';
+    CREATE ANNOTATION std::description :=
+        'Compare two (potentially empty) values for inequality.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
+std::`>=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'gte';
+    CREATE ANNOTATION std::description := 'Greater than or equal.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
+    USING SQL OPERATOR '>=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'gt';
+    CREATE ANNOTATION std::description := 'Greater than.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
+    USING SQL OPERATOR '>';
+};
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'lte';
+    CREATE ANNOTATION std::description := 'Less than or equal.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
+    USING SQL OPERATOR '<=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'lt';
+    CREATE ANNOTATION std::description := 'Less than.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
+    USING SQL OPERATOR '<';
+};
+
+
+CREATE INFIX OPERATOR
 std::`=` (l: anytuple, r: anytuple) -> std::bool {
     CREATE ANNOTATION std::identifier := 'eq';
     CREATE ANNOTATION std::description := 'Compare two values for equality.';

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -118,10 +118,18 @@ def quote_type(type_: Tuple[str, ...] | str):
     if is_array:
         last = last[:-2]
 
+    param = None
+    if '(' in last:
+        last, param = last.split('(', 1)
+        param = '(' + param
+
     last = quote_ident(last)
 
     if is_rowtype:
         last += '%ROWTYPE'
+
+    if param:
+        last += param
 
     if is_array:
         last += '[]'

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -522,6 +522,14 @@ def collapse_query(query: pgast.Query) -> pgast.BaseExpr:
         return query
 
     if (
+        isinstance(query, pgast.SelectStmt)
+        and len(query.target_list) == 1
+        and len(query.from_clause) == 0
+        and select_is_simple(query)
+    ):
+        return query.target_list[0].val
+
+    if (
         not isinstance(query, pgast.SelectStmt)
         or len(query.target_list) != 1
         or len(query.from_clause) != 1

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -25,6 +25,7 @@ from edb.ir import ast as irast
 from edb.edgeql import qltypes
 
 from edb.schema import casts as s_casts
+from edb.schema import name as sn
 
 from edb.pgsql import ast as pgast
 from edb.pgsql import common
@@ -534,7 +535,7 @@ def _compile_config_value(
             ],
         )
         cast_name = s_casts.get_cast_fullname_from_names(
-            'std', 'std::bytes', 'std::json')
+            sn.QualName('std', 'bytes'), sn.QualName('std', 'json'))
         val = pgast.FuncCall(
             name=common.get_cast_backend_name(cast_name, aspect='function'),
             args=[val],

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -27,8 +27,9 @@ import itertools
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 
-from edb.schema import defines as s_defs
 from edb.schema import casts as s_casts
+from edb.schema import defines as s_defs
+from edb.schema import name as sn
 
 from edb.pgsql import ast as pgast
 from edb.pgsql import common
@@ -571,14 +572,15 @@ def serialize_expr_to_json(
     elif irtyputils.is_collection(styperef) and not expr.ser_safe:
         val = coll_as_json_object(expr, styperef=styperef, env=env)
 
-    # TODO: We'll probably want to generalize this to other custom JSON
-    # casts once they exist.
     elif (
-        irtyputils.is_bytes(styperef)
+        styperef.real_base_type.needs_custom_json_cast
         and not expr.ser_safe
     ):
+        base = styperef.real_base_type
         cast_name = s_casts.get_cast_fullname_from_names(
-            'std', 'std::bytes', 'std::json')
+            base.orig_name_hint or base.name_hint,
+            sn.QualName('std', 'json'),
+        )
         val = pgast.FuncCall(
             name=common.get_cast_backend_name(cast_name, aspect='function'),
             args=[expr], null_safe=True, ser_safe=True)

--- a/edb/pgsql/dbops/extensions.py
+++ b/edb/pgsql/dbops/extensions.py
@@ -46,4 +46,19 @@ class CreateExtension(ddl.DDLOperation):
         self.opid = extension.name
 
     def code(self, block: base.PLBlock) -> str:
-        return self.extension.code(block)
+        ext = self.extension
+        name = qi(ext.get_extension_name())
+        schema = qi(ext.schema)
+        return f'CREATE EXTENSION {name} WITH SCHEMA {schema}'
+
+
+class DropExtension(ddl.DDLOperation):
+    def __init__(self, extension, *, conditions=None, neg_conditions=None):
+        super().__init__(conditions=conditions, neg_conditions=neg_conditions)
+        self.extension = extension
+        self.opid = extension.name
+
+    def code(self, block: base.PLBlock) -> str:
+        ext = self.extension
+        name = qi(ext.get_extension_name())
+        return f'DROP EXTENSION {name}'

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3485,9 +3485,11 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
         orig_name = sn.shortname_from_fullname(index.get_name(schema))
         if orig_name == s_indexes.DEFAULT_INDEX:
             root_name = orig_name
+            root_code = None
         else:
             root = index.get_root(schema)
             root_name = root.get_name(schema)
+            root_code = root.get_code(schema)
 
             kwargs = index.get_concrete_kwargs(schema)
             # Get all the concrete kwargs compiled (they are expected to be
@@ -3523,13 +3525,16 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
         index_name = common.get_index_backend_name(
             index.id, module_name, catenate=False)
 
+        if root_code is None:
+            root_code = get_index_code(root_name)
+
         pg_index = dbops.Index(
             name=index_name[1], table_name=table_name, exprs=sql_exprs,
             unique=False, inherit=True,
             predicate=except_src,
             metadata={
                 'schemaname': str(index.get_name(schema)),
-                'code': get_index_code(root_name),
+                'code': root_code,
                 'kwargs': sql_kwarg_exprs,
             }
         )

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1958,6 +1958,7 @@ class DeleteCast(CastCommand, adapts=s_casts.DeleteCast):
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
+        orig_schema = schema
         cast = schema.get(self.classname, type=s_casts.Cast)
         cast_language = cast.get_language(schema)
         cast_code = cast.get_code(schema)
@@ -1965,7 +1966,7 @@ class DeleteCast(CastCommand, adapts=s_casts.DeleteCast):
         schema = super().apply(schema, context)
 
         if cast_language is ql_ast.Language.SQL and cast_code:
-            cast_func = self.make_cast_function(cast, schema)
+            cast_func = self.make_cast_function(cast, orig_schema)
             self.pgops.add(dbops.DropFunction(
                 cast_func.name, cast_func.args))
 
@@ -2434,6 +2435,8 @@ class CreateScalarType(ScalarTypeMetaCommand,
             return schema
 
         if types.is_builtin_scalar(schema, scalar):
+            return schema
+        if scalar.get_sql_type(schema):
             return schema
 
         default = self.get_resolved_attribute_value(
@@ -6946,6 +6949,8 @@ class CreateExtensionPackage(
                 'version': version,
                 'builtin': self.scls.get_builtin(schema),
                 'internal': self.scls.get_internal(schema),
+                'ext_module': str(self.scls.get_ext_module(schema)),
+                'sql_extensions': list(self.scls.get_sql_extensions(schema)),
             }
         }
 
@@ -7032,11 +7037,62 @@ class ExtensionCommand(MetaCommand):
 
 
 class CreateExtension(ExtensionCommand, adapts=s_exts.CreateExtension):
-    pass
+    def _create_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        # XXX
+        schema = super()._create_begin(schema, context)
+        # backend_params = self._get_backend_params(context)
+        # ext_schema = backend_params.instance_params.ext_schema
+
+        package = self.scls.get_package(schema)
+
+        for ext in package.get_sql_extensions(schema):
+            # XXX: heroku!?
+            self.pgops.add(
+                dbops.CreateSchema(name=ext, conditional=True),
+            )
+            self.pgops.add(
+                dbops.CreateExtension(
+                    dbops.Extension(
+                        name=ext,
+                        schema=ext,
+                        # XXX?
+                        # schema=ext_schema,
+                    ),
+                )
+            )
+
+        return schema
 
 
 class DeleteExtension(ExtensionCommand, adapts=s_exts.DeleteExtension):
-    pass
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        extension = schema.get_global(s_exts.Extension, self.classname)
+        package = extension.get_package(schema)
+
+        schema = super().apply(schema, context)
+
+        for ext in package.get_sql_extensions(schema):
+            self.pgops.add(
+                dbops.DropExtension(
+                    dbops.Extension(
+                        name=ext,
+                        schema=ext,
+                    ),
+                )
+            )
+            self.pgops.add(
+                dbops.DropSchema(name=ext),
+            )
+
+        return schema
 
 
 class FutureBehaviorCommand(MetaCommand, s_futures.FutureBehaviorCommand):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3511,14 +3511,15 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
                     as_fragment=True,
                 )
                 kw_ir = kw_expr.irast
-                kw_sql_tree = compiler.compile_ir_to_sql_tree(
+                kw_sql_tree, _ = compiler.compile_ir_to_sql_tree(
                     kw_ir.expr, singleton_mode=True)
-                sql = codegen.SQLSourceGenerator.to_source(kw_sql_tree)
                 # HACK: the compiled SQL is expected to have some unnecessary
-                # casts, strip casts to text as they mess with the requirement
-                # that index expressions are IMMUTABLE.
-                if sql.endswith('::text'):
-                    sql = sql[:-6]
+                # casts, strip them as they mess with the requirement that
+                # index expressions are IMMUTABLE (also indexes expect the
+                # usage of literals and will do their own implicit casts).
+                if isinstance(kw_sql_tree, pg_ast.TypeCast):
+                    kw_sql_tree = kw_sql_tree.arg
+                sql = codegen.SQLSourceGenerator.to_source(kw_sql_tree)
                 sql_kwarg_exprs[name] = sql
 
         module_name = index.get_name(schema).module
@@ -7059,7 +7060,9 @@ class CreateExtension(ExtensionCommand, adapts=s_exts.CreateExtension):
                 dbops.CreateExtension(
                     dbops.Extension(
                         name=ext,
-                        schema=ext,
+                        # XXX: hardcode to put vector stuff into edgedb schema
+                        # so that operations can be easily accessed.
+                        schema='edgedb' if ext == 'vector' else ext ,
                         # XXX?
                         # schema=ext_schema,
                     ),

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -36,7 +36,8 @@ def get_version_key(num_patches: int):
     the key based on the number of schema layout patches that we can
     *see*, we still compute the right key.
     """
-    num_major = sum(p == 'edgeql+schema' for p, _ in PATCHES[:num_patches])
+    num_major = sum(
+        p.startswith('edgeql+schema') for p, _ in PATCHES[:num_patches])
     if num_major == 0:
         return ''
     else:
@@ -55,7 +56,7 @@ def _setup_patches(patches: list[tuple[str, str]]) -> list[tuple[str, str]]:
     npatches = []
     for kind, patch in patches:
         npatches.append((kind, patch))
-        if kind == 'edgeql+schema' and seen_repair:
+        if kind.startswith('edgeql+schema') and seen_repair:
             npatches.append(('repair', ''))
         seen_repair |= kind == 'repair'
     return npatches
@@ -66,6 +67,7 @@ The actual list of patches. The patches are (kind, script) pairs.
 
 There are currently 4 kinds:
  * sql - simply runs a SQL script
+ * metaschema-sql - create a function from metaschema
  * edgeql - runs an edgeql DDL command
  * edgeql+schema - runs an edgeql DDL command and updates the std schemas
  * repair - fix up inconsistencies in *user* schemas

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -74,4 +74,106 @@ The current kinds are:
  * repair - fix up inconsistencies in *user* schemas
 """
 PATCHES: list[tuple[str, str]] = _setup_patches([
+    ('metaschema-sql', 'GetPgTypeForEdgeDBTypeFunction'),
+    ('edgeql+schema+exts', '''
+CREATE FUNCTION sys::_get_pg_type_for_edgedb_type(
+    typeid: std::uuid,
+    kind: std::str,
+    elemid: OPTIONAL std::uuid,
+    sql_type: OPTIONAL std::str,
+) -> std::int64 {
+    USING SQL FUNCTION 'edgedb.get_pg_type_for_edgedb_type';
+    SET volatility := 'STABLE';
+    SET impl_is_strict := false;
+};
+ALTER TYPE schema::ScalarType {
+    CREATE PROPERTY arg_values -> array<std::str>;
+};
+
+CREATE INFIX OPERATOR
+std::`=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'eq';
+    CREATE ANNOTATION std::description := 'Compare two values for equality.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
+    USING SQL OPERATOR r'=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`?=` (l: OPTIONAL anyscalar, r: OPTIONAL anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_eq';
+    CREATE ANNOTATION std::description :=
+        'Compare two (potentially empty) values for equality.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
+std::`!=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'neq';
+    CREATE ANNOTATION std::description := 'Compare two values for inequality.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
+    USING SQL OPERATOR r'<>';
+};
+
+
+CREATE INFIX OPERATOR
+std::`?!=` (l: OPTIONAL anyscalar, r: OPTIONAL anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_neq';
+    CREATE ANNOTATION std::description :=
+        'Compare two (potentially empty) values for inequality.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
+std::`>=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'gte';
+    CREATE ANNOTATION std::description := 'Greater than or equal.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
+    USING SQL OPERATOR '>=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'gt';
+    CREATE ANNOTATION std::description := 'Greater than.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
+    USING SQL OPERATOR '>';
+};
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'lte';
+    CREATE ANNOTATION std::description := 'Less than or equal.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
+    USING SQL OPERATOR '<=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'lt';
+    CREATE ANNOTATION std::description := 'Less than.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
+    USING SQL OPERATOR '<';
+};
+'''),
+    ('ext-pkg', 'vector'),
 ])

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -65,11 +65,12 @@ def _setup_patches(patches: list[tuple[str, str]]) -> list[tuple[str, str]]:
 """
 The actual list of patches. The patches are (kind, script) pairs.
 
-There are currently 4 kinds:
+The current kinds are:
  * sql - simply runs a SQL script
  * metaschema-sql - create a function from metaschema
  * edgeql - runs an edgeql DDL command
  * edgeql+schema - runs an edgeql DDL command and updates the std schemas
+ * ext-pkg - installs an extension package given a name
  * repair - fix up inconsistencies in *user* schemas
 """
 PATCHES: list[tuple[str, str]] = _setup_patches([

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -148,7 +148,7 @@ def get_scalar_base(schema, scalar) -> Tuple[str, ...]:
             # another domain.
             if base := base_type_name_map.get(ancestor.id):
                 pass
-            elif typstr := ancestor.get_sql_type(schema):
+            elif typstr := ancestor.resolve_sql_type(schema):
                 base = tuple(typstr.split('.'))
             else:
                 base = common.get_backend_name(
@@ -170,7 +170,7 @@ def pg_type_from_scalar(
     column_type = base_type_name_map.get(scalar.id)
     if column_type:
         pass
-    elif typstr := scalar.get_sql_type(schema):
+    elif typstr := scalar.resolve_sql_type(schema):
         column_type = tuple(typstr.split('.'))
     else:
         column_type = common.get_backend_name(schema, scalar, catenate=False)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2492,6 +2492,16 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         """
         return schema
 
+    def canonicalize_attributes_recursively(
+        self,
+        schema: s_schema.Schema,
+        context: CommandContext,
+    ) -> s_schema.Schema:
+        schema = self.canonicalize_attributes(schema, context)
+        for sub in self.get_subcommands(type=ObjectCommand):
+            schema = sub.canonicalize_attributes_recursively(schema, context)
+        return schema
+
     def update_field_status(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -388,6 +388,13 @@ class DeleteExtension(
             include_extensions=True,
             linearize_delta=True,
         )
-        self.update(delta.get_subcommands())
+        # delta_schemas claims everything is canonical, because all
+        # objects should be present, and its main audience is dumping
+        # it out as an AST. But the results will be filled with
+        # shells, which we need to get rid of in order for certain
+        # reflection things to work (annotations, for one).
+        for sub in delta.get_subcommands(type=sd.ObjectCommand):
+            schema = sub.canonicalize_attributes_recursively(schema, context)
+            self.add(sub)
 
         return schema

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -28,7 +28,10 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 from edb.edgeql import parser as qlparser
 
+from edb.common import checked
+
 from . import annos as s_anno
+from . import casts as s_casts
 from . import delta as sd
 from . import name as sn
 from . import objects as so
@@ -50,6 +53,20 @@ class ExtensionPackage(
     script = so.SchemaField(
         str,
         compcoef=0.9,
+    )
+
+    sql_extensions = so.SchemaField(
+        checked.FrozenCheckedSet[str],
+        default=so.DEFAULT_CONSTRUCTOR,
+        coerce=True,
+        inheritable=False,
+        compcoef=0.9,
+        patch_level=1,
+    )
+
+    ext_module = so.SchemaField(
+        str, default=None, coerce=True, compcoef=0.9,
+        patch_level=1,
     )
 
     @classmethod
@@ -119,6 +136,12 @@ class ExtensionPackageCommand(
         return super()._cmd_tree_from_ast(schema, astnode, context)
 
 
+# XXX: Trying to CREATE/DROP these from within a transaction managed
+# to get me stuck getting "Cannot serialize global DDL" errors.
+#
+# I'm haven't fully investigated whether it is actually sensible to do
+# this kind of global command in a transaction, but we currently allow
+# it and some tests do it.
 class CreateExtensionPackage(
     ExtensionPackageCommand,
     sd.CreateObject[ExtensionPackage],
@@ -197,6 +220,20 @@ class CreateExtension(
 ):
     astnode = qlast.CreateExtension
 
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        testmode = context.testmode
+        context.testmode = True
+
+        schema = super().apply(schema, context)
+
+        context.testmode = testmode
+
+        return schema
+
     @classmethod
     def _cmd_tree_from_ast(
         cls,
@@ -213,6 +250,26 @@ class CreateExtension(
             cmd.set_attribute_value('version', parsed_version)
 
         return cmd
+
+    def _create_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._create_begin(schema, context)
+
+        if not context.canonical:
+            package = self.scls.get_package(schema)
+            script = package.get_script(schema)
+            if script:
+                block, _ = qlparser.parse_extension_package_body_block(script)
+                for subastnode in block.commands:
+                    subcmd = sd.compile_ddl(
+                        schema, subastnode, context=context)
+                    if subcmd is not None:
+                        self.add(subcmd)
+
+        return schema
 
     def canonicalize_attributes(
         self,
@@ -255,6 +312,7 @@ class CreateExtension(
         self.set_attribute_value('package', pkgs[0])
         return schema
 
+    # XXX: I think this is wrong, but it might not matter ever.
     def _get_ast(
         self,
         schema: s_schema.Schema,
@@ -278,3 +336,57 @@ class DeleteExtension(
 ):
 
     astnode = qlast.DropExtension
+
+    def _delete_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        module = self.scls.get_package(schema).get_ext_module(schema)
+        schema = super()._delete_begin(schema, context)
+
+        if context.canonical or not module:
+            return schema
+
+        # If the extension included a module, delete everything in it.
+        from . import ddl as s_ddl
+
+        module_name = sn.UnqualName(module)
+
+        def _name_in_mod(name: sn.Name) -> bool:
+            return (
+                (isinstance(name, sn.QualName) and name.module == module)
+                or name == module_name
+            )
+
+        # Clean up the casts separately for annoying reasons
+        for obj in schema.get_objects(
+            included_modules=(sn.UnqualName('__derived__'),),
+            type=s_casts.Cast,
+        ):
+            if (
+                _name_in_mod(obj.get_from_type(schema).get_name(schema))
+                or _name_in_mod(obj.get_to_type(schema).get_name(schema))
+            ):
+                drop = obj.init_delta_command(
+                    schema,
+                    sd.DeleteObject,
+                )
+                self.add(drop)
+
+        def filt(schema: s_schema.Schema, obj: so.Object) -> bool:
+            return not _name_in_mod(obj.get_name(schema)) or obj == self.scls
+
+        # We handle deleting the module contents in a heavy-handed way:
+        # do a schema diff.
+        delta = s_ddl.delta_schemas(
+            schema, schema,
+            included_modules=[
+                sn.UnqualName(module),
+            ],
+            schema_b_filters=[filt],
+            linearize_delta=True,
+        )
+        self.update(delta.get_subcommands())
+
+        return schema

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -385,6 +385,7 @@ class DeleteExtension(
                 sn.UnqualName(module),
             ],
             schema_b_filters=[filt],
+            include_extensions=True,
             linearize_delta=True,
         )
         self.update(delta.get_subcommands())

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -774,6 +774,17 @@ class CallableObject(
     impl_is_strict = so.SchemaField(
         bool, default=True, compcoef=0.4)
 
+    # Kind of a hack: indicates that when possible we should pass arguments
+    # to this function as a subquery-as-an-expression. This is important for
+    # functions that see use in ORDER BY clauses that need indexes.
+    # The compilation strategy this asks for /should/ work in general,
+    # but I didn't want to make a major codegen change in an rc3.
+    # We should consider doing this a different way.
+    prefer_subquery_args = so.SchemaField(
+        bool, default=False, compcoef=0.9,
+        patch_level=1,
+    )
+
     def as_create_delta(
         self: CallableObjectT,
         schema: s_schema.Schema,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -111,6 +111,21 @@ def is_index_valid_for_type(
                     )
                 )
             )
+        case 'vector::ivfflat_euclidean':
+            return expr_type.issubclass(
+                schema,
+                schema.get('vector::vector', type=s_scalars.ScalarType),
+            )
+        case 'vector::ivfflat_ip':
+            return expr_type.issubclass(
+                schema,
+                schema.get('vector::vector', type=s_scalars.ScalarType),
+            )
+        case 'vector::ivfflat_cosine':
+            return expr_type.issubclass(
+                schema,
+                schema.get('vector::vector', type=s_scalars.ScalarType),
+            )
 
     return False
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -140,6 +140,15 @@ class Index(
         inheritable=False,
     )
 
+    # Appears in base abstract index definitions and defines how the index
+    # is represented in postgres.
+    code = so.SchemaField(
+        str,
+        default=None,
+        compcoef=None,
+        inheritable=False,
+    )
+
     # These can appear in abstract indexes extending an existing one in order
     # to override exisitng parameters. Also they can appear in concrete
     # indexes.

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -816,6 +816,10 @@ class CreateInheritingObject(
                             ],
                         )
                     )
+            else:
+                if isinstance(node, qlast.CreateObject):
+                    if isinstance(node, qlast.BasesMixin):
+                        node.bases = []
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -253,7 +253,7 @@ class Field(struct.ProtoField, Generic[T]):
                  'allow_ddl_set', 'ddl_identity', 'special_ddl_syntax',
                  'aux_cmd_data', 'describe_visibility',
                  'weak_ref', 'reflection_method', 'reflection_proxy',
-                 'type_is_generic_self', 'is_reducible')
+                 'type_is_generic_self', 'is_reducible', 'patch_level')
 
     #: Name of the field on the target class; assigned by ObjectMeta
     name: str
@@ -310,6 +310,9 @@ class Field(struct.ProtoField, Generic[T]):
     #: this specifies a (ProxyType, linkname) pair of a proxy object type
     #: and the name of the link within that proxy type.
     reflection_proxy: Optional[Tuple[str, str]]
+    #: Which patch for the current major version this field was introduced in.
+    #: Ensures that the data tuples always get extended strictly at the end.
+    patch_level: int
 
     def __init__(
         self,
@@ -333,6 +336,7 @@ class Field(struct.ProtoField, Generic[T]):
         reflection_proxy: Optional[Tuple[str, str]] = None,
         name: Optional[str] = None,
         reflection_name: Optional[str] = None,
+        patch_level: int = -1,
         **kwargs: Any,
     ) -> None:
         """Schema item core attribute definition.
@@ -357,6 +361,7 @@ class Field(struct.ProtoField, Generic[T]):
         self.reflection_method = reflection_method
         self.reflection_proxy = reflection_proxy
         self.is_reducible = issubclass(type_, s_abc.Reducible)
+        self.patch_level = patch_level
 
         if name is not None:
             self.name = name
@@ -655,7 +660,8 @@ class ObjectMeta(type):
         cls._data_safe = data_safe
         cls._fields = fields
         cls._schema_fields = {
-            fn: f for fn, f in fields.items()
+            fn: f
+            for fn, f in sorted(fields.items(), key=lambda f: f[1].patch_level)
             if isinstance(f, SchemaField)
         }
         cls._hashable_fields = {

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -283,6 +283,7 @@ def generate_structure(
                 typeid: std::uuid,
                 kind: std::str,
                 elemid: OPTIONAL std::uuid,
+                sql_type: OPTIONAL std::str,
             ) -> std::int64 {
                 USING SQL FUNCTION 'edgedb.get_pg_type_for_edgedb_type';
                 SET volatility := 'STABLE';

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -477,15 +477,19 @@ def _build_object_mutation_shape(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
                     f'<uuid>$__{var_prefix}id, '
                     f'{kind}, '
-                    f'<uuid>$__{var_prefix}element_type)'
+                    f'<uuid>$__{var_prefix}element_type, '
+                    f'<str>$__{var_prefix}sql_type), '
                 )
             else:
                 assignments.append(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
-                    f'<uuid>$__{var_prefix}id, {kind}, <uuid>{{}})'
+                    f'<uuid>$__{var_prefix}id, {kind}, <uuid>{{}}, '
+                    f'<str>$__{var_prefix}sql_type), '
                 )
             variables[f'__{var_prefix}id'] = json.dumps(
                 str(cmd.get_attribute_value('id')))
+            variables[f'__{var_prefix}sql_type'] = json.dumps(
+                cmd.get_attribute_value('sql_type'))
 
     shape = ',\n'.join(assignments)
 

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -478,18 +478,22 @@ def _build_object_mutation_shape(
                     f'<uuid>$__{var_prefix}id, '
                     f'{kind}, '
                     f'<uuid>$__{var_prefix}element_type, '
-                    f'<str>$__{var_prefix}sql_type), '
+                    f'<str>$__{var_prefix}sql_type2), '
                 )
             else:
                 assignments.append(
                     f'backend_id := sys::_get_pg_type_for_edgedb_type('
                     f'<uuid>$__{var_prefix}id, {kind}, <uuid>{{}}, '
-                    f'<str>$__{var_prefix}sql_type), '
+                    f'<str>$__{var_prefix}sql_type2), '
                 )
+            sql_type = None
+            if isinstance(cmd.scls, s_scalars.ScalarType):
+                sql_type, _ = cmd.scls.resolve_sql_type_scheme(schema)
+
             variables[f'__{var_prefix}id'] = json.dumps(
                 str(cmd.get_attribute_value('id')))
-            variables[f'__{var_prefix}sql_type'] = json.dumps(
-                cmd.get_attribute_value('sql_type'))
+            variables[f'__{var_prefix}sql_type2'] = json.dumps(
+                sql_type)
 
     shape = ',\n'.join(assignments)
 

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -1023,6 +1023,8 @@ def write_meta_delete_object(
 
             parent_variables = {}
 
+            if not hasattr(target, 'id'):
+                breakpoint()
             parent_variables[f'__{target_link}'] = (
                 json.dumps(str(target.id))
             )

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -54,6 +54,11 @@ class ScalarType(
         coerce=True, compcoef=0.909,
     )
 
+    sql_type = so.SchemaField(
+        str, default=None, compcoef=0.9,
+        patch_level=1,
+    )
+
     enum_values = so.SchemaField(
         checked.FrozenCheckedList[str], default=None,
         coerce=True, compcoef=0.8,
@@ -337,6 +342,7 @@ class ScalarTypeCommand(
             and not context.stdmode
             and not abstract
             and not enum
+            and not self.get_attribute_value('sql_type')
         ):
             if not ancestors:
                 hint = (

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -489,7 +489,7 @@ class CreateScalarType(
         context: sd.CommandContext,
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(
-            schema, astnode.replace(bases=None), context)
+            schema, astnode.replace(bases=[]), context)
 
         if isinstance(cmd, sd.CommandGroup):
             for subcmd in cmd.get_subcommands():

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -29,6 +29,7 @@ import itertools
 import immutables as immu
 
 from edb import errors
+from edb.common import adapter
 from edb.common import english
 
 from . import casts as s_casts
@@ -529,10 +530,10 @@ class FlatSchema(Schema):
                 Tuple[Type[so.Object], sn.Name],
                 FrozenSet[uuid.UUID]
             ]
-        ],
+        ] = None,
         globalname_to_id: Optional[
             immu.Map[Tuple[Type[so.Object], sn.Name], uuid.UUID]
-        ],
+        ] = None,
         refs_to: Optional[Refs_T] = None,
     ) -> FlatSchema:
         new = FlatSchema.__new__(FlatSchema)
@@ -1481,6 +1482,44 @@ class FlatSchema(Schema):
     def __repr__(self) -> str:
         return (
             f'<{type(self).__name__} gen:{self._generation} at {id(self):#x}>')
+
+
+def upgrade_schema(schema: FlatSchema) -> FlatSchema:
+    """Repair a schema object serialized by an older patch version
+
+    When an edgeql+schema patch adds fields to schema types, old
+    serialized schemas will be broken, since their tuples are missing
+    the fields.
+
+    In this situation, we run through all the data tuples and fill
+    them out. The upgraded version will then be cached.
+    """
+
+    cls_fields = {}
+    for py_cls in so.ObjectMeta.get_schema_metaclasses():
+        if isinstance(py_cls, adapter.Adapter):
+            continue
+
+        fields = py_cls._schema_fields.values()
+        cls_fields[py_cls] = sorted(fields, key=lambda f: f.index)
+
+    id_to_data = schema._id_to_data
+    fixes = {}
+    for id, typ_name in schema._id_to_type.items():
+        data = id_to_data[id]
+        obj = so.Object.schema_restore((typ_name, id))
+        typ = type(obj)
+
+        tfields = cls_fields[typ]
+        exp_len = len(tfields)
+        if len(data) < exp_len:
+            ldata = list(data)
+            for i in range(len(ldata), exp_len):
+                ldata.append(tfields[i].get_default())
+
+            fixes[id] = tuple(ldata)
+
+    return schema._replace(id_to_data=id_to_data.update(fixes))
 
 
 class SchemaIterator(Generic[so.Object_T]):

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -574,6 +574,7 @@ class InheritingType(so.DerivableInheritingObject, QualifiedType):
 class TypeShell(so.ObjectShell[TypeT_co]):
 
     schemaclass: typing.Type[TypeT_co]
+    extra_args: tuple[qlast.Expr | qlast.TypeExpr, ...] | None
 
     def __init__(
         self,
@@ -584,6 +585,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         expr: Optional[str] = None,
         schemaclass: typing.Type[TypeT_co],
         sourcectx: Optional[parsing.ParserContext] = None,
+        extra_args: tuple[qlast.Expr] | None = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -594,6 +596,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         )
 
         self.expr = expr
+        self.extra_args = extra_args
 
     def resolve(self, schema: s_schema.Schema) -> TypeT_co:
         return schema.get(

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1368,7 +1368,8 @@ async def _init_stdlib(
                 backend_id := sys::_get_pg_type_for_edgedb_type(
                     .id,
                     .__type__.name,
-                    <uuid>{}
+                    <uuid>{},
+                    <str>{},
                 )
             }
             ''',
@@ -1389,6 +1390,7 @@ async def _init_stdlib(
                     .id,
                     .__type__.name,
                     .element_type.id,
+                    <str>{},
                 )
             }
             ''',

--- a/setup.py
+++ b/setup.py
@@ -786,6 +786,7 @@ class build_parsers(setuptools.Command):
         "edb.edgeql.parser.grammar.fragment",
         "edb.edgeql.parser.grammar.sdldocument",
         "edb.edgeql.parser.grammar.migration_body",
+        "edb.edgeql.parser.grammar.extension_package_body",
     ]
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -321,7 +321,6 @@ def _compile_pgvector(build_base, build_temp):
         build_base / 'postgres' / 'install' / 'bin' / 'pg_config'
     ).resolve()
 
-
     cflags = os.environ.get("CFLAGS", "")
     cflags = f"{cflags} {' '.join(SAFE_EXT_CFLAGS)} -std=gnu99"
 
@@ -394,9 +393,7 @@ def _get_pg_source_stamp():
         cwd=ROOT_PATH,
     )
     revision, _, _ = output[1:].partition(' ')
-    # I don't know why we needed the first empty char, but we don't want to
-    # force everyone to rebuild postgres either
-    source_stamp = output[0] + revision
+    source_stamp = revision + '+' + PGVECTOR_COMMIT
     return source_stamp
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,10 @@ EDGEDBGUI_REPO = 'https://github.com/edgedb/edgedb-studio.git'
 # This can be a branch, tag, or commit
 EDGEDBGUI_COMMIT = 'main'
 
+PGVECTOR_REPO = 'https://github.com/pgvector/pgvector.git'
+# This can be a branch, tag, or commit
+PGVECTOR_COMMIT = 'v0.4.2'
+
 SAFE_EXT_CFLAGS: list[str] = []
 if flag := os.environ.get('EDGEDB_OPT_CFLAG'):
     SAFE_EXT_CFLAGS += [flag]
@@ -283,6 +287,62 @@ def _compile_postgres(build_base, *,
                 build_dir / "compile_commands.json",
                 postgres_src / "compile_commands.json",
             )
+
+
+def _compile_pgvector(build_base, build_temp):
+    git_rev = _get_git_rev(PGVECTOR_REPO, PGVECTOR_COMMIT)
+
+    pgv_root = (build_temp / 'pgvector').resolve()
+    if not pgv_root.exists():
+        subprocess.run(
+            [
+                'git',
+                'clone',
+                '--recursive',
+                PGVECTOR_REPO,
+                pgv_root,
+            ],
+            check=True
+        )
+    else:
+        subprocess.run(
+            ['git', 'fetch', '--all'],
+            check=True,
+            cwd=pgv_root,
+        )
+
+    subprocess.run(
+        ['git', 'reset', '--hard', git_rev],
+        check=True,
+        cwd=pgv_root,
+    )
+
+    pg_config = (
+        build_base / 'postgres' / 'install' / 'bin' / 'pg_config'
+    ).resolve()
+
+
+    cflags = os.environ.get("CFLAGS", "")
+    cflags = f"{cflags} {' '.join(SAFE_EXT_CFLAGS)} -std=gnu99"
+
+    subprocess.run(
+        [
+            'make',
+            f'PG_CONFIG={pg_config}',
+        ],
+        cwd=pgv_root,
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            'make',
+            'install',
+            f'PG_CONFIG={pg_config}',
+        ],
+        cwd=pgv_root,
+        check=True,
+    )
 
 
 def _compile_libpg_query():
@@ -567,6 +627,10 @@ class build_postgres(setuptools.Command):
             run_configure=self.configure,
             build_contrib=self.build_contrib,
             produce_compile_commands_json=self.compile_commands,
+        )
+        _compile_pgvector(
+            pathlib.Path(build.build_base).resolve(),
+            pathlib.Path(build.build_temp).resolve(),
         )
 
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12347,6 +12347,16 @@ type default::Foo {
             [{"indexes": [{"except_expr": ".exclude", "expr": ".name"}]}]
         )
 
+    async def test_edgeql_ddl_index_07(self):
+        # Unfortunately we don't really have a way to test that this
+        # actually works, but I looked at the SQL DDL.
+        await self.con.execute(r"""
+            create type Foo {
+                create property fields -> array<str>;
+                create index pg::gin on (.fields);
+            };
+        """)
+
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
             CREATE TYPE Err1 {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15502,6 +15502,7 @@ DDLStatement);
 
 class TestDDLNonIsolated(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False
+    PARALLELISM_GRANULARITY = 'suite'
 
     async def test_edgeql_ddl_consecutive_create_migration_01(self):
         # A regression test for https://github.com/edgedb/edgedb/issues/2085.
@@ -15520,7 +15521,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         };
         ''')
 
-    async def _extension_test(self):
+    async def _extension_test_01(self):
         await self.con.execute('''
             create extension ltree
         ''')
@@ -15565,7 +15566,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             drop extension ltree;
         ''')
 
-    async def test_edgeql_ddl_extensions(self):
+    async def test_edgeql_ddl_extensions_01(self):
         # Make an extension that wraps a tiny bit of the ltree package.
         await self.con.execute('''
         create extension package ltree VERSION '1.0' {
@@ -15610,8 +15611,131 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         ''')
         try:
             async with self._run_and_rollback():
-                await self._extension_test()
+                await self._extension_test_01()
         finally:
             await self.con.execute('''
                 drop extension package ltree VERSION '1.0'
+            ''')
+
+    async def _extension_test_02(self):
+        await self.con.execute('''
+            create extension varchar
+        ''')
+
+        await self.con.execute('''
+            create scalar type vc5 extending varchar::varchar<5>;
+            create type X {
+                create property foo: vc5;
+            };
+        ''')
+
+        await self.assert_query_result(
+            '''
+                describe scalar type vc5;
+            ''',
+            ['create scalar type default::vc5 extending varchar::varchar<5>;'],
+        )
+        await self.assert_query_result(
+            '''
+                describe scalar type vc5 as sdl;
+            ''',
+            ['scalar type default::vc5 extending varchar::varchar<5>;'],
+        )
+
+        await self.assert_query_result(
+            '''
+                select schema::ScalarType { arg_values }
+                filter .name = 'default::vc5'
+            ''',
+            [{'arg_values': ['5']}],
+        )
+
+        await self.con.execute('''
+            insert X { foo := <vc5>"0123456789" }
+        ''')
+
+        await self.assert_query_result(
+            '''
+                select X.foo
+            ''',
+            ['01234'],
+            json_only=True,
+        )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaError,
+            "parameterized scalar types may not have constraints",
+        ):
+            await self.con.execute('''
+                alter scalar type vc5 create constraint expression on (true);
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "invalid scalar type argument",
+        ):
+            await self.con.execute('''
+                create scalar type fail extending varchar::varchar<foo>;
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "does not accept parameters",
+        ):
+            await self.con.execute('''
+                create scalar type yyy extending str<1, 2>;
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "incorrect number of arguments",
+        ):
+            await self.con.execute('''
+                create scalar type yyy extending varchar::varchar<1, 2>;
+            ''')
+
+        # If no params are specified, it just makes a normal scalar type
+        await self.con.execute('''
+            create scalar type vc extending varchar::varchar {
+                create constraint expression on (false);
+            };
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "invalid",
+        ):
+            await self.con.execute('''
+                select <str><vc>'a';
+            ''')
+
+    async def test_edgeql_ddl_extensions_02(self):
+        # Make an extension that wraps some of varchar
+        await self.con.execute('''
+        create extension package varchar VERSION '1.0' {
+          set ext_module := "varchar";
+          set sql_extensions := [];
+          create module varchar;
+          create scalar type varchar::varchar {
+            set id := <uuid>'26dc1396-0196-11ee-a005-ad0eaed0df03';
+            set sql_type := "varchar";
+            set sql_type_scheme := "varchar({__arg_0__})";
+            set num_params := 1;
+          };
+
+          create cast from varchar::varchar to std::str {
+            SET volatility := 'Immutable';
+            USING SQL CAST;
+          };
+          create cast from std::str to varchar::varchar {
+            SET volatility := 'Immutable';
+            USING SQL CAST;
+          };
+        };
+        ''')
+        try:
+            async with self._run_and_rollback():
+                await self._extension_test_02()
+        finally:
+            await self.con.execute('''
+                drop extension package varchar VERSION '1.0'
             ''')

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12357,6 +12357,19 @@ type default::Foo {
             };
         """)
 
+    async def test_edgeql_ddl_abstract_index_01(self):
+        for _ in range(2):
+            await self.con.execute('''
+                create abstract index test(
+                    named only lists: int64
+                ) {
+                    set code := ' ((__col__) NULLS FIRST)';
+                };
+            ''')
+            await self.con.execute('''
+                drop abstract index test;
+            ''')
+
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
             CREATE TYPE Err1 {
@@ -15775,6 +15788,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
           set sql_extensions := [];
           create module varchar;
           create scalar type varchar::varchar {
+            create annotation std::description := 'why are we doing this';
             set id := <uuid>'26dc1396-0196-11ee-a005-ad0eaed0df03';
             set sql_type := "varchar";
             set sql_type_scheme := "varchar({__arg_0__})";
@@ -15789,6 +15803,13 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             SET volatility := 'Immutable';
             USING SQL CAST;
           };
+
+          create abstract index varchar::with_param(
+              named only lists: int64
+          ) {
+              set code := ' ((__col__) NULLS FIRST)';
+          };
+
         };
         ''')
         try:

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -475,7 +475,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         UNIQUE
         """
 
-    def test_edgeql_ir_mult_inference_55(self):
+    def test_edgeql_ir_mult_inference_55a(self):
         """
         FOR x IN {'fire', 'water'}
         UNION (
@@ -486,7 +486,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         UNIQUE
         """
 
-    def test_edgeql_ir_mult_inference_55a(self):
+    def test_edgeql_ir_mult_inference_55b(self):
         """
         FOR letter IN {'I', 'B'}
         UNION (

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9440,9 +9440,9 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             'DESCRIBE SCHEMA AS DDL',
 
             """
+            CREATE EXTENSION NOTEBOOK VERSION '1.0';
             CREATE MODULE default IF NOT EXISTS;
             CREATE MODULE test IF NOT EXISTS;
-            CREATE EXTENSION NOTEBOOK VERSION '1.0';
             CREATE TYPE default::Foo;
             CREATE TYPE test::Bar {
                 CREATE LINK foo: default::Foo;


### PR DESCRIPTION
This uses a squashed version of the latest `pgvector` branch that's been pushed and the pending https://github.com/edgedb/edgedb/pull/5621.

It seems to work, but I haven't really put it through its paces too heavily yet.