### PR TITLE
EdgeDB + SQL equivalent clarification

### DIFF
--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -184,11 +184,11 @@ Indexes can be augmented with annotations.
   **Foreign and primary keys**
 
   In SQL databases, indexes are commonly used to index *primary keys* and
-  *foreign keys*. The EdgeDB equivalents of these are the ``id`` property
-  and links; these are automatically indexed and there is no need to manually
-  declare them. Moreover, any property with an :eql:constraint:`exclusive`
-  constraint is also automatically indexed.
-
+  *foreign keys*. EdgeDB's analog to SQL's primary key is the ``id`` field
+  that gets automatically created for each object, while a link in EdgeDB
+  is the analog to SQL's foreign key. Both of these are automatically indexed.
+  Moreover, any property with an :eql:constraint:`exclusive` constraint
+  is also automatically indexed.
 
 .. list-table::
   :class: seealso

--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -184,9 +184,10 @@ Indexes can be augmented with annotations.
   **Foreign and primary keys**
 
   In SQL databases, indexes are commonly used to index *primary keys* and
-  *foreign keys*. In EdgeDB, these fields are automatically indexed; there's no
-  need to manually declare them. Moreover, any property with an
-  :eql:constraint:`exclusive` constraint is also automatically indexed.
+  *foreign keys*. The EdgeDB equivalents of these are the ``id`` property
+  and links; these are automatically indexed and there is no need to manually
+  declare them. Moreover, any property with an :eql:constraint:`exclusive`
+  constraint is also automatically indexed.
 
 
 .. list-table::


### PR DESCRIPTION
Just a small clarification that the EdgeDB equivalents to primary key and foreign key are the id property and links. The current "these fields are automatically indexed" wording also gives the impression that primary and foreign key are EdgeDB terms.

Context: Doing some writing on indexing and have never used SQL before so wasn't sure what a primary and foreign key was and had to do a bit of searching. There are probably others out there that aren't immediately familiar with SQL.