### PR TITLE
Fix json output of arrays of ranges

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -6716,6 +6716,20 @@ aa \
             [edgedb.Range(0, 10)],
         )
 
+    async def test_edgeql_expr_range_39(self):
+        await self.assert_query_result(
+            r'''
+                select [range(1, 10)];
+            ''',
+            [
+                [
+                    {"lower": 1, "upper": 10,
+                     "inc_lower": True, "inc_upper": False},
+                ]
+            ],
+            json_only=True,
+        )
+
     async def test_edgeql_expr_cannot_assign_id_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'cannot assign to id'):


### PR DESCRIPTION
We were failing to detect that we needed to do the complex
treatement instead of just calling to_json.
Also fix it for future types with custom json casts.

Fixes #5628.