### PR TITLE
Fix moving access policy from child to parent

### DIFF
--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -88,6 +88,17 @@ class AccessPolicy(
         str, default=None, compcoef=0.971, allow_ddl_set=True
     )
 
+    # We don't support SET/DROP OWNED owned on policies so we set its
+    # compcoef to 0.0
+    owned = so.SchemaField(
+        bool,
+        default=False,
+        inheritable=False,
+        compcoef=0.0,
+        reflection_method=so.ReflectionMethod.AS_LINK,
+        special_ddl_syntax=True,
+    )
+
     @classmethod
     def get_schema_class_displayname(cls) -> str:
         return 'access policy'

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11229,6 +11229,13 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
         """)
 
+        await self.migrate(r"""
+            abstract type Parent {
+                access policy asdf allow all;
+            }
+            type Test2 extending Parent;
+        """)
+
     async def test_edgeql_migration_access_policy_02(self):
         # Make sure policies don't interfere with constraints or indexes
         await self.migrate(r"""


### PR DESCRIPTION
We were emitting a DROP OWNED, which doesn't work for access policies.
Set the compcoef on owned to 0.0, like we do for triggers, to force
a drop instead.

Fixes #5735.