### PR TITLE
Make Object.property in indexes detached

### DIFF
--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -589,12 +589,13 @@ class IndexCommand(
                     singletons=frozenset([subject]),
                     apply_query_rewrites=False,
                     track_schema_ref_exprs=track_schema_ref_exprs,
+                    detached=True,
                 ),
             )
 
             # Check that the inferred cardinality is no more than 1
             if expr.irast.cardinality.is_multi():
-                raise errors.ResultCardinalityMismatchError(
+                raise errors.SchemaDefinitionError(
                     f'possibly more than one element returned by '
                     f'the index expression where only singletons '
                     f'are allowed',

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12291,7 +12291,7 @@ type default::Foo {
 
     async def test_edgeql_ddl_index_01(self):
         with self.assertRaisesRegex(
-            edgedb.ResultCardinalityMismatchError,
+            edgedb.SchemaDefinitionError,
             r"possibly more than one element returned by the index expression",
             _line=4, _col=34
         ):
@@ -12304,7 +12304,7 @@ type default::Foo {
 
     async def test_edgeql_ddl_index_02(self):
         with self.assertRaisesRegex(
-            edgedb.ResultCardinalityMismatchError,
+            edgedb.SchemaDefinitionError,
             r"possibly more than one element returned by the index expression",
             _line=5, _col=34
         ):
@@ -12318,7 +12318,7 @@ type default::Foo {
 
     async def test_edgeql_ddl_index_03(self):
         with self.assertRaisesRegex(
-            edgedb.ResultCardinalityMismatchError,
+            edgedb.SchemaDefinitionError,
             r"possibly more than one element returned by the index expression",
             _line=5, _col=34
         ):

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -365,3 +365,18 @@ class TestIndexes(tb.DDLTestCase):
                 }],
             }],
         )
+
+    async def test_index_10(self):
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            r"possibly more than one element returned",
+        ):
+            await self.con.execute(
+                r"""
+                create type Foo {
+                    create property val -> str;
+
+                    create index on (Foo.val);
+                };
+                """
+            )


### PR DESCRIPTION
A followup for https://github.com/edgedb/edgedb/pull/5606#issuecomment-1584376671

This is techincally a breaking change, since any index definitions
that are using `Object.property` will now throw errors. I do think it is
quite minor and will probably not affect anyone, as this pattern is not documented
and treated as detached in all other SDL expressions apart from computeds.
