### PR TITLE
Fix backend_name when creating function in patch

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -40,7 +40,6 @@ from edb.common import verutils
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
-from edb.edgeql import qltypes
 
 from . import expr as s_expr
 from . import name as sn
@@ -2953,6 +2952,34 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
 
         return schema
 
+    def get_prespecified_id(
+        self,
+        context: CommandContext, *,
+        id_field: str = 'id',
+    ) -> Optional[uuid.UUID]:
+        if context.schema_object_ids is None:
+            return None
+
+        mcls = self.get_schema_metaclass()
+        qlclass: Optional[str]
+        if issubclass(mcls, so.QualifiedObject):
+            qlclass = None
+        else:
+            qlclass = mcls.get_ql_class_or_die()
+
+        objname = self.classname
+        if context.compat_ver_is_before(
+            (1, 0, verutils.VersionStage.ALPHA, 5)
+        ):
+            # Pre alpha.5 used to have a different name mangling scheme.
+            objname = sn.compat_name_remangle(str(objname))
+
+        if id_field != 'id':
+            qlclass = f'{qlclass}-{id_field}'
+
+        key = (objname, qlclass)
+        return context.schema_object_ids.get(key)
+
     def canonicalize_attributes(
         self,
         schema: s_schema.Schema,
@@ -2961,22 +2988,7 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
         schema = super().canonicalize_attributes(schema, context)
 
         if context.schema_object_ids is not None:
-            mcls = self.get_schema_metaclass()
-            qlclass: Optional[qltypes.SchemaObjectClass]
-            if issubclass(mcls, so.QualifiedObject):
-                qlclass = None
-            else:
-                qlclass = mcls.get_ql_class_or_die()
-
-            objname = self.classname
-            if context.compat_ver_is_before(
-                (1, 0, verutils.VersionStage.ALPHA, 5)
-            ):
-                # Pre alpha.5 used to have a different name mangling scheme.
-                objname = sn.compat_name_remangle(str(objname))
-
-            key = (objname, qlclass)
-            specified_id = context.schema_object_ids.get(key)
+            specified_id = self.get_prespecified_id(context)
             if specified_id is not None:
                 self.set_attribute_value('id', specified_id)
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1666,12 +1666,16 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
         if not context.canonical:
             fullname = self.classname
             shortname = sn.shortname_from_fullname(fullname)
-            if others := schema.get_functions(
+            if backend_name := self.get_prespecified_id(
+                    context, id_field='backend_name'):
+                pass
+            elif others := schema.get_functions(
                     sn.QualName(fullname.module, shortname.name), ()):
                 backend_name = others[0].get_backend_name(schema)
             else:
                 backend_name = uuidgen.uuid1mc()
-            self.set_attribute_value('backend_name', backend_name)
+            if not self.has_attribute_value('backend_name'):
+                self.set_attribute_value('backend_name', backend_name)
 
             if (
                 self.has_attribute_value("code")

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -45,6 +45,7 @@ from edb.common import uuidgen
 
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as sd
+from edb.schema import functions as s_func
 from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import objects as s_obj
@@ -617,6 +618,14 @@ def _get_schema_object_ids(delta: sd.Command) -> Mapping[
 
         id = cmd.get_attribute_value('id')
         schema_object_ids[cmd.classname, qlclass] = id
+
+        # backend_name in callables is a lot *like* an id, in that it gets
+        # randomly generated and needs to match between things.
+        if isinstance(cmd, s_func.CreateCallableObject):
+            backend_name = cmd.get_attribute_value('backend_name')
+            if backend_name:
+                schema_object_ids[
+                    cmd.classname, f'{qlclass}-backend_name'] = backend_name
 
     return schema_object_ids
 


### PR DESCRIPTION
Currently a function created in a patch will have backend_name
randomly generated for both the stdschema and the reflschema, causing
calls to the function to produce wrong SQL.
Stash the info in schema_object_ids like id.

This is needed for #5801.