### PR TITLE
Remove a hack only necessary on our stable branches

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -226,17 +226,6 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                     for v in sd.sort_by_cross_refs(schema, base_refs.values())
                 }
 
-                # HACK: Because of issue #5661, we previously did not always
-                # properly discover dependencies on __type__ in computeds.
-                # This was fixed, but it may persist in existing databases.
-                # Currently, expr refs are not compared when diffing schemas,
-                # so a schema repair can't fix this. Thus, in addition to
-                # actually fixing the bug, we hack around it by forcing
-                # __type__ to sort to the front.
-                # TODO: Drop this after cherry-picking.
-                if (tname := sn.UnqualName('__type__')) in base_refs:
-                    base_refs[tname] = base_refs.pop(tname)
-
             for k, v in reversed(base_refs.items()):
                 if not v.should_propagate(schema):
                     continue

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -883,7 +883,7 @@ class TestSQL(tb.SQLQueryTestCase):
         # harmonized to agree on the order of columns, we should query
         # information_schema to get the column number instead of
         # hardcoding it.
-        names = set(row[7] for row in csv.reader(out, delimiter="\t"))
+        names = set(row[6] for row in csv.reader(out, delimiter="\t"))
         self.assertEqual(names, {"Forrest Gump", "Saving Private Ryan"})
 
     async def test_sql_query_error_01(self):


### PR DESCRIPTION
Remove a hack from #5715 that made the fix work on databases
created prior to the fix.