### PR TITLE
Some test setup/teardown cleanups

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -626,8 +626,9 @@ class ClusterTestCase(BaseHTTPTestCase):
     # library (e.g. declaring casts).
     INTERNAL_TESTMODE = True
 
-    SETUP_COMMANDS: Sequence[str] = ()
-    TEARDOWN_COMMANDS: Sequence[str] = ()
+    # Setup and teardown commands that run per test
+    PER_TEST_SETUP: Sequence[str] = ()
+    PER_TEST_TEARDOWN: Sequence[str] = ()
 
     @classmethod
     def setUpClass(cls):
@@ -722,7 +723,7 @@ class ClusterTestCase(BaseHTTPTestCase):
             self.xact = self.con.transaction()
             self.loop.run_until_complete(self.xact.start())
 
-        for cmd in self.SETUP_COMMANDS:
+        for cmd in self.PER_TEST_SETUP:
             self.loop.run_until_complete(self.con.execute(cmd))
 
         super().setUp()
@@ -731,7 +732,7 @@ class ClusterTestCase(BaseHTTPTestCase):
         try:
             self.ensure_no_background_server_errors()
 
-            for cmd in self.TEARDOWN_COMMANDS:
+            for cmd in self.PER_TEST_TEARDOWN:
                 self.loop.run_until_complete(self.con.execute(cmd))
         finally:
             try:

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12230,9 +12230,11 @@ class TestEdgeQLMigrationRewrite(EdgeQLMigrationRewriteTestCase):
 
 
 class TestEdgeQLMigrationRewriteNonisolated(TestEdgeQLMigrationRewrite):
+    # N.B: This test suite duplicates all the tests in the above
+    # TestEdgeQLMigrationRewrite, but not in transactions.
     TRANSACTION_ISOLATION = False
 
-    TEARDOWN_COMMANDS = [
+    PER_TEST_TEARDOWN = [
         'rollback;',  # just in case, avoid extra errors
         '''
             start migration to { module default {}; };

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -183,38 +183,9 @@ def get_test_items(**flags):
     return tuple(res)
 
 
-class TestExpressionsWithoutConstantFolding(tb.QueryTestCase):
-
-    SETUP_COMMANDS = ["""
-        CONFIGURE SESSION SET __internal_no_const_folding := true;
-    """]
-
-    async def test_edgeql_no_const_folding_str_concat_01(self):
-        await self.assert_query_result(
-            r"""
-                SELECT 'aaaa' ++ 'bbbb';
-            """,
-            ['aaaabbbb'],
-        )
-
-    async def test_edgeql_no_const_folding_str_concat_02(self):
-        await self.assert_query_result(
-            r"""
-                SELECT 'aaaa' ++ r'\q' ++ $$\n$$;
-            """,
-            [R'aaaa\q\n'],
-        )
-
-
 class TestExpressions(tb.QueryTestCase):
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
-
-    SETUP = """
-    """
-
-    TEARDOWN = """
-    """
 
     async def test_edgeql_expr_emptyset_01(self):
         await self.assert_query_result(
@@ -8390,3 +8361,22 @@ aa \
         await self.con._fetchall("""
             FOR Z IN {(Object,)} UNION Z;
         """, __typenames__=True)
+
+    async def test_edgeql_no_const_folding_str_concat(self):
+        await self.con.execute("""
+            CONFIGURE SESSION SET __internal_no_const_folding := true;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT 'aaaa' ++ 'bbbb';
+            """,
+            ['aaaabbbb'],
+        )
+
+        await self.assert_query_result(
+            r"""
+                SELECT 'aaaa' ++ r'\q' ++ $$\n$$;
+            """,
+            [R'aaaa\q\n'],
+        )


### PR DESCRIPTION
* Rename SETUP/TEARDOWN_COMMANDS to PER_TEST_SETUP/TEARDOWN.
  They are run per-*test*, not per-database, which is the distinction
  from SETUP and TEARDOWN, but that is not at all clear.
* Get rid of TestExpressionsWithoutConstantFolding (incidentally
  the only user of SETUP_COMMANDS`) and merge it into TestExpressions.
  No reason to spin up a database for those pretty trivial tests.
* Drop empty SETUP/TEARDOWN scripts from TestExpressions.