### PR TITLE
Add an ADMINISTER command to do reindex

### DIFF
--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -142,7 +142,6 @@ pub const FUTURE_RESERVED_KEYWORDS: &[&str] = &[
     "partition",
     "raise",
     "refresh",
-    "reindex",
     "revoke",
     "single",
     "when",

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -1007,7 +1007,6 @@ pub fn is_keyword(s: &str) -> bool {
         | "partition"
         | "raise"
         | "refresh"
-        | "reindex"
         | "revoke"
         | "on"
         | "over"

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1440,7 +1440,7 @@ def _compile_ql_reindex(
 
     if len(ql.expr.args) != 1 or ql.expr.kwargs:
         raise errors.QueryError(
-            'object_reindex() takes exactly one position argument',
+            'reindex() takes exactly one position argument',
             context=ql.expr.context,
         )
 
@@ -1453,7 +1453,7 @@ def _compile_ql_reindex(
             pass
         case _:
             raise errors.QueryError(
-                'argument to object_reindex() must be an object type',
+                'argument to reindex() must be an object type',
                 context=arg.context,
             )
 
@@ -1469,7 +1469,7 @@ def _compile_ql_reindex(
 
     if not obj.is_material_object_type(schema):
         raise errors.QueryError(
-            'argument to object_reindex() must be a regular object type',
+            'argument to reindex() must be a regular object type',
             context=arg.context,
         )
 
@@ -1508,7 +1508,7 @@ def _compile_ql_administer(
         return dbstate.MaintenanceQuery(sql=(b'ANALYZE',))
     elif ql.expr.func == 'schema_repair':
         return ddl.administer_repair_schema(ctx, ql)
-    elif ql.expr.func == 'object_reindex':
+    elif ql.expr.func == 'reindex':
         return _compile_ql_reindex(ctx, ql)
     else:
         raise errors.QueryError(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1430,6 +1430,63 @@ def _compile_ql_explain(
     )
 
 
+def _compile_ql_reindex(
+    ctx: CompileContext,
+    ql: qlast.AdministerStmt,
+    *,
+    script_info: Optional[irast.ScriptInfo] = None,
+) -> dbstate.BaseQuery:
+    from edb.schema import utils as s_utils
+
+    if len(ql.expr.args) != 1 or ql.expr.kwargs:
+        raise errors.QueryError(
+            'object_reindex() takes exactly one position argument',
+            context=ql.expr.context,
+        )
+
+    arg = ql.expr.args[0]
+    match arg:
+        case qlast.Path(
+            steps=[qlast.ObjectRef() as objref],
+            partial=False,
+        ):
+            pass
+        case _:
+            raise errors.QueryError(
+                'argument to object_reindex() must be an object type',
+                context=arg.context,
+            )
+
+    current_tx = ctx.state.current_tx()
+    schema = current_tx.get_schema(ctx.compiler_state.std_schema)
+    modaliases = current_tx.get_modaliases()
+    name = s_utils.resolve_name(
+        s_utils.ast_ref_to_name(objref),
+        metaclass=s_objtypes.ObjectType, sourcectx=arg.context,
+        modaliases=modaliases, schema=schema,
+    )
+    obj = schema.get(name, type=s_objtypes.ObjectType, sourcectx=arg.context)
+
+    if not obj.is_material_object_type(schema):
+        raise errors.QueryError(
+            'argument to object_reindex() must be a regular object type',
+            context=arg.context,
+        )
+
+    objs = [obj] + [
+        desc for desc in obj.descendants(schema)
+        if desc.is_material_object_type(schema)
+    ]
+    commands = [
+        f'REINDEX TABLE {pg_common.get_backend_name(schema, obj)}'
+        for obj in objs
+    ]
+
+    return dbstate.MaintenanceQuery(
+        sql=tuple(q.encode('utf-8') for q in commands)
+    )
+
+
 def _compile_ql_administer(
     ctx: CompileContext,
     ql: qlast.AdministerStmt,
@@ -1449,8 +1506,10 @@ def _compile_ql_administer(
             )
 
         return dbstate.MaintenanceQuery(sql=(b'ANALYZE',))
-    elif ql.expr.func == 'repair_schema':
+    elif ql.expr.func == 'schema_repair':
         return ddl.administer_repair_schema(ctx, ql)
+    elif ql.expr.func == 'object_reindex':
+        return _compile_ql_reindex(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15922,11 +15922,11 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             create type test::Bar;
         ''')
         await self.con.execute('''
-            administer object_reindex(Foo)
+            administer reindex(Foo)
         ''')
         await self.con.execute('''
-            administer object_reindex(test::Bar)
+            administer reindex(test::Bar)
         ''')
         await self.con.execute('''
-            administer object_reindex(Object)
+            administer reindex(Object)
         ''')

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15914,3 +15914,19 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             await self.con.execute('''
                 drop extension package ltree_broken VERSION '1.0'
             ''')
+
+    async def test_edgeql_ddl_reindex(self):
+        await self.con.execute('''
+            create type Foo;
+            create module test;
+            create type test::Bar;
+        ''')
+        await self.con.execute('''
+            administer object_reindex(Foo)
+        ''')
+        await self.con.execute('''
+            administer object_reindex(test::Bar)
+        ''')
+        await self.con.execute('''
+            administer object_reindex(Object)
+        ''')

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15917,12 +15917,38 @@ class TestDDLNonIsolated(tb.DDLTestCase):
 
     async def test_edgeql_ddl_reindex(self):
         await self.con.execute('''
-            create type Foo;
+            create type Tgt;
+            create type Foo {
+                create property foo -> str {
+                    create constraint exclusive;
+                };
+                create property bar -> str;
+                create index on (.foo);
+                create constraint exclusive on ((.foo, .bar));
+                create link tgt -> Tgt {
+                    create property foo -> str;
+                };
+                create link tgts -> Tgt {
+                    create property foo -> str;
+                };
+            };
             create module test;
-            create type test::Bar;
+            create type test::Bar extending Foo;
         ''')
         await self.con.execute('''
             administer reindex(Foo)
+        ''')
+        await self.con.execute('''
+            administer reindex(Foo.foo)
+        ''')
+        await self.con.execute('''
+            administer reindex(Foo.bar)
+        ''')
+        await self.con.execute('''
+            administer reindex(Foo.tgt)
+        ''')
+        await self.con.execute('''
+            administer reindex(Foo.tgts)
         ''')
         await self.con.execute('''
             administer reindex(test::Bar)


### PR DESCRIPTION
I had originally called it `reindex_object`, but remembered that
Elvis wanted `NOUN_VERB` names for these functions, so I made it
`object_reindex`.

Verified that it does work to get pgvector indexes that were
created too early working.