### PR TITLE
Add schema for ext::auth module

### DIFF
--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -163,24 +163,6 @@ ALTER TYPE cfg::AbstractConfig {
             'Whether inserts are allowed to set the \'id\' property.';
     };
 
-    # XXX: Remove these and move to extension config mechanism when ready
-    CREATE PROPERTY xxx_auth_signing_key -> std::str {
-        CREATE ANNOTATION std::description :=
-            'The signing key used for auth extension. Must be at \
-            least 32 characters long.';
-        SET default := '00000000000000000000000000000000';
-    };
-
-    CREATE PROPERTY xxx_github_client_secret -> std::str {
-        CREATE ANNOTATION std::description := 'Secret key provided by GitHub';
-        SET default := '00000000000000000000000000000000';
-    };
-
-    CREATE PROPERTY xxx_github_client_id -> std::str {
-        CREATE ANNOTATION std::description := 'ID provided by GitHub';
-        SET default := '00000000000000000000000000000000';
-    };
-
     # Exposed backend settings follow.
     # When exposing a new setting, remember to modify
     # the _read_sys_config function to select the value

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -24,10 +24,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
     create abstract type ext::auth::User;
 
-    create type ext::auth::Identity {
-        create required link user: ext::auth::User;
-    };
-
     create type ext::auth::Provider {
         create required property name: std::str;
         create required property url: std::str {
@@ -35,19 +31,9 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         };
     };
 
-    create type ext::auth::Email {
-        create required property address: std::str;
-        create required property verified: std::bool;
-        create required property primary: std::bool;
-
-        create required link identity: ext::auth::Identity;
-
-        create constraint exclusive on ((.identity, .primary));
-    };
-
-    create type ext::auth::Claims {
+    create type ext::auth::Identity {
         create required link issuer: ext::auth::Provider;
-        create required link subject: ext::auth::Identity;
+        create required link subject: ext::auth::User;
 
         # Standard claims
         create required property sub: std::str;
@@ -65,6 +51,16 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create property zoneinfo: std::str;
         create property locale: std::str;
         create property updated_at: std::datetime;
+    };
+
+    create type ext::auth::Email {
+        create required property address: std::str;
+        create required property verified: std::bool;
+        create required property primary: std::bool;
+
+        create required link identity: ext::auth::Identity;
+
+        create constraint exclusive on ((.identity, .primary));
     };
 
     create type ext::auth::Session {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -22,8 +22,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
     create module ext::auth;
 
-    create abstract type ext::auth::User;
-
     create type ext::auth::Provider {
         create required property name: std::str;
         create required property url: std::str {
@@ -33,9 +31,8 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
     create type ext::auth::Identity {
         create required link issuer: ext::auth::Provider;
-        create required link subject: ext::auth::User;
 
-        # Standard claims
+        # Standard OpenID claims
         create required property sub: std::str;
         create property name: std::str;
         create property given_name: std::str;
@@ -70,6 +67,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property created_at: std::datetime;
         create property expires_at: std::datetime;
 
-        create required link user: ext::auth::User;
+        create required link identity: ext::auth::Identity;
     };
 };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -17,4 +17,63 @@
 #
 
 
-CREATE EXTENSION PACKAGE auth VERSION '1.0';
+CREATE EXTENSION PACKAGE auth VERSION '1.0' {
+    set ext_module := "ext::auth";
+
+    create module ext::auth;
+
+    create abstract type ext::auth::User;
+
+    create type ext::auth::Identity {
+        create required link user: ext::auth::User;
+    };
+
+    create type ext::auth::Provider {
+        create required property name: std::str;
+        create required property url: std::str {
+            create constraint exclusive;
+        };
+    };
+
+    create type ext::auth::Email {
+        create required property address: std::str;
+        create required property verified: std::bool;
+        create required property primary: std::bool;
+
+        create required link identity: ext::auth::Identity;
+
+        create constraint exclusive on ((.identity, .primary));
+    };
+
+    create type ext::auth::Claims {
+        create required link issuer: ext::auth::Provider;
+        create required link subject: ext::auth::Identity;
+
+        # Standard claims
+        create required property sub: std::str;
+        create property name: std::str;
+        create property given_name: std::str;
+        create property family_name: std::str;
+        create property middle_name: std::str;
+        create property nickname: std::str;
+        create property preferred_username: std::str;
+        create property profile: std::str;
+        create property picture: std::str;
+        create property website: std::str;
+        create property gender: std::str;
+        create property birthdate: std::str;
+        create property zoneinfo: std::str;
+        create property locale: std::str;
+        create property updated_at: std::datetime;
+    };
+
+    create type ext::auth::Session {
+        create required property token: std::str {
+            create constraint exclusive;
+        };
+        create required property created_at: std::datetime;
+        create property expires_at: std::datetime;
+
+        create required link user: ext::auth::User;
+    };
+};

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -22,15 +22,8 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
     create module ext::auth;
 
-    create type ext::auth::Provider {
-        create required property name: std::str;
-        create required property url: std::str {
-            create constraint exclusive;
-        };
-    };
-
     create type ext::auth::Identity {
-        create required link issuer: ext::auth::Provider;
+        create required property provider: std::str;
 
         # Standard OpenID claims
         create required property sub: std::str;

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -29,4 +29,23 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
         create constraint exclusive on ((.iss, .sub))
     };
+
+    create type ext::auth::AuthConfig extending cfg::ExtensionConfig {
+        create property auth_signing_key -> std::str {
+            create annotation std::description :=
+                'The signing key used for auth extension. Must be at \
+                least 32 characters long.';
+            set default := '00000000000000000000000000000000';
+        };
+
+        create property github_client_secret -> std::str {
+            create annotation std::description := 'Secret key provided by GitHub';
+            set default := '00000000000000000000000000000000';
+        };
+
+        create property github_client_id -> std::str {
+            create annotation std::description := 'ID provided by GitHub';
+            set default := '00000000000000000000000000000000';
+        };
+    };
 };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -30,22 +30,47 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create constraint exclusive on ((.iss, .sub))
     };
 
+    create type ext::auth::ClientConfig extending cfg::ConfigObject {
+        create required property provider_id: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "ID of the auth provider";
+        };
+
+        create required property provider_name: std::str {
+            set readonly := true;
+            create annotation std::description := "Auth provider name";
+        };
+
+        create required property url: std::str {
+            set readonly := true;
+            create annotation std::description := "Authorization server URL";
+        };
+
+        create required property secret: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "Secret provided by auth provider";
+        };
+
+        create required property client_id: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "ID for client provided by auth provider";
+        };
+    };
+
     create type ext::auth::AuthConfig extending cfg::ExtensionConfig {
+        create multi link providers -> ext::auth::ClientConfig {
+            create annotation std::description :=
+                "Configuration for auth provider clients";
+        };
+
         create property auth_signing_key -> std::str {
             create annotation std::description :=
-                'The signing key used for auth extension. Must be at \
-                least 32 characters long.';
-            set default := '00000000000000000000000000000000';
-        };
-
-        create property github_client_secret -> std::str {
-            create annotation std::description := 'Secret key provided by GitHub';
-            set default := '00000000000000000000000000000000';
-        };
-
-        create property github_client_id -> std::str {
-            create annotation std::description := 'ID provided by GitHub';
-            set default := '00000000000000000000000000000000';
+                "The signing key used for auth extension. Must be at \
+                least 32 characters long.";
+            set default := "00000000000000000000000000000000";
         };
     };
 };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -26,6 +26,8 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property iss: std::str;
         create required property sub: std::str;
         create property email: std::str;
+
+        create constraint exclusive on ((.iss, .sub))
     };
 
     create type ext::auth::Session {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -23,34 +23,9 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     create module ext::auth;
 
     create type ext::auth::Identity {
-        create required property provider: std::str;
-
-        # Standard OpenID claims
+        create required property iss: std::str;
         create required property sub: std::str;
-        create property name: std::str;
-        create property given_name: std::str;
-        create property family_name: std::str;
-        create property middle_name: std::str;
-        create property nickname: std::str;
-        create property preferred_username: std::str;
-        create property profile: std::str;
-        create property picture: std::str;
-        create property website: std::str;
-        create property gender: std::str;
-        create property birthdate: std::str;
-        create property zoneinfo: std::str;
-        create property locale: std::str;
-        create property updated_at: std::datetime;
-    };
-
-    create type ext::auth::Email {
-        create required property address: std::str;
-        create required property verified: std::bool;
-        create required property primary: std::bool;
-
-        create required link identity: ext::auth::Identity;
-
-        create constraint exclusive on ((.identity, .primary));
+        create property email: std::str;
     };
 
     create type ext::auth::Session {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -29,14 +29,4 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
         create constraint exclusive on ((.iss, .sub))
     };
-
-    create type ext::auth::Session {
-        create required property token: std::str {
-            create constraint exclusive;
-        };
-        create required property created_at: std::datetime;
-        create property expires_at: std::datetime;
-
-        create required link identity: ext::auth::Identity;
-    };
 };

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -23,9 +23,16 @@ from . import data
 
 class BaseProvider:
     def __init__(
-        self, name: str, client_id: str, client_secret: str, *, http_factory
+        self,
+        name: str,
+        issuer_url: str,
+        client_id: str,
+        client_secret: str,
+        *,
+        http_factory,
     ):
         self.name = name
+        self.issuer_url = issuer_url
         self.client_id = client_id
         self.client_secret = client_secret
         self.http_factory = http_factory
@@ -40,6 +47,4 @@ class BaseProvider:
         raise NotImplementedError
 
     def _maybe_isoformat_to_timestamp(self, value: str | None) -> float | None:
-        return (
-            datetime.fromisoformat(value).timestamp() if value else None
-        )
+        return datetime.fromisoformat(value).timestamp() if value else None

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -39,9 +39,6 @@ class BaseProvider:
     async def fetch_user_info(self, token: str) -> data.UserInfo:
         raise NotImplementedError
 
-    async def fetch_emails(self, token: str) -> list[data.Email]:
-        raise NotImplementedError
-
     def _maybe_isoformat_to_timestamp(self, value: str | None) -> float | None:
         return (
             datetime.fromisoformat(value).timestamp() if value else None

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -60,12 +60,3 @@ class UserInfo:
             f"email={self.email!r} "
             f"preferred_username={self.preferred_username!r})"
         )
-
-
-@dataclasses.dataclass
-class Email:
-    """Email address"""
-
-    address: str
-    is_verified: bool
-    is_primary: bool

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -26,8 +26,8 @@ from . import data
 
 class GitHubProvider(base.BaseProvider):
     def __init__(self, *args, **kwargs):
-        super().__init__("github", *args, **kwargs)
-        self.auth_domain = "https://github.com"
+        super().__init__("github", "https://github.com", *args, **kwargs)
+        self.auth_domain = self.issuer_url
         self.api_domain = "https://api.github.com"
         self.auth_client = functools.partial(
             self.http_factory, base_url=self.auth_domain

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -84,24 +84,3 @@ class GitHubProvider(base.BaseProvider):
                     payload.get("updated_at")
                 ),
             )
-
-    async def fetch_emails(self, token: str) -> list[data.Email]:
-        async with self.api_client() as client:
-            resp = await client.get(
-                "/user/emails",
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
-            payload = resp.json()
-
-            return [
-                data.Email(
-                    address=d["email"],
-                    is_verified=d["verified"],
-                    is_primary=d["primary"],
-                )
-                for d in payload
-            ]

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -132,7 +132,7 @@ class Router:
 
     def _get_auth_signing_key(self) -> jwk.JWK:
         auth_signing_key = util.get_config(
-            self.db.db_config, "xxx_auth_signing_key"
+            self.db.db_config, "ext::auth::AuthConfig::auth_signing_key"
         )
         key_bytes = base64.b64encode(auth_signing_key.encode())
 

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -57,18 +57,15 @@ class Router:
         try:
             match args:
                 case ("authorize",):
-                    # TODO: this is ambiguous whether it's a name or ID which
-                    # is useful now, but we'll need to pivot to ID sooner than
-                    # later and then rename all of this to provider_id
-                    provider = _get_search_param(
+                    provider_id = _get_search_param(
                         request.url.query.decode("ascii"), "provider"
                     )
                     client = oauth.Client(
-                        db=self.db, provider=provider, base_url=test_url
+                        db=self.db, provider_id=provider_id, base_url=test_url
                     )
                     authorize_url = client.get_authorize_url(
                         redirect_uri=self._get_callback_url(),
-                        state=self._make_state_claims(provider),
+                        state=self._make_state_claims(provider_id),
                     )
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = authorize_url
@@ -78,11 +75,11 @@ class Router:
                     query = request.url.query.decode("ascii")
                     state = _get_search_param(query, "state")
                     code = _get_search_param(query, "code")
-                    provider = self._get_from_claims(state, "provider")
+                    provider_id = self._get_from_claims(state, "provider")
                     redirect_to = self._get_from_claims(state, "redirect_to")
                     client = oauth.Client(
                         db=self.db,
-                        provider=provider,
+                        provider_id=provider_id,
                         base_url=test_url,
                     )
                     await client.handle_callback(code)

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -17,7 +17,6 @@
 #
 
 
-import asyncio
 import urllib.parse
 
 import httpx

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -48,7 +48,7 @@ class HttpClient(httpx.AsyncClient):
 
 
 class Client:
-    def __init__(self, db: Any, provider: str, base_url: str | None = None):
+    def __init__(self, db: Any, provider_id: str, base_url: str | None = None):
         self.db = db
         self.db_config = db.db_config
 
@@ -56,12 +56,17 @@ class Client:
             *args, edgedb_test_url=base_url, **kwargs
         )
 
-        match provider:
+        (provider_name, client_id, client_secret) = self._get_provider_config(
+            provider_id
+        )
+
+        match provider_name:
             case "github":
                 from . import github
 
                 self.provider = github.GitHubProvider(
-                    *self._get_client_credientials("github"),
+                    client_id=client_id,
+                    client_secret=client_secret,
                     http_factory=http_factory,
                 )
             case _:
@@ -81,12 +86,23 @@ class Client:
     async def _handle_identity(self, user_info: data.UserInfo) -> None:
         ...
 
-    def _get_client_credientials(self, client_name: str) -> tuple[str, str]:
-        client_id = util.get_config(
-            self.db_config, f"ext::auth::AuthConfig::{client_name}_client_id"
+    def _get_provider_config(self, provider_id: str) -> tuple[str, str, str]:
+        provider_client_config = util.get_config(
+            self.db_config, "ext::auth::AuthConfig::providers", frozenset
         )
-        client_secret = util.get_config(
-            self.db_config,
-            f"ext::auth::AuthConfig::{client_name}_client_secret",
-        )
-        return client_id, client_secret
+        provider_name: str | None = None
+        client_id: str | None = None
+        client_secret: str | None = None
+        for cfg in provider_client_config:
+            if cfg.provider_id == provider_id:
+                provider_name = cfg.provider_name
+                client_id = cfg.client_id
+                client_secret = cfg.secret
+        r = (provider_name, client_id, client_secret)
+        match r:
+            case (str(_), str(_), str(_)):
+                return r
+            case _:
+                raise errors.InvalidData(
+                    f"Invalid provider configuration: {provider_id}"
+                )

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -78,16 +78,15 @@ class Client:
 
         await self._handle_identity(user_info)
 
-    async def _handle_identity(
-        self, user_info: data.UserInfo
-    ) -> None:
+    async def _handle_identity(self, user_info: data.UserInfo) -> None:
         ...
 
     def _get_client_credientials(self, client_name: str) -> tuple[str, str]:
         client_id = util.get_config(
-            self.db_config, f"xxx_{client_name}_client_id"
+            self.db_config, f"ext::auth::AuthConfig::{client_name}_client_id"
         )
         client_secret = util.get_config(
-            self.db_config, f"xxx_{client_name}_client_secret"
+            self.db_config,
+            f"ext::auth::AuthConfig::{client_name}_client_secret",
         )
         return client_id, client_secret

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -75,17 +75,12 @@ class Client:
 
     async def handle_callback(self, code: str) -> None:
         token = await self.provider.exchange_code(code)
+        user_info = await self.provider.fetch_user_info(token)
 
-        async with asyncio.TaskGroup() as g:
-            user_info_t = g.create_task(self.provider.fetch_user_info(token))
-            emails_t = g.create_task(self.provider.fetch_emails(token))
-        user_info = user_info_t.result()
-        emails = emails_t.result()
-
-        await self._handle_identity(user_info, emails)
+        await self._handle_identity(user_info)
 
     async def _handle_identity(
-        self, user_info: data.UserInfo, emails: list[data.Email]
+        self, user_info: data.UserInfo
     ) -> None:
         ...
 

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -37,7 +37,7 @@ bag = assert_data_shape.bag
 
 
 class BaseHttpExtensionTest(server.QueryTestCase):
-    EXTENSION_CONFIG: List[tuple[str, str]] = []
+    EXTENSION_SETUP: List[str] = []
 
     @classmethod
     def get_extension_name(cls):
@@ -61,14 +61,8 @@ class BaseHttpExtensionTest(server.QueryTestCase):
         cls.loop.run_until_complete(
             cls.con.execute(f'CREATE EXTENSION {extname};')
         )
-        for key, val in cls.EXTENSION_CONFIG:
-            cls.loop.run_until_complete(
-                cls.con.execute(
-                    f"""
-                    CONFIGURE CURRENT DATABASE SET {key} := {val};
-                    """
-                )
-            )
+        for q in cls.EXTENSION_SETUP:
+            cls.loop.run_until_complete(cls.con.execute(q))
 
     @classmethod
     def tearDownClass(cls):

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -37,6 +37,7 @@ bag = assert_data_shape.bag
 
 
 class BaseHttpExtensionTest(server.QueryTestCase):
+    EXTENSION_CONFIG: List[tuple[str, str]] = []
 
     @classmethod
     def get_extension_name(cls):
@@ -60,6 +61,14 @@ class BaseHttpExtensionTest(server.QueryTestCase):
         cls.loop.run_until_complete(
             cls.con.execute(f'CREATE EXTENSION {extname};')
         )
+        for key, val in cls.EXTENSION_CONFIG:
+            cls.loop.run_until_complete(
+                cls.con.execute(
+                    f"""
+                    CONFIGURE CURRENT DATABASE SET {key} := {val};
+                    """
+                )
+            )
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -354,25 +354,6 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
-            emails_request = ("GET", "https://api.github.com", "/user/emails")
-            mock_provider.register_route_handler(*emails_request)(
-                (
-                    [
-                        {
-                            "email": "octocat@example.com",
-                            "verified": True,
-                            "primary": True,
-                        },
-                        {
-                            "email": "octocat+2@example.com",
-                            "verified": False,
-                            "primary": False,
-                        },
-                    ],
-                    200,
-                )
-            )
-
             auth_signing_key = await self.con.query_single(
                 """SELECT assert_single(cfg::Config.xxx_auth_signing_key);"""
             )
@@ -432,9 +413,3 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 "Bearer github_access_token",
             )
 
-            requests_for_emails = mock_provider.requests[emails_request]
-            self.assertEqual(len(requests_for_emails), 1)
-            self.assertEqual(
-                requests_for_emails[0]["headers"]["authorization"],
-                "Bearer github_access_token",
-            )

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -412,4 +412,3 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 requests_for_user[0]["headers"]["authorization"],
                 "Bearer github_access_token",
             )
-

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -152,10 +152,23 @@ class MockAuthProvider:
 class TestHttpExtAuth(tb.ExtAuthTestCase):
     TRANSACTION_ISOLATION = False
 
-    EXTENSION_CONFIG = [
-        ("ext::auth::AuthConfig::auth_signing_key", f"<str>'{'a' * 32}'"),
-        ("ext::auth::AuthConfig::github_client_secret", f"<str>'{'b' * 32}'"),
-        ("ext::auth::AuthConfig::github_client_id", f"<str>'{uuid.uuid4()}'"),
+    EXTENSION_SETUP = [
+        f"""
+        CONFIGURE CURRENT DATABASE SET
+        ext::auth::AuthConfig::auth_signing_key := <str>'{'a' * 32}';
+        """,
+        (
+            f"""
+            CONFIGURE CURRENT DATABASE
+            INSERT ext::auth::ClientConfig {{
+                provider_name := "github",
+                url := "https://github.com",
+                provider_id := <str>'{uuid.uuid4()}',
+                secret := <str>'{"b" * 32}',
+                client_id := <str>'{uuid.uuid4()}'
+            }};
+            """
+        ),
     ]
 
     def http_con_send_request(self, *args, headers=None, **kwargs):
@@ -174,14 +187,16 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
     async def test_http_auth_ext_github_authorize_01(self):
         with MockAuthProvider(), self.http_con() as http_con:
-            client_id = await self.con.query_single(
+            github_provider_config = await self.con.query_single(
                 """
-                SELECT assert_single(
+                SELECT assert_exists(assert_single(
                     cfg::Config.extensions[is ext::auth::AuthConfig]
-                        .github_client_id
-                );
+                        .providers { * } filter .provider_name = "github"
+                ));
                 """
             )
+            github_provider_id = github_provider_config.provider_id
+            client_id = github_provider_config.client_id
 
             auth_signing_key = await self.con.query_single(
                 """
@@ -193,7 +208,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
 
             _, headers, status = self.http_con_request(
-                http_con, {"provider": "github"}, path="authorize"
+                http_con, {"provider": github_provider_id}, path="authorize"
             )
 
             self.assertEqual(status, 302)
@@ -214,7 +229,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             key = jwk.JWK(k=key_bytes.decode(), kty="oct")
             signed_token = jwt.JWT(key=key, algs=["HS256"], jwt=state[0])
             claims = json.loads(signed_token.claims)
-            self.assertEqual(claims.get("provider"), "github")
+            self.assertEqual(claims.get("provider"), github_provider_id)
             self.assertEqual(claims.get("iss"), self.http_addr)
 
             self.assertEqual(
@@ -259,6 +274,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
     async def test_http_auth_ext_github_callback_wrong_key_01(self):
         with MockAuthProvider(), self.http_con() as http_con:
+            github_provider_config = await self.con.query_single(
+                """
+                SELECT assert_exists(assert_single(
+                    cfg::Config.extensions[is ext::auth::AuthConfig]
+                        .providers { * } filter .provider_name = "github"
+                ));
+                """
+            )
+            github_provider_id = github_provider_config.provider_id
             auth_signing_key = "abcd" * 8
 
             expires_at = datetime.datetime.utcnow() + datetime.timedelta(
@@ -266,7 +290,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             missing_provider_state_claims = {
                 "iss": self.http_addr,
-                "provider": "github",
+                "provider": github_provider_id,
                 "exp": expires_at.astimezone().timestamp(),
             }
             state_token = jwt.JWT(
@@ -324,22 +348,17 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
     async def test_http_auth_ext_github_callback_01(self):
         with MockAuthProvider() as mock_provider, self.http_con() as http_con:
-            client_id = await self.con.query_single(
+            github_provider_config = await self.con.query_single(
                 """
-                SELECT assert_single(
+                SELECT assert_exists(assert_single(
                     cfg::Config.extensions[is ext::auth::AuthConfig]
-                        .github_client_id
-                );
+                        .providers { * } filter .provider_name = "github"
+                ));
                 """
             )
-            client_secret = await self.con.query_single(
-                """
-                SELECT assert_single(
-                    cfg::Config.extensions[is ext::auth::AuthConfig]
-                        .github_client_secret
-                );
-                """
-            )
+            github_provider_id = github_provider_config.provider_id
+            client_id = github_provider_config.client_id
+            client_secret = github_provider_config.secret
 
             now = datetime.datetime.utcnow().isoformat()
             token_request = (
@@ -387,7 +406,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             state_claims = {
                 "iss": self.http_addr,
-                "provider": "github",
+                "provider": str(github_provider_id),
                 "exp": expires_at.astimezone().timestamp(),
                 "redirect_to": f"{self.http_addr}/some/path",
             }


### PR DESCRIPTION
The basic structure of the schema is:

- An `Identity` type that represents some authorization server (`iss`) and some identity that exists on that AS (`sub`).

We pared back the modeling here to the barest essentials to allow updating based on usage, so for now, consumers will need to do their own profile-building (gathering any PII they might be interested in).