### PR TITLE
Pin Python version in CI

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -12,7 +12,7 @@
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 <%- endmacro %>
 
 <% macro _init_venv() -%>

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -157,7 +157,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.10.12'
 
       - name: Install Python deps
         run: |

--- a/.github/workflows/test-pool.yml
+++ b/.github/workflows/test-pool.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Generate requirements.txt
       run: |

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     # Build virtualenv
 
@@ -331,7 +331,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     # Build virtualenv
 
@@ -375,7 +375,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -579,7 +579,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -831,7 +831,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -1049,7 +1049,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -1255,7 +1255,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     # Build virtualenv
 
@@ -383,7 +383,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     # Build virtualenv
 
@@ -360,7 +360,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     # Build virtualenv
 
@@ -337,7 +337,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1.2
@@ -413,7 +413,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -548,7 +548,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.12'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -671,7 +671,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.10.12'
 
       - name: Install Python deps
         run: |


### PR DESCRIPTION
Some hosted runner is providing different Python version (patch) and therefore messing up the CI cache. It's safer to pin Python version rather than sharing cache among different Python versions.