### PR TITLE
Inlining CST nodes

### DIFF
--- a/edb/edgeql/parser/grammar/block.py
+++ b/edb/edgeql/parser/grammar/block.py
@@ -31,21 +31,25 @@ from .config import *  # NOQA
 
 
 class SingleStatement(Nonterm):
-    def reduce_Stmt(self, stmt):
+    @parsing.inline(0)
+    def reduce_Stmt(self, _):
         # Expressions
-        self.val = stmt.val
+        pass
 
-    def reduce_DDLStmt(self, stmt):
+    @parsing.inline(0)
+    def reduce_DDLStmt(self, _):
         # Data definition commands
-        self.val = stmt.val
+        pass
 
-    def reduce_SessionStmt(self, stmt):
+    @parsing.inline(0)
+    def reduce_SessionStmt(self, _):
         # Session-local utility commands
-        self.val = stmt.val
+        pass
 
-    def reduce_ConfigStmt(self, stmt):
+    @parsing.inline(0)
+    def reduce_ConfigStmt(self, _):
         # Configuration commands
-        self.val = stmt.val
+        pass
 
 
 class StatementBlock(parsing.ListNonterm, element=SingleStatement,
@@ -56,8 +60,9 @@ class StatementBlock(parsing.ListNonterm, element=SingleStatement,
 class EdgeQLBlock(Nonterm):
     "%start"
 
-    def reduce_StatementBlock_OptSemicolons_EOF(self, block, _semicolon, _eof):
-        self.val = block.val
+    @parsing.inline(0)
+    def reduce_StatementBlock_OptSemicolons_EOF(self, _, _semicolon, _eof):
+        pass
 
     def reduce_OptSemicolons_EOF(self, _semicolon, _eof):
         self.val = []

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -23,6 +23,7 @@ import sys
 import types
 import typing
 
+
 from edb.errors import EdgeQLSyntaxError
 
 from edb.edgeql import ast as qlast
@@ -111,42 +112,49 @@ class NewNontermHelper:
 
 class Semicolons(Nonterm):
     # one or more semicolons
+    @parsing.inline(0)
     def reduce_SEMICOLON(self, tok):
-        self.val = tok
+        pass
 
-    def reduce_Semicolons_SEMICOLON(self, semicolons, _):
-        self.val = semicolons.val
+    @parsing.inline(0)
+    def reduce_Semicolons_SEMICOLON(self, semicolons, semicolon):
+        pass
 
 
 class OptSemicolons(Nonterm):
+    @parsing.inline(0)
     def reduce_Semicolons(self, semicolons):
-        self.val = semicolons.val
+        pass
 
     def reduce_empty(self):
         self.val = None
 
 
 class ExtendingSimple(Nonterm):
+    @parsing.inline(1)
     def reduce_EXTENDING_SimpleTypeNameList(self, _, list):
-        self.val = list.val
+        pass
 
 
 class OptExtendingSimple(Nonterm):
+    @parsing.inline(0)
     def reduce_ExtendingSimple(self, extending):
-        self.val = extending.val
+        pass
 
     def reduce_empty(self):
         self.val = []
 
 
 class Extending(Nonterm):
+    @parsing.inline(1)
     def reduce_EXTENDING_TypeNameList(self, _, list):
-        self.val = list.val
+        pass
 
 
 class OptExtending(Nonterm):
+    @parsing.inline(0)
     def reduce_Extending(self, extending):
-        self.val = extending.val
+        pass
 
     def reduce_empty(self):
         self.val = []
@@ -161,37 +169,42 @@ class OnExpr(Nonterm):
     # NOTE: the reason why we need parentheses around the expression
     # is to disambiguate whether the '{' following the expression is
     # meant to be a shape or a nested DDL/SDL block.
+    @parsing.inline(1)
     def reduce_ON_ParenExpr(self, _, expr):
-        self.val = expr.val
+        pass
 
 
 class OptOnExpr(Nonterm):
     def reduce_empty(self):
         self.val = None
 
+    @parsing.inline(0)
     def reduce_OnExpr(self, expr):
-        self.val = expr.val
+        pass
 
 
 class OptOnTypeExpr(Nonterm):
     def reduce_empty(self):
         self.val = None
 
+    @parsing.inline(1)
     def reduce_ON_FullTypeExpr(self, _, expr):
-        self.val = expr.val
+        pass
 
 
 class OptExceptExpr(Nonterm):
     def reduce_empty(self):
         self.val = None
 
+    @parsing.inline(1)
     def reduce_EXCEPT_ParenExpr(self, _, expr):
-        self.val = expr.val
+        pass
 
 
 class OptConcreteConstraintArgList(Nonterm):
+    @parsing.inline(1)
     def reduce_LPAREN_OptPosCallArgList_RPAREN(self, _lparen, list, _rparen):
-        self.val = list.val
+        pass
 
     def reduce_empty(self):
         self.val = []
@@ -201,8 +214,9 @@ class OptDefault(Nonterm):
     def reduce_empty(self):
         self.val = None
 
+    @parsing.inline(1)
     def reduce_EQUALS_Expr(self, _, expr):
-        self.val = expr.val
+        pass
 
 
 class ParameterKind(Nonterm):
@@ -217,8 +231,9 @@ class OptParameterKind(Nonterm):
     def reduce_empty(self):
         self.val = qltypes.ParameterKind.PositionalParam
 
+    @parsing.inline(0)
     def reduce_ParameterKind(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class FuncDeclArgName(Nonterm):
@@ -266,11 +281,13 @@ class FuncDeclArgList(parsing.ListNonterm, element=FuncDeclArg,
 
 
 class FuncDeclArgs(Nonterm):
+    @parsing.inline(0)
     def reduce_FuncDeclArgList_COMMA(self, list, _):
-        self.val = list.val
+        pass
 
+    @parsing.inline(0)
     def reduce_FuncDeclArgList(self, list):
-        self.val = list.val
+        pass
 
 
 class ProcessFunctionParamsMixin:
@@ -362,8 +379,9 @@ class OptTypeQualifier(Nonterm):
 
 
 class FunctionType(Nonterm):
+    @parsing.inline(0)
     def reduce_FullTypeExpr(self, expr):
-        self.val = expr.val
+        pass
 
 
 class FromFunction(Nonterm):
@@ -515,16 +533,18 @@ class OnSourceDeleteStmt(Nonterm):
 
 
 class OptWhenBlock(Nonterm):
+    @parsing.inline(1)
     def reduce_WHEN_ParenExpr(self, _, expr):
-        self.val = expr.val
+        pass
 
     def reduce_empty(self):
         self.val = None
 
 
 class OptUsingBlock(Nonterm):
+    @parsing.inline(1)
     def reduce_USING_ParenExpr(self, _, expr):
-        self.val = expr.val
+        pass
 
     def reduce_empty(self):
         self.val = None
@@ -633,8 +653,9 @@ class ExtensionVersion(Nonterm):
 
 class OptExtensionVersion(Nonterm):
 
+    @parsing.inline(0)
     def reduce_ExtensionVersion(self, version):
-        self.val = version.val
+        pass
 
     def reduce_empty(self):
         self.val = None
@@ -685,11 +706,13 @@ class IndexArgList(parsing.ListNonterm, element=IndexArg,
 
 
 class OptIndexArgList(Nonterm):
+    @parsing.inline(0)
     def reduce_IndexArgList_COMMA(self, list, _):
-        self.val = list.val
+        pass
 
+    @parsing.inline(0)
     def reduce_IndexArgList(self, list):
-        self.val = list.val
+        pass
 
     def reduce_empty(self):
         self.val = []
@@ -697,14 +720,16 @@ class OptIndexArgList(Nonterm):
 
 class IndexExtArgList(Nonterm):
 
-    def reduce_LPAREN_OptIndexArgList_RPAREN(self, _l, list, _r):
-        self.val = list.val
+    @parsing.inline(1)
+    def reduce_LPAREN_OptIndexArgList_RPAREN(self, *_):
+        pass
 
 
 class OptIndexExtArgList(Nonterm):
 
+    @parsing.inline(0)
     def reduce_IndexExtArgList(self, list):
-        self.val = list.val
+        pass
 
     def reduce_empty(self):
         self.val = []
@@ -784,8 +809,9 @@ class IndexTypeList(parsing.ListNonterm, element=IndexType,
 
 class OptIndexTypeList(Nonterm):
 
+    @parsing.inline(1)
     def reduce_USING_IndexTypeList(self, _, list):
-        self.val = list.val
+        pass
 
     def reduce_empty(self):
         self.val = []

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -53,25 +53,31 @@ _new_nonterm = sdl_nontem_helper._new_nonterm
 
 class DDLStmt(Nonterm):
 
-    def reduce_DatabaseStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DatabaseStmt(self, *_):
+        pass
 
-    def reduce_RoleStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_RoleStmt(self, *_):
+        pass
 
-    def reduce_ExtensionPackageStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_ExtensionPackageStmt(self, *_):
+        pass
 
-    def reduce_OptWithDDLStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_OptWithDDLStmt(self, *_):
+        pass
 
-    def reduce_MigrationStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_MigrationStmt(self, *_):
+        pass
 
 
 class DDLWithBlock(Nonterm):
-    def reduce_WithBlock(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_WithBlock(self, *_):
+        pass
 
 
 class OptWithDDLStmt(Nonterm):
@@ -79,142 +85,186 @@ class OptWithDDLStmt(Nonterm):
         self.val = kids[1].val
         self.val.aliases = kids[0].val.aliases
 
-    def reduce_WithDDLStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_WithDDLStmt(self, *_):
+        pass
 
 
 class WithDDLStmt(Nonterm):
-    def reduce_InnerDDLStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_InnerDDLStmt(self, *_):
+        pass
 
 
 class InnerDDLStmt(Nonterm):
 
-    def reduce_CreatePseudoTypeStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreatePseudoTypeStmt(self, *_):
+        pass
 
-    def reduce_CreateScalarTypeStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateScalarTypeStmt(self, *_):
+        pass
 
-    def reduce_AlterScalarTypeStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterScalarTypeStmt(self, *_):
+        pass
 
-    def reduce_DropScalarTypeStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropScalarTypeStmt(self, *_):
+        pass
 
-    def reduce_CreateAnnotationStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateAnnotationStmt(self, *_):
+        pass
 
-    def reduce_AlterAnnotationStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterAnnotationStmt(self, *_):
+        pass
 
-    def reduce_DropAnnotationStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropAnnotationStmt(self, *_):
+        pass
 
-    def reduce_CreateObjectTypeStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateObjectTypeStmt(self, *_):
+        pass
 
-    def reduce_AlterObjectTypeStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterObjectTypeStmt(self, *_):
+        pass
 
-    def reduce_DropObjectTypeStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropObjectTypeStmt(self, *_):
+        pass
 
-    def reduce_CreateAliasStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateAliasStmt(self, *_):
+        pass
 
-    def reduce_AlterAliasStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterAliasStmt(self, *_):
+        pass
 
-    def reduce_DropAliasStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropAliasStmt(self, *_):
+        pass
 
-    def reduce_CreateConstraintStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateConstraintStmt(self, *_):
+        pass
 
-    def reduce_AlterConstraintStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterConstraintStmt(self, *_):
+        pass
 
-    def reduce_DropConstraintStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropConstraintStmt(self, *_):
+        pass
 
-    def reduce_CreateLinkStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateLinkStmt(self, *_):
+        pass
 
-    def reduce_AlterLinkStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterLinkStmt(self, *_):
+        pass
 
-    def reduce_DropLinkStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropLinkStmt(self, *_):
+        pass
 
-    def reduce_CreatePropertyStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreatePropertyStmt(self, *_):
+        pass
 
-    def reduce_AlterPropertyStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterPropertyStmt(self, *_):
+        pass
 
-    def reduce_DropPropertyStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropPropertyStmt(self, *_):
+        pass
 
-    def reduce_CreateModuleStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateModuleStmt(self, *_):
+        pass
 
-    def reduce_AlterModuleStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterModuleStmt(self, *_):
+        pass
 
-    def reduce_DropModuleStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropModuleStmt(self, *_):
+        pass
 
-    def reduce_CreateFunctionStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateFunctionStmt(self, *_):
+        pass
 
-    def reduce_AlterFunctionStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterFunctionStmt(self, *_):
+        pass
 
-    def reduce_DropFunctionStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropFunctionStmt(self, *_):
+        pass
 
-    def reduce_CreateOperatorStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateOperatorStmt(self, *_):
+        pass
 
-    def reduce_AlterOperatorStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterOperatorStmt(self, *_):
+        pass
 
-    def reduce_DropOperatorStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropOperatorStmt(self, *_):
+        pass
 
-    def reduce_CreateCastStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateCastStmt(self, *_):
+        pass
 
-    def reduce_AlterCastStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterCastStmt(self, *_):
+        pass
 
-    def reduce_CreateGlobalStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateGlobalStmt(self, *_):
+        pass
 
-    def reduce_AlterGlobalStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterGlobalStmt(self, *_):
+        pass
 
-    def reduce_DropGlobalStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropGlobalStmt(self, *_):
+        pass
 
-    def reduce_DropCastStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropCastStmt(self, *_):
+        pass
 
-    def reduce_ExtensionStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_ExtensionStmt(self, *_):
+        pass
 
-    def reduce_FutureStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_FutureStmt(self, *_):
+        pass
 
-    def reduce_CreateIndexStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_CreateIndexStmt(self, *_):
+        pass
 
-    def reduce_AlterIndexStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_AlterIndexStmt(self, *_):
+        pass
 
-    def reduce_DropIndexStmt(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_DropIndexStmt(self, *_):
+        pass
 
 
 class InnerDDLStmtBlock(parsing.ListNonterm, element=InnerDDLStmt,
@@ -223,8 +273,9 @@ class InnerDDLStmtBlock(parsing.ListNonterm, element=InnerDDLStmt,
 
 
 class PointerName(Nonterm):
+    @parsing.inline(0)
     def reduce_PtrNodeName(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_DUNDERTYPE(self, *kids):
         self.val = qlast.ObjectRef(name=kids[0].val)
@@ -321,14 +372,17 @@ def commands_block(parent, *commands, opt=True, production_tpl=ProductionTpl):
 
 class NestedQLBlockStmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_Stmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_OptWithDDLStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_SetFieldStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class NestedQLBlock(ProductionTpl):
@@ -570,8 +624,9 @@ class AlterSimpleExtending(Nonterm):
     def reduce_DROP_EXTENDING_SimpleTypeNameList(self, *kids):
         self.val = qlast.AlterDropInherit(bases=kids[2].val)
 
+    @parsing.inline(0)
     def reduce_AlterAbstract(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class AlterExtending(Nonterm):
@@ -582,8 +637,9 @@ class AlterExtending(Nonterm):
     def reduce_DROP_EXTENDING_TypeNameList(self, *kids):
         self.val = qlast.AlterDropInherit(bases=kids[2].val)
 
+    @parsing.inline(0)
     def reduce_AlterAbstract(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class AlterOwnedStmt(Nonterm):
@@ -639,11 +695,13 @@ class DatabaseName(Nonterm):
 
 class DatabaseStmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_CreateDatabaseStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_DropDatabaseStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 #
@@ -689,11 +747,13 @@ class DropDatabaseStmt(Nonterm):
 
 class ExtensionPackageStmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_CreateExtensionPackageStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_DropExtensionPackageStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 #
@@ -757,11 +817,13 @@ class DropExtensionPackageStmt(Nonterm):
 
 class ExtensionStmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_CreateExtensionStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_DropExtensionStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 #
@@ -808,11 +870,13 @@ class DropExtensionStmt(Nonterm):
 
 class FutureStmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_CreateFutureStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_DropFutureStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 #
@@ -848,14 +912,17 @@ class DropFutureStmt(Nonterm):
 
 class RoleStmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_CreateRoleStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AlterRoleStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_DropRoleStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 #
@@ -867,8 +934,9 @@ class ShortExtending(Nonterm):
 
 
 class OptShortExtending(Nonterm):
+    @parsing.inline(0)
     def reduce_ShortExtending(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []
@@ -1678,8 +1746,9 @@ class CreateConcretePropertyStmt(Nonterm):
 
 
 class OptAlterUsingClause(Nonterm):
+    @parsing.inline(1)
     def reduce_USING_ParenExpr(self, *kids):
-        self.val = kids[1].val
+        pass
 
     def reduce_empty(self):
         self.val = None
@@ -2662,8 +2731,9 @@ commands_block(
 
 class OptCreateOperatorCommandsBlock(Nonterm):
 
+    @parsing.inline(0)
     def reduce_CreateOperatorCommandsBlock(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []
@@ -3189,32 +3259,41 @@ class DropGlobalStmt(Nonterm):
 
 class MigrationStmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_CreateMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AlterMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AlterCurrentMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_StartMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AbortMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_PopulateMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_CommitMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_DropMigrationStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ResetSchemaStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class MigrationBody(typing.NamedTuple):

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -50,31 +50,39 @@ class ExprStmt(Nonterm):
         self.val = kids[1].val
         self.val.aliases = kids[0].val.aliases
 
+    @parsing.inline(0)
     def reduce_ExprStmtCore(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class ExprStmtCore(Nonterm):
+    @parsing.inline(0)
     def reduce_SimpleFor(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_SimpleSelect(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_SimpleGroup(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_InternalGroup(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_SimpleInsert(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_SimpleUpdate(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_SimpleDelete(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class AliasedExpr(Nonterm):
@@ -119,8 +127,9 @@ class GroupingIdentList(ListNonterm, element=GroupingIdent,
 
 
 class GroupingAtom(Nonterm):
+    @parsing.inline(0)
     def reduce_GroupingIdent(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_LPAREN_GroupingIdentList_RPAREN(self, *kids):
         self.val = qlast.GroupingIdentList(elements=kids[1].val)
@@ -192,21 +201,25 @@ class SimpleSelect(Nonterm):
 
 
 class ByClause(Nonterm):
+    @parsing.inline(1)
     def reduce_BY_GroupingElementList(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class UsingClause(Nonterm):
+    @parsing.inline(1)
     def reduce_USING_AliasedExprList(self, *kids):
-        self.val = kids[1].val
+        pass
 
+    @parsing.inline(1)
     def reduce_USING_AliasedExprList_COMMA(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class OptUsingClause(Nonterm):
+    @parsing.inline(0)
     def reduce_UsingClause(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = None
@@ -226,8 +239,9 @@ class SimpleGroup(Nonterm):
 
 
 class OptGroupingAlias(Nonterm):
+    @parsing.inline(1)
     def reduce_COMMA_Identifier(self, *kids):
-        self.val = kids[1].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = None
@@ -342,13 +356,15 @@ class AliasDecl(Nonterm):
             alias=kids[0].val,
             module='::'.join(kids[3].val))
 
+    @parsing.inline(0)
     def reduce_AliasedExpr(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class WithDecl(Nonterm):
+    @parsing.inline(0)
     def reduce_AliasDecl(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class WithDeclList(ListNonterm, element=WithDecl,
@@ -360,16 +376,19 @@ class Shape(Nonterm):
     def reduce_LBRACE_RBRACE(self, *kids):
         self.val = []
 
+    @parsing.inline(1)
     def reduce_LBRACE_ShapeElementList_RBRACE(self, *kids):
-        self.val = kids[1].val
+        pass
 
+    @parsing.inline(1)
     def reduce_LBRACE_ShapeElementList_COMMA_RBRACE(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class OptShape(Nonterm):
+    @parsing.inline(0)
     def reduce_Shape(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []
@@ -398,8 +417,9 @@ class FreeShape(Nonterm):
 
 
 class OptAnySubShape(Nonterm):
-    def reduce_COLON_Shape(self, *kids):
-        self.val = kids[1].val
+    @parsing.inline(1)
+    def reduce_COLON_Shape(self, *_):
+        pass
 
     def reduce_LBRACE(self, *kids):
         raise errors.EdgeQLSyntaxError(
@@ -427,8 +447,9 @@ class ShapeElement(Nonterm):
         self.val.offset = kids[4].val[0]
         self.val.limit = kids[4].val[1]
 
+    @parsing.inline(0)
     def reduce_ComputableShapePointer(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class ShapeElementList(ListNonterm, element=ShapeElement,
@@ -517,8 +538,9 @@ class ShapePath(Nonterm):
 
         self.val = qlast.Path(steps=steps)
 
+    @parsing.inline(0)
     def reduce_Splat(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_AT_PathNodeName(self, *kids):
         self.val = qlast.Path(
@@ -744,8 +766,9 @@ class OptPtrQuals(Nonterm):
     def reduce_empty(self, *kids):
         self.val = PtrQualsSpec()
 
+    @parsing.inline(0)
     def reduce_PtrQuals(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 # We have to inline the OptPtrQuals here because the parser generator
@@ -961,39 +984,45 @@ class UnlessConflictSpecifier(Nonterm):
 
 
 class UnlessConflictCause(Nonterm):
+    @parsing.inline(2)
     def reduce_UNLESS_CONFLICT_UnlessConflictSpecifier(self, *kids):
-        self.val = kids[2].val
+        pass
 
 
 class OptUnlessConflictClause(Nonterm):
+    @parsing.inline(0)
     def reduce_UnlessConflictCause(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = None
 
 
 class FilterClause(Nonterm):
+    @parsing.inline(1)
     def reduce_FILTER_Expr(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class OptFilterClause(Nonterm):
+    @parsing.inline(0)
     def reduce_FilterClause(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = None
 
 
 class SortClause(Nonterm):
+    @parsing.inline(1)
     def reduce_ORDERBY_OrderbyList(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class OptSortClause(Nonterm):
+    @parsing.inline(0)
     def reduce_SortClause(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []
@@ -1012,8 +1041,9 @@ class OrderbyList(ListNonterm, element=OrderbyExpr,
 
 
 class OptSelectLimit(Nonterm):
+    @parsing.inline(0)
     def reduce_SelectLimit(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = (None, None)
@@ -1031,13 +1061,15 @@ class SelectLimit(Nonterm):
 
 
 class OffsetClause(Nonterm):
+    @parsing.inline(1)
     def reduce_OFFSET_Expr(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class LimitClause(Nonterm):
+    @parsing.inline(1)
     def reduce_LIMIT_Expr(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class OptDirection(Nonterm):
@@ -1077,11 +1109,13 @@ class IndirectionEl(Nonterm):
 
 
 class ParenExpr(Nonterm):
+    @parsing.inline(1)
     def reduce_LPAREN_Expr_RPAREN(self, *kids):
-        self.val = kids[1].val
+        pass
 
+    @parsing.inline(1)
     def reduce_LPAREN_ExprStmt_RPAREN(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 class BaseAtomicExpr(Nonterm):
@@ -1091,11 +1125,13 @@ class BaseAtomicExpr(Nonterm):
     # | '__new__' | '__old__' | '__specified__'
     # | NodeName | PathStep
 
+    @parsing.inline(0)
     def reduce_FreeShape(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_Constant(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_DUNDERSOURCE(self, *kids):
         self.val = qlast.Path(steps=[qlast.Source()])
@@ -1115,23 +1151,29 @@ class BaseAtomicExpr(Nonterm):
         )
 
     @parsing.precedence(precedence.P_UMINUS)
+    @parsing.inline(0)
     def reduce_ParenExpr(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_FuncExpr(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_Tuple(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_Collection(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_Set(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_NamedTuple(self, *kids):
-        self.val = kids[0].val
+        pass
 
     @parsing.precedence(precedence.P_DOT)
     def reduce_NodeName(self, *kids):
@@ -1180,11 +1222,13 @@ class Expr(Nonterm):
     # | GLOBAL Name
     # | EXISTS Expr
 
+    @parsing.inline(0)
     def reduce_BaseAtomicExpr(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_Path(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_Expr_Shape(self, *kids):
         self.val = qlast.Shape(expr=kids[0].val, elements=kids[1].val)
@@ -1414,11 +1458,13 @@ class Collection(Nonterm):
 
 
 class OptExprList(Nonterm):
+    @parsing.inline(0)
     def reduce_ExprList_COMMA(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ExprList(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []
@@ -1438,17 +1484,21 @@ class Constant(Nonterm):
     def reduce_ARGUMENT(self, *kids):
         self.val = qlast.Parameter(name=kids[0].val[1:])
 
+    @parsing.inline(0)
     def reduce_BaseNumberConstant(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_BaseStringConstant(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_BaseBooleanConstant(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_BaseBytesConstant(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class BaseNumberConstant(Nonterm):
@@ -1539,11 +1589,13 @@ class Path(Nonterm):
 
 
 class AtomicExpr(Nonterm):
+    @parsing.inline(0)
     def reduce_BaseAtomicExpr(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AtomicPath(self, *kids):
-        self.val = kids[0].val
+        pass
 
     @parsing.precedence(precedence.P_TYPECAST)
     def reduce_LANGBRACKET_FullTypeExpr_RANGBRACKET_AtomicExpr(
@@ -1607,8 +1659,9 @@ class PathStep(Nonterm):
             type='property'
         )
 
+    @parsing.inline(0)
     def reduce_TypeIntersection(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class TypeIntersection(Nonterm):
@@ -1619,8 +1672,9 @@ class TypeIntersection(Nonterm):
 
 
 class OptTypeIntersection(Nonterm):
+    @parsing.inline(0)
     def reduce_TypeIntersection(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self):
         self.val = None
@@ -1628,8 +1682,9 @@ class OptTypeIntersection(Nonterm):
 
 # Used in free shapes
 class FreeStepName(Nonterm):
+    @parsing.inline(0)
     def reduce_ShortNodeName(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_DUNDERTYPE(self, *kids):
         self.val = qlast.ObjectRef(name=kids[0].val)
@@ -1637,8 +1692,9 @@ class FreeStepName(Nonterm):
 
 # Used in shapes, paths and in PROPERTY/LINK definitions.
 class PathStepName(Nonterm):
+    @parsing.inline(0)
     def reduce_PathNodeName(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_DUNDERTYPE(self, *kids):
         self.val = qlast.ObjectRef(name=kids[0].val)
@@ -1675,8 +1731,9 @@ class FuncApplication(Nonterm):
 
 
 class FuncExpr(Nonterm):
+    @parsing.inline(0)
     def reduce_FuncApplication(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class FuncCallArgExpr(Nonterm):
@@ -1725,11 +1782,13 @@ class FuncArgList(ListNonterm, element=FuncCallArg, separator=tokens.T_COMMA):
 
 
 class OptFuncArgList(Nonterm):
+    @parsing.inline(0)
     def reduce_FuncArgList_COMMA(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_FuncArgList(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []
@@ -1753,32 +1812,37 @@ class PosCallArgList(ListNonterm, element=PosCallArg,
 
 
 class OptPosCallArgList(Nonterm):
+    @parsing.inline(0)
     def reduce_PosCallArgList(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []
 
 
 class Identifier(Nonterm):
-    def reduce_IDENT(self, *kids):
-        self.val = kids[0].clean_value
+    def reduce_IDENT(self, ident):
+        self.val = ident.clean_value
 
-    def reduce_UnreservedKeyword(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_UnreservedKeyword(self, *_):
+        pass
 
 
 class PtrIdentifier(Nonterm):
-    def reduce_Identifier(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_Identifier(self, *_):
+        pass
 
-    def reduce_PartialReservedKeyword(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_PartialReservedKeyword(self, *_):
+        pass
 
 
 class AnyIdentifier(Nonterm):
+    @parsing.inline(0)
     def reduce_PtrIdentifier(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_ReservedKeyword(self, *kids):
         name = kids[0].val
@@ -1816,11 +1880,14 @@ class ColonedIdents(
 
 
 class QualifiedName(Nonterm):
-    def reduce_Identifier_DOUBLECOLON_ColonedIdents(self, *kids):
-        self.val = [kids[0].val, *kids[2].val]
+    def reduce_Identifier_DOUBLECOLON_ColonedIdents(self, ident, _, idents):
+        assert ident.val
+        assert idents.val
+        self.val = [ident.val, *idents.val]
 
-    def reduce_DUNDERSTD_DOUBLECOLON_ColonedIdents(self, *kids):
-        self.val = ['__std__', *kids[2].val]
+    def reduce_DUNDERSTD_DOUBLECOLON_ColonedIdents(self, _s, _c, idents):
+        assert idents.val
+        self.val = ['__std__', *idents.val]
 
 
 # this can appear anywhere
@@ -1828,17 +1895,20 @@ class BaseName(Nonterm):
     def reduce_Identifier(self, *kids):
         self.val = [kids[0].val]
 
+    @parsing.inline(0)
     def reduce_QualifiedName(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 # this can appear in link/property definitions
 class PtrName(Nonterm):
-    def reduce_PtrIdentifier(self, *kids):
-        self.val = [kids[0].val]
+    def reduce_PtrIdentifier(self, ptr_identifier):
+        assert ptr_identifier.val
+        self.val = [ptr_identifier.val]
 
-    def reduce_QualifiedName(self, *kids):
-        self.val = kids[0].val
+    @parsing.inline(0)
+    def reduce_QualifiedName(self, *_):
+        pass
 
 
 # Non-collection type.
@@ -1908,11 +1978,13 @@ class CollectionTypeName(Nonterm):
 
 
 class TypeName(Nonterm):
+    @parsing.inline(0)
     def reduce_SimpleTypeName(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_CollectionTypeName(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class TypeNameList(ListNonterm, element=TypeName,
@@ -1925,8 +1997,9 @@ class NontrivialTypeExpr(Nonterm):
     def reduce_TYPEOF_Expr(self, *kids):
         self.val = qlast.TypeOf(expr=kids[1].val)
 
+    @parsing.inline(1)
     def reduce_LPAREN_FullTypeExpr_RPAREN(self, *kids):
-        self.val = kids[1].val
+        pass
 
     def reduce_TypeExpr_PIPE_TypeExpr(self, *kids):
         self.val = qlast.TypeOp(left=kids[0].val, op='|',
@@ -1941,31 +2014,36 @@ class NontrivialTypeExpr(Nonterm):
 # can be used without parentheses in a context where the
 # angle bracket has a different meaning.
 class TypeExpr(Nonterm):
+    @parsing.inline(0)
     def reduce_SimpleTypeName(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_NontrivialTypeExpr(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 # A type expression enclosed in parentheses
 class ParenTypeExpr(Nonterm):
+    @parsing.inline(1)
     def reduce_LPAREN_FullTypeExpr_RPAREN(self, *kids):
-        self.val = kids[1].val
+        pass
 
 
 # This is a type expression which includes collection types,
 # so it can only be directly used in a context where the
 # angle bracket is unambiguous.
 class FullTypeExpr(Nonterm):
+    @parsing.inline(0)
     def reduce_TypeName(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_TYPEOF_Expr(self, *kids):
         self.val = qlast.TypeOf(expr=kids[1].val)
 
+    @parsing.inline(1)
     def reduce_LPAREN_FullTypeExpr_RPAREN(self, *kids):
-        self.val = kids[1].val
+        pass
 
     def reduce_FullTypeExpr_PIPE_FullTypeExpr(self, *kids):
         self.val = qlast.TypeOp(left=kids[0].val, op='|',
@@ -1977,8 +2055,9 @@ class FullTypeExpr(Nonterm):
 
 
 class Subtype(Nonterm):
+    @parsing.inline(0)
     def reduce_FullTypeExpr(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_Identifier_COLON_FullTypeExpr(self, *kids):
         self.val = kids[2].val
@@ -2005,10 +2084,10 @@ class NodeName(Nonterm):
     #
     # This name is safe to be used anywhere as it starts with IDENT only.
 
-    def reduce_BaseName(self, *kids):
+    def reduce_BaseName(self, base_name):
         self.val = qlast.ObjectRef(
-            module='::'.join(kids[0].val[:-1]) or None,
-            name=kids[0].val[-1])
+            module='::'.join(base_name.val[:-1]) or None,
+            name=base_name.val[-1])
 
 
 class NodeNameList(ListNonterm, element=NodeName, separator=tokens.T_COMMA):
@@ -2020,10 +2099,10 @@ class PtrNodeName(Nonterm):
     #
     # This name is safe to be used in most DDL and SDL definitions.
 
-    def reduce_PtrName(self, *kids):
+    def reduce_PtrName(self, ptr_name):
         self.val = qlast.ObjectRef(
-            module='::'.join(kids[0].val[:-1]) or None,
-            name=kids[0].val[-1])
+            module='::'.join(ptr_name.val[:-1]) or None,
+            name=ptr_name.val[-1])
 
 
 class PtrQualifiedNodeName(Nonterm):

--- a/edb/edgeql/parser/grammar/extension_package_body.py
+++ b/edb/edgeql/parser/grammar/extension_package_body.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from edb.common import parsing
+
 from .expressions import Nonterm
 from .precedence import *  # NOQA
 from .tokens import *  # NOQA
@@ -29,5 +31,6 @@ from .ddl import *  # NOQA
 class CreateExtensionPackageBody(Nonterm):
     "%start"
 
+    @parsing.inline(0)
     def reduce_CreateExtensionPackageCommandsBlock_EOF(self, *kids):
-        self.val = kids[0].val
+        pass

--- a/edb/edgeql/parser/grammar/fragment.py
+++ b/edb/edgeql/parser/grammar/fragment.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from edb.common import parsing
+
 from .expressions import Nonterm
 from .expressions import *  # NOQA
 from .precedence import *  # NOQA
@@ -28,8 +30,10 @@ from .tokens import *  # NOQA
 class ExpressionFragment(Nonterm):
     "%start"
 
+    @parsing.inline(0)
     def reduce_ExprStmt_EOF(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_Expr_EOF(self, *kids):
-        self.val = kids[0].val
+        pass

--- a/edb/edgeql/parser/grammar/migration_body.py
+++ b/edb/edgeql/parser/grammar/migration_body.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from edb.common import parsing
+
 from .expressions import Nonterm
 from .precedence import *  # NOQA
 from .tokens import *  # NOQA
@@ -29,5 +31,6 @@ from .ddl import *  # NOQA
 class CreateMigrationBody(Nonterm):
     "%start"
 
+    @parsing.inline(0)
     def reduce_CreateMigrationCommandsBlock_EOF(self, *kids):
-        self.val = kids[0].val
+        pass

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -42,11 +42,13 @@ _new_nonterm = sdl_nontem_helper._new_nonterm
 
 # top-level SDL statements
 class SDLStatement(Nonterm):
+    @parsing.inline(0)
     def reduce_SDLBlockStatement(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_SDLShortStatement_SEMICOLON(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 # a list of SDL statements with optional semicolon separators
@@ -57,78 +59,101 @@ class SDLStatements(parsing.ListNonterm, element=SDLStatement,
 
 # These statements have a block
 class SDLBlockStatement(Nonterm):
+    @parsing.inline(0)
     def reduce_ModuleDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ScalarTypeDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AnnotationDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ObjectTypeDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AliasDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ConstraintDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_LinkDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_PropertyDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_FunctionDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_GlobalDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_IndexDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 # these statements have no {} block
 class SDLShortStatement(Nonterm):
 
+    @parsing.inline(0)
     def reduce_ExtensionRequirementDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_FutureRequirementDeclaration(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ScalarTypeDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AnnotationDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ObjectTypeDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_AliasDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ConstraintDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_LinkDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_PropertyDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_FunctionDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_GlobalDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_IndexDeclarationShort(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 # A rule for an SDL block, either as part of `module` declaration or
@@ -138,12 +163,11 @@ class SDLCommandBlock(Nonterm):
     def reduce_LBRACE_OptSemicolons_RBRACE(self, *kids):
         self.val = []
 
-    def reduce_statement_without_semicolons(self, *kids):
+    def reduce_statement_without_semicolons(self, _0, _1, stmt, _2):
         r"""%reduce LBRACE \
                 OptSemicolons SDLShortStatement \
             RBRACE
         """
-        _, _, stmt, _ = kids
         self.val = [stmt.val]
 
     def reduce_statements_without_optional_trailing_semicolons(self, *kids):
@@ -155,18 +179,17 @@ class SDLCommandBlock(Nonterm):
         _, _, stmts, _, stmt, _ = kids
         self.val = stmts.val + [stmt.val]
 
+    @parsing.inline(2)
     def reduce_LBRACE_OptSemicolons_SDLStatements_RBRACE(self, *kids):
-        _, _, stmts, _ = kids
-        self.val = stmts.val
+        pass
 
+    @parsing.inline(2)
     def reduce_statements_without_optional_trailing_semicolons2(self, *kids):
         r"""%reduce LBRACE \
                 OptSemicolons SDLStatements \
                 Semicolons \
             RBRACE
         """
-        _, _, stmts, _, _ = kids
-        self.val = stmts.val
 
 
 class SDLProductionHelper:
@@ -310,8 +333,7 @@ class FutureRequirementDeclaration(Nonterm):
 
 
 class ModuleDeclaration(Nonterm):
-    def reduce_MODULE_ModuleName_SDLCommandBlock(self, *kids):
-        _, module_name, block = kids
+    def reduce_MODULE_ModuleName_SDLCommandBlock(self, _, module_name, block):
 
         # Check that top-level declarations DO NOT use fully-qualified
         # names and aren't nested module blocks.
@@ -777,9 +799,9 @@ class OptPtrTarget(Nonterm):
     def reduce_empty(self, *kids):
         self.val = None
 
+    @parsing.inline(0)
     def reduce_PtrTarget(self, *kids):
-        (ptr,) = kids
-        self.val = ptr.val
+        pass
 
 
 class ConcreteUnknownPointerBlock(Nonterm):
@@ -1233,8 +1255,9 @@ class LinkDeclarationShort(Nonterm):
 
 
 class OptPtrKind(Nonterm):
+    @parsing.inline(0)
     def reduce_LINK(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self):
         self.val = None

--- a/edb/edgeql/parser/grammar/session.py
+++ b/edb/edgeql/parser/grammar/session.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+from edb.common import parsing
+
 from edb.edgeql import ast as qlast
 
 from .expressions import Nonterm
@@ -26,11 +28,13 @@ from .expressions import *  # NOQA
 
 
 class SessionStmt(Nonterm):
+    @parsing.inline(0)
     def reduce_SetStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_ResetStmt(self, *kids):
-        self.val = kids[0].val
+        pass
 
 
 class SetStmt(Nonterm):

--- a/edb/edgeql/parser/grammar/single.py
+++ b/edb/edgeql/parser/grammar/single.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from edb.common import parsing
+
 from .expressions import Nonterm
 from .precedence import *  # NOQA
 from .tokens import *  # NOQA
@@ -29,8 +31,10 @@ from .ddl import *  # NOQA
 class SingleDDLOrQuery(Nonterm):
     "%start"
 
+    @parsing.inline(0)
     def reduce_Stmt_EOF(self, *kids):
-        self.val = kids[0].val
+        pass
 
+    @parsing.inline(0)
     def reduce_DDLStmt_EOF(self, *kids):
-        self.val = kids[0].val
+        pass

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import typing
 
 from edb import errors
+from edb.common import parsing
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -35,22 +36,27 @@ from . import tokens
 
 class Stmt(Nonterm):
 
+    @parsing.inline(0)
     def reduce_TransactionStmt(self, stmt):
-        self.val = stmt.val
+        pass
 
+    @parsing.inline(0)
     def reduce_DescribeStmt(self, stmt):
         # DESCRIBE
-        self.val = stmt.val
+        pass
 
+    @parsing.inline(0)
     def reduce_AnalyzeStmt(self, stmt):
         # ANALYZE
-        self.val = stmt.val
+        pass
 
+    @parsing.inline(0)
     def reduce_AdministerStmt(self, stmt):
-        self.val = stmt.val
+        pass
 
+    @parsing.inline(0)
     def reduce_ExprStmt(self, stmt):
-        self.val = stmt.val
+        pass
 
 
 class TransactionMode(Nonterm):
@@ -83,8 +89,9 @@ class TransactionModeList(ListNonterm, element=TransactionMode,
 
 class OptTransactionModeList(Nonterm):
 
+    @parsing.inline(0)
     def reduce_TransactionModeList(self, *kids):
-        self.val = kids[0].val
+        pass
 
     def reduce_empty(self, *kids):
         self.val = []


### PR DESCRIPTION
A split off the #5693

Adds parsing.inline(x) which will pick x-th argument
and inline its val instead of calling the method.
This should have no performance inpact on current parser.
