### PR TITLE
Type-annotate pgsql.common.get_backend_name

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3566,7 +3566,9 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
             raise AssertionError(f'index {root_name} is missing the code')
 
         pg_index = dbops.Index(
-            name=index_name[1], table_name=table_name, exprs=sql_exprs,
+            name=index_name[1],
+            table_name=table_name,  # type: ignore
+            exprs=sql_exprs,
             unique=False, inherit=True,
             predicate=predicate_src,
             metadata={
@@ -3973,6 +3975,7 @@ class PointerMetaCommand(
         tab = q(*ptr_stor_info.table_name)
         target_col = ptr_stor_info.column_name
         source = ptr.get_source(orig_schema)
+        assert source
         src_tab = q(*common.get_backend_name(
             orig_schema,
             source,
@@ -4069,6 +4072,7 @@ class PointerMetaCommand(
             # Moving from source table to pointer table.
             self.create_table(ptr, schema, context)
             source = ptr.get_source(orig_schema)
+            assert source
             src_tab = q(*common.get_backend_name(
                 orig_schema,
                 source,
@@ -4173,6 +4177,7 @@ class PointerMetaCommand(
             tab = q(*ptr_stor_info.table_name)
             target_col = ptr_stor_info.column_name
             source = ptr.get_source(orig_schema)
+            assert source
             src_tab = q(*common.get_backend_name(
                 orig_schema,
                 source,

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -31,6 +31,7 @@ from edb.common import context as parser_context
 from edb.common import debug
 from edb.common import exceptions
 from edb.common import uuidgen
+from edb.common.typeutils import not_none
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -4789,25 +4790,23 @@ classref_attr_aliases = {
 def tabname(
     schema: s_schema.Schema, obj: s_obj.QualifiedObject
 ) -> tuple[str, str]:
-    res: tuple[str, str] = common.get_backend_name(
+    return common.get_backend_name(
         schema,
         obj,
         aspect='table',
         catenate=False,
     )
-    return res
 
 
 def inhviewname(
     schema: s_schema.Schema, obj: s_obj.QualifiedObject
 ) -> Tuple[str, str]:
-    res: tuple[str, str] = common.get_backend_name(
+    return common.get_backend_name(
         schema,
         obj,
         aspect='inhview',
         catenate=False,
     )
-    return res
 
 
 def ptr_col_name(
@@ -4960,7 +4959,7 @@ def _generate_extension_views(schema: s_schema.Schema) -> List[dbops.View]:
         schema, s_name.UnqualName('version'), type=s_props.Property)
     ver_t = common.get_backend_name(
         schema,
-        ver.get_target(schema),
+        not_none(ver.get_target(schema)),
         catenate=False,
     )
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -299,6 +299,7 @@ def compile_constraint(
         else:
             subject_table = subject
 
+        assert subject_table
         subject_db_name = common.get_backend_name(
             schema, subject_table, catenate=False
         )


### PR DESCRIPTION
It has argument dependent typing behavior, but can be handled with an
overload pretty easily.