### PR TITLE
Let config views get routed to the right backend schema

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4788,30 +4788,26 @@ classref_attr_aliases = {
 
 def tabname(
     schema: s_schema.Schema, obj: s_obj.QualifiedObject
-) -> Tuple[str, str]:
-    return (
-        'edgedbstd',
-        common.get_backend_name(
-            schema,
-            obj,
-            aspect='table',
-            catenate=False,
-        )[1],
+) -> tuple[str, str]:
+    res: tuple[str, str] = common.get_backend_name(
+        schema,
+        obj,
+        aspect='table',
+        catenate=False,
     )
+    return res
 
 
 def inhviewname(
     schema: s_schema.Schema, obj: s_obj.QualifiedObject
 ) -> Tuple[str, str]:
-    return (
-        'edgedbstd',
-        common.get_backend_name(
-            schema,
-            obj,
-            aspect='inhview',
-            catenate=False,
-        )[1],
+    res: tuple[str, str] = common.get_backend_name(
+        schema,
+        obj,
+        aspect='inhview',
+        catenate=False,
     )
+    return res
 
 
 def ptr_col_name(


### PR DESCRIPTION
Currently we override get_backend_name to force it to be `edgedbstd`,
which is a legacy of when we made it `edgedbss`.

User/extension defined configs will go to `edgedbpub`.