### PR TITLE
Properly track implicit dependance on `__type__` in function calls

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -837,8 +837,9 @@ def finalize_args(
             ):
                 arg_type_path_id = pathctx.extend_path_id(
                     arg.path_id,
-                    ptrcls=arg_type.getptr(
-                        ctx.env.schema, sn.UnqualName('__type__')),
+                    ptrcls=setgen.resolve_ptr(
+                        arg_type, '__type__', track_ref=None, ctx=ctx
+                    ),
                     ctx=ctx,
                 )
         else:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8080,6 +8080,49 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             """,
         ])
 
+    def test_schema_migrations_implicit_type_01(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type Pinnable {
+                    property pinned := __source__ in <Pinnable>{};
+                }
+            """,
+            r"""
+                abstract type Pinnable {
+                    property pinned := __source__ in <Pinnable>{};
+                }
+                type Foo extending Pinnable {}
+            """,
+        ])
+
+    def test_schema_migrations_implicit_type_02(self):
+        self._assert_migration_equivalence([
+            r"""
+                abstract type Person {
+                    multi link friends : Person{
+                        constraint expression on (
+                                __subject__ != __subject__@source
+                            );
+                    };
+
+                }
+            """,
+            r"""
+                abstract type Person {
+                    multi link friends : Person{
+                        constraint expression on (
+                                __subject__ != __subject__@source
+                            );
+                    };
+
+                }
+
+                type Employee extending Person{
+                    department: str;
+                }
+            """,
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -879,7 +879,11 @@ class TestSQL(tb.SQLQueryTestCase):
             "Movie", output=out, format="csv", delimiter="\t"
         )
         out = io.StringIO(out.getvalue().decode("utf-8"))
-        names = set(row[6] for row in csv.reader(out, delimiter="\t"))
+        # FIXME(#5716): Once COPY and information_schema are
+        # harmonized to agree on the order of columns, we should query
+        # information_schema to get the column number instead of
+        # hardcoding it.
+        names = set(row[7] for row in csv.reader(out, delimiter="\t"))
         self.assertEqual(names, {"Forrest Gump", "Saving Private Ryan"})
 
     async def test_sql_query_error_01(self):


### PR DESCRIPTION
When passing objects to functions, there is an implicit dependence on
the `__type__` field (which may be used for function overloading).
This dependence isn't tracked, so in inheritance cases a computed
that depends on it may be processed before `__type__` is inherited.

Fix this by making sure to get `__type__` through proper channels.

Fixes #5661.

In addition to actually fixing it, I added a hack that will make
`__type__` always be processed first, to work around not easily being
able to repair the expr refs in existing databases. We can drop the hack
on our dev branch immediately, though.
(I tested this flow manually.)