### PR TITLE
Fix tuple derefencing and top-level casting in exclusive constraints

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -807,7 +807,7 @@ class RecordIndirectionOp(ImmutableBase):
     name: str
 
 
-IndirectionOp = Slice | Index | ColumnRef | Star | RecordIndirectionOp
+IndirectionOp = Slice | Index | Star | RecordIndirectionOp
 
 
 class Indirection(ImmutableBaseExpr):

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -935,13 +935,13 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         self, node: pgast.RecordIndirectionOp
     ) -> None:
         self.write('.')
-        self.write(node.name)
+        self.write(common.qname(node.name))
 
     def _visit_indirection_ops(
         self, ops: Sequence[pgast.IndirectionOp]
     ) -> None:
         for op in ops:
-            if isinstance(op, (pgast.Star, pgast.ColumnRef)):
+            if isinstance(op, pgast.Star):
                 self.write('.')
             self.visit(op)
 

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -87,11 +87,7 @@ def tuple_getattr(
     if irtyputils.is_persistent_tuple(tuple_typeref):
         set_expr = pgast.Indirection(
             arg=tuple_val,
-            indirection=[
-                pgast.ColumnRef(
-                    name=[attr],
-                ),
-            ],
+            indirection=[pgast.RecordIndirectionOp(name=attr)],
         )
     else:
         set_expr = pgast.SelectStmt(

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -266,11 +266,7 @@ def unnamed_tuple_as_json_object(
         for el_idx, el_type in enumerate(styperef.subtypes):
             val: pgast.BaseExpr = pgast.Indirection(
                 arg=expr,
-                indirection=[
-                    pgast.ColumnRef(
-                        name=[str(el_idx)],
-                    ),
-                ],
+                indirection=[pgast.RecordIndirectionOp(name=str(el_idx))],
             )
             val = serialize_expr_to_json(
                 val, styperef=el_type, nested=True, env=env)
@@ -359,8 +355,8 @@ def named_tuple_as_json_object(
             val: pgast.BaseExpr = pgast.Indirection(
                 arg=expr,
                 indirection=[
-                    pgast.ColumnRef(
-                        name=[el_type.element_name]
+                    pgast.RecordIndirectionOp(
+                        name=el_type.element_name
                     )
                 ]
             )


### PR DESCRIPTION
Previously we generated invalid SQL, for two reasons:
 * "Complex" expressions (including the way we emit tuple
   dereference and casting) need to be parenthesized in
   the code we emit to create an EXCLUDE constraint.
 * We were representing the RHS of a tuple dereference
   as a ColumnRef, which got picked up by our system for
   injecting NEW and OLD into trigger expressions,
   which led to us generating bogus expressions like
   (NEW."<some uuid>").NEW."0".

More aggressively parenthesize in constraints, and stop
inappropriately using ColumnRef and use RecordIndirectionOp instead.
(I suspect that when the ast was designed, we used ColumnRef there
as a hack to avoid the bother of adding a pretty marginal
RecordIndirectionOp, which seems to have been added as part of SQL
support, when added all the postgres AST nodes we had skipped).