### PR TITLE
Get rid of the config spec stored in a global variable

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1213,7 +1213,6 @@ async def _init_stdlib(
     await metaschema.create_pg_extensions(conn, backend_params)
 
     config_spec = config.load_spec_from_schema(stdlib.stdschema)
-    config.set_settings(config_spec)
 
     if tpldbdump is None:
         logger.info('Populating internal SQL structures...')
@@ -1324,7 +1323,6 @@ async def _init_stdlib(
         # _testmode includes extra config settings, so make sure
         # those are picked up.
         config_spec = config.load_spec_from_schema(stdlib.stdschema)
-        config.set_settings(config_spec)
 
     # Make sure that schema backend_id properties are in sync with
     # the database.
@@ -2001,7 +1999,7 @@ async def _pg_ensure_database_not_connected(
             f'database {dbname!r} is being accessed by other users')
 
 
-async def _start(ctx: BootstrapContext) -> None:
+async def _start(ctx: BootstrapContext) -> edbcompiler.CompilerState:
     conn = await _check_catalog_compatibility(ctx)
 
     try:
@@ -2010,7 +2008,7 @@ async def _start(ctx: BootstrapContext) -> None:
         ctx.cluster.overwrite_capabilities(struct.Struct('!Q').unpack(caps)[0])
         _check_capabilities(ctx)
 
-        await edbcompiler.new_compiler_from_pg(conn)
+        return (await edbcompiler.new_compiler_from_pg(conn)).state
 
     finally:
         conn.terminate()
@@ -2035,7 +2033,7 @@ async def _bootstrap_edgedb_super_roles(ctx: BootstrapContext) -> uuid.UUID:
     return superuser_uid
 
 
-async def _bootstrap(ctx: BootstrapContext) -> None:
+async def _bootstrap(ctx: BootstrapContext) -> edbcompiler.CompilerState:
     args = ctx.args
     cluster = ctx.cluster
     backend_params = cluster.get_runtime_params()
@@ -2232,15 +2230,17 @@ async def _bootstrap(ctx: BootstrapContext) -> None:
             args.default_database_user or edbdef.EDGEDB_SUPERUSER,
         )
 
+    return compiler.state
+
 
 async def ensure_bootstrapped(
     cluster: pgcluster.BaseCluster,
     args: edbargs.ServerConfig,
-) -> bool:
+) -> tuple[bool, edbcompiler.CompilerState]:
     """Bootstraps EdgeDB instance if it hasn't been bootstrapped already.
 
     Returns True if bootstrap happened and False if the instance was already
-    bootstrapped.
+    bootstrapped, along with the bootstrap compiler state.
     """
     pgconn = PGConnectionProxy(cluster)
     ctx = BootstrapContext(cluster=cluster, conn=pgconn, args=args)
@@ -2249,10 +2249,10 @@ async def ensure_bootstrapped(
         mode = await _get_cluster_mode(ctx)
         ctx = dataclasses.replace(ctx, mode=mode)
         if mode == ClusterMode.pristine:
-            await _bootstrap(ctx)
-            return True
+            state = await _bootstrap(ctx)
+            return True, state
         else:
-            await _start(ctx)
-            return False
+            state = await _start(ctx)
+            return False, state
     finally:
         pgconn.terminate()

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from .compiler import Compiler
+from .compiler import Compiler, CompilerState
 from .compiler import CompileContext, CompilerDatabaseState
 from .compiler import compile_edgeql_script
 from .compiler import load_std_schema
@@ -34,6 +34,7 @@ from .ddl import repair_schema
 __all__ = (
     'Cardinality',
     'Compiler',
+    'CompilerState',
     'CompileContext',
     'CompilerDatabaseState',
     'QueryUnit',

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -1600,7 +1600,7 @@ def _make_global_rep(typ: s_types.Type, ctx: Context) -> object:
 
 
 class StateSerializerFactory:
-    def __init__(self, std_schema: s_schema.Schema):
+    def __init__(self, std_schema: s_schema.Schema, config_spec: config.Spec):
         """
         {
             module := 'default',
@@ -1635,7 +1635,8 @@ class StateSerializerFactory:
             schema, free_obj, 'state_config'
         )
         config_shape: list[tuple[str, s_types.Type, enums.Cardinality]] = []
-        for setting in config.get_settings().values():
+
+        for setting in config_spec.values():
             if not setting.system:
                 setting_type_name = setting.schema_type_name
                 setting_type = schema.get(setting_type_name, type=s_types.Type)

--- a/edb/server/compiler_pool/remote_worker.py
+++ b/edb/server/compiler_pool/remote_worker.py
@@ -76,7 +76,7 @@ def __init_worker__(
         refl_schema,
         schema_class_layout,
         backend_runtime_params=backend_runtime_params,
-        load_config=True,
+        config_spec=None,
     )
 
 

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -80,7 +80,7 @@ def __init_worker__(
         refl_schema,
         schema_class_layout,
         backend_runtime_params=BACKEND_RUNTIME_PARAMS,
-        load_config=True,
+        config_spec=None,
     )
 
 

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -33,7 +33,6 @@ from .types import ConfigType
 
 
 __all__ = (
-    'get_settings', 'set_settings',
     'lookup',
     'Spec', 'Setting', 'SettingValue',
     'spec_to_json', 'to_json', 'to_edgeql', 'from_json', 'set_value',
@@ -46,27 +45,12 @@ __all__ = (
 )
 
 
-_settings = Spec()
-
-
-def get_settings() -> Spec:
-    return _settings
-
-
-def set_settings(settings: Spec) -> None:
-    global _settings
-    _settings = settings
-
-
 def lookup(
     name: str,
     *configs: Mapping[str, SettingValue],
+    spec: Spec,
     allow_unrecognized: bool = False,
-    spec: Optional[Spec] = None,
 ) -> Any:
-
-    if spec is None:
-        spec = get_settings()
 
     try:
         setting = spec[name]
@@ -91,10 +75,8 @@ def lookup(
 def get_compilation_config(
     config: Mapping[str, SettingValue],
     *,
-    spec: Optional[Spec] = None,
+    spec: Spec,
 ) -> immutables.Map[str, SettingValue]:
-    if spec is None:
-        spec = get_settings()
     return immutables.Map((
         (k, v)
         for k, v in config.items()

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -68,6 +68,7 @@ cdef class DatabaseIndex:
         object _global_schema
         object _factory
         object _default_sysconfig
+        object _sys_config_spec
 
 
 cdef class Database:
@@ -186,6 +187,8 @@ cdef class DatabaseConnectionView:
     cdef commit_implicit_tx(
         self, user_schema, global_schema, cached_reflection
     )
+
+    cpdef get_config_spec(self)
 
     cpdef get_session_config(self)
     cdef set_session_config(self, new_conf)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -430,6 +430,9 @@ cdef class DatabaseConnectionView:
         else:
             self._state_serializer = new_serializer
 
+    cpdef get_config_spec(self):
+        return self._db._index._sys_config_spec
+
     cdef set_session_config(self, new_conf):
         if self._in_tx:
             self._in_tx_config = new_conf
@@ -557,7 +560,7 @@ cdef class DatabaseConnectionView:
 
         state = []
         if self._config:
-            settings = config.get_settings()
+            settings = self.get_config_spec()
             for sval in self._config.values():
                 setting = settings[sval.name]
                 kind = 'B' if setting.backend_setting else 'C'
@@ -936,7 +939,7 @@ cdef class DatabaseConnectionView:
         return side_effects
 
     async def apply_config_ops(self, conn, ops):
-        settings = config.get_settings()
+        settings = self.get_config_spec()
 
         for op in ops:
             if op.scope is config.ConfigScope.INSTANCE:
@@ -1141,14 +1144,19 @@ cdef class DatabaseIndex:
         global_schema,
         sys_config,
         default_sysconfig,  # system config without system override
+        sys_config_spec,
     ):
         self._dbs = {}
         self._server = server
         self._std_schema = std_schema
         self._global_schema = global_schema
         self._default_sysconfig = default_sysconfig
+        self._sys_config_spec = sys_config_spec
+        # TODO: This factory will probably need to become per-db once
+        # config spec differs between databases.
+        self._factory = sertypes.StateSerializerFactory(
+            std_schema, sys_config_spec)
         self.update_sys_config(sys_config)
-        self._factory = sertypes.StateSerializerFactory(std_schema)
 
     def count_connections(self, dbname: str):
         try:
@@ -1169,7 +1177,8 @@ cdef class DatabaseIndex:
             mm.update(sys_config)
             sys_config = mm.finish()
         self._sys_config = sys_config
-        self._comp_sys_config = config.get_compilation_config(sys_config)
+        self._comp_sys_config = config.get_compilation_config(
+            sys_config, spec=self._sys_config_spec)
 
     def has_db(self, dbname):
         return dbname in self._dbs
@@ -1225,7 +1234,7 @@ cdef class DatabaseIndex:
 
     async def _save_system_overrides(self, conn):
         data = config.to_json(
-            config.get_settings(),
+            self._sys_config_spec,
             self._sys_config,
             setting_filter=lambda v: v.source == 'system override',
             include_source=False,
@@ -1246,7 +1255,7 @@ cdef class DatabaseIndex:
         await conn.sql_execute(block.to_string().encode())
 
     async def apply_system_config_op(self, conn, op):
-        spec = config.get_settings()
+        spec = self._sys_config_spec
         op_value = op.get_setting(spec)
         if op.opcode is not None:
             allow_missing = (
@@ -1260,7 +1269,7 @@ cdef class DatabaseIndex:
         # the callbacks below, because certain config changes
         # may cause the backend connection to drop.
         self.update_sys_config(
-            op.apply(config.get_settings(), self._sys_config)
+            op.apply(self._sys_config_spec, self._sys_config)
         )
 
         await self._save_system_overrides(conn)

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -51,6 +51,7 @@ from edb.common import debug
 
 from . import config
 from . import args as srvargs
+from . import compiler as edbcompiler
 from . import daemon
 from . import defines
 from . import pgconnparams
@@ -139,7 +140,9 @@ def _internal_state_dir(runstate_dir):
               f'--runstate-dir to specify the correct location')
 
 
-async def _init_cluster(cluster, args: srvargs.ServerConfig) -> bool:
+async def _init_cluster(
+    cluster, args: srvargs.ServerConfig
+) -> tuple[bool, edbcompiler.CompilerState]:
     from edb.server import bootstrap
 
     new_instance = await bootstrap.ensure_bootstrapped(cluster, args)
@@ -168,6 +171,7 @@ async def _run_server(
     *,
     do_setproctitle: bool,
     new_instance: bool,
+    compiler_state: edbcompiler.CompilerState,
 ):
 
     sockets = service_manager.get_activation_listen_sockets()
@@ -200,6 +204,7 @@ async def _run_server(
             admin_ui=args.admin_ui,
             instance_name=args.instance_name,
             disable_dynamic_system_config=args.disable_dynamic_system_config,
+            compiler_state=compiler_state,
         )
         await sc.wait_for(ss.init())
 
@@ -556,10 +561,12 @@ async def run_server(
                 if cluster_status != "running":
                     abort('specified PostgreSQL instance is not running')
 
-            new_instance = await _init_cluster(cluster, args)
+            new_instance, compiler_state = await _init_cluster(cluster, args)
 
             cfg, backend_settings = initialize_static_cfg(
-                args, is_remote_cluster=not is_local_cluster
+                args,
+                is_remote_cluster=not is_local_cluster,
+                config_spec=compiler_state.config_spec,
             )
             if cfg:
                 from . import pgcon
@@ -637,6 +644,7 @@ async def run_server(
                         int_runstate_dir,
                         do_setproctitle=do_setproctitle,
                         new_instance=new_instance,
+                        compiler_state=compiler_state,
                     )
 
         except server.StartupError as e:
@@ -752,15 +760,15 @@ def _coerce_cfg_value(setting: config.Setting, value):
 def initialize_static_cfg(
     args: srvargs.ServerConfig,
     is_remote_cluster: bool,
+    config_spec: config.Spec
 ) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
     result = []
     backend_settings = {}
     command_line_argument = "A"
     environment_variable = "E"
-    spec = config.get_settings()
 
     def add_config(name, value, type_):
-        setting = spec[name]
+        setting = config_spec[name]
         if is_remote_cluster:
             if setting.backend_setting and setting.requires_restart:
                 if type_ == command_line_argument:
@@ -799,7 +807,7 @@ def initialize_static_cfg(
     setting: config.Setting
     for env_name, env_value, cfg_name in iter_environ():
         try:
-            setting = spec[cfg_name]
+            setting = config_spec[cfg_name]
         except KeyError:
             continue
         choices = setting.enum_values

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -71,6 +71,7 @@ from edb.server.pgcon import errors as pgcon_errors
 
 from edb.pgsql import patches as pg_patches
 
+from . import compiler as edbcompiler
 from . import dbview
 
 if TYPE_CHECKING:
@@ -162,9 +163,12 @@ class Server(ha_base.ClusterProtocol):
         admin_ui: bool = False,
         instance_name: str,
         disable_dynamic_system_config: bool = False,
+        compiler_state: edbcompiler.CompilerState,
     ):
         self.__loop = asyncio.get_running_loop()
-        self._config_settings = config.get_settings()
+
+        # TODO: We can pull more of the initial state out of here
+        self._config_settings = compiler_state.config_spec
 
         # Used to tag PG notifications to later disambiguate them.
         self._server_id = str(uuid.uuid4())
@@ -449,6 +453,13 @@ class Server(ha_base.ClusterProtocol):
         metrics.current_backend_connections.dec()
         conn.terminate()
 
+    def config_lookup(
+        self,
+        name: str,
+        *configs: Mapping[str, config.SettingValue],
+    ) -> Any:
+        return config.lookup(name, *configs, spec=self._config_settings)
+
     async def init(self):
         self._initing = True
         try:
@@ -471,6 +482,7 @@ class Server(ha_base.ClusterProtocol):
                 global_schema=global_schema,
                 sys_config=sys_config,
                 default_sysconfig=default_sysconfig,
+                sys_config_spec=self._config_settings,
             )
 
             self._fetch_roles()
@@ -486,17 +498,17 @@ class Server(ha_base.ClusterProtocol):
 
             if not self._listen_hosts:
                 self._listen_hosts = (
-                    config.lookup('listen_addresses', sys_config)
+                    self.config_lookup('listen_addresses', sys_config)
                     or ('localhost',)
                 )
 
             if self._listen_port is None:
                 self._listen_port = (
-                    config.lookup('listen_port', sys_config)
+                    self.config_lookup('listen_port', sys_config)
                     or defines.EDGEDB_PORT
                 )
 
-            self._stmt_cache_size = config.lookup(
+            self._stmt_cache_size = self.config_lookup(
                 '_pg_prepared_statement_cache_size', sys_config
             )
 
@@ -514,7 +526,7 @@ class Server(ha_base.ClusterProtocol):
             self._idle_gc_handler = None
 
         assert self._dbindex is not None
-        session_idle_timeout = config.lookup(
+        session_idle_timeout = self.config_lookup(
             'session_idle_timeout', self._dbindex.get_sys_config())
 
         timeout = session_idle_timeout.to_microseconds()
@@ -527,7 +539,7 @@ class Server(ha_base.ClusterProtocol):
         return timeout
 
     def _reload_stmt_cache_size(self):
-        size = config.lookup(
+        size = self.config_lookup(
             '_pg_prepared_statement_cache_size', self._dbindex.get_sys_config()
         )
         self._stmt_cache_size = size
@@ -599,7 +611,7 @@ class Server(ha_base.ClusterProtocol):
 
     def _populate_sys_auth(self):
         cfg = self._dbindex.get_sys_config()
-        auth = config.lookup('auth', cfg) or ()
+        auth = self.config_lookup('auth', cfg) or ()
         self._sys_auth = tuple(sorted(auth, key=lambda a: a.priority))
 
     def _get_pgaddr(self):
@@ -672,7 +684,7 @@ class Server(ha_base.ClusterProtocol):
             query = self.get_sys_query(query_name)
             sys_config_json = await syscon.sql_fetch_val(query)
 
-        return config.from_json(config.get_settings(), sys_config_json)
+        return config.from_json(self._config_settings, sys_config_json)
 
     async def reload_sys_config(self):
         cfg = await self.load_sys_config()
@@ -887,7 +899,7 @@ class Server(ha_base.ClusterProtocol):
 
     async def introspect_db_config(self, conn):
         result = await conn.sql_fetch_val(self.get_sys_query('dbconfig'))
-        return config.from_json(config.get_settings(), result)
+        return config.from_json(self._config_settings, result)
 
     async def _early_introspect_db(self, dbname):
         """We need to always introspect the extensions for each database.
@@ -995,7 +1007,7 @@ class Server(ha_base.ClusterProtocol):
                 # a reload of it from the schema.
                 if '+config' in kind:
                     config_spec = config.load_spec_from_schema(self._std_schema)
-                    config.set_settings(config_spec)
+                    self._config_settings = config_spec
 
             if 'reflschema' in updates:
                 self._refl_schema = updates['reflschema']
@@ -1429,7 +1441,8 @@ class Server(ha_base.ClusterProtocol):
             if setting_name == 'listen_addresses':
                 cfg = self._dbindex.get_sys_config()
                 await self._restart_servers_new_addr(
-                    config.lookup('listen_addresses', cfg) or ('localhost',),
+                    self.config_lookup('listen_addresses', cfg)
+                    or ('localhost',),
                     self._listen_port,
                 )
 
@@ -1437,7 +1450,8 @@ class Server(ha_base.ClusterProtocol):
                 cfg = self._dbindex.get_sys_config()
                 await self._restart_servers_new_addr(
                     self._listen_hosts,
-                    config.lookup('listen_port', cfg) or defines.EDGEDB_PORT,
+                    self.config_lookup('listen_port', cfg)
+                    or defines.EDGEDB_PORT,
                 )
 
             elif setting_name == 'session_idle_timeout':
@@ -2389,8 +2403,7 @@ class Server(ha_base.ClusterProtocol):
                     return auth.method
 
         default_method = self._default_auth_method.get(transport)
-        auth_type = config.get_settings().get_type_by_name(
-            default_method.value)
+        auth_type = self._config_settings.get_type_by_name(default_method.value)
         return auth_type()
 
     def is_database_connectable(self, dbname: str) -> bool:

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -33,6 +33,7 @@ from edb.testbase import lang as tb
 from edb.testbase import server as tbs
 from edb.server import args as edbargs
 from edb.server import compiler as edbcompiler
+from edb.server import config
 from edb.server.compiler_pool import amsg
 from edb.server.compiler_pool import pool
 from edb.server.dbview import dbview
@@ -395,6 +396,8 @@ class TestCompilerPool(tbs.TestCase):
                     global_schema=None,
                     sys_config={},
                     default_sysconfig=immutables.Map(),
+                    sys_config_spec=config.load_spec_from_schema(
+                        self._std_schema),
                 ),
                 backend_runtime_params=None,
                 std_schema=self._std_schema,


### PR DESCRIPTION
This is in preparation for having some per-database configuration
settings via extensions.