### PR TITLE
Bump `max_pred_locks_per_transaction` to 1024

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -443,6 +443,7 @@ class Cluster(BaseCluster):
             # inheritance hierarchies.  This is especially important in low
             # `max_connections` scenarios.
             'max_locks_per_transaction': 1024,
+            'max_pred_locks_per_transaction': 1024,
         }
 
         if os.getenv('EDGEDB_DEBUG_PGSERVER'):


### PR DESCRIPTION
In #5636 we bumped `max_locks_per_transaction`.  Do the same for
`max_pred_locks_per_transaction` since EdgeDB uses `serializable`
transaction isolation by default.

Needs backporting to 3.x.
