### PR TITLE
Add support for `offline` readiness state

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -148,7 +148,7 @@
 0x_08_00_00_00   AvailabilityError
 
 0x_08_00_00_01   BackendUnavailableError  #SHOULD_RETRY
-
+0x_08_00_00_02   ServerOfflineError
 
 ####
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -89,6 +89,7 @@ __all__ = base.__all__ + (  # type: ignore
     'AuthenticationError',
     'AvailabilityError',
     'BackendUnavailableError',
+    'ServerOfflineError',
     'BackendError',
     'UnsupportedBackendFeatureError',
     'LogMessage',
@@ -414,6 +415,10 @@ class AvailabilityError(EdgeDBError):
 
 class BackendUnavailableError(AvailabilityError):
     _code = 0x_08_00_00_01
+
+
+class ServerOfflineError(AvailabilityError):
+    _code = 0x_08_00_00_02
 
 
 class BackendError(EdgeDBError):

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -93,8 +93,17 @@ class JOSEKeyMode(enum.StrEnum):
 class ReadinessState(enum.StrEnum):
 
     Default = "default"
+    """Default state: serving normally"""
+
     NotReady = "not_ready"
+    """/server/status/ready returns an error, but clients can still connect."""
+
     ReadOnly = "read_only"
+    """Only read-only queries are allowed."""
+
+    Offline = "offline"
+    """Any existing connections are gracefully terminated and no new
+    connections are allowed."""
 
 
 class ServerAuthMethod(enum.StrEnum):

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1093,6 +1093,12 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             self.write_error(ex)
             self.flush()
 
+            if isinstance(ex, errors.ServerOfflineError):
+                # This server is going into "offline" mode,
+                # close the connection.
+                self.close()
+                return
+
             # The connection was aborted while we were
             # interpreting the error (via compiler/errmech.py).
             if self._con_status == EDGECON_BAD:

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -774,6 +774,12 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
                     self.write_error(ex)
                     self.flush()
 
+                    if isinstance(ex, errors.ServerOfflineError):
+                        # This server is going into "offline" mode,
+                        # close the connection.
+                        self.close()
+                        return
+
                     # The connection was aborted while we were
                     # interpreting the error (via compiler/errmech.py).
                     if self._con_status == EDGECON_BAD:

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -281,6 +281,7 @@ class Server(ha_base.ClusterProtocol):
         self._admin_ui = admin_ui
 
         self._readiness = srvargs.ReadinessState.Default
+        self._readiness_reason = ""
 
         # A set of databases that should not accept new connections.
         self._block_new_connections: set[str] = set()
@@ -332,11 +333,20 @@ class Server(ha_base.ClusterProtocol):
     def is_admin_ui_enabled(self):
         return self._admin_ui
 
+    def is_online(self) -> bool:
+        return self._readiness is not srvargs.ReadinessState.Offline
+
     def is_ready(self) -> bool:
-        return self._readiness is srvargs.ReadinessState.Default
+        return (
+            self._readiness is srvargs.ReadinessState.Default
+            or self._readiness is srvargs.ReadinessState.ReadOnly
+        )
 
     def is_readonly(self) -> bool:
         return self._readiness is srvargs.ReadinessState.ReadOnly
+
+    def get_readiness_reason(self) -> str:
+        return self._readiness_reason
 
     def get_pg_dbname(self, dbname: str) -> str:
         return self._cluster.get_db_name(dbname)
@@ -1991,13 +2001,16 @@ class Server(ha_base.ClusterProtocol):
     def reload_readiness_state(self, state_file):
         try:
             with open(state_file, 'rt') as rt:
-                state = rt.readline().strip()
+                line = rt.readline().strip()
                 try:
+                    state, _, reason = line.partition(":")
                     self._readiness = srvargs.ReadinessState(state)
+                    self._readiness_reason = reason
                     logger.info(
                         "readiness state file changed, "
-                        "setting server readiness to %r",
+                        "setting server readiness to %r%s",
                         state,
+                        f" ({reason})" if reason else "",
                     )
                 except ValueError:
                     logger.warning(
@@ -2024,6 +2037,8 @@ class Server(ha_base.ClusterProtocol):
                 e,
             )
             self._readiness = srvargs.ReadinessState.Default
+
+        self._accepting_connections = self.is_online()
 
     def reload_tls(self, tls_cert_file, tls_key_file):
         logger.info("loading TLS certificates")


### PR DESCRIPTION
Unlike `not_ready`, the `offline` state will drop existing connections
and refuse to accept new ones.  This is useful for whenever there is a
switchover in an HA or upgrade scenario that requires the old instance
to stop serving.
