### PR TITLE
Preserve header value case in BaseHTTPTestCase

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -382,7 +382,7 @@ class BaseHTTPTestCase(TestCase):
     ) -> tuple[bytes, dict[str, str], int]:
         resp = http_con.getresponse()
         resp_body = resp.read()
-        resp_headers = {k.lower(): v.lower() for k, v in resp.getheaders()}
+        resp_headers = {k.lower(): v for k, v in resp.getheaders()}
         return resp_body, resp_headers, resp.status
 
     def http_con_request(

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -38,7 +38,7 @@ class BaseTestHttpAuth(tb_server.ConnectedTestCase):
             _, headers, status = self.http_con_request(con, {}, path="token")
             self.assertEqual(status, 401)
             self.assertEqual(
-                headers, headers | {"www-authenticate": "scram-sha-256"}
+                headers, headers | {"www-authenticate": "SCRAM-SHA-256"}
             )
 
         client_nonce = scram.generate_nonce()


### PR DESCRIPTION
Pulling this work from #5816 and #5824 

While header _keys_ should be case insensitive, header _values_ can contain things like JWTs and other case sensitive information.