### PR TITLE
Avoid recreating ancestor inhviews *twice* on CREATE TYPE

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3699,7 +3699,11 @@ class CreateObjectType(ObjectTypeMetaCommand,
             object=objtype_table,
             text=str(objtype.get_verbosename(schema)),
         ))
-        self.create_inhview(schema, context, objtype)
+        # Don't update ancestors yet: no pointers have been added to
+        # the type yet, so this type won't actually be added to any
+        # ancestor views. We'll fix up the ancestors in
+        # _create_finalize.
+        self.create_inhview(schema, context, objtype, alter_ancestors=False)
         return schema
 
     def _create_finalize(self, schema, context):


### PR DESCRIPTION
Currently we alter ancestor inhviews when we create the initial
inhview for a type. This is pointless: the type hasn't been populated
with pointers like `id` yet, so it won't be included, and the ancestors
will be refreshed in finalize anyway.

This reduces the size of our scripts a bunch, and speeds things up some.