### PR TITLE
Pull more initial state out of bootstrap compiler state

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1334,6 +1334,8 @@ async def _init_stdlib(
         std_schema=stdlib.stdschema,
         reflection_schema=stdlib.reflschema,
         schema_class_layout=stdlib.classlayout,
+        global_intro_query=stdlib.global_intro_query,
+        local_intro_query=stdlib.local_intro_query,
     )
     _, sql = compile_bootstrap_script(
         compiler,
@@ -1407,6 +1409,8 @@ async def _init_stdlib(
         std_schema=schema,
         reflection_schema=stdlib.reflschema,
         schema_class_layout=stdlib.classlayout,
+        global_intro_query=stdlib.global_intro_query,
+        local_intro_query=stdlib.local_intro_query,
     )
 
     await metaschema.generate_more_support_functions(
@@ -1427,6 +1431,8 @@ async def _init_stdlib(
             std_schema=stdlib.stdschema,
             reflection_schema=stdlib.reflschema,
             schema_class_layout=stdlib.classlayout,
+            global_intro_query=stdlib.global_intro_query,
+            local_intro_query=stdlib.local_intro_query,
         )
         _, sql = compile_bootstrap_script(
             compiler,

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -209,6 +209,10 @@ async def _run_server(
             disable_dynamic_system_config=args.disable_dynamic_system_config,
             compiler_state=compiler_state,
         )
+        # This coroutine runs as long as the server,
+        # and compiler_state is *heavy*, so make sure we don't
+        # keep a reference to it.
+        del compiler_state
         await sc.wait_for(ss.init())
 
         tls_cert_newly_generated = False


### PR DESCRIPTION
Continuing on Sully's work in #5836, avoid loading schemas and various
other internal paraphernalia twice, which saves ~20MiB of memory in the
I/O process.
