### PR TITLE
Extract extension names in the compiler

### DIFF
--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -147,8 +147,6 @@ class DDLQuery(BaseQuery):
     single_unit: bool = False
     create_db: Optional[str] = None
     drop_db: Optional[str] = None
-    create_ext: Optional[str] = None
-    drop_ext: Optional[str] = None
     create_db_template: Optional[str] = None
     has_role_ddl: bool = False
     ddl_stmt_id: Optional[str] = None
@@ -279,10 +277,6 @@ class QueryUnit:
     # close all inactive unused pooled connections to the template db.
     create_db_template: Optional[str] = None
 
-    # If non-None, contains name of created/deleted extension.
-    create_ext: Optional[str] = None
-    drop_ext: Optional[str] = None
-
     # If non-None, the DDL statement will emit data packets marked
     # with the indicated ID.
     ddl_stmt_id: Optional[str] = None
@@ -322,6 +316,7 @@ class QueryUnit:
     # the command is run. The schema is pickled.
     user_schema: Optional[bytes] = None
     cached_reflection: Optional[bytes] = None
+    extensions: Optional[set[str]] = None
 
     # If present, represents the future global schema state
     # after the command is run. The schema is pickled.

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -251,17 +251,11 @@ def compile_and_apply_ddl_stmt(
     create_db = None
     drop_db = None
     create_db_template = None
-    create_ext = None
-    drop_ext = None
     if isinstance(stmt, qlast.DropDatabase):
         drop_db = stmt.name.name
     elif isinstance(stmt, qlast.CreateDatabase):
         create_db = stmt.name.name
         create_db_template = stmt.template.name if stmt.template else None
-    elif isinstance(stmt, qlast.CreateExtension):
-        create_ext = stmt.name.name
-    elif isinstance(stmt, qlast.DropExtension):
-        drop_ext = stmt.name.name
 
     if debug.flags.delta_execute:
         debug.header('Delta Script')
@@ -279,8 +273,6 @@ def compile_and_apply_ddl_stmt(
         create_db=create_db,
         drop_db=drop_db,
         create_db_template=create_db_template,
-        create_ext=create_ext,
-        drop_ext=drop_ext,
         has_role_ddl=isinstance(stmt, qlast.RoleCommand),
         ddl_stmt_id=ddl_stmt_id,
         user_schema=current_tx.get_user_schema_if_updated(),  # type: ignore

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -31,7 +31,6 @@ cpdef enum SideEffects:
     RoleChanges = 1 << 3
     GlobalSchemaChanges = 1 << 4
     DatabaseChanges = 1 << 5
-    ExtensionChanges = 1 << 6
 
 
 @cython.final
@@ -91,7 +90,6 @@ cdef class Database:
         readonly object extensions
 
     cdef schedule_config_update(self)
-    cdef schedule_extensions_update(self)
 
     cdef _invalidate_caches(self)
     cdef _clear_state_serializers(self)
@@ -102,6 +100,7 @@ cdef class Database:
     cdef _set_and_signal_new_user_schema(
         self,
         new_schema,
+        extensions,
         reflection_cache=?,
         backend_ids=?,
         db_config=?,
@@ -188,7 +187,7 @@ cdef class DatabaseConnectionView:
     cdef on_error(self)
     cdef on_success(self, query_unit, new_types)
     cdef commit_implicit_tx(
-        self, user_schema, global_schema, cached_reflection
+        self, user_schema, extensions, global_schema, cached_reflection
     )
 
     cpdef get_config_spec(self)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -2858,8 +2858,6 @@ cdef class PGConnection:
                     self.tenant.on_global_schema_change()
                 elif event == 'database-changes':
                     self.tenant.on_remote_database_changes()
-                elif event == 'extension-changes':
-                    self.tenant.on_database_extensions_changes()
                 elif event == 'ensure-database-not-used':
                     dbname = event_payload['dbname']
                     self.tenant.on_remote_database_quarantine(dbname)


### PR DESCRIPTION
... instead of doing so in the I/O process.

This dropped remote event for extension changes added in #4499, because the extension is now just a part of the user schema, which should be updated together with user schema changes.

This partially reverts commit 55cb7446ce0dccecf96498b307b841fb4caadab4.