### PR TITLE
Fix the `__tname__` cardinality fix

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2102,9 +2102,6 @@ def _inline_type_computable(
                 ctx=scopectx
             )
 
-        ctx.env.schema = ptr.set_field_value(
-            ctx.env.schema, 'cardinality', qltypes.SchemaCardinality.One)
-
     view_shape = ctx.env.view_shapes[stype]
     view_shape_ptrs = {p for p, _ in view_shape}
     if ptr not in view_shape_ptrs:

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -245,9 +245,7 @@ def _process_view(
 
     if view_rptr is not None and view_rptr.ptrcls is None:
         target_scls = stype if is_mutation else view_scls
-        derive_ptrcls(
-            view_rptr, target_scls=target_scls,
-            transparent=True, ctx=ctx)
+        derive_ptrcls(view_rptr, target_scls=target_scls, ctx=ctx)
 
     pointers: Dict[s_pointers.Pointer, EarlyShapePtr] = {}
 
@@ -1921,10 +1919,10 @@ def _normalize_view_ptr_expr(
 
 
 def derive_ptrcls(
-        view_rptr: context.ViewRPtr, *,
-        target_scls: s_types.Type,
-        transparent: bool=False,
-        ctx: context.ContextLevel) -> s_pointers.Pointer:
+    view_rptr: context.ViewRPtr, *,
+    target_scls: s_types.Type,
+    ctx: context.ContextLevel
+) -> s_pointers.Pointer:
 
     if view_rptr.ptrcls is None:
         if view_rptr.base_ptrcls is None:

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2102,6 +2102,8 @@ def _inline_type_computable(
                 ctx=scopectx
             )
 
+    # even if the pointer was not created here, or was already present in
+    # the shape, we set defined_here, so it is not inlined in `extend_path`.
     ctx.env.schema = ptr.set_field_value(
         ctx.env.schema, 'defined_here', True
     )

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2102,16 +2102,15 @@ def _inline_type_computable(
                 ctx=scopectx
             )
 
+    ctx.env.schema = ptr.set_field_value(
+        ctx.env.schema, 'defined_here', True
+    )
+
     view_shape = ctx.env.view_shapes[stype]
     view_shape_ptrs = {p for p, _ in view_shape}
     if ptr not in view_shape_ptrs:
         if ptr not in ctx.env.pointer_specified_info:
             ctx.env.pointer_specified_info[ptr] = (None, None, None)
-
-        ctx.env.schema = ptr.set_field_value(
-            ctx.env.schema, 'defined_here', True
-        )
-
         view_shape.insert(0, (ptr, qlast.ShapeOp.ASSIGN))
         shape_ptrs.insert(
             0, ShapePtr(ir_set, ptr, qlast.ShapeOp.ASSIGN, ptr_set))

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -8104,3 +8104,32 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_params_03(self):
         with self.assertRaisesRegex(edgedb.QueryError, "missing a type cast"):
             await self.con.query("select ($0, <std::int64>$0)")
+
+    async def test_edgeql_type_pointer_inlining_01(self):
+        await self.con._fetchall(
+            r'''
+            with
+            data := {0, 1, 2},
+            items := (
+                for item in data union (
+                    with
+                    user := (select schema::Object limit 1)
+                    select user
+                )
+            )
+            select items;
+            ''',
+            __typenames__=True
+        )
+
+    async def test_edgeql_type_pointer_inlining_02(self):
+        await self.con._fetchall(
+            r'''
+            with
+              object_type := (select schema::ObjectType limit 1),
+              pointers := object_type.pointers,
+              pointers_2 := (select pointers limit 1),
+            select pointers_2;
+            ''',
+            __typenames__=True
+        )


### PR DESCRIPTION
A followup for #5508, which is a hack that sets the cardinality of pointers during eql compilation.

This fix was an exploration project and it involved debugging:
- how new stypes are derived and when,
- how shape pointers are created and their cardinality requirements saved into the context,
- how cardinality is inferred (and validated) after the main eql compilation,
- how paths are extended and how does `Pointer.defined_here` work.

Fun times, many breakpoints, a bit better code.