### PR TITLE
Fix analyze issue

### DIFF
--- a/edb/server/compiler/explain/ir_analyze.py
+++ b/edb/server/compiler/explain/ir_analyze.py
@@ -200,8 +200,7 @@ def analyze_queries(
 
             for node in ns:
                 ir_node_to_alias[node] = alias
-                # TODO(Tailhook) is it okay to add all nodes, or just first
-                # like we do for context?
+                break
 
             # Find the enclosing
             sources = reverse_path_rvar_map.get(rvar, ())


### PR DESCRIPTION
This fixes the following query:
```
select Movie {
  title,
  release_year,
  director,
  actors: {name},
  actors_total := count(.actors),
  franchise := .<entries[is Franchise].name,
  movies_in_franchise_total := count(
    .<entries[is Franchise].entries
  )
} order by .title;
```

From this WRONG coarse-grained plan:
```
➊ root                           │  5.5 3434.91   1.0 30.0    64 │ Person, Movie
├──➊ .director                   │  5.5 3434.91   1.0 30.0    64 │
├──➌ .actors                     │  0.0    6.61  30.0  1.0    32 │ Movie.actors, Person
├──➍ .actors_total               │  0.0    6.62  30.0  1.0     8 │ Movie.actors, Person
├──➎ .franchise                  │  0.0   37.99  30.0  1.0    32 │ Franchise, Franchise.entries
╰──➏ .movies_in_franchise_total  │  0.1   61.07  30.0  1.0     8 │ Franchise, TVShow, Movie, Franchise.entries
```

To this better plan (note correct context for `director`):
```
➊ root                           │  4.8 3434.91   1.0 30.0    64 │ Movie
├──➋ .director                   │  0.0    2.12  30.0  0.0    32 │ Person
├──➌ .actors                     │  0.0    6.61  30.0  1.0    32 │ Movie.actors, Person
├──➍ .actors_total               │  0.0    6.62  30.0  1.0     8 │ Movie.actors, Person
├──➎ .franchise                  │  0.0   37.99  30.0  1.0    32 │ Franchise, Franchise.entries
╰──➏ .movies_in_franchise_total  │  0.1   61.07  30.0  1.0     8 │ TVShow, Movie, Franchise, Franchise.entries
```

/cc @raddevon 