### PR TITLE
Fix cardinality inference of calls to functions with OPTIONAL args

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -8819,6 +8819,20 @@ aa \
             }
         """)
 
+    async def test_edgeql_assert_message_crossproduct(self):
+        # Nobody should do this, but specifying a set to the message
+        # argument of an assert function should produce repeated
+        # output.
+        await self.assert_query_result(
+            """
+                select
+                    assert_single(1, message := {"uh", "oh"}) +
+                    assert_distinct(1, message := {"uh", "oh"}) +
+                    assert_exists({1, 2}, message := {"uh", "oh"});
+            """,
+            tb.bag([3] * 8 + [4] * 8),
+        )
+
     async def test_edgeql_assert_exists_01(self):
         await self.con.execute("""
             INSERT User {

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1126,3 +1126,45 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         AT_LEAST_ONE
         """
+
+    def test_edgeql_ir_card_inference_132(self):
+        """
+        select distinct <str>{}
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_133(self):
+        """
+        select distinct 1
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_134(self):
+        """
+        select distinct {1, 2}
+% OK %
+        AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_135(self):
+        """
+        <str>{} if true else {'foo', 'bar'}
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_136(self):
+        """
+        <str>{} if true else 'foo'
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_137(self):
+        """
+        'bar' if true else 'foo'
+% OK %
+        ONE
+        """

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1105,3 +1105,24 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         x: AT_LEAST_ONE
         """
+
+    def test_edgeql_ir_card_inference_129(self):
+        """
+        select assert(<bool>{})
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_130(self):
+        """
+        select assert(<bool>{}, message := {'uh', 'oh'})
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_131(self):
+        """
+        select assert(true, message := {'uh', 'oh'})
+% OK %
+        AT_LEAST_ONE
+        """

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1168,3 +1168,10 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         ONE
         """
+
+    def test_edgeql_ir_card_inference_138(self):
+        """
+        assert_exists(1, message := {"uh", "oh"})
+% OK %
+        AT_LEAST_ONE
+        """


### PR DESCRIPTION
There were two connected issues:
* Calls to functions with an OPTIONAL argument don't get
  a potentially zero result even if a non-OPTIONAL param
  might be zero.
* The cardinality of OPTIONAL arguments is totally ignored,
  even though it can cause the result to be MANY.

We will need to have a think about whether to cherry-pick this fix to 3.0.
This can easily change schema cardinality inference things, so we would run
a schema repair patch.