### PR TITLE
Fix two NULL related bugs with casting between ranges and json

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_06_28_00_00
+EDGEDB_CATALOG_VERSION = 2023_07_14_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -742,18 +742,17 @@ def _cast_json_to_range(
 
     with ctx.new() as subctx:
         subctx.anchors = subctx.anchors.copy()
-        source_path = subctx.create_anchor(ir_set, 'a')
-        check = qlast.FunctionCall(
-            func=('__std__', '__range_validate_json'), args=[source_path]
-        )
-        check_ir = dispatch.compile(check, ctx=subctx)
-        source_path = subctx.create_anchor(check_ir, 'b')
+        source_anchor = subctx.create_anchor(ir_set, 'a')
 
         range_el_t = new_stype.get_element_type(ctx.env.schema)
         ql_range_el_t = typegen.type_to_ql_typeref(range_el_t, ctx=subctx)
         bool_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'bool'))
         ql_bool_t = typegen.type_to_ql_typeref(bool_t, ctx=subctx)
 
+        check = qlast.FunctionCall(
+            func=('__std__', '__range_validate_json'), args=[source_anchor]
+        )
+        source_path = qlast.Path(steps=[qlast.ObjectRef(name='__range__')])
         cast = qlast.FunctionCall(
             func=('__std__', 'range'),
             args=[
@@ -836,7 +835,11 @@ def _cast_json_to_range(
             }
         )
 
-        return dispatch.compile(cast, ctx=subctx)
+        for_query = qlast.ForQuery(
+            iterator=check, iterator_alias='__range__', result=cast
+        )
+
+        return dispatch.compile(for_query, ctx=subctx)
 
 
 def _cast_to_base_array(

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -312,6 +312,7 @@ std::__range_validate_json(v: std::json) -> std::json
     USING SQL $$
     SELECT
         CASE
+        WHEN v = 'null'::jsonb THEN NULL
         WHEN
             empty
             AND (lower IS DISTINCT FROM upper

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -305,14 +305,15 @@ CREATE CAST FROM std::json TO array<anytype> {
 
 
 CREATE FUNCTION
-std::__range_validate_json(v: std::json) -> std::json
+std::__range_validate_json(v: std::json) -> OPTIONAL std::json
 {
     SET volatility := 'Immutable';
     SET internal := true;
     USING SQL $$
     SELECT
         CASE
-        WHEN v = 'null'::jsonb THEN NULL
+        WHEN v = 'null'::jsonb THEN
+            NULL
         WHEN
             empty
             AND (lower IS DISTINCT FROM upper

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -360,6 +360,8 @@ class RangeToJsonFunction(dbops.Function):
     text = r'''
         SELECT
             CASE
+            WHEN val IS NULL THEN
+                NULL
             WHEN isempty(val) THEN
                 jsonb_build_object('empty', true)
             ELSE

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2909,17 +2909,24 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         )
 
     async def test_edgeql_casts_all_null(self):
-        # For *every* concrete cast, try casting a value we know
+        # For *every* cast, try casting a value we know
         # will be represented as NULL.
-
-        # Grab all concrete casts
         casts = await self.con.query('''
             select schema::Cast { from_type: {name}, to_type: {name} }
-            filter .from_type.name not like '%any%'
-            and .to_type.name not like '%any%'
-            and not .from_type IS schema::ObjectType
+            filter not .from_type IS schema::ObjectType
         ''')
-        from_types = {cast.from_type.name for cast in casts}
+
+        def _t(s):
+            # Instantiate polymorphic types
+            return (
+                s
+                .replace('anytype', 'str')
+                .replace('anytuple', 'tuple<str, int64>')
+                .replace('std::anyenum', 'schema::Cardinality')
+                .replace('std::anypoint', 'int64')
+            )
+
+        from_types = {_t(cast.from_type.name) for cast in casts}
         type_keys = {
             name: f'x{i}' for i, name in enumerate(sorted(from_types))
         }
@@ -2928,7 +2935,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         setup = f'''
             CREATE TYPE Null {{
                 {sep.join(
-                    f'CREATE PROPERTY {n} -> {t};'
+                    f'CREATE PROPERTY {n} -> {_t(t)};'
                     for t, n in type_keys.items()
                  )}
             }};
@@ -2938,20 +2945,29 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         # Do each cast
         for cast in casts:
-            prop = type_keys[cast.from_type.name]
-            # FIXME: date_duration not supported yet in the bindings
-            json_only = cast.to_type.name == 'cal::date_duration'
+            prop = type_keys[_t(cast.from_type.name)]
 
             await self.assert_query_result(
                 f'''
                 SELECT Null {{
-                    res := <{cast.to_type.name}>.{prop}
+                    res := <{_t(cast.to_type.name)}>.{prop}
                 }}
                 ''',
                 [{"res": None}],
                 msg=f'{cast.from_type.name} to {cast.to_type.name}',
-                json_only=json_only,
             )
+
+            # For casts from JSON, also do the related operation of
+            # casting from a JSON null, which should produce an empty
+            # set.
+            if cast.from_type.name == 'std::json':
+                await self.assert_query_result(
+                    f'''
+                    SELECT <{_t(cast.to_type.name)}>to_json('null')
+                    ''',
+                    [],
+                    msg=f'json null cast to {cast.to_type.name}',
+                )
 
     async def test_edgeql_casts_uuid_to_object(self):
         persons = await self.con.query('select Person { id }')

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -6542,15 +6542,6 @@ aa \
             r' boolean property'
         ):
             await self.con.execute(r"""
-                select <range<int64>>to_json('null');
-            """)
-
-        async with self.assertRaisesRegexTx(
-            edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_lower"'
-            r' boolean property'
-        ):
-            await self.con.execute(r"""
                 select <range<int64>>to_json('1312');
             """)
 


### PR DESCRIPTION
1. Casting an empty set of ranges represented by a SQL NULL to json
   would produce json object with null fields, rather than an
   empty set of json. Fix that by adding a test to the function.
2. Casting a json null to a range would give an error, rather than
   an empty set. Fix __range_validate_json to not error and tweak
   the casting path in the compiler to produce NULL.

There is a test that tries to test NULL casts for every defined cast,
but it exempted all polymorphic casts. Test the polymorphic ones by
instantiating them with types.
Also extend it to test all json null casts too.