### PR TITLE
Update syntax test.

### DIFF
--- a/edb/edgeql-parser/src/parser.rs
+++ b/edb/edgeql-parser/src/parser.rs
@@ -511,8 +511,17 @@ impl Spec {
         let actions = v
             .actions
             .into_iter()
-            .map(|x| x.into_iter().map(|(k, a)| (get_token_kind(&k), a)))
-            .map(IndexMap::from_iter)
+            .map(|x| {
+                let mut x: Vec<_> = x
+                    .into_iter()
+                    .map(|(k, a)| (get_token_kind(&k), a))
+                    .collect();
+
+                // sort by anything - just to make it deterministic
+                x.sort_by_key(|(k, _)| k.text());
+
+                IndexMap::from_iter(x)
+            })
             .collect();
         let goto = v.goto.into_iter().map(IndexMap::from_iter).collect();
         let inlines = IndexMap::from_iter(v.inlines);

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3640,7 +3640,7 @@ aa';
         # XXX: error recovery quality regression
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Missing '\('",
+                  r"Missing ','",
                   line=2, col=29)
     def test_edgeql_syntax_function_20(self):
         """


### PR DESCRIPTION
Clearly our syntax error detection and recovery has changed the interpretation of `count(foo 1)` as probably missing a comma and not missing another parenthesis.

In practice (in REPL) it seems that `foo 1` is interpreted as a call and results in different error if function `foo` is not found.