### PR TITLE
Fix `--background`

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -647,8 +647,8 @@ _server_options = [
     click.option(
         '-b', '--background', is_flag=True, help='daemonize'),
     click.option(
-        '--pidfile-dir', type=PathPath(), default='/run/edgedb/',
-        help='path to PID file directory'),
+        '--pidfile-dir', type=PathPath(), default=None,
+        help='path to PID file directory, defaults to --runstate-dir'),
     click.option(
         '--daemon-user', type=int),
     click.option(

--- a/edb/server/daemon/pidfile.py
+++ b/edb/server/daemon/pidfile.py
@@ -52,6 +52,13 @@ class PidFile:
             raise DaemonError('pid file is already acquired')
 
         path = self._path
+        pidfile_dir = os.path.dirname(path)
+        if not os.path.isdir(pidfile_dir):
+            raise DaemonError(
+                f"cannot create pid file: {pidfile_dir} "
+                f"does not exist or is not a directory"
+            )
+
         if os.path.exists(path):
             if self.is_locked(path):
                 raise DaemonError(

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -28,7 +28,6 @@ from edb import buildmeta
 from edb.common import debug
 from edb.common import devmode as dm
 from edb.server import args as srv_args
-from edb.server import logsetup
 from edb.server import main as srv_main
 
 
@@ -53,7 +52,6 @@ def server(version=False, **kwargs):
     os.environ['EDGEDB_DEBUG_SERVER'] = '1'
     debug.init_debug_flags()
     kwargs['security'] = srv_args.ServerSecurityMode.InsecureDevMode
-    logsetup.setup_logging(kwargs['log_level'], kwargs['log_to'])
     srv_main.server_main(**kwargs)
 
 


### PR DESCRIPTION
The `--background` server flag isn't really a recommended way of running
the server (it's best to use a proper service manager like systemd for
that), but sometimes it's useful and we implement it, so fix up the bit
rot, improve logging and add a test.

Note: most of this diff are whitespace changes due to context manager
reshuffling.
