### PR TITLE
fix: SQL name resolving

### DIFF
--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -201,7 +201,8 @@ def _lookup_in_table(
 def _lookup_table(tab_name: str, ctx: Context) -> context.Table:
     matched_tables: List[context.Table] = []
     for t in ctx.scope.tables:
-        if t.name == tab_name or t.alias == tab_name:
+        t_name = t.alias or t.name
+        if t_name == tab_name:
             matched_tables.append(t)
 
     if not matched_tables:

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -154,7 +154,7 @@ class TestSQL(tb.SQLQueryTestCase):
         res = await self.scon.fetch(
             '''
             SELECT * FROM "Movie"
-            JOIN "Genre" g ON "Movie".genre_id = "Genre".id
+            JOIN "Genre" g ON "Movie".genre_id = g.id
             '''
         )
         self.assert_shape(res, 2, 7)
@@ -565,6 +565,26 @@ class TestSQL(tb.SQLQueryTestCase):
             """
         )
         self.assertEqual(res, [['24']])
+
+    async def test_sql_query_38(self):
+        res = await self.squery_values(
+            '''
+            WITH users AS (
+              SELECT 1 as id, NULL as managed_by
+              UNION ALL
+              SELECT 2 as id, 1 as managed_by
+            )
+            SELECT id, (
+              SELECT id FROM users e WHERE id = users.managed_by
+            ) as managed_by
+            FROM users
+            ORDER BY id
+            '''
+        )
+        self.assertEqual(res, [
+            [1, None],
+            [2, 1],
+        ])
 
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname


### PR DESCRIPTION
A result of tedious pg_dump debugging.
Tests on Postgres 15 were failing becuase they are using pg_dump 15,
which was producing the following statements that were
not produced by pg_dump 14:

```sql
CREATE TYPE edgedb."__SchemaAccessPolicy" (
    INTERNALLENGTH = variable,
    INPUT = array_in,
    OUTPUT = array_out,
    RECEIVE = array_recv,
    SEND = array_send,
    ANALYZE = array_typanalyze,
    ELEMENT = edgedb."_SchemaAccessPolicy",
    CATEGORY = 'A',
    ALIGNMENT = double,
    STORAGE = extended
);
```

Applying these dumps failed because type
edgedb."_SchemaAccessPolicy" did not exist.

After digging in pg_dump source code a bunch, trying to figure out
why these statements were showing up, I found a query similar to this:

```sql
select
  typname,
  (
    SELECT typarray FROM pg_type te WHERE oid = pg_type.typelem
  ) = oid AS isarray
from pg_type;
```

After inspecting the results, I found that our resolver does not match
`pg_type.typelem` to the outer `pg_type` (as it should), but to the inner
`pg_type`, even though the inner `pg_type` has an alias which should make
the orignal name inaccessible.

So that's the bug. With an easy fix.
Turns out that when I implemented the resolver I did not know this detail,
becuase we even had a test for it.
