### PR TITLE
Avoid leaking database existence information to unauthenticated users

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -278,6 +278,11 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         logger.debug('received connection request by %s to database %s',
                      user, database)
 
+        await self._authenticate(user, params)
+
+        logger.debug('successfully authenticated %s in database %s',
+                     user, database)
+
         if not self.server.is_database_connectable(database):
             raise errors.AccessError(
                 f'database {database!r} does not accept connections'
@@ -285,7 +290,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         await self._start_connection(database)
 
-        await self._authenticate(user, database, params)
+        self.dbname = database
+        self.username = user
 
         if self._transport_proto is srvargs.ServerConnTransport.HTTP:
             return

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -516,9 +516,7 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         if user not in roles:
             raise errors.AuthenticationError('authentication failed')
 
-    async def _authenticate(self, user, database, params):
-        self.dbname = database
-
+    async def _authenticate(self, user, params):
         # The user has already been authenticated by other means
         # (such as the ability to write to a protected socket).
         if self._external_auth:
@@ -537,10 +535,6 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         else:
             raise errors.InternalServerError(
                 f'unimplemented auth method: {authmethod_name}')
-
-        self.username = user
-        logger.debug('successfully authenticated %s in database %s',
-                     user, database)
 
     cdef WriteBuffer _make_authentication_sasl_initial(self, list methods):
         raise NotImplementedError

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -633,6 +633,11 @@ cdef class PgConnection(frontend.FrontendConnection):
         logger.debug('received pg connection request by %s to database %s',
                      user, database)
 
+        await self._authenticate(user, params)
+
+        logger.debug('successfully authenticated %s in database %s',
+                     user, database)
+
         if not self.server.is_database_connectable(database):
             raise pgerror.InvalidAuthSpec(
                 f'database {database!r} does not accept connections',
@@ -642,7 +647,8 @@ cdef class PgConnection(frontend.FrontendConnection):
         self.database = self.server.get_db(dbname=database)
         await self.database.introspection()
 
-        await self._authenticate(user, database, params)
+        self.dbname = database
+        self.username = user
 
         buf = WriteBuffer()
 


### PR DESCRIPTION
Currently, when an unauthenticated user attempts to connect to a
non-existent database, we raise an `UnknownDatabaseError` instead of
`AuthenticationError`.  Make sure we don't do that by moving auth a bit
earlier.
