### PR TITLE
Increase bootstrap timeout on ensure_database_not_connected

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -2140,10 +2140,14 @@ async def _bootstrap(ctx: BootstrapContext) -> None:
             # and wait until it goes away on the server side
             # so that we can safely use the template for new
             # databases.
+            #
+            # The timeout is set weirdly high, because we were getting
+            # frequent timeouts in macos-x86_64 release builds when it
+            # was set to 10s.
             conn.terminate()
             rloop = retryloop.RetryLoop(
                 backoff=retryloop.exp_backoff(),
-                timeout=10.0,
+                timeout=60.0,
                 ignore=errors.ExecutionError,
             )
 


### PR DESCRIPTION
This was timing out in release builds when trying to release 3.0.
I landed it directly on stable/3.x during the 3.0 release and am
now reverse cherry-picking it.