### PR TITLE
Add tuple alias example

### DIFF
--- a/docs/datamodel/aliases.rst
+++ b/docs/datamodel/aliases.rst
@@ -62,7 +62,7 @@ properties or links.
 In effect, this creates a *virtual subtype* of the base type, which can be
 referenced in queries just like any other type.
 
-**Query alias**
+**Expression alias**
 
 Aliases can correspond to an arbitrary EdgeQL expression, including entire
 queries.
@@ -70,8 +70,10 @@ queries.
 .. code-block:: sdl
     :version-lt: 3.0
 
+    # Expression producing a tuple alias
     alias Color := ("Purple", 128, 0, 128);
 
+    # Expression producing a named tuple alias
     alias GameInfo := (
       name := "Li Europan Lingues",
       country := "Iceland",
@@ -87,6 +89,7 @@ queries.
       required property is_published -> bool;
     }
 
+    # Alias produced from a full query
     alias PublishedPosts := (
       select BlogPost
       filter .is_published = true
@@ -94,8 +97,10 @@ queries.
 
 .. code-block:: sdl
 
+    # Expression producing a tuple alias
     alias Color := ("Purple", 128, 0, 128);
 
+    # Expression producing a named tuple alias
     alias GameInfo := (
       name := "Li Europan Lingues",
       country := "Iceland",
@@ -111,6 +116,7 @@ queries.
       required is_published: bool;
     }
 
+    # Alias produced from a full query
     alias PublishedPosts := (
       select BlogPost
       filter .is_published = true

--- a/docs/datamodel/aliases.rst
+++ b/docs/datamodel/aliases.rst
@@ -33,27 +33,6 @@ of all User objects*. After declaring the alias below, you can use ``User`` and
 
   alias UserAlias := User;
 
-**Tuple alias**
-
-A tuple alias has features in common with both scalar and object type aliases.
-Like object type aliases, a tuple alias can hold multiple values that can be
-accessed using the ``.`` dot operator. But like scalar aliases, a tuple alias
-is a standalone expression that does not involve object types.
-
-.. code-block:: sdl
-
-    alias Color := ("Purple", 128, 0, 128);
-
-    alias GameInfo := (
-      name := "Li Europan Lingues",
-      country := "Iceland",
-      date_published := 2023,
-      creators := (
-        (name := "Bob Bobson", age := 20),
-        (name := "Trina Trinadóttir", age := 25),
-      ),
-    );
-
 **Object type alias with computeds**
 
 Object type aliases can include a *shape* that declare additional computed
@@ -91,6 +70,18 @@ queries.
 .. code-block:: sdl
     :version-lt: 3.0
 
+    alias Color := ("Purple", 128, 0, 128);
+
+    alias GameInfo := (
+      name := "Li Europan Lingues",
+      country := "Iceland",
+      date_published := 2023,
+      creators := (
+        (name := "Bob Bobson", age := 20),
+        (name := "Trina Trinadóttir", age := 25),
+      ),
+    );
+
     type BlogPost {
       required property title -> str;
       required property is_published -> bool;
@@ -102,6 +93,18 @@ queries.
     );
 
 .. code-block:: sdl
+
+    alias Color := ("Purple", 128, 0, 128);
+
+    alias GameInfo := (
+      name := "Li Europan Lingues",
+      country := "Iceland",
+      date_published := 2023,
+      creators := (
+        (name := "Bob Bobson", age := 20),
+        (name := "Trina Trinadóttir", age := 25),
+      ),
+    );
 
     type BlogPost {
       required title: str;

--- a/docs/datamodel/aliases.rst
+++ b/docs/datamodel/aliases.rst
@@ -33,6 +33,27 @@ of all User objects*. After declaring the alias below, you can use ``User`` and
 
   alias UserAlias := User;
 
+**Tuple alias**
+
+A tuple alias has features in common with both scalar and object type aliases.
+Like object type aliases, a tuple alias can hold multiple values that can be
+accessed using the ``.`` dot operator. But like scalar aliases, a tuple alias
+is a standalone expression that does not involve object types.
+
+.. code-block:: sdl
+
+    alias Color := ("Purple", 128, 0, 128);
+
+    alias GameInfo := (
+      name := "Li Europan Lingues",
+      country := "Iceland",
+      date_published := 2023,
+      creators := (
+        (name := "Bob Bobson", age := 20),
+        (name := "Trina Trinadóttir", age := 25),
+      ),
+    );
+
 **Object type alias with computeds**
 
 Object type aliases can include a *shape* that declare additional computed

--- a/docs/datamodel/aliases.rst
+++ b/docs/datamodel/aliases.rst
@@ -14,8 +14,9 @@ An **alias** is a *pointer* to a set of values. This set is defined with an
 arbitrary EdgeQL expression.
 
 Like computed properties, this expression is evaluated on the fly whenever the
-alias is referenced in a query. Unlike computed properties, aliases are defined
-independent of an object type; they are standalone expressions.
+alias is referenced in a query. Unlike computed properties, aliases are 
+defined independent of an object type; they are standalone expressions.
+As such, aliases are fairly open ended. Some examples are:
 
 **Scalar alias**
 
@@ -62,7 +63,7 @@ properties or links.
 In effect, this creates a *virtual subtype* of the base type, which can be
 referenced in queries just like any other type.
 
-**Expression alias**
+**Other arbitrary expressions**
 
 Aliases can correspond to an arbitrary EdgeQL expression, including entire
 queries.
@@ -70,10 +71,10 @@ queries.
 .. code-block:: sdl
     :version-lt: 3.0
 
-    # Expression producing a tuple alias
+    # Tuple alias
     alias Color := ("Purple", 128, 0, 128);
 
-    # Expression producing a named tuple alias
+    # Named tuple alias
     alias GameInfo := (
       name := "Li Europan Lingues",
       country := "Iceland",
@@ -89,7 +90,7 @@ queries.
       required property is_published -> bool;
     }
 
-    # Alias produced from a full query
+    # Query alias
     alias PublishedPosts := (
       select BlogPost
       filter .is_published = true
@@ -97,10 +98,10 @@ queries.
 
 .. code-block:: sdl
 
-    # Expression producing a tuple alias
+    # Tuple alias
     alias Color := ("Purple", 128, 0, 128);
 
-    # Expression producing a named tuple alias
+    # Named tuple alias
     alias GameInfo := (
       name := "Li Europan Lingues",
       country := "Iceland",
@@ -116,7 +117,7 @@ queries.
       required is_published: bool;
     }
 
-    # Alias produced from a full query
+    # Query alias
     alias PublishedPosts := (
       select BlogPost
       filter .is_published = true

--- a/docs/datamodel/aliases.rst
+++ b/docs/datamodel/aliases.rst
@@ -65,7 +65,7 @@ referenced in queries just like any other type.
 
 **Other arbitrary expressions**
 
-Aliases can correspond to an arbitrary EdgeQL expression, including entire
+Aliases can correspond to any arbitrary EdgeQL expression, including entire
 queries.
 
 .. code-block:: sdl


### PR DESCRIPTION
The documentation on aliases currently has examples for scalars, objects, and expressions, but none on tuples. Being able to make a tuple might seem to be a bit of a no-brainer but IMO it's good to explicitly mention and give an example as an alias that stands sort of between scalars and objects: has multpile values and works like an object but doesn't need an insert so it's a pointer to a set of values instead of objects in a database.