### PR TITLE
Bump `max_locks_per_transaction` to 1024

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -442,7 +442,7 @@ class Cluster(BaseCluster):
             # EdgeDB queries might touch _lots_ of tables, especially in deep
             # inheritance hierarchies.  This is especially important in low
             # `max_connections` scenarios.
-            'max_locks_per_transaction': 256,
+            'max_locks_per_transaction': 1024,
         }
 
         if os.getenv('EDGEDB_DEBUG_PGSERVER'):


### PR DESCRIPTION
People seem to still be running into "out of shared memory" issues, so
bump `max_locks_per_transaction` again, this time to `1024`.  This
should be safe to do as EdgeDB does not maintain a ton of concurrent
connections to Postgres.

Needs backpatching to 3.0 and 2.x.
