### PR TITLE
Add an EMPTY_SCHEMA variable and use it instead of FlatSchema()

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -156,7 +156,7 @@ def delta_schemas(
 
     if schema_a is None:
         if include_std_diff:
-            schema_a = s_schema.FlatSchema()
+            schema_a = s_schema.EMPTY_SCHEMA
         else:
             schema_a = schema_b
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1485,6 +1485,9 @@ class FlatSchema(Schema):
             f'<{type(self).__name__} gen:{self._generation} at {id(self):#x}>')
 
 
+EMPTY_SCHEMA = FlatSchema()
+
+
 def upgrade_schema(schema: FlatSchema) -> FlatSchema:
     """Repair a schema object serialized by an older patch version
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -953,9 +953,9 @@ async def _make_stdlib(
     global_ids: Mapping[str, uuid.UUID],
 ) -> StdlibBits:
     schema: s_schema.Schema = s_schema.ChainedSchema(
-        s_schema.FlatSchema(),
-        s_schema.FlatSchema(),
-        s_schema.FlatSchema(),
+        s_schema.EMPTY_SCHEMA,
+        s_schema.EMPTY_SCHEMA,
+        s_schema.EMPTY_SCHEMA,
     )
     schema, _ = s_mod.Module.create_in_schema(
         schema,
@@ -1134,7 +1134,7 @@ def _compile_intro_queries_stdlib(
     *,
     compiler: edbcompiler.Compiler,
     user_schema: s_schema.Schema,
-    global_schema: s_schema.Schema=s_schema.FlatSchema(),
+    global_schema: s_schema.Schema=s_schema.EMPTY_SCHEMA,
     reflection: s_refl.SchemaReflectionParts,
 ) -> Tuple[str, str]:
     compilerctx = edbcompiler.new_compiler_context(
@@ -2141,7 +2141,7 @@ async def _bootstrap(ctx: BootstrapContext) -> edbcompiler.CompilerState:
             report_configs_typedesc_2_0,
         )
 
-        schema = s_schema.FlatSchema()
+        schema = s_schema.EMPTY_SCHEMA
         schema = await _init_defaults(schema, compiler, tpl_ctx.conn)
 
         # Run analyze on the template database, so that new dbs start

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -254,7 +254,7 @@ def new_compiler_context(
     *,
     compiler_state: CompilerState,
     user_schema: s_schema.Schema,
-    global_schema: s_schema.Schema=s_schema.FlatSchema(),
+    global_schema: s_schema.Schema=s_schema.EMPTY_SCHEMA,
     modaliases: Optional[Mapping[Optional[str], str]] = None,
     expected_cardinality_one: bool = False,
     json_parameters: bool = False,
@@ -1317,7 +1317,7 @@ def _compile_schema_storage_stmt(
             s_schema.ChainedSchema(
                 ctx.compiler_state.std_schema,
                 ctx.compiler_state.refl_schema,
-                s_schema.FlatSchema()
+                s_schema.EMPTY_SCHEMA
             )
         )
 
@@ -1646,7 +1646,7 @@ def _compile_ql_query(
             ir.schema = s_schema.ChainedSchema(
                 top_schema=ir.schema._top_schema,
                 global_schema=ir.schema._global_schema,
-                base_schema=s_schema.FlatSchema(),
+                base_schema=s_schema.EMPTY_SCHEMA,
             )
         query_asts = pickle.dumps((ql, ir, sql_res.ast, explain_data))
     else:

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -462,7 +462,7 @@ def _start_migration(
         assert ctx.compiler_state.std_schema is not None
         base_schema = s_schema.ChainedSchema(
             ctx.compiler_state.std_schema,
-            s_schema.FlatSchema(),
+            s_schema.EMPTY_SCHEMA,
             current_tx.get_global_schema(),
         )
         target_schema = s_ddl.apply_sdl(
@@ -958,7 +958,7 @@ def _start_migration_rewrite(
         # Start from an empty schema except for `module default`
     base_schema = s_schema.ChainedSchema(
         ctx.compiler_state.std_schema,
-        s_schema.FlatSchema(),
+        s_schema.EMPTY_SCHEMA,
         current_tx.get_global_schema(),
     )
     base_schema = s_ddl.apply_sdl(  # type: ignore
@@ -1113,7 +1113,7 @@ def _reset_schema(
 
     empty_schema = s_schema.ChainedSchema(
         ctx.compiler_state.std_schema,
-        s_schema.FlatSchema(),
+        s_schema.EMPTY_SCHEMA,
         current_tx.get_global_schema(),
     )
     empty_schema = s_ddl.apply_sdl(  # type: ignore
@@ -1183,7 +1183,7 @@ def repair_schema(
 
     empty_schema = s_schema.ChainedSchema(
         ctx.compiler_state.std_schema,
-        s_schema.FlatSchema(),
+        s_schema.EMPTY_SCHEMA,
         current_tx.get_global_schema(),
     )
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -755,7 +755,7 @@ class Server(ha_base.ClusterProtocol):
 
         return s_refl.parse_into(
             base_schema=self._std_schema,
-            schema=s_schema.FlatSchema(),
+            schema=s_schema.EMPTY_SCHEMA,
             data=json_data,
             schema_class_layout=self._schema_class_layout,
         )
@@ -776,13 +776,13 @@ class Server(ha_base.ClusterProtocol):
 
         base_schema = s_schema.ChainedSchema(
             self._std_schema,
-            s_schema.FlatSchema(),
+            s_schema.EMPTY_SCHEMA,
             global_schema or self.get_global_schema(),
         )
 
         return s_refl.parse_into(
             base_schema=base_schema,
-            schema=s_schema.FlatSchema(),
+            schema=s_schema.EMPTY_SCHEMA,
             data=json_data,
             schema_class_layout=self._schema_class_layout,
         )

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -273,7 +273,7 @@ def _load_std_schema():
                 std_dirs_hash, 'transient-stdschema.pickle')
 
         if schema is None:
-            schema = s_schema.FlatSchema()
+            schema = s_schema.EMPTY_SCHEMA
             for modname in [*s_schema.STD_SOURCES, *s_schema.TESTMODE_SOURCES]:
                 schema = s_std.load_std_module(schema, modname)
             schema, _ = s_std.make_schema_version(schema)

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -299,8 +299,8 @@ async def _get_dbs_and_roles(
     compiler = await edbcompiler.new_compiler_from_pg(pgconn)
     compilerctx = edbcompiler.new_compiler_context(
         compiler_state=compiler.state,
-        user_schema=s_schema.FlatSchema(),
-        global_schema=s_schema.FlatSchema(),
+        user_schema=s_schema.EMPTY_SCHEMA,
+        global_schema=s_schema.EMPTY_SCHEMA,
         expected_cardinality_one=False,
         output_format=edbcompiler.OutputFormat.JSON,
         bootstrap_mode=True,


### PR DESCRIPTION
This is a pretty marginal performance improvement but I think it's a
little cleaner too.