### PR TITLE
Avoid dynamically generating classes for composite config values

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3585,7 +3585,10 @@ class ApplySessionConfigFunction(dbops.Function):
             setting = config_spec[setting_name]
 
             valql = '"value"->>0'
-            if issubclass(setting.type, statypes.Duration):
+            if (
+                isinstance(setting.type, type)
+                and issubclass(setting.type, statypes.Duration)
+            ):
                 valql = f"""
                     edgedb._interval_to_ms(({valql})::interval)::text || 'ms'
                 """

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -29,7 +29,7 @@ from .ops import OpCode, Operation, SettingValue
 from .ops import spec_to_json, to_json, from_json, set_value, to_edgeql
 from .ops import value_from_json, value_to_json_value, coerce_single_value
 from .spec import Spec, Setting, load_spec_from_schema
-from .types import ConfigType
+from .types import ConfigType, CompositeConfigType
 
 
 __all__ = (
@@ -38,7 +38,7 @@ __all__ = (
     'spec_to_json', 'to_json', 'to_edgeql', 'from_json', 'set_value',
     'value_from_json', 'value_to_json_value',
     'ConfigScope', 'OpCode', 'Operation',
-    'ConfigType',
+    'ConfigType', 'CompositeConfigType',
     'load_spec_from_schema',
     'get_compilation_config',
     'coerce_single_value',

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -19,8 +19,7 @@
 
 from __future__ import annotations
 
-import dataclasses
-
+from typing import *
 
 from edb import errors
 from edb.common import typeutils
@@ -28,16 +27,34 @@ from edb.common import typing_inspect
 from edb.schema import objects as s_obj
 from edb.schema import name as s_name
 
+from edb.ir import statypes
+
+
+if TYPE_CHECKING:
+    from . import spec
+
+
+class ConfigTypeSpec(statypes.CompositeTypeSpec):
+    def __call__(self, **kwargs) -> CompositeConfigType:
+        return CompositeConfigType(self, **kwargs)
+
+    def from_pyvalue(
+        self, v, *, spec, allow_missing=False
+    ) -> CompositeConfigType:
+        return CompositeConfigType.from_pyvalue(
+            v, tspec=self, spec=spec, allow_missing=allow_missing
+        )
+
 
 class ConfigType:
 
     @classmethod
-    def from_pyvalue(cls, v, *, spec, allow_missing=False):
+    def from_pyvalue(cls, v, *, tspec, spec, allow_missing=False):
         """Subclasses override this to allow creation from Python scalars."""
         raise NotImplementedError
 
     @classmethod
-    def from_json_value(cls, v, *, spec):
+    def from_json_value(cls, v, *, tspec, spec):
         raise NotImplementedError
 
     def to_json_value(self):
@@ -49,20 +66,63 @@ class ConfigType:
 
 
 class CompositeConfigType(ConfigType):
+    _tspec: statypes.CompositeTypeSpec
+    _compare_keys: tuple[str, ...]
+
+    def __init__(self, tspec: statypes.CompositeTypeSpec, **kwargs) -> None:
+        object.__setattr__(self, '_tspec', tspec)
+        for f in tspec.fields.values():
+            if f.name in kwargs:
+                object.__setattr__(self, f.name, kwargs[f.name])
+            elif f.default is not statypes.MISSING:
+                object.__setattr__(self, f.name, f.default)
+        object.__setattr__(self, '_compare_keys', tuple(
+            f.name for f in tspec.fields.values() if f.unique
+        ))
+
+    def __setattr__(self, k, v) -> None:
+        raise TypeError(f"{self._tspec.name} is immutable")
+
+    def __eq__(self, rhs: Any) -> bool:
+        if (
+            not isinstance(rhs, CompositeConfigType)
+            or self._tspec != rhs._tspec
+        ):
+            return NotImplemented
+        compare_keys = self._compare_keys
+        return (
+            tuple(getattr(self, k) for k in compare_keys)
+            == tuple(getattr(rhs, k) for k in compare_keys)
+        )
+
+    def __hash__(self) -> int:
+        return hash(tuple(getattr(self, k) for k in self._compare_keys))
+
+    def __repr__(self) -> str:
+        body = ', '.join(
+            f'{f.name}={getattr(self, f.name)!r}'
+            for f in self._tspec.fields.values()
+            if hasattr(self, f.name)
+        )
+        return f'{self._tspec.name}({body})'
 
     @classmethod
-    def from_pyvalue(cls, data, *, spec, allow_missing=False):
+    def from_pyvalue(cls, data, *,
+                     tspec: statypes.CompositeTypeSpec,
+                     spec: spec.Spec,
+                     allow_missing=False) -> CompositeConfigType:
         if not isinstance(data, dict):
-            raise cls._err(f'expected a dict value, got {type(data)!r}')
+            raise cls._err(tspec, f'expected a dict value, got {type(data)!r}')
 
         data = dict(data)
         tname = data.pop('_tname', None)
         if tname is not None:
             if '::' in tname:
                 tname = s_name.QualName.from_string(tname).name
-            cls = spec.get_type_by_name(tname)
+            tspec = spec.get_type_by_name(tname)
+        assert tspec
 
-        fields = {f.name: f for f in dataclasses.fields(cls)}
+        fields = tspec.fields
 
         items = {}
         inv_keys = []
@@ -89,7 +149,7 @@ class CompositeConfigType(ConfigType):
                 if container not in (frozenset, list):
                     raise RuntimeError(
                         f'invalid type annotation on '
-                        f'{cls.__name__}.{fieldname}: '
+                        f'{tspec.name}.{fieldname}: '
                         f'{f_type!r} is not supported')
 
                 eltype = typing_inspect.get_args(f_type, evaluate=True)[0]
@@ -100,12 +160,13 @@ class CompositeConfigType(ConfigType):
                     value = container(value)
                 else:
                     raise cls._err(
+                        tspec,
                         f'invalid {fieldname!r} field value: expecting '
                         f'{eltype.__name__} or a list thereof, but got '
                         f'{type(value).__name__}'
                     )
 
-            elif (issubclass(f_type, CompositeConfigType)
+            elif (isinstance(f_type, ConfigTypeSpec)
                     and isinstance(value, dict)):
 
                 tname = value.get('_tname', None)
@@ -115,12 +176,13 @@ class CompositeConfigType(ConfigType):
                     actual_f_type = spec.get_type_by_name(tname)
                 else:
                     actual_f_type = f_type
-                    value['_tname'] = f_type.__name__
+                    value['_tname'] = f_type.name
 
-                value = actual_f_type.from_pyvalue(value, spec=spec)
+                value = cls.from_pyvalue(value, tspec=actual_f_type, spec=spec)
 
-            elif not isinstance(value, f_type):
+            elif not isinstance(f_type, type) or not isinstance(value, f_type):
                 raise cls._err(
+                    tspec,
                     f'invalid {fieldname!r} field value: expecting '
                     f'{f_type.__name__}, but got {type(value).__name__}'
                 )
@@ -128,38 +190,39 @@ class CompositeConfigType(ConfigType):
             items[fieldname] = value
 
         if inv_keys:
-            inv_keys = ', '.join(repr(r) for r in inv_keys)
-            raise cls._err(f'unknown fields: {inv_keys}')
+            sinv_keys = ', '.join(repr(r) for r in inv_keys)
+            raise cls._err(tspec, f'unknown fields: {sinv_keys}')
 
         for fieldname, field in fields.items():
-            if fieldname not in items and field.default is dataclasses.MISSING:
+            if fieldname not in items and field.default is statypes.MISSING:
                 if allow_missing:
                     items[fieldname] = None
                 else:
-                    raise cls._err(f'missing required field: {fieldname!r}')
+                    raise cls._err(
+                        tspec, f'missing required field: {fieldname!r}'
+                    )
 
         try:
-            return cls(**items)
+            return cls(tspec, **items)
         except (TypeError, ValueError) as ex:
-            raise cls._err(str(ex))
+            raise cls._err(tspec, str(ex))
 
     @classmethod
     def get_edgeql_typeid(cls):
         return s_obj.get_known_type_id('std::json')
 
     @classmethod
-    def from_json_value(cls, s, *, spec):
-        return cls.from_pyvalue(s, spec=spec)
+    def from_json_value(cls, s, *, tspec: statypes.CompositeTypeSpec, spec):
+        return cls.from_pyvalue(s, tspec=tspec, spec=spec)
 
     def to_json_value(self):
         dct = {}
-        dct['_tname'] = self.__class__.__name__
+        dct['_tname'] = self._tspec.name
 
-        for f in dataclasses.fields(self):
+        for f in self._tspec.fields.values():
             f_type = f.type
             value = getattr(self, f.name)
-            if (isinstance(f_type, type)
-                    and issubclass(f_type, CompositeConfigType)
+            if (isinstance(f_type, statypes.CompositeTypeSpec)
                     and value is not None):
                 value = value.to_json_value()
             elif typing_inspect.is_generic_type(f_type):
@@ -170,6 +233,8 @@ class CompositeConfigType(ConfigType):
         return dct
 
     @classmethod
-    def _err(cls, msg):
+    def _err(
+        cls, tspec: statypes.CompositeTypeSpec, msg: str
+    ) -> errors.ConfigurationError:
         return errors.ConfigurationError(
-            f'invalid {cls.__name__.lower()!r} value: {msg}')
+            f'invalid {tspec.name.lower()!r} value: {msg}')

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -829,7 +829,7 @@ def initialize_static_cfg(
             )
         if setting.type == bool:
             env_value = env_value == 'true'
-        elif not issubclass(setting.type, statypes.ScalarType):
+        elif not issubclass(setting.type, statypes.ScalarType):  # type: ignore
             env_value = setting.type(env_value)  # type: ignore
         add_config(cfg_name, env_value, environment_variable)
 

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -524,7 +524,7 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         else:
             authmethod = await self.server.get_auth_method(
                 user, self._transport_proto)
-            authmethod_name = type(authmethod).__name__
+            authmethod_name = authmethod._tspec.name
 
         if authmethod_name == 'SCRAM':
             await self._auth_scram(user)

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -18,14 +18,12 @@
 
 
 import asyncio
-import dataclasses
 import datetime
 import json
 import platform
 import random
 import tempfile
 import textwrap
-import typing
 import unittest
 
 import immutables
@@ -39,6 +37,9 @@ from edb.edgeql import quote as qlquote
 
 from edb.testbase import server as tb
 from edb.schema import objects as s_obj
+
+from edb.ir import statypes
+
 
 from edb.server import args
 from edb.server import cluster
@@ -60,15 +61,24 @@ def make_port_value(*, protocol='graphql+http',
         concurrency=concurrency, port=port, **kwargs)
 
 
-@dataclasses.dataclass(frozen=True, eq=True)
-class Port(types.CompositeConfigType):
+Field = statypes.CompositeTypeSpecField
 
-    protocol: str
-    database: str
-    port: int
-    concurrency: int
-    user: str
-    address: typing.FrozenSet[str] = frozenset({'localhost'})
+
+def _mk_fields(*fields):
+    return immutables.Map({f.name: f for f in fields})
+
+
+Port = types.ConfigTypeSpec(
+    name='Port',
+    fields=_mk_fields(
+        Field('protocol', str),
+        Field('database', str),
+        Field('port', int),
+        Field('concurrency', int),
+        Field('user', str),
+        Field('address', frozenset[str], default=frozenset({'localhost'})),
+    ),
+)
 
 
 testspec1 = spec.Spec(


### PR DESCRIPTION
Instead, generate "specs" that describe them and that will be packaged
with plain old data. The goal here is to avoid complications caused by
dynamically created classes when composite config data needs to be
pickled and when the config spec gets reloaded.