### PR TITLE
Make state serializers in the compiler

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -384,6 +384,12 @@ class CompilerState:
     local_intro_query: Optional[str]
     global_intro_query: Optional[str]
 
+    @functools.cached_property
+    def state_serializer_factory(self) -> sertypes.StateSerializerFactory:
+        return sertypes.StateSerializerFactory(
+            self.std_schema, self.config_spec
+        )
+
 
 class Compiler:
 
@@ -2118,6 +2124,8 @@ def _try_compile(
         non_trailing_ctx = dataclasses.replace(
             ctx, output_format=enums.OutputFormat.NONE)
 
+    final_user_schema: Optional[s_schema.Schema] = None
+
     for i, stmt in enumerate(statements):
         is_trailing_stmt = i == statements_len - 1
         stmt_ctx = ctx if is_trailing_stmt else non_trailing_ctx
@@ -2201,6 +2209,7 @@ def _try_compile(
             unit.has_role_ddl = comp.has_role_ddl
             unit.ddl_stmt_id = comp.ddl_stmt_id
             if comp.user_schema is not None:
+                final_user_schema = comp.user_schema
                 unit.user_schema = pickle.dumps(comp.user_schema, -1)
             if comp.cached_reflection is not None:
                 unit.cached_reflection = \
@@ -2219,6 +2228,7 @@ def _try_compile(
             unit.sql = comp.sql
             unit.cacheable = comp.cacheable
             if comp.user_schema is not None:
+                final_user_schema = comp.user_schema
                 unit.user_schema = pickle.dumps(comp.user_schema, -1)
             if comp.cached_reflection is not None:
                 unit.cached_reflection = \
@@ -2248,6 +2258,7 @@ def _try_compile(
             unit.sql = comp.sql
             unit.cacheable = comp.cacheable
             if comp.user_schema is not None:
+                final_user_schema = comp.user_schema
                 unit.user_schema = pickle.dumps(comp.user_schema, -1)
             if comp.cached_reflection is not None:
                 unit.cached_reflection = \
@@ -2350,6 +2361,13 @@ def _try_compile(
         rv.in_type_id = in_type_id.bytes
         rv.in_type_args = in_type_args
         rv.in_type_data = in_type_data
+
+    if final_user_schema:
+        rv.state_serializer = ctx.compiler_state.state_serializer_factory.make(
+            final_user_schema,
+            ctx.state.current_tx().get_global_schema(),
+            ctx.protocol_version,
+        )
 
     # Sanity checks
     for unit in rv:  # pragma: no cover

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1067,7 +1067,11 @@ class Compiler:
             )
 
         ddl_source = edgeql.Source.from_string(schema_ddl_text)
+
+        # The state serializer generated below is somehow inappropriate,
+        # so it's simply ignored here and the I/O process will do it on its own
         units = compile(ctx=ctx, source=ddl_source).units
+
         schema = ctx.state.current_tx().get_schema(
             ctx.compiler_state.std_schema)
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2366,7 +2366,7 @@ def _try_compile(
         rv.in_type_args = in_type_args
         rv.in_type_data = in_type_data
 
-    if final_user_schema:
+    if final_user_schema is not None:
         rv.state_serializer = ctx.compiler_state.state_serializer_factory.make(
             final_user_schema,
             ctx.state.current_tx().get_global_schema(),

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -373,6 +373,8 @@ class QueryUnitGroup:
 
     units: List[QueryUnit] = dataclasses.field(default_factory=list)
 
+    state_serializer: Optional[sertypes.StateSerializer] = None
+
     def __iter__(self) -> Iterator[QueryUnit]:
         return iter(self.units)
 

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -94,6 +94,7 @@ cdef class Database:
     cdef schedule_extensions_update(self)
 
     cdef _invalidate_caches(self)
+    cdef _clear_state_serializers(self)
     cdef _cache_compiled_query(self, key, query_unit)
     cdef _new_view(self, query_cache, protocol_version)
     cdef _remove_view(self, view)
@@ -106,6 +107,7 @@ cdef class Database:
         db_config=?,
     )
     cdef get_state_serializer(self, protocol_version)
+    cdef set_state_serializer(self, protocol_version, serializer)
 
 
 cdef class DatabaseConnectionView:

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1500,6 +1500,11 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             raise
         else:
             _dbview.on_success(query_unit, {})
+            # _execute_utility_stmt is only used in restore(), where the state
+            # serializer is not coming with the COMMIT command. However, we try
+            # to keep the state serializer here anyways in case of future use
+            if query_unit_group.state_serializer is not None:
+                _dbview.set_state_serializer(query_unit_group.state_serializer)
 
     async def restore(self):
         cdef:

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -164,6 +164,9 @@ async def execute(
         raise
     else:
         side_effects = dbv.on_success(query_unit, new_types)
+        state_serializer = compiled.query_unit_group.state_serializer
+        if state_serializer is not None:
+            dbv.set_state_serializer(state_serializer)
         if side_effects:
             signal_side_effects(dbv, side_effects)
         if not dbv.in_tx() and not query_unit.tx_rollback:
@@ -335,6 +338,8 @@ async def execute_script(
             state = dbv.serialize_state()
             if state is not orig_state:
                 conn.last_state = state
+        if unit_group.state_serializer is not None:
+            dbv.set_state_serializer(unit_group.state_serializer)
 
     finally:
         if sent and sent < len(unit_group):


### PR DESCRIPTION
This is to release the I/O process from long-running blocking computation.

- [x] Make serializer in the compiler
- [x] Use serializer properly in the dbview
