### PR TITLE
Fix casts to scalars

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -154,7 +154,10 @@ def compile_cast(
     elif orig_stype.issubclass(ctx.env.schema, json_t):
         if (
             new_stype.is_enum(ctx.env.schema)
-            or not _is_topmost_concrete_scalar(new_stype, ctx)
+            or (
+                isinstance(new_stype, s_scalars.ScalarType)
+                and not new_stype.get_builtin(ctx.env.schema)
+            )
         ):
             # Casts from json to may have special handling.
             # So we turn it into json->str and str->x.
@@ -251,17 +254,6 @@ def _has_common_concrete_scalar(
         and (orig_base := orig_stype.maybe_get_topmost_concrete_base(schema))
         and (new_base := new_stype.maybe_get_topmost_concrete_base(schema))
         and orig_base == new_base
-    )
-
-
-def _is_topmost_concrete_scalar(
-    stype: s_types.Type,
-    ctx: context.ContextLevel
-) -> bool:
-    return bool(
-        isinstance(stype, s_scalars.ScalarType)
-        and (base := stype.maybe_get_topmost_concrete_base(ctx.env.schema))
-        and base == stype
     )
 
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -144,72 +144,73 @@ def compile_cast(
             cardinality_mod=cardinality_mod, ctx=ctx)
 
     json_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'json'))
-    if new_stype.issubclass(ctx.env.schema, json_t):
-
-        if ir_set.path_id.is_objtype_path():
-            # JSON casts of objects are special: we want the full shape
-            # and not just an identity.
-            viewgen.late_compile_view_shapes(ir_set, ctx=ctx)
-        else:
+    if (
+        new_stype.issubclass(ctx.env.schema, json_t)
+        and ir_set.path_id.is_objtype_path()
+    ):
+        # JSON casts of objects are special: we want the full shape
+        # and not just an identity.
+        viewgen.late_compile_view_shapes(ir_set, ctx=ctx)
+    elif orig_stype.issubclass(ctx.env.schema, json_t):
+        if (
+            new_stype.is_enum(ctx.env.schema)
+            or not _is_topmost_concrete_scalar(new_stype, ctx)
+        ):
             # Casts from json to may have special handling.
             # So we turn it into json->str and str->x.
-            if new_stype.is_enum(ctx.env.schema) or (
-                isinstance(new_stype, s_scalars.ScalarType)
-                and not new_stype.get_builtin(ctx.env.schema)
-            ):
-                str_typ = ctx.env.get_schema_type_and_track(
-                    sn.QualName('std', 'str')
-                )
-                str_ir = compile_cast(ir_expr, str_typ, srcctx=srcctx, ctx=ctx)
+            str_typ = ctx.env.get_schema_type_and_track(
+                sn.QualName('std', 'str')
+            )
+            str_ir = compile_cast(ir_expr, str_typ, srcctx=srcctx, ctx=ctx)
 
-                return compile_cast(
-                    str_ir,
-                    new_stype,
-                    cardinality_mod=cardinality_mod,
-                    srcctx=srcctx,
-                    ctx=ctx,
-                )
+            return compile_cast(
+                str_ir,
+                new_stype,
+                cardinality_mod=cardinality_mod,
+                srcctx=srcctx,
+                ctx=ctx,
+            )
 
-            if isinstance(
-                new_stype, s_types.Array
-            ) and not new_stype.get_subtypes(ctx.env.schema)[0].issubclass(
-                ctx.env.schema, json_t
-            ):
-                # Turn casts from json->array<T> into json->array<json>
-                # and array<json>->array<T>.
-                ctx.env.schema, json_array_typ = s_types.Array.from_subtypes(
-                    ctx.env.schema, [json_t]
-                )
-                json_array_ir = compile_cast(
-                    ir_expr,
-                    json_array_typ,
-                    cardinality_mod=cardinality_mod,
-                    srcctx=srcctx,
-                    ctx=ctx,
-                )
-                return compile_cast(
-                    json_array_ir, new_stype, srcctx=srcctx, ctx=ctx
-                )
+        elif isinstance(
+            new_stype, s_types.Array
+        ) and not new_stype.get_subtypes(ctx.env.schema)[0].issubclass(
+            ctx.env.schema, json_t
+        ):
+            # Turn casts from json->array<T> into json->array<json>
+            # and array<json>->array<T>.
+            ctx.env.schema, json_array_typ = s_types.Array.from_subtypes(
+                ctx.env.schema, [json_t]
+            )
+            json_array_ir = compile_cast(
+                ir_expr,
+                json_array_typ,
+                cardinality_mod=cardinality_mod,
+                srcctx=srcctx,
+                ctx=ctx,
+            )
+            return compile_cast(
+                json_array_ir, new_stype, srcctx=srcctx, ctx=ctx
+            )
 
-            if isinstance(new_stype, s_types.Tuple):
-                return _cast_json_to_tuple(
-                    ir_set,
-                    orig_stype,
-                    new_stype,
-                    cardinality_mod,
-                    srcctx=srcctx,
-                    ctx=ctx,
-                )
+        elif isinstance(new_stype, s_types.Tuple):
+            return _cast_json_to_tuple(
+                ir_set,
+                orig_stype,
+                new_stype,
+                cardinality_mod,
+                srcctx=srcctx,
+                ctx=ctx,
+            )
 
-            if isinstance(new_stype, s_types.Range):
-                return _cast_json_to_range(
-                    ir_set,
-                    orig_stype,
-                    new_stype,
-                    cardinality_mod,
-                    srcctx=srcctx,
-                    ctx=ctx,
-                )
+        elif isinstance(new_stype, s_types.Range):
+            return _cast_json_to_range(
+                ir_set,
+                orig_stype,
+                new_stype,
+                cardinality_mod,
+                srcctx=srcctx,
+                ctx=ctx,
+            )
 
     # Constraints and indexes require an immutable expression, but pg cast is
     # only stable. In this specific case, we use cast wrapper function that
@@ -250,6 +251,17 @@ def _has_common_concrete_scalar(
         and (orig_base := orig_stype.maybe_get_topmost_concrete_base(schema))
         and (new_base := new_stype.maybe_get_topmost_concrete_base(schema))
         and orig_base == new_base
+    )
+
+
+def _is_topmost_concrete_scalar(
+    stype: s_types.Type,
+    ctx: context.ContextLevel
+) -> bool:
+    return bool(
+        isinstance(stype, s_scalars.ScalarType)
+        and (base := stype.maybe_get_topmost_concrete_base(ctx.env.schema))
+        and base == stype
     )
 
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2624,6 +2624,25 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             [[42]],
         )
 
+    async def test_edgeql_casts_custom_scalar_06(self):
+        await self.con.execute(
+            '''
+            create scalar type x extending str {
+                create constraint expression on (false)
+            };
+        '''
+        )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, 'invalid x'
+        ):
+            await self.con.query("""SELECT <x>42""")
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, 'invalid x'
+        ):
+            await self.con.query("""SELECT <x>to_json('"a"')""")
+
     async def test_edgeql_casts_tuple_params_01(self):
         # insert tuples into a nested array
         def nest(data):


### PR DESCRIPTION
Closes #5616

We've had a codepath to fix this bug for enum already, but now I extended it to anything that:
- is a scalar,
- it not the top-most concrete base of itself,
- is not an object (does not have a `ir_set.path_id`).
