### PR TITLE
Do not lose constraint errmessage when a constraint is ALTERed

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -766,13 +766,6 @@ class ConstraintCommand(
                 attrs['subjectexpr'] = base_subjectexpr
                 inherited['subjectexpr'] = True
 
-        errmessage = attrs.get('errmessage')
-        if not errmessage:
-            errmessage = constr_base.get_errmessage(schema)
-            inherited['errmessage'] = True
-
-        attrs['errmessage'] = errmessage
-
         if subject is not orig_subject:
             # subject has been redefined
             assert isinstance(subject, qlast.Base)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6426,6 +6426,38 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+    def test_schema_migrations_equivalence_constraint_11(self):
+        self._assert_migration_equivalence([r"""
+            type Foo {
+              required property name -> str {
+                constraint max_len_value(200) {
+                  errmessage := "name is too long";
+                }
+              }
+              constraint exclusive on (.name) {
+                errmessage := "exclusivity!";
+              }
+            }
+        """, r"""
+            type Foo {
+              required property name -> str {
+                constraint max_len_value(201) {
+                  errmessage := "name is too long";
+                }
+              }
+              constraint exclusive on (.name) {
+                errmessage := "exclusivity!";
+              }
+            }
+        """, r"""
+            type Foo {
+              required property name -> str;
+              constraint exclusive on (.name) {
+                errmessage := "exclusivity!";
+              }
+            }
+        """])
+
     def test_schema_migrations_equivalence_policies_01(self):
         self._assert_migration_equivalence([r"""
             type X {


### PR DESCRIPTION
The worst part here was that this could occur when the constraint
was altered *implicitly* by _propagate_if_expr_refs because a
pointer that it used was modified.