### PR TITLE
Give a type to evaluate_to_config_op

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -458,15 +458,15 @@ def object_type_to_python_type(
 @functools.singledispatch
 def evaluate_to_config_op(
         ir: irast.Base,
-        schema: s_schema.Schema) -> Any:
+        schema: s_schema.Schema) -> config.Operation:
     raise UnsupportedExpressionError(
         f'no config op evaluation handler for {ir.__class__}')
 
 
-@evaluate_to_config_op.register
+@evaluate_to_config_op.register(irast.ConfigSet)
 def evaluate_config_set(
         ir: irast.ConfigSet,
-        schema: s_schema.Schema) -> Any:
+        schema: s_schema.Schema) -> config.Operation:
 
     if ir.scope == qltypes.ConfigScope.GLOBAL:
         raise UnsupportedExpressionError(
@@ -488,10 +488,10 @@ def evaluate_config_set(
     )
 
 
-@evaluate_to_config_op.register
+@evaluate_to_config_op.register(irast.ConfigReset)
 def evaluate_config_reset(
         ir: irast.ConfigReset,
-        schema: s_schema.Schema) -> Any:
+        schema: s_schema.Schema) -> config.Operation:
 
     if ir.selector is not None:
         raise UnsupportedExpressionError(


### PR DESCRIPTION
It wasn't typed for an annoying reason, which is that singledispatch
tries to read the whole type annotation, which fails here because it
happens as part of a circular import. Just pass the type to the
function so it doesn't muck around.