### PR TITLE
Fix an issue with multiranges.

### DIFF
--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -181,6 +181,9 @@ def __infer_type_introspection(
     elif irtyputils.is_range(ir.typeref):
         return cast(s_objtypes.ObjectType,
                     env.schema.get('schema::Range'))
+    elif irtyputils.is_multirange(ir.typeref):
+        return cast(s_objtypes.ObjectType,
+                    env.schema.get('schema::Multirange'))
     else:
         raise errors.QueryError(
             'unexpected type in INTROSPECT', context=ir.context)

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -1958,6 +1958,27 @@ std::max(vals: SET OF array<cal::date_duration>) -> OPTIONAL array<cal::date_dur
 ## Range functions
 
 
+# FIXME: These functions introduce the concrete multirange types into the
+# schema. That's why they exist for each concrete type explicitly and aren't
+# defined generically for anytype.
+CREATE FUNCTION std::multirange_unpack(
+    val: multirange<cal::local_datetime>,
+) -> set of range<cal::local_datetime>
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'unnest';
+};
+
+
+CREATE FUNCTION std::multirange_unpack(
+    val: multirange<cal::local_date>,
+) -> set of range<cal::local_date>
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'unnest';
+};
+
+
 CREATE FUNCTION
 std::range_unpack(
     val: range<cal::local_datetime>,

--- a/edb/lib/std/31-rangefuncs.edgeql
+++ b/edb/lib/std/31-rangefuncs.edgeql
@@ -409,9 +409,57 @@ CREATE FUNCTION std::overlaps(
 };
 
 
+# FIXME: These functions introduce the concrete multirange types into the
+# schema. That's why they exist for each concrete type explicitly and aren't
+# defined generically for anytype.
 CREATE FUNCTION std::multirange_unpack(
-    val: multirange<anypoint>,
-) -> set of range<anypoint>
+    val: multirange<std::int32>,
+) -> set of range<std::int32>
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'unnest';
+};
+
+
+CREATE FUNCTION std::multirange_unpack(
+    val: multirange<std::int64>,
+) -> set of range<std::int64>
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'unnest';
+};
+
+
+CREATE FUNCTION std::multirange_unpack(
+    val: multirange<std::float32>,
+) -> set of range<std::float32>
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'unnest';
+};
+
+
+CREATE FUNCTION std::multirange_unpack(
+    val: multirange<std::float64>,
+) -> set of range<std::float64>
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'unnest';
+};
+
+
+CREATE FUNCTION std::multirange_unpack(
+    val: multirange<std::decimal>,
+) -> set of range<std::decimal>
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'unnest';
+};
+
+
+CREATE FUNCTION std::multirange_unpack(
+    val: multirange<std::datetime>,
+) -> set of range<std::datetime>
 {
     SET volatility := 'Immutable';
     USING SQL FUNCTION 'unnest';

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -160,6 +160,7 @@ def array_as_json_object(
     if (
         is_tuple
         or irtyputils.is_range(el_type)
+        or irtyputils.is_multirange(el_type)
         or el_type.real_base_type.needs_custom_json_cast
     ):
         coldeflist = []


### PR DESCRIPTION
Not all multiranges are present in the base schema. That causes issues when they need to be used as array subtypes for parameters as they cannot be found by ID at all.

This PR makes sure that all base multirange types are part of the standard schema.

It also fixes JSON serialization of an array of multiranges.