### PR TITLE
Move Typescript-related comment into own block

### DIFF
--- a/docs/datamodel/globals.rst
+++ b/docs/datamodel/globals.rst
@@ -44,7 +44,9 @@ which client library you're using.
 
     import createClient from 'edgedb';
 
-    const baseClient = createClient()
+    const baseClient = createClient();
+    // returns a new Client instance that stores the provided 
+    // globals and sends them along with all future queries:
     const clientWithGlobals = baseClient.withGlobals({
       current_user_id: '2141a5b4-5634-4ccc-b835-437863534c51',
     });
@@ -104,9 +106,6 @@ which client library you're using.
 
     set global current_user_id := <uuid>'2141a5b4-5634-4ccc-b835-437863534c51';
 
-
-The ``.withGlobals/.with_globals`` method returns a new ``Client`` instance
-that stores the provided globals and sends them along with all future queries.
 
 Cardinality
 -----------


### PR DESCRIPTION
Quick doc fix for this page:

https://www.edgedb.com/docs/datamodel/globals

At the moment it contains a line that applies only to Typescript that shows up no matter which language sample is selected:

```The .withGlobals/.with_globals method returns a new Client instance that stores the provided globals and sends them along with all future queries.```

Easiest fix is probably just to turn it to a doc comment inside the Typescript code sample.