### PR TITLE
Fix and add tests for multi-tenant server

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -114,7 +114,7 @@ jobs:
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         if [[ "${{ matrix.multi-tenant-mode }}" == "multi-tenant" ]]; then
           export EDGEDB_SERVER_MULTITENANT_CONFIG_FILE=/tmp/edb.mt.json
-          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\"}}" > /tmp/edb.mt.json
+          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\",\"admin\":true}}" > /tmp/edb.mt.json
         fi
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
           edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN

--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -33,17 +33,20 @@ jobs:
          - ''
          - 'NOCREATEDB NOCREATEROLE'
          - 'CREATEDB NOCREATEROLE'
-        remote-compiler: [ '' ]
+        multi-tenant-mode: [ '' ]
         include:
           - postgres-version: 13
             single-mode: ''
-            remote-compiler: ''
+            multi-tenant-mode: ''
           - postgres-version: 14
             single-mode: ''
-            remote-compiler: 'remote-compiler'
+            multi-tenant-mode: 'remote-compiler'
+          - postgres-version: 14
+            single-mode: ''
+            multi-tenant-mode: 'multi-tenant'
           - postgres-version: 15
             single-mode: ''
-            remote-compiler: ''
+            multi-tenant-mode: ''
     services:
       postgres:
         image: fantix/pgvector:${{ matrix.postgres-version }}
@@ -103,7 +106,16 @@ jobs:
         else
           export EDGEDB_TEST_BACKEND_DSN=postgres://postgres:postgres@localhost/postgres
         fi
+        if [[ "${{ matrix.multi-tenant-mode }}" == "remote-compiler" ]]; then
+          export EDGEDB_TEST_REMOTE_COMPILER=localhost:5660
+          export _EDGEDB_SERVER_COMPILER_POOL_SECRET=secret
+          __EDGEDB_DEVMODE=1 edgedb-server compiler --pool-size 2 &
+        fi
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
+        if [[ "${{ matrix.multi-tenant-mode }}" == "multi-tenant" ]]; then
+          export EDGEDB_SERVER_MULTITENANT_CONFIG_FILE=/tmp/edb.mt.json
+          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\"}}" > /tmp/edb.mt.json
+        fi
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
           edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
         else

--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -114,7 +114,7 @@ jobs:
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         if [[ "${{ matrix.multi-tenant-mode }}" == "multi-tenant" ]]; then
           export EDGEDB_SERVER_MULTITENANT_CONFIG_FILE=/tmp/edb.mt.json
-          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\",\"admin\":true}}" > /tmp/edb.mt.json
+          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\",\"admin\":true,\"max-backend-connections\":10}}" > /tmp/edb.mt.json
         fi
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
           edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -322,17 +322,20 @@ jobs:
          - ''
          - 'NOCREATEDB NOCREATEROLE'
          - 'CREATEDB NOCREATEROLE'
-        remote-compiler: [ '' ]
+        multi-tenant-mode: [ '' ]
         include:
           - postgres-version: 13
             single-mode: ''
-            remote-compiler: ''
+            multi-tenant-mode: ''
           - postgres-version: 14
             single-mode: ''
-            remote-compiler: 'remote-compiler'
+            multi-tenant-mode: 'remote-compiler'
+          - postgres-version: 14
+            single-mode: ''
+            multi-tenant-mode: 'multi-tenant'
           - postgres-version: 15
             single-mode: ''
-            remote-compiler: ''
+            multi-tenant-mode: ''
     services:
       postgres:
         image: fantix/pgvector:${{ matrix.postgres-version }}
@@ -504,7 +507,16 @@ jobs:
         else
           export EDGEDB_TEST_BACKEND_DSN=postgres://postgres:postgres@localhost/postgres
         fi
+        if [[ "${{ matrix.multi-tenant-mode }}" == "remote-compiler" ]]; then
+          export EDGEDB_TEST_REMOTE_COMPILER=localhost:5660
+          export _EDGEDB_SERVER_COMPILER_POOL_SECRET=secret
+          __EDGEDB_DEVMODE=1 edgedb-server compiler --pool-size 2 &
+        fi
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
+        if [[ "${{ matrix.multi-tenant-mode }}" == "multi-tenant" ]]; then
+          export EDGEDB_SERVER_MULTITENANT_CONFIG_FILE=/tmp/edb.mt.json
+          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\"}}" > /tmp/edb.mt.json
+        fi
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
           edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
         else

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -515,7 +515,7 @@ jobs:
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         if [[ "${{ matrix.multi-tenant-mode }}" == "multi-tenant" ]]; then
           export EDGEDB_SERVER_MULTITENANT_CONFIG_FILE=/tmp/edb.mt.json
-          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\"}}" > /tmp/edb.mt.json
+          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\",\"admin\":true}}" > /tmp/edb.mt.json
         fi
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
           edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -515,7 +515,7 @@ jobs:
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         if [[ "${{ matrix.multi-tenant-mode }}" == "multi-tenant" ]]; then
           export EDGEDB_SERVER_MULTITENANT_CONFIG_FILE=/tmp/edb.mt.json
-          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\",\"admin\":true}}" > /tmp/edb.mt.json
+          echo "{\"localhost\":{\"instance-name\":\"localtest\",\"backend-dsn\":\"$EDGEDB_TEST_BACKEND_DSN\",\"admin\":true,\"max-backend-connections\":10}}" > /tmp/edb.mt.json
         fi
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
           edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN

--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -149,6 +149,7 @@
 
 0x_08_00_00_01   BackendUnavailableError  #SHOULD_RETRY
 0x_08_00_00_02   ServerOfflineError  #SHOULD_RECONNECT #SHOULD_RETRY
+0x_08_00_00_03   NoSuchTenantError  #SHOULD_RECONNECT #SHOULD_RETRY
 
 ####
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -90,6 +90,7 @@ __all__ = base.__all__ + (  # type: ignore
     'AvailabilityError',
     'BackendUnavailableError',
     'ServerOfflineError',
+    'NoSuchTenantError',
     'BackendError',
     'UnsupportedBackendFeatureError',
     'LogMessage',
@@ -419,6 +420,10 @@ class BackendUnavailableError(AvailabilityError):
 
 class ServerOfflineError(AvailabilityError):
     _code = 0x_08_00_00_02
+
+
+class NoSuchTenantError(AvailabilityError):
+    _code = 0x_08_00_00_03
 
 
 class BackendError(EdgeDBError):

--- a/edb/protocol/protocol.pyx
+++ b/edb/protocol/protocol.pyx
@@ -58,7 +58,7 @@ cdef class Connection:
     async def connect(self):
         await self._protocol.connect()
 
-    async def execute(self, query):
+    async def execute(self, query, state_id=b'\0' * 16, state=b''):
         await self.send(
             messages.Execute(
                 annotations=[],
@@ -70,9 +70,9 @@ cdef class Connection:
                 implicit_limit=0,
                 input_typedesc_id=b'\0' * 16,
                 output_typedesc_id=b'\0' * 16,
-                state_typedesc_id=b'\0' * 16,
+                state_typedesc_id=state_id,
                 arguments=b'',
-                state_data=b'',
+                state_data=state,
             ),
             messages.Sync(),
         )

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1271,25 +1271,6 @@ def parse_args(**kwargs: Any):
             " is not a regular file"
         )
 
-    if kwargs['multitenant_config_file']:
-        for name in (
-            "tenant_id",
-            "backend_dsn",
-            "startup_script",
-            "instance_name",
-            "max_backend_connections",
-            "readiness_state_file",
-            "jwt_sub_allowlist_file",
-            "jwt_revocation_list_file",
-        ):
-            if kwargs.get(name):
-                opt = "--" + name.replace("_", "-")
-                abort(f"The {opt} and --multitenant-config-file options "
-                      f"are mutually exclusive.")
-        if kwargs['compiler_pool_mode'] is not CompilerPoolMode.MultiTenant:
-            abort("must use --compiler-pool-mode=fixed_multi_tenant "
-                  "in multi-tenant mode")
-
     if kwargs['log_level']:
         kwargs['log_level'] = kwargs['log_level'].lower()[0]
 
@@ -1310,6 +1291,28 @@ def parse_args(**kwargs: Any):
             )
 
     del kwargs['bootstrap_script']
+
+    if kwargs['multitenant_config_file']:
+        for name in (
+            "tenant_id",
+            "backend_dsn",
+            "backend_adaptive_ha",
+            "bootstrap_only",
+            "bootstrap_command",
+            "bootstrap_command_file",
+            "instance_name",
+            "max_backend_connections",
+            "readiness_state_file",
+            "jwt_sub_allowlist_file",
+            "jwt_revocation_list_file",
+        ):
+            if kwargs.get(name):
+                opt = "--" + name.replace("_", "-")
+                abort(f"The {opt} and --multitenant-config-file options "
+                      f"are mutually exclusive.")
+        if kwargs['compiler_pool_mode'] is not CompilerPoolMode.MultiTenant:
+            abort("must use --compiler-pool-mode=fixed_multi_tenant "
+                  "in multi-tenant mode")
 
     bootstrap_script_text: Optional[str]
     if kwargs['bootstrap_command_file']:

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -1281,6 +1281,11 @@ class MultiTenantWorker(Worker):
             self._cache.pop(client_id, None)
             self._last_used_by_client.pop(client_id, None)
 
+    async def call(self, method_name, *args, sync_state=None):
+        if method_name == "compile_in_tx":
+            args = (args[0], 0, *args[1:])
+        return await super().call(method_name, *args, sync_state=sync_state)
+
 
 @srvargs.CompilerPoolMode.MultiTenant.assign_implementation
 class MultiTenantPool(FixedPool):

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -313,6 +313,14 @@ class MultiTenantServer(server.BaseServer):
         except Exception:
             logger.critical("Failed to remove Tenant %s", sni, exc_info=True)
 
+    def get_debug_info(self):
+        parent = super().get_debug_info()
+        parent["tenants"] = {
+            name: tenant.get_debug_info()
+            for name, tenant in self._tenants.items()
+        }
+        return parent
+
 
 async def run_server(
     args: srvargs.ServerConfig,

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -113,7 +113,11 @@ class MultiTenantServer(server.BaseServer):
             self._tenants_by_sslobj[sslobj] = tenant
 
     def get_default_tenant(self) -> edbtenant.Tenant:
-        raise errors.AuthenticationError("Illegal tenant")
+        raise errors.NoSuchTenantError(
+            "No such tenant configured.",
+            hint="Please try again later, or "
+                 "double check the SNI/server name in TLS connection",
+        )
 
     def retrieve_tenant(self, sslobj) -> edbtenant.Tenant | None:
         return self._tenants_by_sslobj.pop(sslobj, None)

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -78,7 +78,7 @@ cdef class HttpProtocol:
 
     cdef write(self, HttpRequest request, HttpResponse response)
 
-    cdef unhandled_exception(self, ex)
+    cdef unhandled_exception(self, bytes status, ex)
     cdef resume(self)
     cdef close(self)
     cdef inline _schedule_handle_request(self, request)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -573,16 +573,18 @@ class BaseServer:
             + defines.MAX_UNIX_SOCKET_PATH_LENGTH
             + 1
         ), "admin Unix socket length exceeds maximum allowed"
-        # TODO(fantix): run multiple UNIX domain sockets in multi-tenant server
         admin_unix_srv = await self.__loop.create_unix_server(
             lambda: binary.new_edge_connection(
-                self, self.get_default_tenant(), external_auth=True
+                self, self._get_admin_tenant(), external_auth=True
             ),
             admin_unix_sock_path
         )
         os.chmod(admin_unix_sock_path, stat.S_IRUSR | stat.S_IWUSR)
         logger.info('Serving admin on %s', admin_unix_sock_path)
         return admin_unix_srv
+
+    def _get_admin_tenant(self) -> edbtenant.Tenant:
+        return self.get_default_tenant()
 
     async def _start_servers(
         self,

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1343,7 +1343,9 @@ class Tenant(ha_base.ClusterProtocol):
                 tenant_id=self._tenant_id,
             ),
             user_roles=self._roles,
-            pg_addr=self.get_pgaddr(),
+            pg_addr={
+                k: v for k, v in self.get_pgaddr().items() if k not in ["ssl"]
+            },
             pg_pool=self._pg_pool._build_snapshot(now=time.monotonic()),
         )
 
@@ -1359,7 +1361,11 @@ class Tenant(ha_base.ClusterProtocol):
                 dbs[db.name] = dict(
                     name=db.name,
                     dbver=db.dbver,
-                    config=serialize_config(db.db_config),
+                    config=(
+                        None
+                        if db.db_config is None
+                        else serialize_config(db.db_config)
+                    ),
                     extensions=sorted(db.extensions),
                     query_cache_size=db.get_query_cache_size(),
                     connections=[

--- a/tests/test_backend_connect.py
+++ b/tests/test_backend_connect.py
@@ -154,6 +154,7 @@ class ClusterTestCase(tb.TestCase):
         result = CliRunner().invoke(get_default_args, [])
         arg_input = pickle.loads(result.stdout_bytes)
         arg_input["data_dir"] = pathlib.Path(cluster.get_data_dir())
+        arg_input["multitenant_config_file"] = ""
         arg_input["tls_cert_mode"] = "generate_self_signed"
         arg_input["jose_key_mode"] = "generate"
         cls.dbname = cluster.get_db_name('edgedb')

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -38,6 +38,10 @@ class TestServerAuth(tb.ConnectedTestCase):
     PARALLELISM_GRANULARITY = 'system'
     TRANSACTION_ISOLATION = False
 
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE INSTANCE in multi-tenant mode",
+    )
     async def test_server_auth_01(self):
         if not self.has_create_role:
             self.skipTest('create role is not supported by the backend')
@@ -311,6 +315,10 @@ class TestServerAuth(tb.ConnectedTestCase):
                 CONFIGURE INSTANCE RESET Auth FILTER .comment = 'test'
             """)
 
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE INSTANCE in multi-tenant mode",
+    )
     async def test_server_auth_jwt_2(self):
         jwk_fd, jwk_file = tempfile.mkstemp()
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -21,6 +21,7 @@ import asyncio
 import dataclasses
 import datetime
 import json
+import os
 import platform
 import random
 import tempfile
@@ -36,6 +37,7 @@ from edb import buildmeta
 from edb import errors
 from edb.edgeql import qltypes
 from edb.edgeql import quote as qlquote
+from edb.protocol import messages
 
 from edb.testbase import server as tb
 from edb.schema import objects as s_obj
@@ -1315,6 +1317,10 @@ class TestSeparateCluster(tb.TestCase):
         platform.system() == "Darwin",
         "loopback aliases aren't set up on macOS by default"
     )
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE INSTANCE in multi-tenant mode",
+    )
     async def test_server_proto_configure_listen_addresses(self):
         con1 = con2 = con3 = con4 = con5 = None
 
@@ -1371,6 +1377,10 @@ class TestSeparateCluster(tb.TestCase):
                         closings.append(con.aclose())
                 await asyncio.gather(*closings)
 
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE SYSTEM in multi-tenant mode",
+    )
     async def test_server_config_idle_connection_01(self):
         async with tb.start_edgedb_server(
             http_endpoint_security=args.ServerEndpointSecurityMode.Optional,
@@ -1407,6 +1417,10 @@ class TestSeparateCluster(tb.TestCase):
             metrics
         )
 
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE SYSTEM in multi-tenant mode",
+    )
     async def test_server_config_idle_connection_02(self):
         from edb import protocol
 
@@ -1459,7 +1473,11 @@ class TestSeparateCluster(tb.TestCase):
                     ignore=AssertionError):
                 async with tr:
                     info = sd.fetch_server_info()
-                    dbconf = info['databases']['edgedb']['config']
+                    if 'databases' in info:
+                        databases = info['databases']
+                    else:
+                        databases = info['tenants']['localhost']['databases']
+                    dbconf = databases['edgedb']['config']
                     self.assertEqual(
                         dbconf.get('__internal_sess_testvalue'), 5)
 
@@ -1477,12 +1495,19 @@ class TestSeparateCluster(tb.TestCase):
                     ignore=AssertionError):
                 async with tr:
                     info = sd.fetch_server_info()
-                    dbconf = info['databases']['edgedb']['config']
+                    if 'databases' in info:
+                        databases = info['databases']
+                    else:
+                        databases = info['tenants']['localhost']['databases']
+                    dbconf = databases['edgedb']['config']
                     self.assertEqual(
                         dbconf.get('__internal_sess_testvalue'), 10)
 
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE INSTANCE in multi-tenant mode",
+    )
     async def test_server_config_backend_levels(self):
-
         async def assert_conf(con, name, expected_val):
             val = await con.query_single(f'''
                 select assert_single(cfg::Config.{name})
@@ -1675,27 +1700,48 @@ class TestSeparateCluster(tb.TestCase):
         ) as sd:
             conn = await sd.connect_test_protocol()
 
-            await conn.execute('''
+            query = '''
                 configure session set
                     session_idle_transaction_timeout :=
                         <duration>'1 second'
-            ''')
+            '''
+            await conn.send(
+                messages.Execute(
+                    annotations=[],
+                    command_text=query,
+                    output_format=messages.OutputFormat.NONE,
+                    expected_cardinality=messages.Cardinality.MANY,
+                    allowed_capabilities=messages.Capability.ALL,
+                    compilation_flags=messages.CompilationFlag(9),
+                    implicit_limit=0,
+                    input_typedesc_id=b'\0' * 16,
+                    output_typedesc_id=b'\0' * 16,
+                    state_typedesc_id=b'\0' * 16,
+                    arguments=b'',
+                    state_data=b'',
+                ),
+                messages.Sync(),
+            )
+            state_msg = await conn.recv_match(messages.CommandComplete)
+            await conn.recv_match(messages.ReadyForCommand)
 
-            await conn.execute('''
+            await conn.execute(
+                '''
                 start transaction
-            ''')
+                ''',
+                state_id=state_msg.state_typedesc_id,
+                state=state_msg.state_data,
+            )
 
-            await conn.execute('''
-                select sys::_sleep(4)
-            ''')
-
-            await conn.recv_match(
+            await asyncio.wait_for(conn.recv_match(
                 protocol.ErrorResponse,
                 message='terminating connection due to '
                         'idle-in-transaction timeout'
-            )
+            ), 8)
 
-            with self.assertRaises(edgedb.ClientConnectionClosedError):
+            with self.assertRaises(
+                edgedb.ClientConnectionFailedTemporarilyError
+            ):
                 await conn.execute('''
                     select 1
                 ''')
@@ -1856,6 +1902,10 @@ class TestStaticServerConfig(tb.TestCase):
             async with tb.start_edgedb_server(env=env):
                 pass
 
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE INSTANCE in multi-tenant mode",
+    )
     async def test_server_config_default(self):
         p1 = tb.find_available_port(max_value=32767)
         async with tb.start_edgedb_server(


### PR DESCRIPTION
- [x] Added new retryable error type `NoSuchTenantError`
- [x] Return HTTP 503 instead of 400 on `NoSuchTenantError`
- [x] Return HTTP 500 instead of 400 on general error in `handle_request()`
- [x] Allow one specified tenant to serve on the UNIX socket for testing purposes only
- [x] Run full test suite nightly using multi-tenant server ([sample run](https://github.com/edgedb/edgedb/actions/runs/5786915596))
- [x] Recover the remote-compiler nightly test
- [x] Add test case to cover the basic function of `--multitenant-config-file` 
- [x] Fix GraphQL compilation in remote compiler
- [x] Fix transaction compilation in multi-tenant server