### PR TITLE
Add no-op GitHub OAuth callback handler

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -12,7 +12,7 @@
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 <%- endmacro %>
 
 <% macro _init_venv() -%>

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     # Build virtualenv
 
@@ -331,7 +331,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     # Build virtualenv
 
@@ -375,7 +375,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -579,7 +579,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -831,7 +831,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -1049,7 +1049,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -1255,7 +1255,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     # Build virtualenv
 
@@ -383,7 +383,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     # Build virtualenv
 
@@ -360,7 +360,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     # Build virtualenv
 
@@ -413,7 +413,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -548,7 +548,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10.12'
+        python-version: '3.11.3'
 
     - name: Handle virtualenv
       uses: syphar/restore-virtualenv@v1

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -20,14 +20,10 @@ from datetime import datetime
 
 from . import data
 
+
 class BaseProvider:
     def __init__(
-        self,
-        name: str,
-        client_id: str,
-        client_secret: str,
-        *,
-        http_factory
+        self, name: str, client_id: str, client_secret: str, *, http_factory
     ):
         self.name = name
         self.client_id = client_id
@@ -46,9 +42,7 @@ class BaseProvider:
     async def fetch_emails(self, token: str) -> list[data.Email]:
         raise NotImplementedError
 
-    def _maybe_isoformat_to_timestamp(
-        self, value: str | None
-    ) -> int | None:
+    def _maybe_isoformat_to_timestamp(self, value: str | None) -> int | None:
         return (
             int(datetime.fromisoformat(value).timestamp()) if value else None
         )

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -16,6 +16,9 @@
 # limitations under the License.
 #
 
+from datetime import datetime
+
+from . import data
 
 class BaseProvider:
     def __init__(self, name: str, client_id: str, client_secret: str):
@@ -29,5 +32,15 @@ class BaseProvider:
     async def exchange_code(self, code: str) -> str:
         raise NotImplementedError
 
-    async def fetch_user_info(self, token: str) -> dict[str, str]:
+    async def fetch_user_info(self, token: str) -> data.UserInfo:
         raise NotImplementedError
+
+    async def fetch_emails(self, token: str) -> list[data.Email]:
+        raise NotImplementedError
+
+    def _maybe_isoformat_to_timestamp(
+        self, value: str | None
+    ) -> int | None:
+        return (
+            int(datetime.fromisoformat(value).timestamp()) if value else None
+        )

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -21,10 +21,18 @@ from datetime import datetime
 from . import data
 
 class BaseProvider:
-    def __init__(self, name: str, client_id: str, client_secret: str):
+    def __init__(
+        self,
+        name: str,
+        client_id: str,
+        client_secret: str,
+        *,
+        http_factory
+    ):
         self.name = name
         self.client_id = client_id
         self.client_secret = client_secret
+        self.http_factory = http_factory
 
     def get_code_url(self, state: str, redirect_uri: str) -> str:
         raise NotImplementedError

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -1,0 +1,71 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import dataclasses
+from typing import Optional
+
+
+@dataclasses.dataclass
+class UserInfo:
+    """
+    OpenID Connect compatible user info.
+    See: https://openid.net/specs/openid-connect-core-1_0.html
+    """
+
+    sub: str
+    name: Optional[str] = None
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
+    middle_name: Optional[str] = None
+    nickname: Optional[str] = None
+    preferred_username: Optional[str] = None
+    profile: Optional[str] = None
+    picture: Optional[str] = None
+    website: Optional[str] = None
+    email: Optional[str] = None
+    email_verified: Optional[bool] = None
+    gender: Optional[str] = None
+    birthdate: Optional[str] = None
+    zoneinfo: Optional[str] = None
+    locale: Optional[str] = None
+    phone_number: Optional[str] = None
+    phone_number_verified: Optional[bool] = None
+    address: Optional[dict[str, str]] = None
+    updated_at: Optional[int] = None
+
+    def __str__(self) -> str:
+        return self.sub
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"sub={self.sub!r} "
+            f"name={self.name!r} "
+            f"email={self.email!r} "
+            f"preferred_username={self.preferred_username!r})"
+        )
+
+
+@dataclasses.dataclass
+class Email:
+    """Email address"""
+
+    address: str
+    is_verified: bool
+    is_primary: bool

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -17,7 +17,6 @@
 #
 
 
-import httpx
 import urllib.parse
 
 from . import base
@@ -46,8 +45,7 @@ class GitHubProvider(base.BaseProvider):
             "client_secret": self.client_secret,
         }
 
-        async with self.http_factory(
-                base_url='https://github.com') as client:
+        async with self.http_factory(base_url='https://github.com') as client:
             resp = await client.post(
                 "/login/oauth/access_token",
                 json=data,
@@ -59,7 +57,8 @@ class GitHubProvider(base.BaseProvider):
 
     async def fetch_user_info(self, token: str) -> data.UserInfo:
         async with self.http_factory(
-                base_url='https://api.github.com') as client:
+            base_url='https://api.github.com'
+        ) as client:
             resp = await client.get(
                 "/user",
                 headers={
@@ -82,7 +81,8 @@ class GitHubProvider(base.BaseProvider):
 
     async def fetch_emails(self, token: str) -> list[data.Email]:
         async with self.http_factory(
-                base_url='https://api.github.com') as client:
+            base_url='https://api.github.com'
+        ) as client:
             resp = await client.get(
                 "/user/emails",
                 headers={

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -38,7 +38,7 @@ class GitHubProvider(base.BaseProvider):
         encoded = urllib.parse.urlencode(params)
         return f"https://github.com/login/oauth/authorize?{encoded}"
 
-    async def exchange_access_token(self, code: str) -> str:
+    async def exchange_code(self, code: str) -> str:
         data = {
             "grant_type": "authorization_code",
             "code": code,
@@ -51,6 +51,7 @@ class GitHubProvider(base.BaseProvider):
                 "https://github.com/login/oauth/access_token",
                 json=data,
             )
+            print(f"resp: {resp.text!r}")
             token = resp.json()["access_token"]
 
             return token

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -53,7 +53,12 @@ class Router:
                     provider = _get_search_param(
                         request.url.query.decode("ascii"), "provider"
                     )
-                    client = oauth.Client(db=self.db, provider=provider)
+                    client = oauth.Client(
+                        db=self.db,
+                        provider=provider,
+                        request=request,
+                        test_mode=self.test_mode,
+                    )
                     authorize_url = client.get_authorize_url(
                         redirect_uri=self._get_callback_url(),
                         state=self._make_state_claims(provider),
@@ -81,12 +86,6 @@ class Router:
 
                 case _:
                     raise errors.NotFound("Unknown OAuth endpoint")
-
-        except Exception as ex:
-            from edb.common import markup
-            markup.dump(ex)
-            raise
-
 
         except errors.NotFound as ex:
             _fail_with_error(

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -30,6 +30,7 @@ from edb import errors as edb_errors
 from edb.common import debug
 from edb.common import markup
 
+from . import oauth
 from . import errors
 from . import util
 
@@ -45,8 +46,6 @@ class Router:
         try:
             match args:
                 case ("authorize",):
-                    from . import oauth
-
                     # TODO: this is ambiguous whether it's a name or ID which
                     # is useful now, but we'll need to pivot to ID sooner than
                     # later and then rename all of this to provider_id
@@ -63,8 +62,6 @@ class Router:
                     response.close_connection = True
 
                 case ("callback",):
-                    from . import oauth
-
                     query = request.url.query.decode("ascii")
                     state = _get_search_param(query, "state")
                     code = _get_search_param(query, "code")

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -23,7 +23,7 @@ import urllib.parse
 import httpx
 
 
-from typing import *
+from typing import Any
 
 from . import errors, util, data
 
@@ -49,21 +49,13 @@ class HttpClient(httpx.AsyncClient):
 
 
 class Client:
-    def __init__(self, db: Any, provider: str, request, test_mode):
+    def __init__(self, db: Any, provider: str, base_url: str | None = None):
         self.db = db
         self.db_config = db.db_config
 
-        if (
-            test_mode
-            and request.params
-            and b'oauth-test-server' in request.params
-        ):
-            test_url = request.params[b'oauth-test-server'].decode()
-            http_factory = lambda *args, **kwargs: HttpClient(
-                *args, edgedb_test_url=test_url, **kwargs
-            )
-        else:
-            http_factory = HttpClient
+        http_factory = lambda *args, **kwargs: HttpClient(
+            *args, edgedb_test_url=base_url, **kwargs
+        )
 
         match provider:
             case "github":

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -553,7 +553,11 @@ cdef class HttpProtocol:
                     )
                     extension_base_path = f"{request.url.schema.decode()}://" \
                                           f"{netloc}/db/{dbname}/ext/auth"
-                    handler = auth_ext.http.Router(db, extension_base_path)
+                    handler = auth_ext.http.Router(
+                        db=db,
+                        base_path=extension_base_path,
+                        test_mode=self.server.in_test_mode(),
+                    )
                     await handler.handle_request(request, response, args)
 
         elif route == 'auth':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     'setproctitle~=1.2',
 
     'httpx~=0.24.1',
+    'respx~=0.20.2',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     'setproctitle~=1.2',
 
     'httpx~=0.24.1',
-    'respx~=0.20.2',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ skip-string-normalization = true
 # ========================
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 plugins = "edb/tools/mypy/plugin.py"
 follow_imports = "normal"
 ignore_missing_imports = true

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -300,7 +300,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 """SELECT assert_single(cfg::Config.xxx_github_client_id);"""
             )
             client_secret = await self.con.query_single(
-                """SELECT assert_single(cfg::Config.xxx_github_client_secret);"""
+                """
+                SELECT assert_single(cfg::Config.xxx_github_client_secret);
+                """
             )
 
             now = datetime.datetime.utcnow().isoformat()


### PR DESCRIPTION
This adds the necessary requests to complete the authorization code flow for GitHub as well as request user data and emails for the authenticated user. It purposefully does not yet do anything with that data (going to do that as a separate PR).