### PR TITLE
Avoid very slow error formatting in non-error cases

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -830,7 +830,14 @@ def resolve_ptr_with_intersections(
 
     err = errors.InvalidReferenceError(msg, context=source_context)
 
-    if direction is s_pointers.PointerDirection.Outbound:
+    if (
+        direction is s_pointers.PointerDirection.Outbound
+        # In some call sites, we call resolve_ptr "experimentally",
+        # not tracking references and swallowing failures. Don't do an
+        # expensive (30% of compilation time in some benchmarks!)
+        # error enrichment for cases that won't really error.
+        and track_ref is not False
+    ):
         s_utils.enrich_schema_lookup_error(
             err,
             s_name.UnqualName(pointer_name),


### PR DESCRIPTION
When resolve_ptr fails, it does a very slow error enrichment step that
computes levenshtein distances with a ton of different schema
objects. This is fine for actual error cases, but resolve_ptr gets
called in some call sites that swallow the error.

Skip doing the formatting in those cases. This gave a 30% speedup on
some queries.

I did this by checking the `track_ref` variable, since the only cases
where it makes sense to not track references is when we aren't serious
about the lookup, and because adding another param seemed
clunky. Maybe we should just add another, though.