### PR TITLE
Add a pgvector extension package

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -104,7 +104,14 @@ def compile_cast(
     ):
         return _find_object_by_id(ir_expr, new_stype, ctx=ctx)
 
-    if isinstance(ir_set.expr, irast.Array):
+    json_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'json'))
+    if (
+        isinstance(ir_set.expr, irast.Array)
+        and (
+            isinstance(new_stype, s_types.Array)
+            or new_stype.issubclass(ctx.env.schema, json_t)
+        )
+    ):
         return _cast_array_literal(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
@@ -112,9 +119,22 @@ def compile_cast(
         return _cast_tuple(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
-    if orig_stype.is_array() and not s_types.is_type_compatible(
+    if isinstance(orig_stype, s_types.Array) and not s_types.is_type_compatible(
         orig_stype, new_stype, schema=ctx.env.schema
     ):
+        if (
+            not isinstance(new_stype, s_types.Array)
+            and isinstance(
+                (el_type := orig_stype.get_subtypes(ctx.env.schema)[0]),
+                s_scalars.ScalarType,
+            )
+        ):
+            # We're not casting to another array, so for purposes of matching
+            # the right cast we want to reduce orig_stype to an array of the
+            # built-in base type as that's what the cast will actually
+            # expect.
+            ir_set = _cast_to_base_array(ir_set, el_type, orig_stype, ctx=ctx)
+
         return _cast_array(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
@@ -143,7 +163,6 @@ def compile_cast(
             ir_set, orig_stype, new_stype,
             cardinality_mod=cardinality_mod, ctx=ctx)
 
-    json_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'json'))
     if (
         new_stype.issubclass(ctx.env.schema, json_t)
         and ir_set.path_id.is_objtype_path()
@@ -820,6 +839,23 @@ def _cast_json_to_range(
         return dispatch.compile(cast, ctx=subctx)
 
 
+def _cast_to_base_array(
+    ir_set: irast.Set,
+    el_stype: s_scalars.ScalarType,
+    orig_stype: s_types.Array,
+    ctx: context.ContextLevel,
+    cardinality_mod: Optional[qlast.CardinalityModifier]=None
+) -> irast.Set:
+
+    base_stype = el_stype.get_base_for_cast(ctx.env.schema)
+    assert isinstance(base_stype, s_types.Type)
+    _, new_stype = s_types.Array.from_subtypes(ctx.env.schema, [base_stype])
+
+    return _inheritance_cast_to_ir(
+        ir_set, orig_stype, new_stype,
+        cardinality_mod=cardinality_mod, ctx=ctx)
+
+
 def _cast_array(
         ir_set: irast.Set,
         orig_stype: s_types.Type,
@@ -839,8 +875,13 @@ def _cast_array(
                 context=srcctx)
         assert isinstance(new_stype, s_types.Array)
         el_type = new_stype.get_subtypes(ctx.env.schema)[0]
-    else:
+    elif new_stype.is_json(ctx.env.schema):
         el_type = new_stype
+    else:
+        # We're casting an array into something that's not an array (e.g. a
+        # vector), so we don't need to match element types.
+        return _cast_to_ir(
+            ir_set, direct_cast, orig_stype, new_stype, ctx=ctx)
 
     orig_el_type = orig_stype.get_subtypes(ctx.env.schema)[0]
 

--- a/edb/lib/ext/pgvector.edgeql
+++ b/edb/lib/ext/pgvector.edgeql
@@ -1,0 +1,165 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+create extension package pgvector version '0.4.0' {
+    set ext_module := "ext::pgvector";
+    set sql_extensions := ["vector >=0.4.0,<0.5.0"];
+
+    create module ext::pgvector;
+
+    create scalar type ext::pgvector::vector extending std::anyscalar {
+        set id := <uuid>"9565dd88-04f5-11ee-a691-0b6ebe179825";
+        set sql_type := "vector";
+        set sql_type_scheme := "vector({__arg_0__})";
+        set num_params := 1;
+    };
+
+    create cast from ext::pgvector::vector to std::json {
+        set volatility := 'Immutable';
+        using sql 'SELECT val::text::jsonb';
+    };
+
+    create cast from std::json to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql $$
+        SELECT (
+            nullif(val, 'null'::jsonb)::text::vector
+        )
+        $$;
+    };
+
+    # All casts from numerical arrays should allow assignment casts.
+    create cast from array<std::float32> to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from array<std::float64> to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from array<std::int16> to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql $$
+        SELECT val::float4[]::vector
+        $$;
+        allow assignment;
+    };
+
+    create cast from array<std::int32> to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from array<std::int64> to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql $$
+        SELECT val::float4[]::vector
+        $$;
+        allow assignment;
+    };
+
+    create cast from ext::pgvector::vector to array<std::float32> {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create function ext::pgvector::euclidean_distance(
+        a: ext::pgvector::vector,
+        b: ext::pgvector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <-> b';
+    };
+
+    create function ext::pgvector::neg_inner_product(
+        a: ext::pgvector::vector,
+        b: ext::pgvector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT (a <#> b)';
+    };
+
+    create function ext::pgvector::cosine_distance(
+        a: ext::pgvector::vector,
+        b: ext::pgvector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <=> b';
+    };
+
+    create function ext::pgvector::euclidean_norm(
+        a: ext::pgvector::vector
+    ) -> std::float64 {
+        using sql function 'vector_norm';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function ext::pgvector::set_probes(num: std::int64) -> std::int64 {
+	using sql $$
+            select num from (
+	        select set_config('ivfflat.probes', num::text, true)
+            ) as dummy;
+	$$;
+    };
+
+    create function ext::pgvector::_get_probes() -> optional std::int64 {
+        using sql $$
+          select nullif(current_setting('ivfflat.probes'), '')::int8
+        $$;
+    };
+
+    create abstract index ext::pgvector::ivfflat_euclidean(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for euclidean distance.';
+        set code :=
+            'ivfflat (__col__ vector_l2_ops) WITH (lists = __kw_lists__)';
+    };
+
+    create abstract index ext::pgvector::ivfflat_ip(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for inner product.';
+        set code :=
+            'ivfflat (__col__ vector_ip_ops) WITH (lists = __kw_lists__)';
+    };
+
+    create abstract index ext::pgvector::ivfflat_cosine(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for cosine distance.';
+        set code :=
+            'ivfflat (__col__ vector_cosine_ops) WITH (lists = __kw_lists__)';
+    };
+};

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -611,6 +611,92 @@ std::find(haystack: array<anytype>, needle: anytype,
 # ----------------------------
 
 CREATE INFIX OPERATOR
+std::`=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'eq';
+    CREATE ANNOTATION std::description := 'Compare two values for equality.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
+    USING SQL OPERATOR r'=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`?=` (l: OPTIONAL anyscalar, r: OPTIONAL anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_eq';
+    CREATE ANNOTATION std::description :=
+        'Compare two (potentially empty) values for equality.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
+std::`!=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'neq';
+    CREATE ANNOTATION std::description := 'Compare two values for inequality.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
+    USING SQL OPERATOR r'<>';
+};
+
+
+CREATE INFIX OPERATOR
+std::`?!=` (l: OPTIONAL anyscalar, r: OPTIONAL anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_neq';
+    CREATE ANNOTATION std::description :=
+        'Compare two (potentially empty) values for inequality.';
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+
+
+CREATE INFIX OPERATOR
+std::`>=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'gte';
+    CREATE ANNOTATION std::description := 'Greater than or equal.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
+    USING SQL OPERATOR '>=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'gt';
+    CREATE ANNOTATION std::description := 'Greater than.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
+    USING SQL OPERATOR '>';
+};
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'lte';
+    CREATE ANNOTATION std::description := 'Less than or equal.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
+    USING SQL OPERATOR '<=';
+};
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: anyscalar, r: anyscalar) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'lt';
+    CREATE ANNOTATION std::description := 'Less than.';
+    SET volatility := 'Immutable';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
+    USING SQL OPERATOR '<';
+};
+
+
+CREATE INFIX OPERATOR
 std::`=` (l: anytuple, r: anytuple) -> std::bool {
     CREATE ANNOTATION std::identifier := 'eq';
     CREATE ANNOTATION std::description := 'Compare two values for equality.';

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -7017,34 +7017,86 @@ class ExtensionCommand(MetaCommand):
     pass
 
 
+def _parse_spec(spec: str) -> tuple[str, list[tuple[str, str]]]:
+    if ' ' not in spec:
+        return (spec, [])
+
+    ext, versions = spec.split(' ', 1)
+    clauses = versions.split(',')
+    pclauses = []
+    for clause in clauses:
+        for i in range(len(clause)):
+            if clause[i].isnumeric():
+                break
+        pclauses.append((clause[:i], clause[i:]))
+
+    return ext, pclauses
+
+
 class CreateExtension(ExtensionCommand, adapts=s_exts.CreateExtension):
+    def _create_extension(self, ext_spec: str) -> None:
+        ext, vclauses = _parse_spec(ext_spec)
+
+        # Dynamically select the highest version extension that matches
+        # the provided version specification.
+        lclauses = []
+        for op, ver in vclauses:
+            pver = f"string_to_array({ql(ver)}, '.')::int8[]"
+            assert op in {'=', '>', '>=', '<', '<='}
+            lclauses.append(f'v.split {op} {pver}')
+        cond = ' and '.join(lclauses) if lclauses else 'true'
+
+        qry = textwrap.dedent(f'''\
+            with v as (
+               select name, version,
+               string_to_array(version, '.')::int8[] as split
+               from pg_available_extension_versions
+               where name = {ql(ext)}
+            )
+            select edgedb.raise_on_null(
+              (
+                 select v.version from v
+                 where {cond}
+                 order by split desc limit 1
+               ),
+               'feature_not_supported',
+               msg => (
+                 'could not find extension satisfying ' || {ql(ext_spec)}
+                  || ': ' ||
+                  coalesce(
+                    'only found versions ' ||
+                      (select string_agg(v.version, ', ' order by v.split)
+                       from v),
+                    'extension not found'))
+            )
+            into _dummy_text;
+        ''')
+        self.pgops.add(dbops.Query(qry))
+
+        # XXX: hardcode to put stuff into edgedb schema
+        # so that operations can be easily accessed.
+        # N.B: this won't work on heroku; is that fine?
+        target_schema = 'edgedb'
+
+        self.pgops.add(dbops.Query(textwrap.dedent(f"""\
+            EXECUTE
+              'CREATE EXTENSION {ext} WITH SCHEMA {target_schema} VERSION '''
+              || _dummy_text || ''''
+        """)))
+
     def _create_begin(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        # XXX
         schema = super()._create_begin(schema, context)
         # backend_params = self._get_backend_params(context)
         # ext_schema = backend_params.instance_params.ext_schema
 
         package = self.scls.get_package(schema)
 
-        for ext in package.get_sql_extensions(schema):
-            # XXX: heroku!?
-            self.pgops.add(
-                dbops.CreateSchema(name=ext, conditional=True),
-            )
-            self.pgops.add(
-                dbops.CreateExtension(
-                    dbops.Extension(
-                        name=ext,
-                        schema=ext,
-                        # XXX?
-                        # schema=ext_schema,
-                    ),
-                )
-            )
+        for ext_spec in package.get_sql_extensions(schema):
+            self._create_extension(ext_spec)
 
         return schema
 
@@ -7060,7 +7112,9 @@ class DeleteExtension(ExtensionCommand, adapts=s_exts.DeleteExtension):
 
         schema = super().apply(schema, context)
 
-        for ext in package.get_sql_extensions(schema):
+        for ext_spec in package.get_sql_extensions(schema):
+            ext, _ = _parse_spec(ext_spec)
+
             self.pgops.add(
                 dbops.DropExtension(
                     dbops.Extension(
@@ -7068,9 +7122,6 @@ class DeleteExtension(ExtensionCommand, adapts=s_exts.DeleteExtension):
                         schema=ext,
                     ),
                 )
-            )
-            self.pgops.add(
-                dbops.DropSchema(name=ext),
             )
 
         return schema

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3489,14 +3489,15 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
                     as_fragment=True,
                 )
                 kw_ir = kw_expr.irast
-                kw_sql_tree = compiler.compile_ir_to_sql_tree(
+                kw_sql_tree, _ = compiler.compile_ir_to_sql_tree(
                     kw_ir.expr, singleton_mode=True)
-                sql = codegen.SQLSourceGenerator.to_source(kw_sql_tree)
                 # HACK: the compiled SQL is expected to have some unnecessary
-                # casts, strip casts to text as they mess with the requirement
-                # that index expressions are IMMUTABLE.
-                if sql.endswith('::text'):
-                    sql = sql[:-6]
+                # casts, strip them as they mess with the requirement that
+                # index expressions are IMMUTABLE (also indexes expect the
+                # usage of literals and will do their own implicit casts).
+                if isinstance(kw_sql_tree, pg_ast.TypeCast):
+                    kw_sql_tree = kw_sql_tree.arg
+                sql = codegen.SQLSourceGenerator.to_source(kw_sql_tree)
                 sql_kwarg_exprs[name] = sql
 
         module_name = index.get_name(schema).module

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -337,6 +337,20 @@ class DeleteExtension(
 
     astnode = qlast.DropExtension
 
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        testmode = context.testmode
+        context.testmode = True
+
+        schema = super().apply(schema, context)
+
+        context.testmode = testmode
+
+        return schema
+
     def _canonicalize(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -111,6 +111,15 @@ def is_index_valid_for_type(
                     )
                 )
             )
+        case (
+            'ext::pgvector::ivfflat_euclidean'
+            | 'ext::pgvector::ivfflat_ip'
+            | 'ext::pgvector::ivfflat_cosine'
+        ):
+            return expr_type.issubclass(
+                schema,
+                schema.get('ext::pgvector::vector', type=s_scalars.ScalarType),
+            )
 
     return False
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -36,6 +36,7 @@ from edb.edgeql import compiler as qlcompiler
 
 from . import abc as s_abc
 from . import annos as s_anno
+from . import casts as s_casts
 from . import delta as sd
 from . import expr as s_expr
 from . import inheriting
@@ -1291,7 +1292,14 @@ class Array(
         schema: s_schema.Schema,
     ) -> bool:
         if not isinstance(other, Array):
-            return False
+            from . import scalars as s_scalars
+
+            if not isinstance(other, s_scalars.ScalarType):
+                return False
+            if other.is_polymorphic(schema):
+                return False
+            right = other.get_base_for_cast(schema)
+            return s_casts.is_assignment_castable(schema, self, right)
 
         return self.get_element_type(schema).assignment_castable_to(
             other.get_element_type(schema), schema)
@@ -1302,7 +1310,14 @@ class Array(
         schema: s_schema.Schema,
     ) -> bool:
         if not isinstance(other, Array):
-            return False
+            from . import scalars as s_scalars
+
+            if not isinstance(other, s_scalars.ScalarType):
+                return False
+            if other.is_polymorphic(schema):
+                return False
+            right = other.get_base_for_cast(schema)
+            return s_casts.is_assignment_castable(schema, self, right)
 
         return self.get_element_type(schema).castable_to(
             other.get_element_type(schema), schema)

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1003,6 +1003,7 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
     TEARDOWN: Optional[str] = None
     SCHEMA: Optional[Union[str, pathlib.Path]] = None
     DEFAULT_MODULE: str = 'default'
+    EXTENSIONS: List[str] = []
 
     BASE_TEST_CLASS = True
 
@@ -1150,12 +1151,15 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
         if cls.INTERNAL_TESTMODE:
             script += '\nCONFIGURE SESSION SET __internal_testmode := true;'
 
+        schema = []
+        # Incude the extensions before adding schemas.
+        for ext in cls.EXTENSIONS:
+            schema.append(f'using extension {ext};')
+
         # Look at all SCHEMA entries and potentially create multiple
         # modules, but always create the test module, if not `default`.
         if cls.DEFAULT_MODULE != 'default':
-            schema = [f'\nmodule {cls.DEFAULT_MODULE} {{}}']
-        else:
-            schema = []
+            schema.append(f'\nmodule {cls.DEFAULT_MODULE} {{}}')
         for name in dir(cls):
             m = re.match(r'^SCHEMA(?:_(\w+))?', name)
             if m:

--- a/tests/schemas/dump_v4_default.esdl
+++ b/tests/schemas/dump_v4_default.esdl
@@ -1,0 +1,25 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+scalar type v3 extending ext::pgvector::vector<3>;
+
+type L2 {
+    required vec: v3;
+    index ext::pgvector::ivfflat_euclidean(lists := 100) on (.vec);
+}

--- a/tests/schemas/dump_v4_setup.edgeql
+++ b/tests/schemas/dump_v4_setup.edgeql
@@ -1,0 +1,26 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+set module default;
+
+for x in range_unpack(range(1, 1000))
+union (
+    # Large, varied, but deterministic dataset.
+    insert L2 {vec := [x % 10, math::ln(x), x / 7 % 13]}
+);

--- a/tests/schemas/pgvector.esdl
+++ b/tests/schemas/pgvector.esdl
@@ -1,0 +1,71 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+scalar type v3 extending ext::pgvector::vector<3>;
+
+scalar type myf64 extending float64 {
+    constraint max_value(100);
+}
+scalar type deepf64 extending myf64;
+
+
+type Basic {
+    required p_str: str;
+    p_json: json {rewrite insert using (to_json(__subject__.p_str))};
+}
+
+type L2 {
+    required vec: v3;
+    index ext::pgvector::ivfflat_euclidean(lists := 100) on (.vec);
+}
+
+type IP {
+    required vec: v3;
+    index ext::pgvector::ivfflat_ip(lists := 100) on (.vec);
+}
+
+type Cosine {
+    required vec: v3;
+    index ext::pgvector::ivfflat_cosine(lists := 100) on (.vec);
+}
+
+type Con {
+    required vec: v3 {
+        constraint expression on (
+            ext::pgvector::cosine_distance(
+                __subject__, <ext::pgvector::vector>[1, 1, 1]
+            ) < 0.2
+        )
+    }
+}
+
+
+type Raw {
+    required val: float64;
+
+    p_int16: int16 {rewrite insert using (<int16>__subject__.val)};
+    p_int32: int32 {rewrite insert using (<int32>__subject__.val)};
+    p_int64: int64 {rewrite insert using (<int64>__subject__.val)};
+    p_bigint: bigint {rewrite insert using (<bigint>__subject__.val)};
+    p_float32: float32 {rewrite insert using (<float32>__subject__.val)};
+    p_decimal: decimal {rewrite insert using (<decimal>__subject__.val)};
+
+    p_myf64: myf64 {rewrite insert using (<myf64>__subject__.val)};
+    p_deepf64: deepf64 {rewrite insert using (<deepf64>__subject__.val)};
+}

--- a/tests/schemas/pgvector_setup.edgeql
+++ b/tests/schemas/pgvector_setup.edgeql
@@ -1,0 +1,32 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+for x in {0, 3, 4.25, 6.75}
+union (
+    insert Raw {val := x}
+);
+
+
+for x in {[0, 1, 2.3], [1, 1, 10.11], [4.5, 6.7, 8.9]}
+union (
+    (insert Basic {p_str := to_str(<json>x)}),
+    (insert L2 {vec := <v3>x}),
+    (insert IP {vec := <v3>x}),
+    (insert Cosine {vec := <v3>x}),
+);

--- a/tests/test_dump_v4.py
+++ b/tests/test_dump_v4.py
@@ -1,0 +1,78 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+from edb.testbase import server as tb
+
+
+class DumpTestCaseMixin:
+
+    async def ensure_schema_data_integrity(self):
+        tx = self.con.transaction()
+        await tx.start()
+        try:
+            await self._ensure_schema_data_integrity()
+        finally:
+            await tx.rollback()
+
+    async def _ensure_schema_data_integrity(self):
+        await self.assert_query_result(
+            r'''
+                select count(L2)
+            ''',
+            [
+                999
+            ]
+        )
+
+        await self.assert_query_result(
+            r'''
+                with x := range_unpack(range(1, 1000))
+                select all(
+                    L2.vec in <v3>[x % 10, math::ln(x), x / 7 % 13]
+                )
+            ''',
+            [
+                True
+            ]
+        )
+
+
+class TestDumpV4(tb.StableDumpTestCase, DumpTestCaseMixin):
+    EXTENSIONS = ["pgvector"]
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump_v4_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump_v4_setup.edgeql')
+
+    async def test_dumpv4_dump_restore(self):
+        await self.check_dump_restore(
+            DumpTestCaseMixin.ensure_schema_data_integrity)
+
+
+class TestDumpV4Compat(
+    tb.DumpCompatTestCase,
+    DumpTestCaseMixin,
+    dump_subdir='dumpv4',
+    check_method=DumpTestCaseMixin.ensure_schema_data_integrity,
+):
+    pass

--- a/tests/test_edgeql_vector.py
+++ b/tests/test_edgeql_vector.py
@@ -1,0 +1,780 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+
+import edgedb
+
+from edb.testbase import server as tb
+from edb.tools import test
+
+
+class TestEdgeQLVector(tb.QueryTestCase):
+    EXTENSIONS = ['pgvector']
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'pgvector.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'pgvector_setup.edgeql')
+
+    @classmethod
+    def get_setup_script(cls):
+        res = super().get_setup_script()
+
+        # HACK: As a debugging cycle hack, when RELOAD is true, we reload the
+        # extension package from the file, so we can test without a bootstrap.
+        RELOAD = False
+
+        if RELOAD:
+            root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            with open(os.path.join(root, 'edb/lib/ext/pgvector.edgeql')) as f:
+                contents = f.read()
+            to_add = '''
+                drop extension package pgvector version '0.4.0';
+            ''' + contents
+            splice = '__internal_testmode := true;'
+            res = res.replace(splice, splice + to_add)
+
+        return res
+
+    async def test_edgeql_vector_cast_01(self):
+        # Basic casts to and from json. Also a cast into an
+        # array<float32>.
+        await self.assert_query_result(
+            '''
+                select <json><ext::pgvector::vector>[1, 2, 3.5];
+            ''',
+            [[1, 2, 3.5]],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>
+                  to_json('[1.5, 2, 3]');
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+    async def test_edgeql_vector_cast_02(self):
+        # Basic casts from json.
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>to_json((
+                    select _ := Basic.p_str order by _
+                ))
+            ''',
+            [[0, 1, 2.3], [1, 1, 10.11], [4.5, 6.7, 8.9]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>(
+                    select _ := Basic.p_json order by _
+                )
+            ''',
+            [[0, 1, 2.3], [1, 1, 10.11], [4.5, 6.7, 8.9]],
+        )
+
+    async def test_edgeql_vector_cast_03(self):
+        # Casts from numeric array expressions.
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector><array<int16>>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector><array<int32>>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector><array<int64>>[1.0, 2.0, 3.0];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector><array<float32>>[1.5, 2, 3];
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector><array<float64>>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+    async def test_edgeql_vector_cast_04(self):
+        # Casts from numeric array expressions.
+        res = [0, 3, 4, 7]
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(
+                        Raw.p_int16 order by Raw.p_int16
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(
+                        Raw.p_int32 order by Raw.p_int32
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(
+                        Raw.p_int64 order by Raw.p_int64
+                    );
+            ''',
+            [res],
+        )
+
+    async def test_edgeql_vector_cast_05(self):
+        # Casts from numeric array expressions.
+        res = [0, 3, 4.25, 6.75]
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(
+                        Raw.p_float32 order by Raw.p_float32
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(
+                        Raw.val order by Raw.val
+                    );
+            ''',
+            [res],
+        )
+
+    async def test_edgeql_vector_cast_06(self):
+        # Casts from literal numeric arrays.
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>
+                    [<int16>1, <int16>2, <int16>3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>
+                    [<int32>1, <int32>2, <int32>3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>[1.5, 2, 3];
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::vector>
+                    [<float32>1.5, <float32>2, <float32>3];
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+    async def test_edgeql_vector_cast_07(self):
+        await self.assert_query_result(
+            '''
+                select <array<float32>><v3>[11, 3, 4];
+            ''',
+            [[11, 3, 4]],
+        )
+
+    async def test_edgeql_vector_cast_08(self):
+        # Casts from arrays of derived types.
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector><array<myf64>>[1, 2.3, 4.5];
+            ''',
+            [[1, 2.3, 4.5]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector><array<deepf64>>[1, 2.3, 4.5];
+            ''',
+            [[1, 2.3, 4.5]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(<myf64>{1, 2.3, 4.5});
+            ''',
+            [[1, 2.3, 4.5]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(<deepf64>{1, 2.3, 4.5});
+            ''',
+            [[1, 2.3, 4.5]],
+        )
+
+    async def test_edgeql_vector_cast_09(self):
+        # Casts from arrays of derived types.
+        res = [0, 3, 4.25, 6.75]
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(
+                        Raw.p_myf64 order by Raw.p_myf64
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::vector>array_agg(
+                        Raw.p_deepf64 order by Raw.p_deepf64
+                    );
+            ''',
+            [res],
+        )
+
+    async def test_edgeql_vector_cast_10(self):
+        # Arrays of vectors.
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select [
+                    <vector>[0, 1],
+                    <vector>[2, 3],
+                    <vector>[4, 5, 6],
+                ]
+            ''',
+            [[[0, 1], [2, 3], [4, 5, 6]]],
+            json_only=True,
+        )
+
+        # Arrays of vectors.
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <json>[
+                    <vector>[0, 1],
+                    <vector>[2, 3],
+                    <vector>[4, 5, 6],
+                ]
+            ''',
+            [[[0, 1], [2, 3], [4, 5, 6]]],
+            json_only=True,
+        )
+
+    async def test_edgeql_vector_cast_11(self):
+        # Vectors in tuples.
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select (
+                    <vector>[0, 1],
+                    <vector>[2, 3],
+                    <vector>[4, 5, 6],
+                )
+            ''',
+            [[[0, 1], [2, 3], [4, 5, 6]]],
+            json_only=True,
+        )
+
+    async def test_edgeql_vector_op_01(self):
+        # Comparison operators.
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2, 3] =
+                    <ext::pgvector::vector>[0, 1, 1];
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2, 3] !=
+                    <ext::pgvector::vector>[0, 1, 1];
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2, 3] ?=
+                    <ext::pgvector::vector>{};
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2, 3] ?!=
+                    <ext::pgvector::vector>{};
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>{} ?=
+                    <ext::pgvector::vector>{};
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2] <
+                    <ext::pgvector::vector>[2, 3];
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2] <=
+                    <ext::pgvector::vector>[2, 3];
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2] >
+                    <ext::pgvector::vector>[2, 3];
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::vector>[1, 2] >=
+                    <ext::pgvector::vector>[2, 3];
+            ''',
+            [False],
+        )
+
+    async def test_edgeql_vector_op_02(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <vector>to_json('[3, 0]') in {
+                    <vector>to_json('[1, 2]'),
+                    <vector>to_json('[3, 4]'),
+                };
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <vector>to_json('[3, 0]') not in {
+                    <vector>to_json('[1, 2]'),
+                    <vector>to_json('[3, 4]'),
+                };
+            ''',
+            [True],
+        )
+
+    @test.xerror("len will eventually be a trait function or something")
+    async def test_edgeql_vector_func_01(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select len(
+                    <vector>to_json('[1.2, 3.4, 5, 6]'),
+                );
+            ''',
+            [4],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select len(default::L2.vec) limit 1;
+            ''',
+            [3],
+        )
+
+    async def test_edgeql_vector_func_02(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select euclidean_distance(
+                    <vector>[3, 4],
+                    <vector>[0, 0],
+                );
+            ''',
+            [5],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select euclidean_distance(
+                    default::L2.vec,
+                    <vector>[0, 1, 0],
+                );
+            ''',
+            {2.299999952316284, 10.159335266542493, 11.48694872607437},
+        )
+
+    async def test_edgeql_vector_func_03(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select euclidean_norm(<vector>[3, 4]);
+            ''',
+            [5],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select euclidean_norm(default::L2.vec);
+            ''',
+            {2.5079872331917934, 10.208432276239787, 12.014573942925704},
+        )
+
+    async def test_edgeql_vector_func_04(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select neg_inner_product(
+                    <vector>[1, 2],
+                    <vector>[3, 4],
+                );
+            ''',
+            [-11],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select neg_inner_product(
+                    default::IP.vec,
+                    <vector>[3, 4, 1],
+                );
+            ''',
+            {-6.299999952316284, -17.109999656677246, -49.19999885559082},
+        )
+
+    async def test_edgeql_vector_func_05(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select cosine_distance(
+                    <vector>[3, 0],
+                    <vector>[3, 4],
+                );
+            ''',
+            [0.4],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select cosine_distance(
+                    default::Cosine.vec,
+                    <vector>[3, 4, 1],
+                );
+            ''',
+            {0.5073612713543951, 0.6712965405380352, 0.19689922670600213},
+        )
+
+    @test.xerror("mean will eventually be a trait function or something")
+    async def test_edgeql_vector_func_06(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <array<float32>>
+                    mean({
+                        <vector>[3, 0],
+                        <vector>[0, 4],
+                    });
+            ''',
+            [[1.5, 2]],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <array<float32>>
+                    mean(default::L2.vec);
+            ''',
+            [[1.8333334, 2.8999999, 7.103333]],
+        )
+
+    async def test_edgeql_vector_insert_01(self):
+        # Test assignment casts
+        res = [0, 3, 4]
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                insert L2 {
+                    vec := array_agg(
+                        Raw.p_int16 order by Raw.p_int16
+                    )[:3]
+                }
+            """)
+            await self.assert_query_result(
+                '''
+                    with res := <array<float32>>$res
+                    select <array<float32>>(
+                        select L2
+                        filter .vec = <ext::pgvector::vector>res
+                    ).vec
+                ''',
+                [res],
+                variables=dict(res=res),
+            )
+
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                insert L2 {
+                    vec := array_agg(
+                        Raw.p_int32 order by Raw.p_int32
+                    )[:3]
+                }
+            """)
+            await self.assert_query_result(
+                '''
+                    with res := <array<float32>>$res
+                    select <array<float32>>(
+                        select L2
+                        filter .vec = <ext::pgvector::vector>res
+                    ).vec
+                ''',
+                [res],
+                variables=dict(res=res),
+            )
+
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                insert L2 {
+                    vec := array_agg(
+                        Raw.p_int64 order by Raw.p_int64
+                    )[:3]
+                }
+            """)
+            await self.assert_query_result(
+                '''
+                    with res := <array<float32>>$res
+                    select <array<float32>>(
+                        select L2
+                        filter .vec = <ext::pgvector::vector>res
+                    ).vec
+                ''',
+                [res],
+                variables=dict(res=res),
+            )
+
+    async def test_edgeql_vector_insert_02(self):
+        # Test assignment casts
+        res = [0, 3, 4.25]
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                insert L2 {
+                    vec := array_agg(
+                        Raw.p_float32 order by Raw.p_float32
+                    )[:3]
+                }
+            """)
+            await self.assert_query_result(
+                '''
+                    with res := <array<float32>>$res
+                    select <array<float32>>(
+                        select L2
+                        filter .vec = <ext::pgvector::vector>res
+                    ).vec
+                ''',
+                [res],
+                variables=dict(res=res),
+            )
+
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                insert L2 {
+                    vec := array_agg(
+                        Raw.val order by Raw.val
+                    )[:3]
+                }
+            """)
+            await self.assert_query_result(
+                '''
+                    with res := <array<float32>>$res
+                    select <array<float32>>(
+                        select L2
+                        filter .vec = <ext::pgvector::vector>res
+                    ).vec
+                ''',
+                [res],
+                variables=dict(res=res),
+            )
+
+    async def test_edgeql_vector_constraint_01(self):
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                insert Con {
+                    vec := [1, 1, 2]
+                }
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.ConstraintViolationError, ''
+        ):
+            await self.con.execute(r"""
+                insert Con {
+                    vec := [1, 20, 1]
+                }
+            """)
+
+    async def _assert_index_use(self, query, *args, index_type):
+        def look(obj):
+            if isinstance(obj, dict) and obj.get('plan_type') == "IndexScan":
+                return any(
+                    prop['title'] == 'index_name'
+                    and f'pgvector::ivfflat_{index_type}' in prop['value']
+                    for prop in obj.get('properties', [])
+                )
+
+            if isinstance(obj, dict):
+                return any([look(v) for v in obj.values()])
+            elif isinstance(obj, list):
+                return any(look(v) for v in obj)
+            else:
+                return False
+
+        plan = await self.con.query_json(f'analyze {query}', *args)
+        if not look(json.loads(plan)):
+            raise AssertionError("query did not use ivfflat index")
+
+    async def _check_index(self, obj, func, index_type):
+        # Test that we actually hit the indexes by looking at the query plans.
+
+        obj_id = (await self.con.query_single(f"""
+            insert {obj} {{
+                vec := [1, 1, 2]
+            }}
+        """)).id
+        await self.con.execute(f"""
+            insert {obj} {{
+                vec := [-1, -1, 2]
+            }}
+        """)
+        embedding = [0.5, -0.1, 0.666]
+
+        await self._assert_index_use(
+            f'''
+            with vec as module ext::pgvector,
+                 base := (select {obj} filter .id = <uuid>$0),
+            select {obj}
+            filter {obj}.id != base.id
+            order by vec::{func}(.vec, base.vec)
+            empty last limit 5;
+            ''',
+            obj_id,
+            index_type=index_type,
+        )
+
+        await self._assert_index_use(
+            f'''
+            with vec as module ext::pgvector
+            select {obj}
+            order by vec::{func}(.vec, <v3>to_json(<str>$0))
+            empty last limit 5;
+            ''',
+            str(embedding),
+            index_type=index_type,
+        )
+
+        await self._assert_index_use(
+            f'''
+            with vec as module ext::pgvector
+            select {obj}
+            order by vec::{func}(.vec, <v3><json>$0)
+            empty last limit 5;
+            ''',
+            json.dumps(embedding),
+            index_type=index_type,
+        )
+
+        await self._assert_index_use(
+            f'''
+            with vec as module ext::pgvector
+            select {obj}
+            order by vec::{func}(.vec, <v3><array<float32>>$0)
+            empty last limit 5;
+            ''',
+            embedding,
+            index_type=index_type,
+        )
+
+    async def test_edgeql_vector_index_01(self):
+        await self._check_index('L2', 'euclidean_distance', 'euclidean')
+
+    async def test_edgeql_vector_index_02(self):
+        await self._check_index('Cosine', 'cosine_distance', 'cosine')
+
+    async def test_edgeql_vector_index_03(self):
+        await self._check_index('IP', 'neg_inner_product', 'ip')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2262,9 +2262,9 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def _assert_migration_consistency(
         self,
         schema_text: str,
-        multi_module: bool = False,
+        explicit_modules: bool = False,
     ) -> s_schema.Schema:
-        if multi_module:
+        if explicit_modules:
             migration_text = f'''
                 START MIGRATION TO {{
                     {schema_text}
@@ -3383,7 +3383,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_02(self):
         schema = r'''
@@ -3398,7 +3398,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_03(self):
         # Test abstract and concrete constraints order of declaration,
@@ -3417,7 +3417,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_04(self):
         # View and type from different modules
@@ -3429,7 +3429,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_05(self):
         # View and type from different modules
@@ -3441,7 +3441,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_06(self):
         # Type and annotation from different modules.
@@ -3454,7 +3454,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         abstract annotation other::my_anno;
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_07(self):
         # Type and annotation from different modules.
@@ -3468,7 +3468,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         abstract annotation other::my_anno;
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_08(self):
         schema = r'''
@@ -3482,7 +3482,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_09(self):
         schema = r'''
@@ -3498,7 +3498,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_10(self):
         # Test prop default and function order of definition.
@@ -3514,7 +3514,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_11(self):
         # Test prop default and function order of definition.
@@ -3531,7 +3531,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_multi_module_12(self):
         # Test prop default and function order of definition.
@@ -3551,7 +3551,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_nested_module_01(self):
         schema = r'''
@@ -3565,7 +3565,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_nested_module_02(self):
         schema = r'''
@@ -3583,7 +3583,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_nested_module_03(self):
         schema = r'''
@@ -3592,7 +3592,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         };
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_nested_module_04(self):
         schema = r'''
@@ -3605,7 +3605,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             errors.InvalidReferenceError,
             "function '_test::abs' does not exist"
         ):
-            self._assert_migration_consistency(schema, multi_module=True)
+            self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_nested_module_05(self):
         schema = r'''
@@ -3619,7 +3619,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         }
         '''
 
-        self._assert_migration_consistency(schema, multi_module=True)
+        self._assert_migration_consistency(schema, explicit_modules=True)
 
     def test_schema_get_migration_default_ptrs_01(self):
         schema = r'''
@@ -9469,6 +9469,49 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             module test {
                 type Bar {
                     link foo: default::Foo;
+                };
+            };
+            """,
+            explicit_modules=True,
+        )
+
+    @test.xfail('''
+        describe command includes module pgvector
+
+        ... this *doesn't* happen when actually testing via the CLI, though?
+    ''')
+    def test_schema_describe_schema_03(self):
+        self._assert_describe(
+            """
+            using extension pgvector version '0.4';
+            module default {
+                scalar type v3 extending ext::pgvector::vector<3>;
+
+                type Foo {
+                    data: v3;
+                }
+            };
+            """,
+
+            'describe schema as ddl',
+
+            """
+            create extension vector version '0.4';
+            create module default if not exists;
+            create scalar type default::v3 extending ext::pgvector::vector<3>;
+            create type default::Foo {
+                create property data: default::v3;
+            };
+            """,
+
+            'describe schema as sdl',
+
+            r"""
+            using extension pgvector version '0.4';
+            module default {
+                scalar type v3 extending ext::pgvector::vector<3>;
+                type Foo {
+                    property data: default::v3;
                 };
             };
             """,


### PR DESCRIPTION
Contents go into ext::pgvector.

Some compiler changes were made to get various array <-> vector casts
to work.

The test suite includes tests that the indexes are used.