### PR TITLE
Handle decimal params in edgeql_http protocol without losing precision

### DIFF
--- a/edb/server/protocol/edgeql_ext.pyx
+++ b/edb/server/protocol/edgeql_ext.pyx
@@ -61,7 +61,7 @@ async def handle_request(
     try:
         if request.method == b'POST':
             if request.content_type and b'json' in request.content_type:
-                body = json.loads(request.body)
+                body = json.loads(request.body, parse_float=decimal.Decimal)
                 if not isinstance(body, dict):
                     raise TypeError(
                         'the body of the request must be a JSON object')

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -533,11 +533,22 @@ async def execute_json(
         return None
 
 
+class DecimalEncoder(json.JSONEncoder):
+    def encode(self, obj):
+        if isinstance(obj, dict):
+            return '{' + ', '.join(
+                    f'{self.encode(k)}: {self.encode(v)}'
+                    for (k, v) in obj.items()
+                ) + '}'
+        if isinstance(obj, list):
+            return '[' + ', '.join(map(self.encode, obj)) + ']'
+        if isinstance(obj, decimal.Decimal):
+            return f'{obj:f}'
+        return super().encode(obj)
+
+
 cdef bytes _encode_json_value(object val):
-    if isinstance(val, decimal.Decimal):
-        jarg = str(val)
-    else:
-        jarg = json.dumps(val)
+    jarg = json.dumps(val, cls=DecimalEncoder)
 
     return b'\x01' + jarg.encode('utf-8')
 

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -18,6 +18,9 @@
 
 
 import os
+import urllib
+import json
+import decimal
 
 import edgedb
 
@@ -357,3 +360,24 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
                 [True],
                 use_http_post=use_http_post,
             )
+
+    def test_http_edgeql_decimal_params_01(self):
+        req_data = b'''{
+            "query": "select <array<decimal>>$test",
+            "variables": {
+                "test": [1234567890123456789.01234567890123456789]
+            }
+        }'''
+
+        req = urllib.request.Request(self.http_addr, method='POST')
+        req.add_header('Content-Type', 'application/json')
+        response = urllib.request.urlopen(
+            req, req_data, context=self.tls_context
+        )
+        resp_data = json.loads(response.read(), parse_float=decimal.Decimal)
+
+        self.assert_data_shape(resp_data, {
+            'data': [
+                [decimal.Decimal('1234567890123456789.01234567890123456789')]
+            ]
+        })


### PR DESCRIPTION
Currently when using the edgeql_http protocol, decimal query params are decoded as floats and lose precision. Since decimals are returned in results with full precision, it seems query params should also support decimals the same way?.