### PR TITLE
Create extensions conditionally

### DIFF
--- a/edb/pgsql/dbops/extensions.py
+++ b/edb/pgsql/dbops/extensions.py
@@ -40,16 +40,25 @@ class Extension:
 
 
 class CreateExtension(ddl.DDLOperation):
-    def __init__(self, extension, *, conditions=None, neg_conditions=None):
+    def __init__(
+        self,
+        extension,
+        *,
+        conditions=None,
+        neg_conditions=None,
+        conditional=False,
+    ):
         super().__init__(conditions=conditions, neg_conditions=neg_conditions)
         self.extension = extension
         self.opid = extension.name
+        self.conditional = conditional
 
     def code(self, block: base.PLBlock) -> str:
         ext = self.extension
         name = qi(ext.get_extension_name())
         schema = qi(ext.schema)
-        return f'CREATE EXTENSION {name} WITH SCHEMA {schema}'
+        condition = "IF NOT EXISTS " if self.conditional else ''
+        return f'CREATE EXTENSION {condition}{name} WITH SCHEMA {schema}'
 
 
 class DropExtension(ddl.DDLOperation):

--- a/edb/pgsql/params.py
+++ b/edb/pgsql/params.py
@@ -59,7 +59,12 @@ class BackendInstanceParams(NamedTuple):
     base_superuser: Optional[str] = None
     max_connections: int = 500
     reserved_connections: int = 0
+
     ext_schema: str = "edgedbext"
+    """A Postgres schema where extensions can be created."""
+
+    existing_exts: Optional[Mapping[str, str]] = None
+    """A map of preexisting extensions in the target backend with schemas."""
 
 
 class BackendRuntimeParams(NamedTuple):

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1357,11 +1357,10 @@ async def _init_stdlib(
         schema = t.set_field_value(
             schema, 'backend_id', entry['backend_id'])
 
-    if backend_params.instance_params.ext_schema != "edgedbext":
-        # Patch functions referring to extensions, because
-        # some backends require extensions to be hosted in
-        # hardcoded schemas (e.g. Heroku)
-        await metaschema.patch_pg_extensions(conn, backend_params)
+    # Patch functions referring to extensions, because
+    # some backends require extensions to be hosted in
+    # hardcoded schemas (e.g. Heroku)
+    await metaschema.patch_pg_extensions(conn, backend_params)
 
     stdlib = stdlib._replace(stdschema=schema)
     version_key = patches.get_version_key(len(patches.PATCHES))
@@ -2060,17 +2059,6 @@ async def _bootstrap(ctx: BootstrapContext) -> edbcompiler.CompilerState:
             )
         )
 
-    if args.backend_capability_sets.must_be_absent:
-        caps = backend_params.instance_params.capabilities
-        disabled = []
-        for cap in args.backend_capability_sets.must_be_absent:
-            if caps & cap:
-                caps &= ~cap
-                disabled.append(cap)
-        if disabled:
-            logger.info(f"the following backend capabilities are disabled: "
-                        f"{', '.join(str(cap.name) for cap in disabled)}")
-            cluster.overwrite_capabilities(caps)
     _check_capabilities(ctx)
 
     if backend_params.has_create_role:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -415,6 +415,7 @@ async def _get_remote_pgcluster(
     cluster = await pgcluster.get_remote_pg_cluster(
         args.backend_dsn,
         tenant_id=tenant_id,
+        specified_capabilities=args.backend_capability_sets,
     )
 
     instance_params = cluster.get_runtime_params().instance_params

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -35,6 +35,7 @@ from edb import buildmeta
 from edb.common import supervisor
 from edb.common import uuidgen
 
+from edb.server import args as srvargs
 from edb.server import defines
 from edb.server.ha import base as ha_base
 from edb.pgsql import common as pgcommon
@@ -846,6 +847,7 @@ async def get_remote_pg_cluster(
     dsn: str,
     *,
     tenant_id: Optional[str] = None,
+    specified_capabilities: Optional[srvargs.BackendCapabilitySets] = None,
 ) -> RemoteCluster:
     parsed = urllib.parse.urlparse(dsn)
     ha_backend = None
@@ -1056,6 +1058,23 @@ async def get_remote_pg_cluster(
         if max_connections == -1:
             max_connections = await _get_pg_settings(conn, 'max_connections')
         capabilities = await _detect_capabilities(conn)
+
+        if (
+            specified_capabilities is not None
+            and specified_capabilities.must_be_absent
+        ):
+            disabled = []
+            for cap in specified_capabilities.must_be_absent:
+                if capabilities & cap:
+                    capabilities &= ~cap
+                    disabled.append(cap)
+            if disabled:
+                logger.info(
+                    f"the following backend capabilities are explicitly "
+                    f"disabled by server command line: "
+                    f"{', '.join(str(cap.name) for cap in disabled)}"
+                )
+
         if t_id != buildmeta.get_default_tenant_id():
             # GOTCHA: This tenant_id check cannot protect us from running
             # multiple EdgeDB servers using the default tenant_id with
@@ -1078,14 +1097,38 @@ async def get_remote_pg_cluster(
                 "remote server did not report its version "
                 "in ParameterStatus")
 
-        ext_schema = await conn.sql_fetch_val(
-            b'''
-            SELECT COALESCE(
-                (SELECT schema_name FROM information_schema.schemata
-                WHERE schema_name = 'heroku_ext'),
-                'edgedbext')
-            ''',
-        )
+        if capabilities & pgparams.BackendCapabilities.CREATE_DATABASE:
+            # If we can create databases, assume we're free to create
+            # extensions in them as well.
+            ext_schema = "edgedbext"
+            existing_exts = {}
+        else:
+            ext_schema = (await conn.sql_fetch_val(
+                b'''
+                SELECT COALESCE(
+                    (SELECT schema_name FROM information_schema.schemata
+                    WHERE schema_name = 'heroku_ext'),
+                    'edgedbext')
+                ''',
+            )).decode("utf-8")
+
+            existing_exts_data = await conn.sql_fetch(
+                b"""
+                SELECT
+                    extname,
+                    nspname
+                FROM
+                    pg_extension
+                    INNER JOIN pg_namespace
+                        ON (pg_extension.extnamespace = pg_namespace.oid)
+                """
+            )
+
+            existing_exts = {
+                r[0].decode("utf-8"): r[1].decode("utf-8")
+                for r in existing_exts_data
+            }
+
         instance_params = pgparams.BackendInstanceParams(
             capabilities=capabilities,
             version=buildmeta.parse_pg_version(pg_ver_string),
@@ -1093,7 +1136,8 @@ async def get_remote_pg_cluster(
             max_connections=int(max_connections),
             reserved_connections=await _get_reserved_connections(conn),
             tenant_id=t_id,
-            ext_schema=ext_schema.decode("utf-8"),
+            ext_schema=ext_schema,
+            existing_exts=existing_exts,
         )
     finally:
         conn.terminate()


### PR DESCRIPTION
Certain PostgreSQL providers disable `CREATE EXTENSION` and force you to
enable extensions using a different method (usually their UI).  To
accommodate this, check if the necessary extensions already exist prior
to bootstrap, and if they do, don't attempt to re-create them.

I've reorganized the "extension capability" code a bit to make it clear
that we only need to bother with custom extension logic in "single
database" mode.

Fixes: #5890
