### PR TITLE
Clarify that distinct automatically orders items

### DIFF
--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -98,12 +98,13 @@ Sets
     Produces a set of all unique elements in the given set.
 
     ``distinct`` is a set operator that returns a new set where
-    no member is equal to any other member.
+    no member is equal to any other member. The items in a set
+    returned by ``distinct`` will be in ascending order.
 
     .. code-block:: edgeql-repl
 
-        db> select distinct {1, 2, 2, 3};
-        {1, 2, 3}
+        db> select distinct {4, 4, 10, -1};
+        {-1, 4, 10}
 
 
 ----------


### PR DESCRIPTION
Something small I noticed today when doing some queries with `distinct` and `order by`: the sets returned from distinct were already ordered! Seems like an important point to note.

(Also may help with ChatGPT which insists that sets returned by distinct are not ordered)