### PR TITLE
Respect `cfg::` annotations on object configuration

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1847,9 +1847,14 @@ def _compile_ql_config_op(ctx: CompileContext, ql: qlast.Base):
             for glob in ir.globals
         ]
 
-    is_backend_setting = bool(getattr(ir, 'backend_setting', None))
-    requires_restart = bool(getattr(ir, 'requires_restart', False))
-    is_system_config = bool(getattr(ir, 'is_system_config', False))
+    if isinstance(ir, irast.Statement):
+        cfg_ir = ir.expr.expr
+    else:
+        cfg_ir = ir
+
+    is_backend_setting = bool(getattr(cfg_ir, 'backend_setting', None))
+    requires_restart = bool(getattr(cfg_ir, 'requires_restart', False))
+    is_system_config = bool(getattr(cfg_ir, 'is_system_config', False))
 
     sql_res = pg_compiler.compile_ir_to_sql_tree(
         ir,

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1454,7 +1454,7 @@ class Server(ha_base.ClusterProtocol):
     def before_alter_system_config(self):
         if self._disable_dynamic_system_config:
             raise errors.ConfigurationError(
-                "Changing the value of system config is disabled"
+                "cannot change this configuration value in this instance"
             )
 
     async def _after_system_config_add(self, setting_name, value):

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1917,7 +1917,7 @@ class TestDynamicSystemConfig(tb.TestCase):
                 ''')
 
                 with self.assertRaisesRegex(
-                    edgedb.ConfigurationError, "disabled"
+                    edgedb.ConfigurationError, "cannot change"
                 ):
                     await conn.query(f'''
                         CONFIGURE INSTANCE


### PR DESCRIPTION
Currently, `CONFIGURE INSTANCE INSERT` would improperly ignore the
annotations.
