### PR TITLE
Ensure changing scalar base types throws appropriately

### DIFF
--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -321,6 +321,12 @@ class ScalarType(
                 ),
             )
             alter.add(rebase)
+
+        # Changing enum_values is the respoinsiblity of the rebase command.
+        # Either it's in the one we synthesized above, or, the rebase is doomed
+        # to throw. When we run the ddl directly, the ALTER will not have a
+        # enum_values set, so discard here for symmetry.
+        alter.discard_attribute('enum_values')
         return alter
 
 
@@ -687,8 +693,9 @@ class RebaseScalarType(
                 new_bases, pos = first_bases
 
                 if len(self.added_bases) > 1 or len(new_bases) > 1:
+                    dn = self.scls.get_displayname(schema)
                     raise errors.SchemaError(
-                        f'enums may not have multiple supertypes')
+                        f'enum {dn} may not have multiple supertypes')
 
                 new_base = new_bases[0]
                 if isinstance(new_base, AnonymousEnumTypeShell):

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -42,6 +42,7 @@ from . import schema as s_schema
 from . import types as s_types
 from . import utils as s_utils
 
+
 class ScalarType(
     s_types.InheritingType,
     constraints.ConsistencySubject,
@@ -730,14 +731,17 @@ class RebaseScalarType(
 
             schema = super().apply(schema, context)
 
+            self.validate_scalar_bases(schema, context)
+
             new_concrete = self.scls.maybe_get_topmost_concrete_base(schema)
             if old_concrete != new_concrete and not scls.is_view(schema):
                 old_name = (old_concrete.get_displayname(schema) if old_concrete
                             else 'None')
 
                 if self.scls.is_concrete_enum(schema):
-                    new_name = (
-                        f"enum<{', '.join(scls.get_enum_values(schema))}>")
+                    values = self.scls.get_enum_values(schema)
+                    assert values is not None
+                    new_name = _prettyprint_enum(values)
                 elif new_concrete:
                     new_name = new_concrete.get_displayname(schema)
                 else:
@@ -747,8 +751,6 @@ class RebaseScalarType(
                     f'cannot change concrete base of scalar type '
                     f'{scls.get_displayname(schema)} from '
                     f'{old_name} to {new_name}')
-
-            self.validate_scalar_bases(schema, context)
 
         return schema
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -11324,7 +11324,7 @@ type default::Foo {
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                'enums may not have multiple supertypes'):
+                'enum default::Color may not have multiple supertypes'):
             await self.con.execute('''
                 ALTER SCALAR TYPE Color
                     EXTENDING enum<Bad>, enum<AlsoBad>;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5974,7 +5974,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'cannot change concrete base of a scalar type'):
+                r'cannot change concrete base of scalar type '
+                r'default::Foo from std::str to std::int64'):
             await self.con.execute('''
                 alter scalar type Foo {
                     drop extending str;
@@ -11301,7 +11302,8 @@ type default::Foo {
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                'enumeration must be the only supertype specified'):
+                "cannot add supertype scalar type 'std::str' to enum type "
+                "default::Color"):
             await self.con.execute('''
                 ALTER SCALAR TYPE Color EXTENDING str FIRST;
             ''')
@@ -11311,8 +11313,7 @@ type default::Foo {
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                'cannot add another enum as supertype, '
-                'use EXTENDING without position qualification'):
+                'cannot add supertype enum<Bad> to enum type default::Color'):
             await self.con.execute('''
                 ALTER SCALAR TYPE Color
                     EXTENDING enum<Bad> LAST;
@@ -11323,7 +11324,7 @@ type default::Foo {
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                'cannot set more than one enum as supertype'):
+                'enums may not have multiple supertypes'):
             await self.con.execute('''
                 ALTER SCALAR TYPE Color
                     EXTENDING enum<Bad>, enum<AlsoBad>;


### PR DESCRIPTION
Rework scalar error messages. There were several wrinkles here, including enum
scalars being treated differently when generating the alter delta and when
running commands from scratch. Try to sanify the checks a little so it always
works as expected, and spruce up some error messages along the way.
