### PR TITLE
Move Elixir client link to official bindings

### DIFF
--- a/docs/clients/index.rst
+++ b/docs/clients/index.rst
@@ -14,10 +14,7 @@ Client Libraries
 * `Rust <rust/index>`_
 * `.NET <dotnet/index>`_
 * `Java <java/index>`_
-
-**Community-Maintained Clients**
-
-* `Elixir <https://github.com/nsidnev/edgedb-elixir>`_
+* `Elixir <https://github.com/edgedb/edgedb-elixir>`_
 
 **HTTP Protocols**
 


### PR DESCRIPTION
For now, I've updated the URL to the repo under the `edgedb` org. If and when we bring the Elixir documentation onto the site, we can update it to point to that.