### PR TITLE
Partial paths in triggers refer to __new__

### DIFF
--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -84,8 +84,10 @@ def compile_trigger(
                 source, path_id=old_path, ignore_rewrites=True, ctx=sctx)
             old_set.expr = irast.TriggerAnchor(typeref=old_set.typeref)
             anchors['__old__'] = old_set
+
         if qltypes.TriggerKind.Delete not in kinds:
             anchors['__new__'] = new_set
+            sctx.partial_path_prefix = new_set
 
         for name, ir in anchors.items():
             if scope == qltypes.TriggerScope.Each:

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -185,7 +185,7 @@ class RewriteCommand(
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,
                     schema_object_context=self.get_schema_metaclass(),
-                    path_prefix_anchor="__subject__",
+                    path_prefix_anchor=qlast.Subject().name,
                     anchors=anchors,
                     singletons=singletons,
                     apply_query_rewrites=not context.stdmode,

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -170,6 +170,7 @@ class TriggerCommand(
             scope = self._get_scope(schema)
             kinds = self._get_kinds(schema)
 
+            path_prefix_anchor = None
             anchors: dict[str, pathid.PathId | s_types.Type] = {}
             if qltypes.TriggerKind.Insert not in kinds:
                 anchors['__old__'] = pathid.PathId.from_type(
@@ -181,6 +182,7 @@ class TriggerCommand(
                     schema, source, typename=sn.QualName(
                         module='__derived__', name='__new__')
                 )
+                path_prefix_anchor = '__new__'
 
             singletons = (
                 frozenset(anchors.values())
@@ -198,6 +200,7 @@ class TriggerCommand(
                         modaliases=context.modaliases,
                         schema_object_context=self.get_schema_metaclass(),
                         anchors=anchors,
+                        path_prefix_anchor=path_prefix_anchor,
                         singletons=singletons,
                         apply_query_rewrites=not context.stdmode,
                         track_schema_ref_exprs=track_schema_ref_exprs,


### PR DESCRIPTION
Follow up for https://github.com/edgedb/edgedb/pull/5606#issuecomment-1584376671.

Triggers that are not Delete, can now contain partial paths
that refer to `__new__`. Not a breaking change.
