### PR TITLE
Fix edgeql+schema patches

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -801,28 +801,28 @@ def prepare_patch(
 
         # Similarly, only do config system updates if requested.
         if '+config' in kind:
-            config_spec = config.load_spec_from_schema(schema)
-            (
-                sysqueries,
-                report_configs_typedesc_1_0,
-                report_configs_typedesc_2_0,
-            ) = _compile_sys_queries(
-                reflschema,
-                compiler,
-                config_spec,
-            )
-
-            updates.update(dict(
-                sysqueries=sysqueries.encode('utf-8'),
-                report_configs_typedesc_1_0=report_configs_typedesc_1_0,
-                report_configs_typedesc_2_0=report_configs_typedesc_2_0,
-                configspec=config.spec_to_json(config_spec).encode('utf-8'),
-            ))
-
             support_view_commands.add_command(
                 metaschema.get_config_views(schema))
 
-        support_view_commands.generate(subblock)
+        # Though we always update the instdata for the config system,
+        # because it is currently the most convenient way to make sure
+        # all the versioned fields get updated.
+        config_spec = config.load_spec_from_schema(schema)
+        (
+            sysqueries,
+            report_configs_typedesc_1_0,
+            report_configs_typedesc_2_0,
+        ) = _compile_sys_queries(
+            reflschema,
+            compiler,
+            config_spec,
+        )
+        updates.update(dict(
+            sysqueries=sysqueries.encode('utf-8'),
+            report_configs_typedesc_1_0=report_configs_typedesc_1_0,
+            report_configs_typedesc_2_0=report_configs_typedesc_2_0,
+            configspec=config.spec_to_json(config_spec).encode('utf-8'),
+        ))
 
     compiler = edbcompiler.new_compiler(
         std_schema=schema,


### PR DESCRIPTION
The introduction of edgeql+schema+config patches in #5658 broke
application of the simpler edgeql+schema patches. This is because
certain instdata fields were made versioned, but were only being
updated on edgeql+schema+config patches, which caused them to
not be found after an edgeql+schema patch.

Fix it by unconditionally updating those fields on an edgeql+schema
patch.

This is a forward port of #5804, which I already merged to 3.x.
(Though of course I can go make changes to that if there are changes
requested here.)