### PR TITLE
Get rid of noqa annotations on overloads

### DIFF
--- a/edb/common/checked.py
+++ b/edb/common/checked.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 import collections.abc
 import itertools
@@ -137,11 +138,11 @@ class FrozenCheckedList(
     def __getitem__(self, index: int) -> T:
         ...
 
-    @overload  # NoQA: F811
-    def __getitem__(self, index: slice) -> FrozenCheckedList[T]:  # NoQA: F811
+    @overload
+    def __getitem__(self, index: slice) -> FrozenCheckedList[T]:
         ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Any:  # NoQA: F811
+    def __getitem__(self, index: Union[int, slice]) -> Any:
         if isinstance(index, slice):
             return self.__class__(self._container[index])
 
@@ -184,11 +185,11 @@ class CheckedList(
     def __getitem__(self, index: int) -> T:
         ...
 
-    @overload  # NoQA: F811
-    def __getitem__(self, index: slice) -> CheckedList[T]:  # NoQA: F811
+    @overload
+    def __getitem__(self, index: slice) -> CheckedList[T]:
         ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Any:  # NoQA: F811
+    def __getitem__(self, index: Union[int, slice]) -> Any:
         if isinstance(index, slice):
             return self.__class__(self._container[index])
 
@@ -202,15 +203,15 @@ class CheckedList(
     def __setitem__(self, index: int, value: T) -> None:
         ...
 
-    @overload  # NoQA: F811
-    def __setitem__(  # NoQA: F811
+    @overload
+    def __setitem__(
         self,
         index: slice,
         value: Iterable[T]
     ) -> None:
         ...
 
-    def __setitem__(  # NoQA: F811
+    def __setitem__(
             self, index: Union[int, slice], value: Any) -> None:
         if isinstance(index, int):
             self._container[index] = self._check_type(value)
@@ -223,11 +224,11 @@ class CheckedList(
     def __delitem__(self, index: int) -> None:
         ...
 
-    @overload  # NoQA: F811
-    def __delitem__(self, index: slice) -> None:  # NoQA: F811
+    @overload
+    def __delitem__(self, index: slice) -> None:
         ...
 
-    def __delitem__(self, index: Union[int, slice]) -> None:  # NoQA: F811
+    def __delitem__(self, index: Union[int, slice]) -> None:
         del self._container[index]
 
     def insert(self, index: int, value: T) -> None:

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -127,6 +127,7 @@ dispatch.py
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 # WARNING: this package is in a tight import loop with various modules
 # in edb.schema, so no direct imports from either this package or
@@ -195,7 +196,7 @@ def compile_ast_to_ir(
 
 
 @overload
-def compile_ast_to_ir(  # noqa
+def compile_ast_to_ir(
     tree: qlast.ConfigOp,
     schema: s_schema.Schema,
     *,
@@ -206,7 +207,7 @@ def compile_ast_to_ir(  # noqa
 
 
 @overload
-def compile_ast_to_ir(  # noqa
+def compile_ast_to_ir(
     tree: qlast.Base,
     schema: s_schema.Schema,
     *,
@@ -217,7 +218,7 @@ def compile_ast_to_ir(  # noqa
 
 
 @compiler_entrypoint
-def compile_ast_to_ir(  # noqa
+def compile_ast_to_ir(
     tree: qlast.Base,
     schema: s_schema.Schema,
     *,

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 import collections
 import dataclasses
@@ -319,7 +320,7 @@ class Environment:
             self.schema_ref_exprs.setdefault(sobj, set()).add(expr)
 
     @overload
-    def get_schema_object_and_track(  # NoQA: F811
+    def get_schema_object_and_track(
         self,
         name: s_name.Name,
         expr: Optional[qlast.Base],
@@ -333,7 +334,7 @@ class Environment:
         ...
 
     @overload
-    def get_schema_object_and_track(  # NoQA: F811
+    def get_schema_object_and_track(
         self,
         name: s_name.Name,
         expr: Optional[qlast.Base],
@@ -346,7 +347,7 @@ class Environment:
     ) -> Optional[s_obj.Object]:
         ...
 
-    def get_schema_object_and_track(  # NoQA: F811
+    def get_schema_object_and_track(
         self,
         name: s_name.Name,
         expr: Optional[qlast.Base],

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 from typing import *
+from typing import overload
 
 from edb import errors
 
@@ -165,7 +166,7 @@ def _ql_typename_to_type(
 
 
 @overload
-def ptrcls_from_ptrref(  # NoQA: F811
+def ptrcls_from_ptrref(
     ptrref: irast.PointerRef, *,
     ctx: context.ContextLevel,
 ) -> s_pointers.Pointer:
@@ -173,7 +174,7 @@ def ptrcls_from_ptrref(  # NoQA: F811
 
 
 @overload
-def ptrcls_from_ptrref(  # NoQA: F811
+def ptrcls_from_ptrref(
     ptrref: irast.TupleIndirectionPointerRef, *,
     ctx: context.ContextLevel,
 ) -> irast.TupleIndirectionLink:
@@ -181,7 +182,7 @@ def ptrcls_from_ptrref(  # NoQA: F811
 
 
 @overload
-def ptrcls_from_ptrref(  # NoQA: F811
+def ptrcls_from_ptrref(
     ptrref: irast.TypeIntersectionPointerRef, *,
     ctx: context.ContextLevel,
 ) -> irast.TypeIntersectionLink:
@@ -189,14 +190,14 @@ def ptrcls_from_ptrref(  # NoQA: F811
 
 
 @overload
-def ptrcls_from_ptrref(  # NoQA: F811
+def ptrcls_from_ptrref(
     ptrref: irast.BasePointerRef, *,
     ctx: context.ContextLevel,
 ) -> s_pointers.PointerLike:
     ...
 
 
-def ptrcls_from_ptrref(  # NoQA: F811
+def ptrcls_from_ptrref(
     ptrref: irast.BasePointerRef, *,
     ctx: context.ContextLevel,
 ) -> s_pointers.PointerLike:

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 import uuid
 
@@ -482,7 +483,7 @@ def ptrref_from_ptrcls(
 
 
 @overload
-def ptrref_from_ptrcls(  # NoQA: F811
+def ptrref_from_ptrcls(
     *,
     schema: s_schema.Schema,
     ptrcls: s_pointers.PointerLike,
@@ -492,7 +493,7 @@ def ptrref_from_ptrcls(  # NoQA: F811
     ...
 
 
-def ptrref_from_ptrcls(  # NoQA: F811
+def ptrref_from_ptrcls(
     *,
     schema: s_schema.Schema,
     ptrcls: s_pointers.PointerLike,
@@ -729,14 +730,14 @@ def ptrcls_from_ptrref(
 
 
 @overload
-def ptrcls_from_ptrref(  # NoQA: F811
+def ptrcls_from_ptrref(
     ptrref: irast.BasePointerRef, *,
     schema: s_schema.Schema,
 ) -> Tuple[s_schema.Schema, s_pointers.PointerLike]:
     ...
 
 
-def ptrcls_from_ptrref(  # NoQA: F811
+def ptrcls_from_ptrref(
     ptrref: irast.BasePointerRef, *,
     schema: s_schema.Schema,
 ) -> Tuple[s_schema.Schema, s_pointers.PointerLike]:

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import functools
 import dataclasses
 from typing import *
+from typing import overload
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
@@ -511,7 +512,7 @@ def get_ptrref_storage_info(
 
 
 @overload
-def get_ptrref_storage_info(  # NoQA: F811
+def get_ptrref_storage_info(
     ptrref: irast.BasePointerRef, *,
     resolve_type: bool=...,
     link_bias: bool=...,
@@ -520,7 +521,7 @@ def get_ptrref_storage_info(  # NoQA: F811
     ...
 
 
-def get_ptrref_storage_info(  # NoQA: F811
+def get_ptrref_storage_info(
     ptrref: irast.BasePointerRef,
     *,
     resolve_type: bool = True,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 import collections
 import collections.abc
@@ -727,7 +728,7 @@ class Command(
         ...
 
     @overload
-    def get_subcommands(  # NoQA: F811
+    def get_subcommands(
         self,
         *,
         type: None = None,
@@ -738,7 +739,7 @@ class Command(
     ) -> Tuple[Command, ...]:
         ...
 
-    def get_subcommands(  # NoQA: F811
+    def get_subcommands(
         self,
         *,
         type: Union[Type[Command_T], None] = None,
@@ -787,14 +788,14 @@ class Command(
         ...
 
     @overload
-    def get_prerequisites(  # NoQA: F811
+    def get_prerequisites(
         self,
         *,
         type: None = None,
     ) -> Tuple[Command, ...]:
         ...
 
-    def get_prerequisites(  # NoQA: F811
+    def get_prerequisites(
         self,
         *,
         type: Union[Type[Command_T], None] = None,
@@ -814,14 +815,14 @@ class Command(
         ...
 
     @overload
-    def get_caused(  # NoQA: F811
+    def get_caused(
         self,
         *,
         type: None = None,
     ) -> Tuple[Command, ...]:
         ...
 
-    def get_caused(  # NoQA: F811
+    def get_caused(
         self,
         *,
         type: Union[Type[Command_T], None] = None,
@@ -1390,13 +1391,13 @@ class CommandContext:
         ...
 
     @overload
-    def get(  # NoQA: F811
+    def get(
         self,
         cls: Union[Type[Command_T], Type[CommandContextToken[Command_T]]],
     ) -> Optional[CommandContextToken[Command_T]]:
         ...
 
-    def get(  # NoQA: F811
+    def get(
         self,
         cls: Union[Type[Command_T], Type[CommandContextToken[Command_T]]],
     ) -> Optional[CommandContextToken[Command_T]]:
@@ -2449,7 +2450,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         ...
 
     @overload
-    def get_object(  # NoQA: F811
+    def get_object(
         self,
         schema: s_schema.Schema,
         context: CommandContext,
@@ -2460,7 +2461,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
     ) -> Optional[so.Object_T]:
         ...
 
-    def get_object(  # NoQA: F811
+    def get_object(
         self,
         schema: s_schema.Schema,
         context: CommandContext,
@@ -2807,7 +2808,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         ...
 
     @overload
-    def get_object(  # NoQA: F811
+    def get_object(
         self,
         schema: s_schema.Schema,
         context: CommandContext,
@@ -2818,7 +2819,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
     ) -> Optional[so.QualifiedObject_T]:
         ...
 
-    def get_object(  # NoQA: F811
+    def get_object(
         self,
         schema: s_schema.Schema,
         context: CommandContext,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 from edb import edgeql
 from edb import errors
@@ -453,7 +454,7 @@ class IndexCommand(
         ...
 
     @overload
-    def get_object(  # NoQA: F811
+    def get_object(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
@@ -464,7 +465,7 @@ class IndexCommand(
     ) -> Optional[Index]:
         ...
 
-    def get_object(  # NoQA: F811
+    def get_object(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 from typing import *
+from typing import overload
 
 import abc
 import collections
@@ -214,7 +215,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get_referrers(  # NoQA: F811
+    def get_referrers(
         self,
         scls: so.Object,
         *,
@@ -224,7 +225,7 @@ class Schema(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_referrers(  # NoQA: F811
+    def get_referrers(
         self,
         scls: so.Object,
         *,
@@ -256,7 +257,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get_by_id(  # NoQA: F811
+    def get_by_id(
         self,
         obj_id: uuid.UUID,
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
@@ -266,7 +267,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get_by_id(  # NoQA: F811
+    def get_by_id(
         self,
         obj_id: uuid.UUID,
         default: None = None,
@@ -275,7 +276,7 @@ class Schema(abc.ABC):
     ) -> Optional[so.Object_T]:
         ...
 
-    def get_by_id(  # NoQA: F811
+    def get_by_id(
         self,
         obj_id: uuid.UUID,
         default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
@@ -304,7 +305,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get_global(  # NoQA: F811
+    def get_global(
         self,
         objtype: Type[so.Object_T],
         name: Union[str, sn.Name],
@@ -312,7 +313,7 @@ class Schema(abc.ABC):
     ) -> Optional[so.Object_T]:
         ...
 
-    def get_global(  # NoQA: F811
+    def get_global(
         self,
         objtype: Type[so.Object_T],
         name: Union[str, sn.Name],
@@ -330,7 +331,7 @@ class Schema(abc.ABC):
         raise NotImplementedError
 
     @overload
-    def get(  # NoQA: F811
+    def get(
         self,
         name: Union[str, sn.Name],
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
@@ -343,7 +344,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get(  # NoQA: F811
+    def get(
         self,
         name: Union[str, sn.Name],
         default: None,
@@ -356,7 +357,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get(  # NoQA: F811
+    def get(
         self,
         name: Union[str, sn.Name],
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
@@ -370,7 +371,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get(  # NoQA: F811
+    def get(
         self,
         name: Union[str, sn.Name],
         default: None,
@@ -384,7 +385,7 @@ class Schema(abc.ABC):
         ...
 
     @overload
-    def get(  # NoQA: F811
+    def get(
         self,
         name: Union[str, sn.Name],
         default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
@@ -397,7 +398,7 @@ class Schema(abc.ABC):
     ) -> Optional[so.Object]:
         ...
 
-    def get(  # NoQA: F811
+    def get(
         self,
         name: Union[str, sn.Name],
         default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
@@ -419,7 +420,7 @@ class Schema(abc.ABC):
         )
 
     @abc.abstractmethod
-    def _get(  # NoQA: F811
+    def _get(
         self,
         name: Union[str, sn.Name],
         default: Union[so.Object, so.NoDefaultT, None],
@@ -1297,7 +1298,7 @@ class FlatSchema(Schema):
 
             return result  # type: ignore
 
-    def _get_by_id(  # NoQA: F811
+    def _get_by_id(
         self,
         obj_id: uuid.UUID,
         default: Union[so.Object_T, so.NoDefaultT, None],

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 from . import delta as sd
 from . import indexes
@@ -63,7 +64,7 @@ class Source(
         default=so.DEFAULT_CONSTRUCTOR)
 
     @overload
-    def maybe_get_ptr(  # NoQA: F811
+    def maybe_get_ptr(
         self,
         schema: s_schema.Schema,
         name: sn.UnqualName,
@@ -73,7 +74,7 @@ class Source(
         ...
 
     @overload
-    def maybe_get_ptr(  # NoQA: F811
+    def maybe_get_ptr(
         self,
         schema: s_schema.Schema,
         name: sn.UnqualName,
@@ -82,7 +83,7 @@ class Source(
     ) -> Optional[s_pointers.Pointer]:
         ...
 
-    def maybe_get_ptr(  # NoQA: F811
+    def maybe_get_ptr(
         self,
         schema: s_schema.Schema,
         name: sn.UnqualName,
@@ -99,7 +100,7 @@ class Source(
         return ptr
 
     @overload
-    def getptr(  # NoQA: F811
+    def getptr(
         self,
         schema: s_schema.Schema,
         name: sn.UnqualName,
@@ -109,7 +110,7 @@ class Source(
         ...
 
     @overload
-    def getptr(  # NoQA: F811
+    def getptr(
         self,
         schema: s_schema.Schema,
         name: sn.UnqualName,
@@ -118,7 +119,7 @@ class Source(
     ) -> s_pointers.Pointer:
         ...
 
-    def getptr(  # NoQA: F811
+    def getptr(
         self,
         schema: s_schema.Schema,
         name: sn.UnqualName,

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 from typing import *
+from typing import overload
 
 import collections.abc
 import dataclasses
@@ -843,7 +844,7 @@ def describe_input_shape(
 
 
 @overload
-def describe_input_shape(  # noqa: F811
+def describe_input_shape(
     t: s_types.Type,
     input_shapes: InputShapeMap,
     *,
@@ -853,7 +854,7 @@ def describe_input_shape(  # noqa: F811
 
 
 @overload
-def describe_input_shape(  # noqa: F811
+def describe_input_shape(
     t: s_types.Type,
     input_shapes: InputShapeMap,
     *,
@@ -863,7 +864,7 @@ def describe_input_shape(  # noqa: F811
     ...
 
 
-def describe_input_shape(  # noqa: F811
+def describe_input_shape(
     t: s_types.Type,
     input_shapes: InputShapeMap,
     *,


### PR DESCRIPTION
We need to add an explicit import of `overload` to get flake8 to
understand, but that's fine.