### PR TITLE
Bump httptools to 0.6.0 to include upstream fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dynamic = ["entry-points", "version"]
 dependencies = [
     'edgedb==1.3.0',
 
-    'httptools>=0.3.0',
+    'httptools>=0.6.0',
     'immutables>=0.18',
     'parsing~=2.0',
     'uvloop~=0.17.0',


### PR DESCRIPTION
(even though the future EdgeDB builds shall pick up httptools 0.6 automatically, but let's bump it anyways to be sure)