### PR TITLE
Add support for statement variants of prepared statement comands

### DIFF
--- a/edb/.gitignore
+++ b/edb/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Cython debug files
+*.html

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -136,6 +136,9 @@ class flags(metaclass=FlagsMeta):
     server_proto = Flag(
         doc="Print server protocol querying messages.")
 
+    server_clobber_pg_conns = Flag(
+        doc="Discard Postgres connections when releasing them to the pool.")
+
     http_inject_cors = Flag(
         doc="Inject 'Access-Control-Allow-Origin: *' header in HTTP ports.")
 

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -1125,15 +1125,19 @@ class TransactionOptions(Base):
     options: dict[str, BaseExpr]
 
 
+class PrepareStmt(Statement):
+    name: str
+    argtypes: typing.Optional[typing.List[Base]]
+    query: BaseRelation
+
+
 class ExecuteStmt(Statement):
     name: str
     params: typing.Optional[typing.List[Base]]
 
 
-class PrepareStmt(Statement):
+class DeallocateStmt(Statement):
     name: str
-    argtypes: typing.Optional[typing.List[Base]]
-    query: BaseRelation
 
 
 class SQLValueFunctionOP(enum.IntEnum):

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -184,6 +184,7 @@ def _build_stmt(node: Node, c: Context) -> pgast.Query | pgast.Statement:
             "TransactionStmt": _build_transaction_stmt,
             "PrepareStmt": _build_prepare,
             "ExecuteStmt": _build_execute,
+            "DeallocateStmt": _build_deallocate,
             "CreateStmt": _build_create,
             "CreateTableAsStmt": _build_create_table_as,
             "LockStmt": _build_lock,
@@ -429,6 +430,10 @@ def _build_execute(n: Node, c: Context) -> pgast.ExecuteStmt:
     return pgast.ExecuteStmt(
         name=n["name"], params=_maybe_list(n, c, "params", _build_base_expr)
     )
+
+
+def _build_deallocate(n: Node, c: Context) -> pgast.DeallocateStmt:
+    return pgast.DeallocateStmt(name=n["name"])
 
 
 def _build_create_table_as(n: Node, c: Context) -> pgast.CreateTableAsStmt:

--- a/edb/server/cache/stmt_cache.pyx
+++ b/edb/server/cache/stmt_cache.pyx
@@ -69,6 +69,12 @@ cdef class StatementsCache:
                 f'maxsize is expected to be greater than 0, got {maxsize}')
         self._maxsize = maxsize
 
+    def items(self):
+        return self._dict.items()
+
+    def clear(self):
+        self._dict.clear()
+
     def __getitem__(self, key):
         o = self._dict[key]
         self._dict_move_to_end(key)  # last=True

--- a/edb/server/pgcon/pgcon.pxd
+++ b/edb/server/pgcon/pgcon.pxd
@@ -29,6 +29,7 @@ from edb.server.pgproto.pgproto cimport (
     FRBuffer,
 )
 
+from edb.server.dbview cimport dbview
 from edb.server.pgproto.debug cimport PG_DEBUG
 
 from edb.server.cache cimport stmt_cache
@@ -59,16 +60,17 @@ cdef enum PGAuthenticationState:
 
 
 cdef enum PGAction:
-    START_IMPLICIT = 0
+    START_IMPLICIT_TX = 0
     PARSE = 1
     BIND = 2
     DESCRIBE_STMT = 3
-    DESCRIBE_PORTAL = 4
-    EXECUTE = 5
-    CLOSE_STMT = 6
-    CLOSE_PORTAL = 7
-    FLUSH = 8
-    SYNC = 9
+    DESCRIBE_STMT_ROWS = 4
+    DESCRIBE_PORTAL = 5
+    EXECUTE = 6
+    CLOSE_STMT = 7
+    CLOSE_PORTAL = 8
+    FLUSH = 9
+    SYNC = 10
 
 
 cdef class PGMessage:
@@ -79,12 +81,16 @@ cdef class PGMessage:
         str orig_portal_name
         object args
         object query_unit
-        bint be_parse
+        bint frontend_only
+        bint valid
+        bint injected
 
         object orig_query
         object fe_settings
 
-    cdef inline bint frontend_only(self)
+    cdef inline bint is_frontend_only(self)
+    cdef inline bint is_valid(self)
+    cdef inline bint is_injected(self)
 
 
 @cython.final
@@ -145,7 +151,8 @@ cdef class PGConnection:
     cdef fallthrough(self)
     cdef fallthrough_idle(self)
 
-    cdef bint before_prepare(self, stmt_name, dbver, WriteBuffer outbuf)
+    cdef bint before_prepare(
+        self, bytes stmt_name, int dbver, WriteBuffer outbuf)
     cdef write_sync(self, WriteBuffer outbuf)
 
     cdef make_clean_stmt_message(self, bytes stmt_name)
@@ -174,7 +181,6 @@ cdef class PGConnection:
         dict type_id_map,
     )
 
-    cdef _write_sql_extended_query(self, actions, int dbver, dbv)
     cdef _rewrite_sql_error_response(self, PGMessage action, WriteBuffer buf)
 
     cpdef set_stmt_cache_size(self, int maxsize)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -76,6 +76,7 @@ from edb.server import compiler
 from edb.server import defines
 from edb.server.cache cimport stmt_cache
 from edb.server.dbview cimport dbview
+from edb.server.protocol cimport pg_ext
 from edb.server import pgconnparams
 from edb.server import metrics
 
@@ -95,6 +96,7 @@ DEF TCP_KEEPCNT = 3
 
 DEF COPY_SIGNATURE = b"PGCOPY\n\377\r\n\0"
 
+DEF TEXT_OID = 25
 
 cdef object CARD_NO_RESULT = compiler.Cardinality.NO_RESULT
 cdef object FMT_NONE = compiler.OutputFormat.NONE
@@ -442,37 +444,62 @@ cdef class PGMessage:
         str portal_name=None,
         args=None,
         query_unit=None,
-        orig_query=None,
         fe_settings=None,
+        injected=False,
     ):
         self.action = action
         self.stmt_name = stmt_name
         self.orig_portal_name = portal_name
         if portal_name:
             self.portal_name = b'u' + portal_name.encode("utf-8")
-        elif portal_name is not None:
+        else:
             self.portal_name = b''
         self.args = args
         self.query_unit = query_unit
 
-        self.orig_query = orig_query
         self.fe_settings = fe_settings
+        self.valid = True
+        self.injected = injected
+        if self.query_unit is not None:
+            self.frontend_only = self.query_unit.frontend_only
+        else:
+            self.frontend_only = False
 
-    cdef inline bint frontend_only(self):
-        if self.query_unit is None:
-            return False
-        return self.query_unit.frontend_only
+    cdef inline bint is_frontend_only(self):
+        return self.frontend_only
+
+    def invalidate(self):
+        self.valid = False
+
+    cdef inline bint is_valid(self):
+        return self.valid
+
+    cdef inline bint is_injected(self):
+        return self.injected
+
+    def as_injected(self) -> PGMessage:
+        return PGMessage(
+            action=self.action,
+            stmt_name=self.stmt_name,
+            portal_name=self.orig_portal_name,
+            args=self.args,
+            query_unit=self.query_unit,
+            fe_settings=self.fe_settings,
+            injected=True,
+        )
 
     def __repr__(self):
         rv = []
-        if self.action == PGAction.START_IMPLICIT:
-            rv.append("START_IMPLICIT")
+        if self.action == PGAction.START_IMPLICIT_TX:
+            rv.append("START_IMPLICIT_TX")
         elif self.action == PGAction.PARSE:
             rv.append("PARSE")
         elif self.action == PGAction.BIND:
             rv.append("BIND")
         elif self.action == PGAction.DESCRIBE_STMT:
             rv.append("DESCRIBE_STMT")
+        elif self.action == PGAction.DESCRIBE_STMT_ROWS:
+            rv.append("DESCRIBE_STMT_ROWS")
         elif self.action == PGAction.DESCRIBE_PORTAL:
             rv.append("DESCRIBE_PORTAL")
         elif self.action == PGAction.EXECUTE:
@@ -491,6 +518,8 @@ cdef class PGMessage:
             rv.append(f"portal_name={self.orig_portal_name!r}")
         if self.args is not None:
             rv.append(f"args={self.args}")
+        rv.append(f"frontend_only={self.is_frontend_only()}")
+        rv.append(f"injected={self.is_injected()}")
         if self.query_unit is not None:
             rv.append(f"query_unit={self.query_unit}")
         if len(rv) > 1:
@@ -559,7 +588,8 @@ cdef class PGConnection:
     def debug_print(self, *args):
         print(
             '::PGCONN::',
-            self.backend_pid,
+            hex(id(self)),
+            f'pgpid: {self.backend_pid}',
             *args,
         )
 
@@ -594,6 +624,7 @@ cdef class PGConnection:
         self.transport.abort()
         self.transport = None
         self.connected = False
+        self.prep_stmts.clear()
 
     def terminate(self):
         if not self.transport:
@@ -603,6 +634,7 @@ cdef class PGConnection:
         self.transport.close()
         self.transport = None
         self.connected = False
+        self.prep_stmts.clear()
 
         if self.msg_waiter and not self.msg_waiter.done():
             self.msg_waiter.set_exception(ConnectionAbortedError())
@@ -697,11 +729,18 @@ cdef class PGConnection:
                 # serialization conflicts.
                 raise error
 
-    cdef bint before_prepare(self, stmt_name, dbver, WriteBuffer outbuf):
+    cdef bint before_prepare(
+        self,
+        bytes stmt_name,
+        int dbver,
+        WriteBuffer outbuf,
+    ):
         cdef bint parse = 1
 
         while self.prep_stmts.needs_cleanup():
             stmt_name_to_clean = self.prep_stmts.cleanup_one()
+            if self.debug:
+                self.debug_print(f"discarding ps {stmt_name_to_clean!r}")
             outbuf.write_buffer(
                 self.make_clean_stmt_message(stmt_name_to_clean))
 
@@ -709,6 +748,8 @@ cdef class PGConnection:
             if self.prep_stmts[stmt_name] == dbver:
                 parse = 0
             else:
+                if self.debug:
+                    self.debug_print(f"discarding ps {stmt_name_to_clean!r}")
                 outbuf.write_buffer(
                     self.make_clean_stmt_message(stmt_name))
                 del self.prep_stmts[stmt_name]
@@ -1509,230 +1550,35 @@ cdef class PGConnection:
             metrics.backend_query_duration.observe(time.monotonic() - started_at)
             await self.after_command()
 
-    async def sql_simple_query(
+    async def sql_apply_state(
         self,
-        query_units,
-        frontend.AbstractFrontendConnection fe_conn,
-        int dbver,
-        dbv,
+        dbv: pg_ext.ConnectionView,
     ):
-        cdef:
-            char mtype, field_type
-            WriteBuffer buf, msg_buf
-            bytes stmt_name, query
-            bint sync_received = 0, state_synced = 0
-
-        state = None
-        if not dbv.in_tx():
-            state = dbv.serialize_state()
-            if self.last_state == state:
-                state = None
-        dbv.start_implicit()
         self.before_command()
         try:
-            buf = WriteBuffer.new()
+            state = dbv.serialize_state()
             if state is not None:
-                if self.debug:
-                    self.debug_print("pg_ext state:", state)
+                buf = WriteBuffer.new()
                 self._build_apply_sql_state_req(state, buf)
-                # We need to close the implicit transaction with a SYNC here
-                # because the next command may be "BEGIN DEFERRABLE".
                 self.write_sync(buf)
-            for unit in query_units:
-                if self.debug:
-                    self.debug_print('pg_ext SQL:', unit.stmt_name, unit.query)
-                if unit.frontend_only:
-                    continue
-                query = unit.query.encode("utf8")
-                stmt_name = unit.stmt_name
-                if not stmt_name or self.before_prepare(stmt_name, dbver, buf):
-                    msg_buf = WriteBuffer.new_message(b'P')
-                    msg_buf.write_bytestring(stmt_name)
-                    msg_buf.write_bytestring(query)
-                    msg_buf.write_int16(0)
-                    buf.write_buffer(msg_buf.end_message())
+                self.write(buf)
 
-                msg_buf = WriteBuffer.new_message(b'B')
-                msg_buf.write_bytestring(b'')  # unnamed portal
-                msg_buf.write_bytestring(stmt_name)
-                msg_buf.write_int16(0)  # number of parameter format codes
-                msg_buf.write_int16(0)  # number of parameter values
-                msg_buf.write_int16(0)  # text for all result columns
-                buf.write_buffer(msg_buf.end_message())
-
-                msg_buf = WriteBuffer.new_message(b'D')
-                msg_buf.write_byte(b'P')  # describe portal
-                msg_buf.write_bytestring(b'')  # unnamed portal
-                buf.write_buffer(msg_buf.end_message())
-
-                msg_buf = WriteBuffer.new_message(b'E')
-                msg_buf.write_bytestring(b'')  # unnamed portal
-                msg_buf.write_int32(0)  # no limit
-                buf.write_buffer(msg_buf.end_message())
-
-            msg_buf = WriteBuffer.new_message(b'C')
-            msg_buf.write_byte(b'P')  # close portal
-            msg_buf.write_bytestring(b'')  # unnamed portal
-            buf.write_buffer(msg_buf.end_message())
-
-            self.write_sync(buf)
-            self.write(buf)
-
-            if state is not None:
                 await self._parse_apply_state_resp(
                     2 if state != EMPTY_SQL_STATE else 1
                 )
                 await self.wait_for_sync()
                 self.last_state = state
-            state_synced = 1
-
-            buf = WriteBuffer.new()
-            for unit in query_units:
-                while not sync_received:
-                    if unit.frontend_only:
-                        dbv.on_success(unit)
-                        if unit.set_vars is not None:
-                            assert len(unit.set_vars) == 1
-                            # CommandComplete
-                            msg_buf = WriteBuffer.new_message(b'C')
-                            if next(iter(unit.set_vars.values())) is None:
-                                msg_buf.write_bytestring(b'RESET')
-                            else:
-                                msg_buf.write_bytestring(b'SET')
-                            buf.write_buffer(msg_buf.end_message())
-                        elif unit.get_var is not None:
-                            # RowDescription
-                            msg_buf = WriteBuffer.new_message(b'T')
-                            msg_buf.write_int16(1)  # number of fields
-                            # field name
-                            msg_buf.write_str(unit.get_var, "utf-8")
-                            # object ID of the table to identify the field
-                            msg_buf.write_int32(0)
-                            # attribute number of the column in prev table
-                            msg_buf.write_int16(0)
-                            # object ID of the field's data type
-                            msg_buf.write_int32(25)
-                            # data type size
-                            msg_buf.write_int16(-1)
-                            # type modifier
-                            msg_buf.write_int32(-1)
-                            # format code being used for the field
-                            msg_buf.write_int16(0)
-                            buf.write_buffer(msg_buf.end_message())
-
-                            # DataRow
-                            msg_buf = WriteBuffer.new_message(b'D')
-                            msg_buf.write_int16(1)  # number of column values
-                            msg_buf.write_len_prefixed_utf8(
-                                dbv.current_fe_settings()[unit.get_var]
-                            )
-                            buf.write_buffer(msg_buf.end_message())
-
-                            # CommandComplete
-                            msg_buf = WriteBuffer.new_message(b'C')
-                            msg_buf.write_bytestring(b'SHOW')
-                            buf.write_buffer(msg_buf.end_message())
-                        break
-
-                    if not self.buffer.take_message():
-                        if buf.len() > 0:
-                            fe_conn.write(buf)
-                            fe_conn.flush()
-                            buf = WriteBuffer.new()
-                        await self.wait_for_message()
-
-                    mtype = self.buffer.get_message_type()
-
-                    if mtype == b'1':  # ParseComplete
-                        if unit.stmt_name:
-                            self.prep_stmts[unit.stmt_name] = dbver
-                        self.buffer.finish_message()
-
-                    elif mtype == b'2':  # BindComplete
-                        self.buffer.finish_message()
-
-                    elif mtype == b'n':  # NoData
-                        self.buffer.finish_message()
-
-                    elif mtype == b'I':  # EmptyQueryResponse
-                        # This is always followed by ReadyForQuery, because the
-                        # SQL parser will drop empty queries unless the whole
-                        # query is just an empty string.
-                        self.buffer.redirect_messages(buf, mtype, 0)
-                        break
-
-                    elif mtype == b'C':  # CommandComplete
-                        self.buffer.redirect_messages(buf, mtype, 0)
-                        dbv.on_success(unit)
-                        break
-
-                    elif mtype == b'E':  # ErrorResponse
-                        msg_buf = WriteBuffer.new_message(b'E')
-                        while True:
-                            field_type = self.buffer.read_byte()
-                            if field_type == b'P':  # Position
-                                self._write_error_position(
-                                    msg_buf,
-                                    query,
-                                    self.buffer.read_null_str(),
-                                    unit.translation_data
-                                )
-                            else:
-                                msg_buf.write_byte(field_type)
-                                if field_type == b'\0':
-                                    break
-                                msg_buf.write_bytestring(self.buffer.read_null_str())
-                        self.buffer.finish_message()
-                        buf.write_buffer(msg_buf.end_message())
-                        dbv.on_error()
-                        break
-
-                    elif mtype == b'Z':  # ReadyForQuery
-                        # ReadyForQuery is received before all query units are
-                        # enumerated, this usually means an early exit due to
-                        # errors
-                        sync_received = 1
-
-                    else:
-                        self.buffer.redirect_messages(buf, mtype, 0)
-
-            while True:
-                if not self.buffer.take_message():
-                    if buf.len() > 0:
-                        fe_conn.write(buf)
-                        fe_conn.flush()
-                        buf = WriteBuffer.new()
-                    await self.wait_for_message()
-                mtype = self.buffer.get_message_type()
-                if mtype == b'3':  # CloseComplete
-                    self.buffer.discard_message()
-                elif mtype == b'Z':  # ReadyForQuery
-                    msg_buf = WriteBuffer.new_message(b'Z')
-                    msg_buf.write_byte(self.parse_sync_message())
-                    buf.write_buffer(msg_buf.end_message())
-                    break
-                else:
-                    # Other messages like ParameterStatus should be forwarded
-                    self.buffer.redirect_messages(buf, mtype, 0)
-
-            if buf.len() > 0:
-                fe_conn.write(buf)
-                fe_conn.flush()
         finally:
             await self.after_command()
-            dbv.end_implicit()
-            # There could be multiple transactions in the same simple query, so
-            # last_state should be always updated after the initial state sync
-            if state_synced and not dbv.in_tx():
-                self.last_state = dbv.serialize_state()
 
     async def sql_extended_query(
         self,
-        actions: list[tuple],
-        frontend.AbstractFrontendConnection fe_conn,
-        int dbver,
-        dbv,
-    ):
+        actions: list[PGMessage],
+        fe_conn: frontend.AbstractFrontendConnection,
+        dbver: int,
+        dbv: pg_ext.ConnectionView,
+        send_sync_on_error: bool = False,
+    ) -> tuple[bool, bool]:
         self.before_command()
         try:
             state = self._write_sql_extended_query(actions, dbver, dbv)
@@ -1744,7 +1590,11 @@ cdef class PGConnection:
                 self.last_state = state
             try:
                 return await self._parse_sql_extended_query(
-                    actions, fe_conn, dbver, dbv
+                    actions,
+                    fe_conn,
+                    dbver,
+                    dbv,
+                    send_sync_on_error=send_sync_on_error,
                 )
             finally:
                 if not dbv.in_tx():
@@ -1752,7 +1602,12 @@ cdef class PGConnection:
         finally:
             await self.after_command()
 
-    cdef _write_sql_extended_query(self, actions, int dbver, dbv):
+    def _write_sql_extended_query(
+        self,
+        actions: list[PGMessage],
+        dbver: int,
+        dbv: pg_ext.ConnectionView,
+    ) -> bytes:
         cdef:
             WriteBuffer buf, msg_buf
             PGMessage action
@@ -1767,18 +1622,23 @@ cdef class PGConnection:
             self.write_sync(buf)
         prepared = set()
         for action in actions:
-            if action.frontend_only():
+            if action.is_frontend_only():
                 continue
 
             if action.action == PGAction.PARSE:
-                sql_text, data, _ = action.args
+                sql_text, data = action.args
                 if action.stmt_name in prepared:
-                    action.be_parse = False
+                    action.frontend_only = True
                 else:
-                    action.be_parse = self.before_prepare(
+                    be_parse = self.before_prepare(
                         action.stmt_name, dbver, buf
                     )
-                if action.be_parse:
+                    if not be_parse:
+                        if self.debug:
+                            self.debug_print(
+                                'Parse cache hit', action.stmt_name, sql_text)
+                        action.frontend_only = True
+                if not action.is_frontend_only():
                     prepared.add(action.stmt_name)
                     msg_buf = WriteBuffer.new_message(b'P')
                     msg_buf.write_bytestring(action.stmt_name)
@@ -1791,13 +1651,32 @@ cdef class PGConnection:
                         )
 
             elif action.action == PGAction.BIND:
-                msg_buf = WriteBuffer.new_message(b'B')
-                msg_buf.write_bytestring(action.portal_name)
-                msg_buf.write_bytestring(action.stmt_name)
-                msg_buf.write_bytes(action.args)
-                buf.write_buffer(msg_buf.end_message())
+                if action.query_unit is not None and action.query_unit.prepare:
+                    be_stmt_name = action.query_unit.prepare.be_stmt_name
+                    if be_stmt_name in prepared:
+                        action.frontend_only = True
+                    else:
+                        be_parse = self.before_prepare(
+                            be_stmt_name, dbver, buf
+                        )
+                        if not be_parse:
+                            if self.debug:
+                                self.debug_print(
+                                    'Parse cache hit', be_stmt_name)
+                            action.frontend_only = True
+                            prepared.add(be_stmt_name)
 
-            elif action.action == PGAction.DESCRIBE_STMT:
+                if not action.is_frontend_only():
+                    msg_buf = WriteBuffer.new_message(b'B')
+                    msg_buf.write_bytestring(action.portal_name)
+                    msg_buf.write_bytestring(action.stmt_name)
+                    msg_buf.write_bytes(action.args)
+                    buf.write_buffer(msg_buf.end_message())
+
+            elif (
+                action.action
+                in (PGAction.DESCRIBE_STMT, PGAction.DESCRIBE_STMT_ROWS)
+            ):
                 msg_buf = WriteBuffer.new_message(b'D')
                 msg_buf.write_byte(b'S')
                 msg_buf.write_bytestring(action.stmt_name)
@@ -1810,16 +1689,62 @@ cdef class PGConnection:
                 buf.write_buffer(msg_buf.end_message())
 
             elif action.action == PGAction.EXECUTE:
-                msg_buf = WriteBuffer.new_message(b'E')
-                msg_buf.write_bytestring(action.portal_name)
-                msg_buf.write_int32(action.args)
-                buf.write_buffer(msg_buf.end_message())
+                if action.query_unit is not None and action.query_unit.prepare:
+                    be_stmt_name = action.query_unit.prepare.be_stmt_name
+
+                    if be_stmt_name in prepared:
+                        action.frontend_only = True
+                    else:
+                        be_parse = self.before_prepare(
+                            be_stmt_name, dbver, buf
+                        )
+                        if not be_parse:
+                            if self.debug:
+                                self.debug_print(
+                                    'Parse cache hit', be_stmt_name)
+                            action.frontend_only = True
+                            prepared.add(be_stmt_name)
+
+                if (
+                    action.query_unit is not None
+                    and action.query_unit.deallocate is not None
+                    and self.before_prepare(
+                        action.query_unit.deallocate.be_stmt_name, dbver, buf
+                    )
+                ):
+                    # This prepared statement does not actually exist
+                    # on this connection, so there's nothing to DEALLOCATE.
+                    action.frontend_only = True
+
+                if not action.is_frontend_only():
+                    msg_buf = WriteBuffer.new_message(b'E')
+                    msg_buf.write_bytestring(action.portal_name)
+                    msg_buf.write_int32(action.args)
+                    buf.write_buffer(msg_buf.end_message())
 
             elif action.action == PGAction.CLOSE_PORTAL:
-                msg_buf = WriteBuffer.new_message(b'C')
-                msg_buf.write_byte(b'P')
-                msg_buf.write_bytestring(action.portal_name)
-                buf.write_buffer(msg_buf.end_message())
+                if action.query_unit is not None and action.query_unit.prepare:
+                    be_stmt_name = action.query_unit.prepare.be_stmt_name
+                    if be_stmt_name in prepared:
+                        action.frontend_only = True
+
+                if not action.is_frontend_only():
+                    msg_buf = WriteBuffer.new_message(b'C')
+                    msg_buf.write_byte(b'P')
+                    msg_buf.write_bytestring(action.portal_name)
+                    buf.write_buffer(msg_buf.end_message())
+
+            elif action.action == PGAction.CLOSE_STMT:
+                if action.query_unit is not None and action.query_unit.prepare:
+                    be_stmt_name = action.query_unit.prepare.be_stmt_name
+                    if be_stmt_name in prepared:
+                        action.frontend_only = True
+
+                if not action.is_frontend_only():
+                    msg_buf = WriteBuffer.new_message(b'C')
+                    msg_buf.write_byte(b'S')
+                    msg_buf.write_bytestring(action.stmt_name)
+                    buf.write_buffer(msg_buf.end_message())
 
             elif action.action == PGAction.FLUSH:
                 msg_buf = WriteBuffer.new_message(b'H')
@@ -1840,11 +1765,12 @@ cdef class PGConnection:
 
     async def _parse_sql_extended_query(
         self,
-        actions: list[tuple],
-        frontend.AbstractFrontendConnection fe_conn,
-        int dbver,
-        dbv,
-    ):
+        actions: list[PGMessage],
+        fe_conn: frontend.AbstractFrontendConnection,
+        dbver: int,
+        dbv: pg_ext.ConnectionView,
+        send_sync_on_error: bool,
+    ) -> tuple[bool, bool]:
         cdef:
             WriteBuffer buf, msg_buf
             PGMessage action
@@ -1861,42 +1787,34 @@ cdef class PGConnection:
 
             if ignore_till_sync and action.action != PGAction.SYNC:
                 continue
-            elif action.action == PGAction.PARSE:
-                if not action.be_parse:  # we won't receive ParseComplete
-                    if action.args[-1]:
-                        # We hit a cached prepared statement but the
-                        # frontend still needs a ParseComplete
-                        msg_buf = WriteBuffer.new_message(b'1')
-                        buf.write_buffer(msg_buf.end_message())
-                    continue
-            elif action.action == PGAction.CLOSE_STMT:
-                msg_buf = WriteBuffer.new_message(b'3')  # CloseComplete
-                buf.write_buffer(msg_buf.end_message())
-                continue
             elif action.action == PGAction.FLUSH:
                 if buf.len() > 0:
                     fe_conn.write(buf)
                     fe_conn.flush()
                     buf = WriteBuffer.new()
                 continue
-            elif action.action == PGAction.START_IMPLICIT:
+            elif action.action == PGAction.START_IMPLICIT_TX:
                 dbv.start_implicit()
                 continue
-            elif action.frontend_only():
-                # FE PARSE and CLOSE_STMT is already handled previously
-                if action.action == PGAction.BIND:
+            elif action.is_frontend_only():
+                if action.action == PGAction.PARSE:
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(b'1')
+                        buf.write_buffer(msg_buf.end_message())
+                elif action.action == PGAction.BIND:
                     dbv.create_portal(
                         action.orig_portal_name, action.query_unit
                     )
-                    msg_buf = WriteBuffer.new_message(b'2')  # BindComplete
-                    buf.write_buffer(msg_buf.end_message())
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(b'2')  # BindComplete
+                        buf.write_buffer(msg_buf.end_message())
                 elif action.action == PGAction.DESCRIBE_STMT:
                     # ParameterDescription
-                    msg_buf = WriteBuffer.new_message(b't')
-                    msg_buf.write_int16(0)  # number of parameters
-                    buf.write_buffer(msg_buf.end_message())
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(b't')
+                        msg_buf.write_int16(0)  # number of parameters
+                        buf.write_buffer(msg_buf.end_message())
                 elif action.action == PGAction.EXECUTE:
-                    dbv.on_success(action.query_unit)
                     if action.query_unit.set_vars is not None:
                         assert len(action.query_unit.set_vars) == 1
                         # CommandComplete
@@ -1909,6 +1827,25 @@ cdef class PGConnection:
                             msg_buf.write_bytestring(b'SET')
                         buf.write_buffer(msg_buf.end_message())
                     elif action.query_unit.get_var is not None:
+                        # RowDescription
+                        msg_buf = WriteBuffer.new_message(b'T')
+                        msg_buf.write_int16(1)  # number of fields
+                        # field name
+                        msg_buf.write_str(action.query_unit.get_var, "utf-8")
+                        # object ID of the table to identify the field
+                        msg_buf.write_int32(0)
+                        # attribute number of the column in prev table
+                        msg_buf.write_int16(0)
+                        # object ID of the field's data type
+                        msg_buf.write_int32(TEXT_OID)
+                        # data type size
+                        msg_buf.write_int16(-1)
+                        # type modifier
+                        msg_buf.write_int32(-1)
+                        # format code being used for the field
+                        msg_buf.write_int16(0)
+                        buf.write_buffer(msg_buf.end_message())
+
                         # DataRow
                         msg_buf = WriteBuffer.new_message(b'D')
                         msg_buf.write_int16(1)  # number of column values
@@ -1923,10 +1860,28 @@ cdef class PGConnection:
                         msg_buf = WriteBuffer.new_message(b'C')
                         msg_buf.write_bytestring(b'SHOW')
                         buf.write_buffer(msg_buf.end_message())
+                    elif not action.is_injected():
+                        # NoData
+                        msg_buf = WriteBuffer.new_message(b'n')
+                        buf.write_buffer(msg_buf.end_message())
+                        # CommandComplete
+                        msg_buf = WriteBuffer.new_message(b'C')
+                        assert action.query_unit.command_tag, \
+                            "emulated SQL unit has no command_tag"
+                        msg_buf.write_bytestring(action.query_unit.command_tag)
+                        buf.write_buffer(msg_buf.end_message())
+
+                    dbv.on_success(action.query_unit)
+                    fe_conn.on_success(action.query_unit)
                 elif action.action == PGAction.CLOSE_PORTAL:
-                    dbv.close_portal(action.orig_portal_name)
-                    msg_buf = WriteBuffer.new_message(b'3')  # CloseComplete
-                    buf.write_buffer(msg_buf.end_message())
+                    dbv.close_portal_if_exists(action.orig_portal_name)
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(b'3') # CloseComplete
+                        buf.write_buffer(msg_buf.end_message())
+                elif action.action == PGAction.CLOSE_STMT:
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(b'3')  # CloseComplete
+                        buf.write_buffer(msg_buf.end_message())
                 if (
                     action.action == PGAction.DESCRIBE_STMT or
                     action.action == PGAction.DESCRIBE_PORTAL
@@ -1945,7 +1900,7 @@ cdef class PGConnection:
                         # attribute number of the column in prev table
                         msg_buf.write_int16(0)
                         # object ID of the field's data type
-                        msg_buf.write_int32(25)
+                        msg_buf.write_int32(TEXT_OID)
                         # data type size
                         msg_buf.write_int16(-1)
                         # type modifier
@@ -1965,7 +1920,24 @@ cdef class PGConnection:
 
                 mtype = self.buffer.get_message_type()
                 if self.debug:
-                    self.debug_print('recv backend message: ', chr(mtype))
+                    self.debug_print(f'recv backend message: {chr(mtype)!r}')
+                    if ignore_till_sync:
+                        self.debug_print("ignoring until SYNC")
+
+                if ignore_till_sync and mtype != b'Z':
+                    self.buffer.discard_message()
+                    continue
+
+                if (
+                    mtype == b'3'
+                    and action.action != PGAction.CLOSE_PORTAL
+                    and action.action != PGAction.CLOSE_STMT
+                ):
+                    # before_prepare() initiates LRU cleanup for
+                    # prepared statements, so CloseComplete may
+                    # appear here.
+                    self.buffer.discard_message()
+                    continue
 
                 # ParseComplete
                 if mtype == b'1' and action.action == PGAction.PARSE:
@@ -1973,7 +1945,7 @@ cdef class PGConnection:
                     if self.debug:
                         self.debug_print('PARSE COMPLETE MSG')
                     self.prep_stmts[action.stmt_name] = dbver
-                    if action.args[-1]:
+                    if not action.is_injected():
                         msg_buf = WriteBuffer.new_message(mtype)
                         buf.write_buffer(msg_buf.end_message())
                     break
@@ -1986,8 +1958,9 @@ cdef class PGConnection:
                     dbv.create_portal(
                         action.orig_portal_name, action.query_unit
                     )
-                    msg_buf = WriteBuffer.new_message(mtype)
-                    buf.write_buffer(msg_buf.end_message())
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(mtype)
+                        buf.write_buffer(msg_buf.end_message())
                     break
 
                 elif (
@@ -1995,15 +1968,23 @@ cdef class PGConnection:
                     mtype == b'T' or mtype == b'n'
                 ) and (
                     action.action == PGAction.DESCRIBE_STMT or
+                    action.action == PGAction.DESCRIBE_STMT_ROWS or
                     action.action == PGAction.DESCRIBE_PORTAL
                 ):
                     data = self.buffer.consume_message()
                     if self.debug:
                         self.debug_print('END OF DESCRIBE', mtype)
-                    msg_buf = WriteBuffer.new_message(mtype)
-                    msg_buf.write_bytes(data)
-                    buf.write_buffer(msg_buf.end_message())
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(mtype)
+                        msg_buf.write_bytes(data)
+                        buf.write_buffer(msg_buf.end_message())
                     break
+
+                elif (
+                    mtype == b't'
+                    and action.action == PGAction.DESCRIBE_STMT_ROWS
+                ):
+                    self.buffer.consume_message()
 
                 elif (
                     # CommandComplete, EmptyQueryResponse, PortalSuspended
@@ -2012,65 +1993,107 @@ cdef class PGConnection:
                     data = self.buffer.consume_message()
                     if self.debug:
                         self.debug_print('END OF EXECUTE', mtype)
+                    fe_conn.on_success(action.query_unit)
                     dbv.on_success(action.query_unit)
-                    msg_buf = WriteBuffer.new_message(mtype)
-                    msg_buf.write_bytes(data)
-                    buf.write_buffer(msg_buf.end_message())
+
+                    if (
+                        action.query_unit is not None
+                        and action.query_unit.prepare is not None
+                    ):
+                        be_stmt_name = action.query_unit.prepare.be_stmt_name
+                        if self.debug:
+                            self.debug_print(
+                                f"remembering ps {be_stmt_name}, "
+                                f"dbver {dbver}"
+                            )
+                        self.prep_stmts[be_stmt_name] = dbver
+
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(mtype)
+                        msg_buf.write_bytes(data)
+                        buf.write_buffer(msg_buf.end_message())
                     break
 
                 # CloseComplete
                 elif mtype == b'3' and action.action == PGAction.CLOSE_PORTAL:
                     self.buffer.finish_message()
                     if self.debug:
-                        self.debug_print('CLOSE COMPLETE MSG')
-                    dbv.close_portal(action.orig_portal_name)
-                    msg_buf = WriteBuffer.new_message(mtype)
-                    buf.write_buffer(msg_buf.end_message())
+                        self.debug_print('CLOSE COMPLETE MSG (PORTAL)')
+                    dbv.close_portal_if_exists(action.orig_portal_name)
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(mtype)
+                        buf.write_buffer(msg_buf.end_message())
+                    break
+
+                elif mtype == b'3' and action.action == PGAction.CLOSE_STMT:
+                    self.buffer.finish_message()
+                    if self.debug:
+                        self.debug_print('CLOSE COMPLETE MSG (STATEMENT)')
+                    if not action.is_injected():
+                        msg_buf = WriteBuffer.new_message(mtype)
+                        buf.write_buffer(msg_buf.end_message())
                     break
 
                 elif mtype == b'E':  # ErrorResponse
                     rv = False
                     if self.debug:
-                        self.debug_print('ERROR RESPONSE MSG')
+                        self.debug_print('ERROR RESPONSE MSG', send_sync_on_error)
+                    fe_conn.on_error(action.query_unit)
                     dbv.on_error()
                     self._rewrite_sql_error_response(action, buf)
-                    ignore_till_sync = True
                     fe_conn.write(buf)
-                    buf = WriteBuffer.new()
                     fe_conn.flush()
-                    break
+                    buf = WriteBuffer.new()
+                    ignore_till_sync = True
+                    if send_sync_on_error:
+                        be_buf = WriteBuffer.new()
+                        if self.debug:
+                            self.debug_print("sent backend message: 'Z'")
+                        self.write_sync(be_buf)
+                        self.write(be_buf)
+                    else:
+                        break
 
                 elif mtype == b'Z':  # ReadyForQuery
                     ignore_till_sync = False
                     dbv.end_implicit()
                     status = self.parse_sync_message()
-                    rv = True
                     msg_buf = WriteBuffer.new_message(b'Z')
                     msg_buf.write_byte(status)
                     buf.write_buffer(msg_buf.end_message())
 
                     fe_conn.write(buf)
                     fe_conn.flush()
-                    return rv
+                    return True, True
 
                 else:
-                    if self.debug:
-                        self.debug_print('REDIRECT OTHER MSG', mtype)
-                    self.buffer.redirect_messages(buf, mtype, 0)
+                    if not action.is_injected():
+                        if self.debug:
+                            self.debug_print('REDIRECT OTHER MSG', mtype)
+                        self.buffer.redirect_messages(buf, mtype, 0)
+                    else:
+                        logger.warning(
+                            f"discarding unexpected backend message: "
+                            f"{chr(mtype)!r}"
+                        )
+                        self.buffer.discard_message()
 
         if buf.len() > 0:
             fe_conn.write(buf)
-        return rv
+        return rv, False
 
     def _write_error_position(
         self,
         msg_buf: WriteBuffer,
         query: bytes,
         pos_bytes: bytes,
-        translation_data: Optional[SQLSourceGeneratorTranslationData]
+        translation_data: Optional[SQLSourceGeneratorTranslationData],
+        offset: int = 0,
     ):
         if translation_data:
             pos = int(pos_bytes.decode('utf8'))
+            if offset > 0 or pos + offset > 0:
+                pos += offset
             pos = translation_data.translate(pos)
             # pg uses 1-based indexes
             pos += 1
@@ -2133,13 +2156,26 @@ cdef class PGConnection:
                         message.encode('utf-8')
                     )
                 elif field_type == b'P':
-                    qu = (action.query_unit.translation_data
-                          if action.query_unit else None)
+                    if action.query_unit is not None:
+                        qu = action.query_unit
+                        query_text = qu.query.encode("utf-8")
+                        if qu.prepare is not None:
+                            offset = -55
+                            translation_data = qu.prepare.translation_data
+                        else:
+                            offset = 0
+                            translation_data = qu.translation_data
+                    else:
+                        query_text = b""
+                        translation_data = None
+                        offset = 0
+
                     self._write_error_position(
                         msg_buf,
-                        action.args[0],
+                        query_text,
                         self.buffer.read_null_str(),
-                        qu
+                        translation_data,
+                        offset,
                     )
                 else:
                     msg_buf.write_byte(field_type)

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -145,7 +145,11 @@ cdef class FrontendConnection(AbstractFrontendConnection):
                 conn.pinned_by = None
                 self._pinned_pgcon = None
                 if not self._pgcon_released_in_connection_lost:
-                    self.server.release_pgcon(self.dbname, conn)
+                    self.server.release_pgcon(
+                        self.dbname,
+                        conn,
+                        discard=debug.flags.server_clobber_pg_conns,
+                    )
             else:
                 self._pinned_pgcon_in_tx = True
         else:
@@ -153,7 +157,11 @@ cdef class FrontendConnection(AbstractFrontendConnection):
             self._pinned_pgcon_in_tx = False
             self._pinned_pgcon = None
             if not self._pgcon_released_in_connection_lost:
-                self.server.release_pgcon(self.dbname, conn)
+                self.server.release_pgcon(
+                    self.dbname,
+                    conn,
+                    discard=debug.flags.server_clobber_pg_conns,
+                )
 
     def on_aborted_pgcon(self, pgcon.PGConnection conn):
         try:

--- a/edb/server/protocol/pg_ext.pxd
+++ b/edb/server/protocol/pg_ext.pxd
@@ -45,8 +45,10 @@ cdef class ConnectionView:
     cdef inline _reset_tx_state(
         self, bint chain_implicit, bint chain_explicit
     )
+    cpdef inline close_portal_if_exists(self, str name)
     cpdef inline close_portal(self, str name)
     cdef inline find_portal(self, str name)
+    cdef inline portal_exists(self, str name)
 
 
 cdef class PgConnection(frontend.FrontendConnection):
@@ -56,6 +58,9 @@ cdef class PgConnection(frontend.FrontendConnection):
 
         bytes secret
         dict prepared_stmts
+        dict sql_prepared_stmts
+        dict sql_prepared_stmts_map
+        dict wrapping_prepared_stmts
         bint ignore_till_sync
 
         object sslctx

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -43,13 +43,10 @@ from edb.server.pgcon import errors as pgerror
 from edb.server.pgcon.pgcon cimport PGAction, PGMessage
 from edb.server.protocol cimport frontend
 
+DEFAULT_SETTINGS = dbstate.DEFAULT_SQL_SETTINGS
+DEFAULT_FE_SETTINGS = dbstate.DEFAULT_SQL_FE_SETTINGS
+
 cdef object logger = logging.getLogger('edb.server')
-cdef object DEFAULT_SETTINGS = immutables.Map()
-cdef object DEFAULT_FE_SETTINGS = immutables.Map({
-    "search_path": "public",
-    "server_version": defines.PGEXT_POSTGRES_VERSION,
-    "server_version_num": str(defines.PGEXT_POSTGRES_VERSION_NUM),
-})
 cdef object DEFAULT_STATE = json.dumps(dict(DEFAULT_SETTINGS)).encode('utf-8')
 
 encodings.aliases.aliases["sql_ascii"] = "ascii"
@@ -299,6 +296,9 @@ cdef class ConnectionView:
                 f"cursor \"{name}\" does not exist",
             ) from None
 
+    cpdef inline close_portal_if_exists(self, str name):
+        return self._in_tx_portals.pop(name, None)
+
     def create_portal(self, str name, query_unit):
         if not self.in_tx():
             raise RuntimeError(
@@ -319,6 +319,9 @@ cdef class ConnectionView:
                 pgerror.ERROR_INVALID_CURSOR_NAME,
                 f"cursor \"{name}\" does not exist",
             ) from None
+
+    cdef inline portal_exists(self, str name):
+        return name in self._in_tx_portals
 
     def serialize_state(self):
         if self.in_tx():
@@ -341,7 +344,12 @@ cdef class PgConnection(frontend.FrontendConnection):
         super().__init__(server, **kwargs)
         self._dbview = ConnectionView()
         self._id = str(<int32_t><uint32_t>(int(self._id) % (2 ** 32)))
-        self.prepared_stmts = {}
+        self.prepared_stmts = {}  # via extended query Parse
+        self.sql_prepared_stmts = {}  # via a PREPARE statement
+        self.sql_prepared_stmts_map = {}
+        # Tracks prepared statements of operations
+        # on *other* prepared statements.
+        self.wrapping_prepared_stmts = {}
         self.ignore_till_sync = False
 
         self.sslctx = sslctx
@@ -674,12 +682,12 @@ cdef class PgConnection(frontend.FrontendConnection):
                     self.debug_print(f"ParameterStatus: {name}={value}")
             self.write(buf)
             # Try to sync the settings, especially client_encoding.
-            # sql_simple_query() will return a ReadyForQuery and flush the buf.
-            await conn.sql_simple_query(
-                [], self, self.database.dbver, self._dbview
-            )
+            await conn.sql_apply_state(self._dbview)
         finally:
             self.maybe_release_pgcon(conn)
+
+        self.write(self.ready_for_query())
+        self.flush()
 
     cdef inline WriteBuffer ready_for_query(self):
         cdef WriteBuffer msg_buf
@@ -694,22 +702,54 @@ cdef class PgConnection(frontend.FrontendConnection):
             msg_buf.write_byte(b'I')
         return msg_buf.end_message()
 
+    def on_success(self, query_unit):
+        if query_unit.deallocate is not None:
+            stmt_name = query_unit.deallocate.stmt_name
+            self.sql_prepared_stmts.pop(stmt_name, None)
+            self.sql_prepared_stmts_map.pop(stmt_name, None)
+            self.prepared_stmts.pop(stmt_name, None)
+            # If any wrapping prepared statements referred to this
+            # prepared statement, invalidate them.
+            for wrapping_ps in self.wrapping_prepared_stmts.pop(stmt_name, []):
+                action = self.prepared_stmts.get(wrapping_ps)
+                if action is not None:
+                    action.invalidate()
+
+    def on_error(self, query_unit):
+        if query_unit.prepare is not None:
+            stmt_name = query_unit.prepare.stmt_name
+            self.sql_prepared_stmts.pop(stmt_name, None)
+            self.sql_prepared_stmts_map.pop(stmt_name, None)
+            self.prepared_stmts.pop(stmt_name, None)
+            # If any wrapping prepared statements referred to this
+            # prepared statement, invalidate them.
+            for wrapping_ps in self.wrapping_prepared_stmts.pop(stmt_name, []):
+                action = self.prepared_stmts.get(wrapping_ps)
+                if action is not None:
+                    action.invalidate()
+
     async def main_step(self, char mtype):
-        cdef WriteBuffer buf
+        cdef:
+            WriteBuffer buf
+            ConnectionView dbv
+
+        dbv = self._dbview
 
         if self.debug:
-            self.debug_print("main_step", mtype)
+            self.debug_print("main_step", repr(chr(mtype)))
+            if self.ignore_till_sync:
+                self.debug_print("ignoring")
 
         if mtype == b'S':  # Sync
             self.buffer.finish_message()
             if self.debug:
                 self.debug_print("Sync")
-            if self._dbview._in_tx_implicit:
+            if dbv._in_tx_implicit:
                 actions = [PGMessage(PGAction.SYNC)]
                 conn = await self.get_pgcon()
                 try:
-                    success = await conn.sql_extended_query(
-                        actions, self, self.database.dbver, self._dbview)
+                    success, _ = await conn.sql_extended_query(
+                        actions, self, self.database.dbver, dbv)
                     self.ignore_till_sync = not success
                 finally:
                     self.maybe_release_pgcon(conn)
@@ -729,19 +769,12 @@ cdef class PgConnection(frontend.FrontendConnection):
             self.buffer.discard_message()
 
         elif mtype == b'Q':  # Query
-            query_str = self.buffer.read_null_str().decode("utf8")
-            self.buffer.finish_message()
-            if self.debug:
-                self.debug_print("Query", query_str)
             try:
-                # Emulate Postgres to close the anonymous stmt/portal
-                # once the Q message is taken
-                self.prepared_stmts.pop("", None)
-                try:
-                    self._dbview.close_portal("")
-                except pgerror.BackendError:
-                    pass
-                query_units = await self.compile(query_str, self._dbview)
+                query_str = self.buffer.read_null_str().decode("utf8")
+                self.buffer.finish_message()
+                if self.debug:
+                    self.debug_print("Query", query_str)
+                actions = await self.simple_query(query_str)
             except Exception as ex:
                 self.write_error(ex)
                 self.write(self.ready_for_query())
@@ -750,12 +783,23 @@ cdef class PgConnection(frontend.FrontendConnection):
             else:
                 conn = await self.get_pgcon()
                 try:
-                    await conn.sql_simple_query(
-                        query_units, self, self.database.dbver, self._dbview
+                    _, rq_sent = await conn.sql_extended_query(
+                        actions,
+                        self,
+                        self.database.dbver,
+                        dbv,
+                        send_sync_on_error=True,
                     )
-                    self.ignore_till_sync = False
+                except Exception as ex:
+                    self.write_error(ex)
+                    self.write(self.ready_for_query())
+                else:
+                    if not rq_sent:
+                        self.write(self.ready_for_query())
                 finally:
                     self.maybe_release_pgcon(conn)
+
+                self.flush()
 
         elif (
             mtype == b'P' or mtype == b'B' or mtype == b'D' or mtype == b'E' or
@@ -771,9 +815,13 @@ cdef class PgConnection(frontend.FrontendConnection):
             else:
                 conn = await self.get_pgcon()
                 try:
-                    success = await conn.sql_extended_query(
-                        actions, self, self.database.dbver, self._dbview)
+                    success, _ = await conn.sql_extended_query(
+                        actions, self, self.database.dbver, dbv)
                     self.ignore_till_sync = not success
+                except Exception as ex:
+                    self.write_error(ex)
+                    self.flush()
+                    self.ignore_till_sync = True
                 finally:
                     self.maybe_release_pgcon(conn)
 
@@ -789,6 +837,89 @@ cdef class PgConnection(frontend.FrontendConnection):
                     "MESSAGE", chr(mtype), self.buffer.consume_message()
                 )
             raise pgerror.FeatureNotSupported()
+
+    async def simple_query(self, query_str: str) -> list[PGMessage]:
+        cdef:
+            PGMessage parse_action
+
+        actions = []
+        dbv = self._dbview
+        query_units = await self.compile(query_str, dbv)
+        already_in_implicit_tx = dbv._in_tx_implicit
+
+        if not already_in_implicit_tx:
+            actions.append(PGMessage(PGAction.START_IMPLICIT_TX))
+
+        for qu in query_units:
+            if qu.execute is not None:
+                fe_settings = dbv.current_fe_settings()
+                known_be_name = (
+                    self.sql_prepared_stmts_map.get(qu.execute.stmt_name))
+                recompile = (
+                    qu.fe_settings != fe_settings
+                    or qu.execute.be_stmt_name != known_be_name.encode("utf-8")
+                )
+                actions.extend(await self._ensure_nested_ps_exists(
+                    dbv, qu, force_recompilation=recompile))
+            else:
+                recompile = False
+            if recompile:
+                parse_action, new_stmts = await self._parse_statement(
+                    stmt_name=None,
+                    query_str=qu.orig_query,
+                    parse_data=b"\x00\x00",
+                    dbv=dbv,
+                    force_recompilation=True,
+                    injected_action=True,
+                )
+            else:
+                parse_action, new_stmts = await self._parse_unit(
+                    stmt_name=None,
+                    unit=qu,
+                    parse_data=b"\x00\x00",
+                    dbv=dbv,
+                    injected_action=True,
+                )
+            parse_unit = parse_action.query_unit
+            actions.append(parse_action)
+            actions.append(
+                PGMessage(
+                    PGAction.BIND,
+                    portal_name="",
+                    stmt_name=parse_unit.stmt_name,
+                    args=b"\x00\x01\x00\x01\x00\x00\x00\x00",
+                    query_unit=parse_unit,
+                    injected=True,
+                )
+            )
+            actions.append(
+                PGMessage(
+                    PGAction.DESCRIBE_STMT_ROWS,
+                    stmt_name=parse_unit.stmt_name,
+                    query_unit=parse_unit,
+                )
+            )
+            actions.append(
+                PGMessage(
+                    PGAction.EXECUTE,
+                    args=0,
+                    portal_name="",
+                    query_unit=parse_unit,
+                    injected=False,
+                )
+            )
+            actions.append(
+                PGMessage(
+                    PGAction.CLOSE_PORTAL,
+                    portal_name="",
+                    query_unit=parse_unit,
+                    injected=True,
+                )
+            )
+
+        actions.append(PGMessage(PGAction.SYNC))
+
+        return actions
 
     async def extended_query(self):
         cdef:
@@ -811,7 +942,7 @@ cdef class PgConnection(frontend.FrontendConnection):
         # This also means no partial action is executed in the backend for now.
         while self.buffer.take_message():
             if not in_implicit:
-                actions.append(PGMessage(PGAction.START_IMPLICIT))
+                actions.append(PGMessage(PGAction.START_IMPLICIT_TX))
                 in_implicit = True
                 with managed_error():
                     dbv.start_implicit()
@@ -826,43 +957,29 @@ cdef class PgConnection(frontend.FrontendConnection):
                     self.debug_print("Parse", repr(stmt_name), query_str, data)
 
                 with managed_error():
-                    if stmt_name and stmt_name in self.prepared_stmts:
+                    if (
+                        stmt_name and (
+                            stmt_name in self.prepared_stmts
+                            or stmt_name in self.sql_prepared_stmts
+                        )
+                    ):
                         raise pgerror.new(
                             pgerror.ERROR_DUPLICATE_PREPARED_STATEMENT,
                             f"prepared statement \"{stmt_name}\" already "
                             f"exists",
                         )
 
-                    fe_settings = dbv.current_fe_settings()
-                    query_units = await self.compile(query_str, dbv)
-                    if len(query_units) > 1:
-                        raise pgerror.new(
-                            pgerror.ERROR_SYNTAX_ERROR,
-                            "cannot insert multiple commands into a prepared "
-                            "statement",
+                    parse_action, new_stmts = await self._parse_statement(
+                        stmt_name, query_str, data, dbv)
+                    if parse_action.query_unit.execute is not None:
+                        actions.extend(
+                            await self._ensure_nested_ps_exists(
+                                dbv,
+                                parse_action.query_unit,
+                            )
                         )
-                    unit = query_units[0]
-                    sql_text = unit.query.encode("utf-8")
-                    parse_hash = hashlib.sha1(sql_text)
-                    parse_hash.update(data)
-                    parse_hash = b'p' + parse_hash.hexdigest().encode("latin1")
-                    actions.append(
-                        PGMessage(
-                            PGAction.PARSE,
-                            stmt_name=parse_hash,
-                            args=(sql_text, data, True),
-                            query_unit=unit,
-                        )
-                    )
-                    self.prepared_stmts[stmt_name] = PGMessage(
-                        PGAction.PARSE,
-                        stmt_name=parse_hash,
-                        args=(sql_text, data, False),
-                        query_unit=unit,
-                        orig_query=query_str,
-                        fe_settings=fe_settings,
-                    )
-                    fresh_stmts.add(stmt_name)
+                    fresh_stmts.update(new_stmts)
+                    actions.append(parse_action)
 
             elif mtype == b'B':  # Bind
                 portal_name = self.buffer.read_null_str().decode("utf8")
@@ -874,52 +991,12 @@ cdef class PgConnection(frontend.FrontendConnection):
                     )
 
                 with managed_error():
-                    if stmt_name not in self.prepared_stmts:
-                        raise pgerror.new(
-                            pgerror.ERROR_INVALID_SQL_STATEMENT_NAME,
-                            f"prepared statement \"{stmt_name}\" does not "
-                            f"exist",
-                        )
-
-                    # Replay Parse if it wasn't done in this extended_query()
-                    # call
-                    parse_action = self.prepared_stmts[stmt_name]
-                    if stmt_name not in fresh_stmts:
-
-                        # HACK: some of the statically compiler-evaluated
-                        # queries like `current_schema` depend on the
-                        # fe_settings, we need to re-compile if the fe_settings
-                        # mismatch.
-                        fe_settings = dbv.current_fe_settings()
-                        if parse_action.fe_settings is not fe_settings:
-                            query_units = await self.compile(
-                                parse_action.orig_query, dbv
-                            )
-                            if len(query_units) > 1:
-                                raise pgerror.new(
-                                    pgerror.ERROR_SYNTAX_ERROR,
-                                    "cannot insert multiple commands into a "
-                                    "prepared statement",
-                                )
-                            unit = query_units[0]
-                            sql_text = unit.query.encode("utf-8")
-                            parse_hash = hashlib.sha1(sql_text)
-                            parse_hash.update(parse_action.args[1])
-                            parse_hash = b'p' + parse_hash.hexdigest().encode(
-                                "latin1"
-                            )
-                            parse_action = PGMessage(
-                                PGAction.PARSE,
-                                stmt_name=parse_hash,
-                                args=(sql_text, parse_action.args[1], False),
-                                query_unit=unit,
-                                orig_query=parse_action.orig_query,
-                                fe_settings=fe_settings,
-                            )
-                            self.prepared_stmts[stmt_name] = parse_action
-
-                        actions.append(parse_action)
-                        fresh_stmts.add(stmt_name)
+                    parse_action = await self._ensure_ps_locality(
+                        dbv,
+                        stmt_name,
+                        fresh_stmts,
+                        actions,
+                    )
                     actions.append(
                         PGMessage(
                             PGAction.BIND,
@@ -940,18 +1017,12 @@ cdef class PgConnection(frontend.FrontendConnection):
 
                 with managed_error():
                     if kind == b'S':  # prepared statement
-                        if name not in self.prepared_stmts:
-                            raise pgerror.new(
-                                pgerror.ERROR_INVALID_SQL_STATEMENT_NAME,
-                                f"prepared statement \"{name}\" does not "
-                                f"exist",
-                            )
-                        parse_action = self.prepared_stmts[name]
-                        # Replay Parse if it wasn't done
-                        # in this extended_query() call
-                        if name not in fresh_stmts:
-                            fresh_stmts.add(name)
-                            actions.append(parse_action)
+                        parse_action = await self._ensure_ps_locality(
+                            dbv,
+                            name,
+                            fresh_stmts,
+                            actions,
+                        )
                         actions.append(
                             PGMessage(
                                 PGAction.DESCRIBE_STMT,
@@ -995,7 +1066,8 @@ cdef class PgConnection(frontend.FrontendConnection):
 
             elif mtype == b'C':  # Close
                 kind = self.buffer.read_byte()
-                name = self.buffer.read_null_str().decode("utf8")
+                name_bytes = self.buffer.read_null_str()
+                name = name_bytes.decode("utf8")
                 self.buffer.finish_message()
                 if self.debug:
                     self.debug_print("Close", kind, repr(name))
@@ -1012,7 +1084,12 @@ cdef class PgConnection(frontend.FrontendConnection):
                         # the LRU cache in pgcon.pyx, we don't close it here
                         fresh_stmts.discard(name)
                         self.prepared_stmts.pop(name)
-                        actions.append(PGMessage(PGAction.CLOSE_STMT))
+                        actions.append(
+                            PGMessage(
+                                PGAction.CLOSE_STMT,
+                                stmt_name=name_bytes,
+                            ),
+                        )
 
                     elif kind == b'P':  # portal
                         actions.append(
@@ -1020,7 +1097,7 @@ cdef class PgConnection(frontend.FrontendConnection):
                                 PGAction.CLOSE_PORTAL,
                                 portal_name=name,
                                 query_unit=dbv.close_portal(name),
-                            )
+                            ),
                         )
 
                     else:
@@ -1050,14 +1127,270 @@ cdef class PgConnection(frontend.FrontendConnection):
             self.debug_print("extended_query", actions)
         return actions
 
-    async def compile(self, query_str, ConnectionView dbv):
+    async def _ensure_ps_locality(
+        self,
+        dbv: ConnectionView,
+        stmt_name: str,
+        local_stmts: set[str],
+        actions: list[PGMessage],
+    ) -> PGMessage:
+        """Make sure given *stmt_name* is known by Postgres
+
+        Frontend SQL connections do not normally own Postgres connections,
+        so there is no affinity between them.  Thus, whenever we receive
+        a message operating on some prepared statement, we must ensure
+        that this statement has been prepared in the currently active
+        Postgres connection.  We rely on pgcon LRU to actually make a
+        decision on whether to issue the injected Parse messages.
+
+        NB: this method mutates *local_stmts* and *actions*.
+        """
+        cdef:
+            PGMessage parse_action
+
+        parse_action = self.prepared_stmts.get(stmt_name)
+        if parse_action is None:
+            raise pgerror.new(
+                pgerror.ERROR_INVALID_SQL_STATEMENT_NAME,
+                f"prepared statement \"{stmt_name}\" does not "
+                f"exist",
+            )
+
+        if stmt_name not in local_stmts:
+            # Non-local statement, so inject its Parse.
+            fe_settings = dbv.current_fe_settings()
+            qu = parse_action.query_unit
+            assert qu is not None
+            if parse_action.fe_settings != fe_settings:
+                # Some of the statically compiler-evaluated
+                # queries like `current_schema` depend on the
+                # fe_settings, we need to re-compile if the
+                # fe_settings have changed.
+                parse_action.invalidate()
+
+            if (
+                qu.execute is not None
+                and (
+                    qu.execute.be_stmt_name
+                    != self.sql_prepared_stmts_map.get(
+                        qu.execute.stmt_name).encode("utf-8")
+                )
+            ):
+                # Likewise, re-compile if this is an EXECUTE query
+                # and the translated name of the prepared statement
+                # has changed (e.g. due to it having been deallocated
+                # and prepared with a different query).
+                parse_action.invalidate()
+
+            if not parse_action.is_valid():
+                parse_actions, new_stmts = await self._reparse(
+                    stmt_name,
+                    parse_action,
+                    dbv,
+                )
+                local_stmts.update(new_stmts)
+                actions.extend(parse_actions)
+                parse_action = self.prepared_stmts[stmt_name]
+            else:
+                actions.append(parse_action.as_injected())
+                local_stmts.add(stmt_name)
+
+        return parse_action
+
+    async def _reparse(
+        self,
+        str stmt_name,
+        PGMessage parse_action,
+        ConnectionView dbv,
+    ):
+        actions = []
+        qu = parse_action.query_unit
+        assert qu is not None
+
+        if self.debug:
+            self.debug_print("reparsing", stmt_name, parse_action)
+
+        if (
+            qu.prepare is not None
+            or qu.execute is not None
+        ):
+            actions.extend(
+                await self._ensure_nested_ps_exists(
+                    dbv,
+                    qu,
+                    force_recompilation=True,
+                ),
+            )
+
+        outer_parse_action, new_stmts = await self._parse_statement(
+            stmt_name,
+            qu.orig_query,
+            parse_action.args[1],
+            dbv,
+            force_recompilation=True,
+            injected_action=True,
+        )
+
+        actions.append(outer_parse_action)
+
+        return actions, new_stmts
+
+    async def _ensure_nested_ps_exists(
+        self,
+        dbv: ConnectionView,
+        execute_unit: dbstate.SQLQueryUnit,
+        force_recompilation: bool = False,
+    ) -> list[PGMessage]:
+        cdef:
+            PGMessage sql_parse_action
+
+        exec_data = execute_unit.execute
+        prep_qu = self.sql_prepared_stmts.pop(exec_data.stmt_name, None)
+        actions = []
+
+        if prep_qu is None:
+            raise pgerror.new(
+                pgerror.ERROR_INVALID_SQL_STATEMENT_NAME,
+                f"prepared statement "
+                f"\"{exec_data.stmt_name}\" does not "
+                f"exist",
+            )
+
+        sql_parse_action, _ = await self._parse_statement(
+            prep_qu.stmt_name.decode("utf-8"),
+            prep_qu.orig_query,
+            b"\x00\x00",
+            dbv,
+            injected_action=True,
+            force_recompilation=force_recompilation,
+        )
+        actions.append(sql_parse_action)
+        parse_stmt_name = sql_parse_action.stmt_name
+        portal_name = parse_stmt_name.decode("utf-8")
+        parse_query_unit = sql_parse_action.query_unit
+        actions.append(
+            PGMessage(
+                PGAction.BIND,
+                portal_name=portal_name,
+                stmt_name=parse_stmt_name,
+                args=b"\x00\x01\x00\x01\x00\x00\x00\x00",
+                query_unit=parse_query_unit,
+                injected=True,
+            )
+        )
+        actions.append(
+            PGMessage(
+                PGAction.EXECUTE,
+                args=0,
+                portal_name=portal_name,
+                query_unit=parse_query_unit,
+                injected=True,
+            )
+        )
+        actions.append(
+            PGMessage(
+                PGAction.CLOSE_PORTAL,
+                portal_name=portal_name,
+                query_unit=parse_query_unit,
+                injected=True,
+            )
+        )
+        return actions
+
+    async def _parse_statement(
+        self,
+        stmt_name: str | None,
+        query_str: str,
+        parse_data: bytes,
+        dbv: ConnectionView,
+        force_recompilation: bool = False,
+        injected_action: bool = False,
+    ):
+        """Generate a PARSE action for *query_str*.
+
+        The *query_str* string must contain exactly one SQL statement.
+        """
+        stmts = set()
+
+        query_units = await self.compile(
+            query_str, dbv, ignore_cache=force_recompilation)
+        if len(query_units) > 1:
+            raise pgerror.new(
+                pgerror.ERROR_SYNTAX_ERROR,
+                "cannot insert multiple commands into a prepared "
+                "statement",
+            )
+
+        return await self._parse_unit(
+            stmt_name,
+            query_units[0],
+            parse_data,
+            dbv,
+            injected_action=injected_action,
+        )
+
+    async def _parse_unit(
+        self,
+        stmt_name: str | None,
+        unit: dbstate.SQLQueryUnit,
+        parse_data: bytes,
+        dbv: ConnectionView,
+        injected_action: bool = False,
+    ):
+        stmts = set()
+
+        fe_settings = dbv.current_fe_settings()
+        nested_ps_name = None
+        if unit.prepare is not None:
+            # Statement-level PREPARE
+            nested_ps_name = unit.prepare.stmt_name
+            unit = self._validate_prepare_stmt(unit)
+            stmts.add(nested_ps_name)
+            self.sql_prepared_stmts[nested_ps_name] = unit
+            self.sql_prepared_stmts_map[nested_ps_name] = (
+                unit.prepare.be_stmt_name.decode("utf-8"))
+        elif unit.execute is not None:
+            # Statement-level EXECUTE
+            nested_ps_name = unit.execute.stmt_name
+            unit = self._validate_execute_stmt(unit)
+        elif unit.deallocate is not None:
+            # Statement-level DEALLOCATE
+            nested_ps_name = unit.deallocate.stmt_name
+            unit = self._validate_deallocate_stmt(unit)
+
+        action = PGMessage(
+            PGAction.PARSE,
+            stmt_name=unit.stmt_name,
+            args=(unit.query.encode("utf-8"), parse_data),
+            query_unit=unit,
+            fe_settings=fe_settings,
+            injected=injected_action,
+        )
+
+        if stmt_name is not None and nested_ps_name is not None:
+            # This is a prepared statement of an operation on *another*
+            # prepared statement, and so we must track this relationship
+            # in case the nested prepared statement gets deallocated.
+            try:
+                self.wrapping_prepared_stmts[nested_ps_name].add(stmt_name)
+            except KeyError:
+                self.wrapping_prepared_stmts[nested_ps_name] = set([stmt_name])
+
+        if stmt_name is not None:
+            self.prepared_stmts[stmt_name] = action
+            stmts.add(stmt_name)
+
+        return action, stmts
+
+    async def compile(self, query_str, ConnectionView dbv, ignore_cache=False):
         if self.debug:
             self.debug_print("Compile", query_str)
         fe_settings = dbv.current_fe_settings()
         key = (hashlib.sha1(query_str.encode("utf-8")).digest(), fe_settings)
-        result = self.database.lookup_compiled_sql(key)
-        if result is not None:
-            return result
+        if not ignore_cache:
+            result = self.database.lookup_compiled_sql(key)
+            if result is not None:
+                return result
         compiler_pool = self.server.get_compiler_pool()
         result = await compiler_pool.compile_sql(
             self.dbname,
@@ -1068,6 +1401,7 @@ cdef class PgConnection(frontend.FrontendConnection):
             self.database._index.get_compilation_system_config(),
             query_str,
             dbv.fe_transaction_state(),
+            self.sql_prepared_stmts_map,
             self.dbname,
             self.username,
         )
@@ -1075,6 +1409,44 @@ cdef class PgConnection(frontend.FrontendConnection):
         if self.debug:
             self.debug_print("Compile result", result)
         return result
+
+    def _validate_prepare_stmt(self, qu):
+        assert qu.prepare is not None
+        stmt_name = qu.prepare.stmt_name
+        if (
+            stmt_name in self.prepared_stmts
+            or stmt_name in self.sql_prepared_stmts
+        ):
+            raise pgerror.new(
+                pgerror.ERROR_DUPLICATE_PREPARED_STATEMENT,
+                f"prepared statement \"{stmt_name}\" "
+                f"already exists",
+            )
+        return qu
+
+    def _validate_execute_stmt(self, qu):
+        assert qu.execute is not None
+        stmt_name = qu.execute.stmt_name
+        sql_ps = self.sql_prepared_stmts.get(stmt_name)
+        if sql_ps is None:
+            raise pgerror.new(
+                pgerror.ERROR_INVALID_SQL_STATEMENT_NAME,
+                f"prepared statement \"{stmt_name}\" does "
+                f"not exist",
+            )
+        return qu
+
+    def _validate_deallocate_stmt(self, qu):
+        assert qu.deallocate is not None
+        stmt_name = qu.deallocate.stmt_name
+        sql_ps = self.sql_prepared_stmts.get(stmt_name)
+        if sql_ps is None:
+            raise pgerror.new(
+                pgerror.ERROR_INVALID_SQL_STATEMENT_NAME,
+                f"prepared statement \"{stmt_name}\" does "
+                f"not exist",
+            )
+        return qu
 
 
 def new_pg_connection(server, sslctx, endpoint_security):

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -302,6 +302,9 @@ class Server(ha_base.ClusterProtocol):
 
             await asyncio.sleep(30)
 
+    def get_server_id(self):
+        return self._server_id
+
     def get_listen_hosts(self):
         return self._listen_hosts
 

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -841,7 +841,6 @@ class TestEdgeQLSelect(tb.BaseDocTest):
         EXECUTE fooplan(1, 'Hunter Valley', 't', 200.00)
         """
 
-    @test.xerror("unsupported")
     def test_sql_parse_query_11(self):
         """
         DEALLOCATE a123


### PR DESCRIPTION
This adds support for `PREPARE`, `EXECUTE` and `DEALLOCATE` at SQL
level.  There is a fair bit of cleanup as well, removing unnecessary
duplication in the form of `sql_simple_query` as we translate client
simple query requests to extended query requests anyway.
