### PR TITLE
[3.x] Fix edgeql+schema patches

### DIFF
--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -189,5 +189,5 @@ ALTER TYPE cfg::AbstractConfig {
     };
 }
 '''),
-    ('edgeql+schema', ''), # function pg_table_is_visible
+    ('edgeql+schema', ''),  # refresh function pg_table_is_visible
 ])

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -801,21 +801,23 @@ def prepare_patch(
 
         # Similarly, only do config system updates if requested.
         if '+config' in kind:
-            config_spec = config.load_spec_from_schema(schema)
-            sysqueries, report_configs_typedesc = _compile_sys_queries(
-                reflschema,
-                compiler,
-                config_spec,
-            )
-
-            updates.update(dict(
-                sysqueries=sysqueries.encode('utf-8'),
-                report_configs_typedesc=report_configs_typedesc,
-                configspec=config.spec_to_json(config_spec).encode('utf-8'),
-            ))
-
             support_view_commands.add_command(
                 metaschema.get_config_views(schema))
+
+        # Though we always update the instdata for the config system,
+        # because it is currently the most convenient way to make sure
+        # all the versioned fields get updated.
+        config_spec = config.load_spec_from_schema(schema)
+        sysqueries, report_configs_typedesc = _compile_sys_queries(
+            reflschema,
+            compiler,
+            config_spec,
+        )
+        updates.update(dict(
+            sysqueries=sysqueries.encode('utf-8'),
+            report_configs_typedesc=report_configs_typedesc,
+            configspec=config.spec_to_json(config_spec).encode('utf-8'),
+        ))
 
         support_view_commands.generate(subblock)
 


### PR DESCRIPTION
The introduction of edgeql+schema+config patches in #5658 broke application of the simpler edgeql+schema patches. This is because certain instdata fields were made versioned, but were only being updated on edgeql+schema+config patches, which caused them to not be found after an edgeql+schema patch.

Fix it by unconditionally updating those fields on an edgeql+schema patch.

I'll forward port this if it passes