### PR TITLE
Fix more extension migration problems

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -6919,6 +6919,7 @@ class CreateExtensionPackage(
         version = self.scls.get_version(schema)._asdict()
         version['stage'] = version['stage'].name.lower()
 
+        ext_module = self.scls.get_ext_module(schema)
         metadata = {
             ext_id: {
                 'id': ext_id,
@@ -6928,7 +6929,7 @@ class CreateExtensionPackage(
                 'version': version,
                 'builtin': self.scls.get_builtin(schema),
                 'internal': self.scls.get_internal(schema),
-                'ext_module': str(self.scls.get_ext_module(schema)),
+                'ext_module': ext_module and str(ext_module),
                 'sql_extensions': list(self.scls.get_sql_extensions(schema)),
             }
         }

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2492,16 +2492,6 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         """
         return schema
 
-    def canonicalize_attributes_recursively(
-        self,
-        schema: s_schema.Schema,
-        context: CommandContext,
-    ) -> s_schema.Schema:
-        schema = self.canonicalize_attributes(schema, context)
-        for sub in self.get_subcommands(type=ObjectCommand):
-            schema = sub.canonicalize_attributes_recursively(schema, context)
-        return schema
-
     def update_field_status(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -33,6 +33,8 @@ from edb.common import checked
 from . import annos as s_anno
 from . import casts as s_casts
 from . import delta as sd
+from . import functions as s_func
+from . import modules as s_mod
 from . import name as sn
 from . import objects as so
 from . import schema as s_schema
@@ -64,7 +66,7 @@ class ExtensionPackage(
     )
 
     ext_module = so.SchemaField(
-        str, default=None, coerce=True, compcoef=0.9)
+        str, default=None, compcoef=0.9)
 
     @classmethod
     def get_schema_class_displayname(cls) -> str:
@@ -88,6 +90,7 @@ class Extension(
 
     package = so.SchemaField(
         ExtensionPackage,
+        compcoef=0.0,
     )
 
 
@@ -334,20 +337,20 @@ class DeleteExtension(
 
     astnode = qlast.DropExtension
 
-    def _delete_begin(
+    def _canonicalize(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-    ) -> s_schema.Schema:
-        module = self.scls.get_package(schema).get_ext_module(schema)
-        schema = super()._delete_begin(schema, context)
+        scls: Extension,
+    ) -> List[sd.Command]:
+        commands = super()._canonicalize(schema, context, scls)
 
-        if context.canonical or not module:
-            return schema
+        module = scls.get_package(schema).get_ext_module(schema)
+
+        if not module:
+            return commands
 
         # If the extension included a module, delete everything in it.
-        from . import ddl as s_ddl
-
         module_name = sn.UnqualName(module)
 
         def _name_in_mod(name: sn.Name) -> bool:
@@ -366,32 +369,24 @@ class DeleteExtension(
                 or _name_in_mod(obj.get_to_type(schema).get_name(schema))
             ):
                 drop = obj.init_delta_command(
-                    schema,
-                    sd.DeleteObject,
+                    schema, sd.DeleteObject
                 )
-                self.add(drop)
+                commands.append(drop)
 
-        def filt(schema: s_schema.Schema, obj: so.Object) -> bool:
-            return not _name_in_mod(obj.get_name(schema)) or obj == self.scls
+        # Delete everything in the module
+        for obj in schema.get_objects(
+            included_modules=(module_name,),
+        ):
+            if not isinstance(obj, s_func.Parameter):
+                drop, _, _ = obj.init_delta_branch(
+                    schema, context, sd.DeleteObject
+                )
+                commands.append(drop)
 
-        # We handle deleting the module contents in a heavy-handed way:
-        # do a schema diff.
-        delta = s_ddl.delta_schemas(
-            schema, schema,
-            included_modules=[
-                sn.UnqualName(module),
-            ],
-            schema_b_filters=[filt],
-            include_extensions=True,
-            linearize_delta=True,
-        )
-        # delta_schemas claims everything is canonical, because all
-        # objects should be present, and its main audience is dumping
-        # it out as an AST. But the results will be filled with
-        # shells, which we need to get rid of in order for certain
-        # reflection things to work (annotations, for one).
-        for sub in delta.get_subcommands(type=sd.ObjectCommand):
-            schema = sub.canonicalize_attributes_recursively(schema, context)
-            self.add(sub)
+        # We add the module delete directly as add_caused, since the sorting
+        # we do doesn't work.
+        module_obj = schema.get_global(s_mod.Module, module_name)
 
-        return schema
+        self.add_caused(module_obj.init_delta_command(schema, sd.DeleteObject))
+
+        return commands

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -927,6 +927,31 @@ class Collection(Type, s_abc.Collection):
             _collection_impls[schema_name] = cls
             cls._schema_name = schema_name
 
+    def as_create_delta(
+        self: CollectionTypeT,
+        schema: s_schema.Schema,
+        context: so.ComparisonContext,
+    ) -> sd.ObjectCommand[CollectionTypeT]:
+        delta = super().as_create_delta(schema=schema, context=context)
+        assert isinstance(delta, sd.CreateObject)
+        if not isinstance(self, CollectionExprAlias):
+            delta.if_not_exists = True
+        return delta
+
+    def as_delete_delta(
+        self: CollectionTypeT,
+        *,
+        schema: s_schema.Schema,
+        context: so.ComparisonContext,
+    ) -> sd.ObjectCommand[CollectionTypeT]:
+        delta = super().as_delete_delta(schema=schema, context=context)
+        assert isinstance(delta, sd.DeleteObject)
+        if not isinstance(self, CollectionExprAlias):
+            delta.if_exists = True
+            delta.if_unused = True
+            delta.canonical = False
+        return delta
+
     @classmethod
     def get_displayname_static(cls, name: s_name.Name) -> str:
         if isinstance(name, s_name.QualName):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15803,6 +15803,13 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             SET volatility := 'Immutable';
             USING SQL CAST;
           };
+          # This is meaningless but I need to test having an array in a cast.
+          create cast from varchar::varchar to array<std::float32> {
+            SET volatility := 'Immutable';
+            USING SQL $$
+              select array[0.0]
+            $$
+          };
 
           create abstract index varchar::with_param(
               named only lists: int64


### PR DESCRIPTION
* Casts actually can get dropped now, so fix collection handling
 * We need to always create collections with if_not_exists and
   if_unused when computing deltas, since we can't see into the
   extension to know if they will do it.
 * Totally rework extension delete. Calling delta_objects from the
   actual DDL execution flow is *not* a good idea and we shouldn't
   do it.