### PR TITLE
Add `contains` for JSON.

### DIFF
--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -550,7 +550,22 @@ std::contains(haystack: array<anytype>, needle: anytype) -> std::bool
     # and we want it to be inlined so that pg::gin indexes work with it.
     SET impl_is_strict := false;
     USING SQL $$
-	SELECT "haystack" @> ARRAY["needle"]
+    SELECT "haystack" @> ARRAY["needle"]
+    $$;
+};
+
+
+CREATE FUNCTION
+std::contains(haystack: json, needle: json) -> std::bool
+{
+    CREATE ANNOTATION std::description :=
+        'A polymorphic function to test if one JSON value contains another JSON value.';
+    SET volatility := 'Immutable';
+    # Postgres only manages to inline this function if it isn't marked strict,
+    # and we want it to be inlined so that pg::gin indexes work with it.
+    SET impl_is_strict := false;
+    USING SQL $$
+    SELECT "haystack" @> "needle"
     $$;
 };
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -65,7 +65,14 @@ def is_index_valid_for_type(
         case 'pg::btree':
             return True
         case 'pg::gin':
-            return expr_type.is_array()
+            return (
+                expr_type.is_array()
+                or
+                expr_type.issubclass(
+                    schema,
+                    schema.get('std::json', type=s_scalars.ScalarType),
+                )
+            )
         case 'fts::textsearch':
             return expr_type.issubclass(
                 schema, schema.get('std::str', type=s_scalars.ScalarType))

--- a/tests/schemas/explain.esdl
+++ b/tests/schemas/explain.esdl
@@ -108,13 +108,19 @@ type URL extending Named {
 }
 
 type RangeTest {
-    required property rval -> range<int64>;
-    required property mval -> multirange<int64>;
-    required property rdate -> range<cal::local_date>;
-    required property mdate -> multirange<cal::local_date>;
+    required rval: range<int64>;
+    required mval: multirange<int64>;
+    required rdate: range<cal::local_date>;
+    required mdate: multirange<cal::local_date>;
 
     index pg::gist on (.rval);
     index pg::gist on (.mval);
     index pg::gist on (.rdate);
     index pg::gist on (.mdate);
+}
+
+type JSONTest {
+    required val: json;
+
+    index pg::gin on (.val);
 }

--- a/tests/schemas/explain_setup.edgeql
+++ b/tests/schemas/explain_setup.edgeql
@@ -181,4 +181,9 @@ for x in range_unpack(range(0, 500_000)) union (
 );
 
 
+for x in range_unpack(range(0, 100_000)) union (
+    insert JSONTest{val := <json>(a:=x, b:=round(random()*1000))}
+);
+
+
 administer statistics_update();

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -1873,6 +1873,53 @@ class TestEdgeQLExplain(tb.QueryTestCase):
             self.get_gist_index_expected_res('mdate', 'IndexScan'),
         )
 
+    async def test_edgeql_explain_json_contains_01(self):
+        res = await self.explain('''
+            select JSONTest {id, val}
+            filter contains(.val, <json>(a := 123))
+        ''')
+        self.assert_plan(
+            res['fine_grained']['subplans'][1],
+            {
+                "pipeline": [
+                    {
+                        "plan_type": "BitmapHeapScan",
+                    },
+                ],
+                "subplans": [
+                    {
+                        "pipeline": [
+                            {
+                                "plan_type": "BitmapIndexScan",
+                                "properties": tb.bag([
+                                    {
+                                        'important': False,
+                                        'title': 'parent_relationship',
+                                        'type': 'text',
+                                        'value': 'Outer',
+                                    },
+                                    {
+                                        'important': True,
+                                        'title': 'index_name',
+                                        'type': 'index',
+                                        'value':
+                                            f"index 'pg::gin' of object"
+                                            f" type 'default::JSONTest'"
+                                            f" on (.val)",
+                                    },
+                                    {
+                                        'important': False,
+                                        'title': 'index_cond',
+                                        'type': 'expr',
+                                    },
+                                ]),
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
 
 class NameTranslation(unittest.TestCase):
 


### PR DESCRIPTION
Add the `contains` function for JSON and make `pg::gin` index valid for JSON (it's this operation that is optimized by GIN index).

Fixes #5703