### PR TITLE
Don't unpickle schema in I/O process

### DIFF
--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -186,14 +186,12 @@ async def handle_request(
 
             # only use the backend if schema is required
             if static_exc is errormech.SchemaRequired:
-                ex = errormech.interpret_backend_error(
-                    s_schema.ChainedSchema(
-                        tenant.server.get_std_schema(),
-                        db.user_schema,
-                        tenant.get_global_schema(),
-                    ),
+                compiler_pool = tenant.server.get_compiler_pool()
+                ex = await compiler_pool.interpret_backend_error(
+                    db.user_schema_pickled,
+                    tenant.get_global_schema_pickled(),
                     ex.fields,
-                    from_graphql=True,
+                    True,
                 )
             else:
                 ex = static_exc

--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -227,8 +227,8 @@ async def compile(
     compiler_pool = server.get_compiler_pool()
     return await compiler_pool.compile_graphql(
         db.name,
-        db.user_schema,
-        tenant.get_global_schema(),
+        db.user_schema_pickled,
+        tenant.get_global_schema_pickled(),
         db.reflection_cache,
         db.db_config,
         db._index.get_compilation_system_config(),

--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -188,8 +188,8 @@ async def handle_request(
             if static_exc is errormech.SchemaRequired:
                 compiler_pool = tenant.server.get_compiler_pool()
                 ex = await compiler_pool.interpret_backend_error(
-                    db.user_schema_pickled,
-                    tenant.get_global_schema_pickled(),
+                    db.user_schema_pickle,
+                    tenant.get_global_schema_pickle(),
                     ex.fields,
                     True,
                 )
@@ -225,8 +225,8 @@ async def compile(
     compiler_pool = server.get_compiler_pool()
     return await compiler_pool.compile_graphql(
         db.name,
-        db.user_schema_pickled,
-        tenant.get_global_schema_pickled(),
+        db.user_schema_pickle,
+        tenant.get_global_schema_pickle(),
         db.reflection_cache,
         db.db_config,
         db._index.get_compilation_system_config(),

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -975,6 +975,24 @@ class Compiler:
         global_schema = self.parse_json_schema(global_schema_json, None)
         return pickle.dumps(global_schema, -1)
 
+    def parse_user_schema_db_config(
+        self,
+        user_schema_json: bytes,
+        db_config_json: bytes,
+        global_schema_pickled: bytes,
+    ) -> tuple[bytes, Mapping[str, config.SettingValue], list[config.Setting]]:
+        global_schema = pickle.loads(global_schema_pickled)
+        user_schema = self.parse_json_schema(user_schema_json, global_schema)
+        db_config = self.parse_db_config(db_config_json, user_schema)
+        ext_config_settings = config.load_ext_settings_from_schema(
+            s_schema.ChainedSchema(
+                self.state.std_schema,
+                user_schema,
+                s_schema.EMPTY_SCHEMA,
+            )
+        )
+        return pickle.dumps(user_schema, -1), db_config, ext_config_settings
+
     def describe_database_dump(
         self,
         user_schema_json: bytes,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1078,8 +1078,8 @@ class Compiler:
 
     def describe_database_restore(
         self,
-        user_schema: s_schema.Schema,
-        global_schema: s_schema.Schema,
+        user_schema_pickled: bytes,
+        global_schema_pickled: bytes,
         dump_server_ver_str: str,
         dump_catalog_version: Optional[int],
         schema_ddl: bytes,
@@ -1102,8 +1102,8 @@ class Compiler:
         dump_catalog_version = dump_catalog_version or 0
 
         state = dbstate.CompilerConnectionState(
-            user_schema=user_schema,
-            global_schema=global_schema,
+            user_schema=pickle.loads(user_schema_pickled),
+            global_schema=pickle.loads(global_schema_pickled),
             modaliases=DEFAULT_MODULE_ALIASES_MAP,
             session_config=EMPTY_MAP,
             database_config=EMPTY_MAP,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -981,9 +981,9 @@ class Compiler:
         self,
         user_schema_json: bytes,
         db_config_json: bytes,
-        global_schema_pickled: bytes,
+        global_schema_pickle: bytes,
     ) -> dbstate.ParsedDatabase:
-        global_schema = pickle.loads(global_schema_pickled)
+        global_schema = pickle.loads(global_schema_pickle)
         user_schema = self.parse_json_schema(user_schema_json, global_schema)
         db_config = self.parse_db_config(db_config_json, user_schema)
         ext_config_settings = config.load_ext_settings_from_schema(
@@ -999,7 +999,7 @@ class Compiler:
             defines.CURRENT_PROTOCOL,
         )
         return dbstate.ParsedDatabase(
-            user_schema_pickled=pickle.dumps(user_schema, -1),
+            user_schema_pickle=pickle.dumps(user_schema, -1),
             database_config=db_config,
             ext_config_settings=ext_config_settings,
             protocol_version=defines.CURRENT_PROTOCOL,
@@ -1009,11 +1009,11 @@ class Compiler:
     def make_state_serializer(
         self,
         protocol_version: defines.ProtocolVersion,
-        user_schema_pickled: bytes,
-        global_schema_pickled: bytes,
+        user_schema_pickle: bytes,
+        global_schema_pickle: bytes,
     ) -> sertypes.StateSerializer:
-        user_schema = pickle.loads(user_schema_pickled)
-        global_schema = pickle.loads(global_schema_pickled)
+        user_schema = pickle.loads(user_schema_pickle)
+        global_schema = pickle.loads(global_schema_pickle)
         return self.state.state_serializer_factory.make(
             user_schema,
             global_schema,
@@ -1105,8 +1105,8 @@ class Compiler:
 
     def describe_database_restore(
         self,
-        user_schema_pickled: bytes,
-        global_schema_pickled: bytes,
+        user_schema_pickle: bytes,
+        global_schema_pickle: bytes,
         dump_server_ver_str: str,
         dump_catalog_version: Optional[int],
         schema_ddl: bytes,
@@ -1129,8 +1129,8 @@ class Compiler:
         dump_catalog_version = dump_catalog_version or 0
 
         state = dbstate.CompilerConnectionState(
-            user_schema=pickle.loads(user_schema_pickled),
-            global_schema=pickle.loads(global_schema_pickled),
+            user_schema=pickle.loads(user_schema_pickle),
+            global_schema=pickle.loads(global_schema_pickle),
             modaliases=DEFAULT_MODULE_ALIASES_MAP,
             session_config=EMPTY_MAP,
             database_config=EMPTY_MAP,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -971,6 +971,10 @@ class Compiler:
         )
         return config.from_json(spec, db_config_json)
 
+    def parse_global_schema(self, global_schema_json: bytes) -> bytes:
+        global_schema = self.parse_json_schema(global_schema_json, None)
+        return pickle.dumps(global_schema, -1)
+
     def describe_database_dump(
         self,
         user_schema_json: bytes,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -919,6 +919,25 @@ class Compiler:
 
         return compile(ctx=ctx, source=source), ctx.state
 
+    def interpret_backend_error(
+        self,
+        user_schema: bytes,
+        global_schema: bytes,
+        error_fields: dict[str, str],
+        from_graphql: bool,
+    ) -> errors.EdgeDBError:
+        from . import errormech
+
+        schema = s_schema.ChainedSchema(
+            self.state.std_schema,
+            pickle.loads(user_schema),
+            pickle.loads(global_schema),
+        )
+        rv: errors.EdgeDBError = errormech.interpret_backend_error(
+            schema, error_fields, from_graphql=from_graphql
+        )
+        return rv
+
     def describe_database_dump(
         self,
         user_schema: s_schema.Schema,

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -472,7 +472,7 @@ class SQLQueryUnit:
 
 @dataclasses.dataclass
 class ParsedDatabase:
-    user_schema_pickled: bytes
+    user_schema_pickle: bytes
     database_config: immutables.Map[str, config.SettingValue]
     ext_config_settings: list[config.Setting]
 

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -470,6 +470,16 @@ class SQLQueryUnit:
     """If frontend_only is True, only issue CommandComplete with this tag."""
 
 
+@dataclasses.dataclass
+class ParsedDatabase:
+    user_schema_pickled: bytes
+    database_config: immutables.Map[str, config.SettingValue]
+    ext_config_settings: list[config.Setting]
+
+    protocol_version: defines.ProtocolVersion
+    state_serializer: sertypes.StateSerializer
+
+
 SQLSettings = immutables.Map[Optional[str], Optional[str | list[str]]]
 DEFAULT_SQL_SETTINGS: SQLSettings = immutables.Map()
 DEFAULT_SQL_FE_SETTINGS: SQLSettings = immutables.Map({

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -315,6 +315,7 @@ class QueryUnit:
     user_schema: Optional[bytes] = None
     cached_reflection: Optional[bytes] = None
     extensions: Optional[set[str]] = None
+    ext_config_settings: Optional[list[config.Setting]] = None
 
     # If present, represents the future global schema state
     # after the command is run. The schema is pickled.

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -570,6 +570,22 @@ class AbstractPool:
         finally:
             self._release_worker(worker)
 
+    async def interpret_backend_error(
+        self,
+        *args,
+        **kwargs
+    ):
+        worker = await self._acquire_worker()
+        try:
+            return await worker.call(
+                'interpret_backend_error',
+                *args,
+                **kwargs
+            )
+
+        finally:
+            self._release_worker(worker)
+
     async def describe_database_dump(
         self,
         *args,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -571,6 +571,22 @@ class AbstractPool:
         finally:
             self._release_worker(worker)
 
+    async def parse_user_schema_db_config(
+        self,
+        *args,
+        **kwargs,
+    ):
+        worker = await self._acquire_worker()
+        try:
+            return await worker.call(
+                'parse_user_schema_db_config',
+                *args,
+                **kwargs,
+            )
+
+        finally:
+            self._release_worker(worker)
+
     async def describe_database_dump(
         self,
         *args,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -587,6 +587,22 @@ class AbstractPool:
         finally:
             self._release_worker(worker)
 
+    async def make_state_serializer(
+        self,
+        *args,
+        **kwargs,
+    ):
+        worker = await self._acquire_worker()
+        try:
+            return await worker.call(
+                'make_state_serializer',
+                *args,
+                **kwargs,
+            )
+
+        finally:
+            self._release_worker(worker)
+
     async def describe_database_dump(
         self,
         *args,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -199,9 +199,6 @@ class AbstractPool:
             )
         self._dbindex = dbindex
 
-    def remove_dbindex(self, client_id: int):
-        pass
-
     @functools.lru_cache(maxsize=None)
     def _get_init_args(self):
         init_args = self._get_init_args_uncached()
@@ -1315,7 +1312,7 @@ class MultiTenantPool(FixedPool):
         # not currently used
         pass
 
-    def remove_dbindex(self, client_id: int):
+    def drop_tenant(self, client_id: int):
         for worker in self._workers.values():
             worker.invalidate(client_id)
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -555,6 +555,22 @@ class AbstractPool:
         finally:
             self._release_worker(worker)
 
+    async def parse_global_schema(
+        self,
+        *args,
+        **kwargs,
+    ):
+        worker = await self._acquire_worker()
+        try:
+            return await worker.call(
+                'parse_global_schema',
+                *args,
+                **kwargs
+            )
+
+        finally:
+            self._release_worker(worker)
+
     async def describe_database_dump(
         self,
         *args,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -76,7 +76,7 @@ def _pickle_memoized(schema):
 class BaseWorker:
 
     _dbs: immutables.Map[str, state.PickledDatabaseState]
-    _global_schema_pickled: bytes
+    _global_schema_pickle: bytes
 
     def __init__(
         self,
@@ -85,7 +85,7 @@ class BaseWorker:
         std_schema,
         refl_schema,
         schema_class_layout,
-        global_schema_pickled,
+        global_schema_pickle,
         system_config,
     ):
         self._dbs = dbs
@@ -93,7 +93,7 @@ class BaseWorker:
         self._std_schema = std_schema
         self._refl_schema = refl_schema
         self._schema_class_layout = schema_class_layout
-        self._global_schema_pickled = global_schema_pickled
+        self._global_schema_pickle = global_schema_pickle
         self._system_config = system_config
         self._last_pickled_state = None
 
@@ -191,14 +191,14 @@ class AbstractPool:
         return self._make_init_args(*self._dbindex.get_cached_compiler_args())
 
     @functools.lru_cache(1)
-    def _make_init_args(self, dbs, global_schema_pickled, system_config):
+    def _make_init_args(self, dbs, global_schema_pickle, system_config):
         init_args = (
             dbs,
             self._backend_runtime_params,
             self._std_schema,
             self._refl_schema,
             self._schema_class_layout,
-            global_schema_pickled,
+            global_schema_pickle,
             system_config,
         )
         pickled_args = pickle.dumps(init_args, -1)
@@ -218,8 +218,8 @@ class AbstractPool:
         method_name: str,
         worker: BaseWorker,
         dbname,
-        user_schema_pickled,
-        global_schema_pickled,
+        user_schema_pickle,
+        global_schema_pickle,
         reflection_cache,
         database_config,
         system_config,
@@ -229,42 +229,42 @@ class AbstractPool:
             *,
             worker: BaseWorker,
             dbname,
-            user_schema_pickled=None,
-            global_schema_pickled=None,
+            user_schema_pickle=None,
+            global_schema_pickle=None,
             reflection_cache=None,
             database_config=None,
             system_config=None,
         ):
             worker_db = worker._dbs.get(dbname)
             if worker_db is None:
-                assert user_schema_pickled is not None
+                assert user_schema_pickle is not None
                 assert reflection_cache is not None
-                assert global_schema_pickled is not None
+                assert global_schema_pickle is not None
                 assert database_config is not None
                 assert system_config is not None
 
                 worker._dbs = worker._dbs.set(
                     dbname,
                     state.PickledDatabaseState(
-                        user_schema_pickled=user_schema_pickled,
+                        user_schema_pickle=user_schema_pickle,
                         reflection_cache=reflection_cache,
                         database_config=database_config,
                     ),
                 )
-                worker._global_schema_pickled = global_schema_pickled
+                worker._global_schema_pickle = global_schema_pickle
                 worker._system_config = system_config
             else:
                 if (
-                    user_schema_pickled is not None
+                    user_schema_pickle is not None
                     or reflection_cache is not None
                     or database_config is not None
                 ):
                     worker._dbs = worker._dbs.set(
                         dbname,
                         state.PickledDatabaseState(
-                            user_schema_pickled=(
-                                user_schema_pickled
-                                or worker_db.user_schema_pickled
+                            user_schema_pickle=(
+                                user_schema_pickle
+                                or worker_db.user_schema_pickle
                             ),
                             reflection_cache=(
                                 reflection_cache
@@ -276,8 +276,8 @@ class AbstractPool:
                         ),
                     )
 
-                if global_schema_pickled is not None:
-                    worker._global_schema_pickled = global_schema_pickled
+                if global_schema_pickle is not None:
+                    worker._global_schema_pickle = global_schema_pickle
                 if system_config is not None:
                     worker._system_config = system_config
 
@@ -287,23 +287,23 @@ class AbstractPool:
 
         if worker_db is None:
             preargs.extend([
-                user_schema_pickled,
+                user_schema_pickle,
                 _pickle_memoized(reflection_cache),
-                global_schema_pickled,
+                global_schema_pickle,
                 _pickle_memoized(database_config),
                 _pickle_memoized(system_config),
             ])
             to_update = {
-                'user_schema_pickled': user_schema_pickled,
+                'user_schema_pickle': user_schema_pickle,
                 'reflection_cache': reflection_cache,
-                'global_schema_pickled': global_schema_pickled,
+                'global_schema_pickle': global_schema_pickle,
                 'database_config': database_config,
                 'system_config': system_config,
             }
         else:
-            if worker_db.user_schema_pickled is not user_schema_pickled:
-                preargs.append(user_schema_pickled)
-                to_update['user_schema_pickled'] = user_schema_pickled
+            if worker_db.user_schema_pickle is not user_schema_pickle:
+                preargs.append(user_schema_pickle)
+                to_update['user_schema_pickle'] = user_schema_pickle
             else:
                 preargs.append(None)
 
@@ -313,9 +313,9 @@ class AbstractPool:
             else:
                 preargs.append(None)
 
-            if worker._global_schema_pickled is not global_schema_pickled:
-                preargs.append(global_schema_pickled)
-                to_update['global_schema_pickled'] = global_schema_pickled
+            if worker._global_schema_pickle is not global_schema_pickle:
+                preargs.append(global_schema_pickle)
+                to_update['global_schema_pickle'] = global_schema_pickle
             else:
                 preargs.append(None)
 
@@ -354,8 +354,8 @@ class AbstractPool:
     async def compile(
         self,
         dbname,
-        user_schema_pickled,
-        global_schema_pickled,
+        user_schema_pickle,
+        global_schema_pickle,
         reflection_cache,
         database_config,
         system_config,
@@ -368,8 +368,8 @@ class AbstractPool:
                 "compile",
                 worker,
                 dbname,
-                user_schema_pickled,
-                global_schema_pickled,
+                user_schema_pickle,
+                global_schema_pickle,
                 reflection_cache,
                 database_config,
                 system_config,
@@ -444,8 +444,8 @@ class AbstractPool:
     async def compile_notebook(
         self,
         dbname,
-        user_schema_pickled,
-        global_schema_pickled,
+        user_schema_pickle,
+        global_schema_pickle,
         reflection_cache,
         database_config,
         system_config,
@@ -458,8 +458,8 @@ class AbstractPool:
                 "compile_notebook",
                 worker,
                 dbname,
-                user_schema_pickled,
-                global_schema_pickled,
+                user_schema_pickle,
+                global_schema_pickle,
                 reflection_cache,
                 database_config,
                 system_config,
@@ -477,8 +477,8 @@ class AbstractPool:
     async def compile_graphql(
         self,
         dbname,
-        user_schema_pickled,
-        global_schema_pickled,
+        user_schema_pickle,
+        global_schema_pickle,
         reflection_cache,
         database_config,
         system_config,
@@ -491,8 +491,8 @@ class AbstractPool:
                 "compile_graphql",
                 worker,
                 dbname,
-                user_schema_pickled,
-                global_schema_pickled,
+                user_schema_pickle,
+                global_schema_pickle,
                 reflection_cache,
                 database_config,
                 system_config,
@@ -510,8 +510,8 @@ class AbstractPool:
     async def compile_sql(
         self,
         dbname,
-        user_schema_pickled,
-        global_schema_pickled,
+        user_schema_pickle,
+        global_schema_pickle,
         reflection_cache,
         database_config,
         system_config,
@@ -524,8 +524,8 @@ class AbstractPool:
                 "compile_sql",
                 worker,
                 dbname,
-                user_schema_pickled,
-                global_schema_pickled,
+                user_schema_pickle,
+                global_schema_pickle,
                 reflection_cache,
                 database_config,
                 system_config,
@@ -1118,14 +1118,14 @@ class RemotePool(AbstractPool):
                 (await worker).close()
 
     @functools.lru_cache(1)
-    def _make_init_args(self, dbs, global_schema_pickled, system_config):
+    def _make_init_args(self, dbs, global_schema_pickle, system_config):
         init_args = (
             dbs,
             self._backend_runtime_params,
             self._std_schema,
             self._refl_schema,
             self._schema_class_layout,
-            global_schema_pickled,
+            global_schema_pickle,
             system_config,
         )
         std_args = (
@@ -1135,7 +1135,7 @@ class RemotePool(AbstractPool):
         return init_args, (
             pickle.dumps(std_args, -1),
             pickle.dumps(client_args, -1),
-            global_schema_pickled,
+            global_schema_pickle,
             pickle.dumps(system_config, -1),
         )
 
@@ -1227,7 +1227,7 @@ class RemotePool(AbstractPool):
 class TenantSchema:
     client_id: int
     dbs: immutables.Map[str, state.PickledDatabaseState]
-    global_schema_pickled: bytes
+    global_schema_pickle: bytes
     system_config: Any
 
 
@@ -1375,8 +1375,8 @@ class MultiTenantPool(FixedPool):
         method_name: str,
         worker: BaseWorker,
         dbname,
-        user_schema_pickled,
-        global_schema_pickled,
+        user_schema_pickle,
+        global_schema_pickle,
         reflection_cache,
         database_config,
         system_config,
@@ -1388,58 +1388,58 @@ class MultiTenantPool(FixedPool):
             worker: MultiTenantWorker,
             client_id,
             dbname,
-            user_schema_pickled=None,
-            global_schema_pickled=None,
+            user_schema_pickle=None,
+            global_schema_pickle=None,
             reflection_cache=None,
             database_config=None,
             instance_config=None,
         ):
             tenant_schema = worker.get_tenant_schema(client_id)
             if tenant_schema is None:
-                assert user_schema_pickled is not None
+                assert user_schema_pickle is not None
                 assert reflection_cache is not None
-                assert global_schema_pickled is not None
+                assert global_schema_pickle is not None
                 assert database_config is not None
                 assert instance_config is not None
 
                 tenant_schema = TenantSchema(
                     client_id,
                     immutables.Map([(dbname, state.PickledDatabaseState(
-                        user_schema_pickled,
+                        user_schema_pickle,
                         reflection_cache,
                         database_config,
                     ))]),
-                    global_schema_pickled,
+                    global_schema_pickle,
                     instance_config,
                 )
                 worker.set_tenant_schema(client_id, tenant_schema)
             else:
                 worker_db = tenant_schema.dbs.get(dbname)
                 if worker_db is None:
-                    assert user_schema_pickled is not None
+                    assert user_schema_pickle is not None
                     assert reflection_cache is not None
                     assert database_config is not None
 
                     tenant_schema.dbs = tenant_schema.dbs.set(
                         dbname,
                         state.PickledDatabaseState(
-                            user_schema_pickled=user_schema_pickled,
+                            user_schema_pickle=user_schema_pickle,
                             reflection_cache=reflection_cache,
                             database_config=database_config,
                         ),
                     )
 
                 elif (
-                    user_schema_pickled is not None
+                    user_schema_pickle is not None
                     or reflection_cache is not None
                     or database_config is not None
                 ):
                     tenant_schema.dbs = tenant_schema.dbs.set(
                         dbname,
                         state.PickledDatabaseState(
-                            user_schema_pickled=(
-                                user_schema_pickled
-                                or worker_db.user_schema_pickled
+                            user_schema_pickle=(
+                                user_schema_pickle
+                                or worker_db.user_schema_pickle
                             ),
                             reflection_cache=(
                                 reflection_cache or worker_db.reflection_cache
@@ -1450,8 +1450,8 @@ class MultiTenantPool(FixedPool):
                         )
                     )
 
-                if global_schema_pickled is not None:
-                    tenant_schema.global_schema_pickled = global_schema_pickled
+                if global_schema_pickle is not None:
+                    tenant_schema.global_schema_pickle = global_schema_pickle
                 if instance_config is not None:
                     tenant_schema.system_config = instance_config
             worker.flush_invalidation()
@@ -1463,9 +1463,9 @@ class MultiTenantPool(FixedPool):
             # make room for the new client in this worker
             worker.maybe_invalidate_last()
             to_update = {
-                "user_schema_pickled": user_schema_pickled,
+                "user_schema_pickle": user_schema_pickle,
                 "reflection_cache": reflection_cache,
-                "global_schema_pickled": global_schema_pickled,
+                "global_schema_pickle": global_schema_pickle,
                 "database_config": database_config,
                 "instance_config": system_config,
             }
@@ -1473,30 +1473,30 @@ class MultiTenantPool(FixedPool):
             worker_db = tenant_schema.dbs.get(dbname)
             if worker_db is None:
                 to_update = {
-                    "user_schema_pickled": user_schema_pickled,
+                    "user_schema_pickle": user_schema_pickle,
                     "reflection_cache": reflection_cache,
                     "database_config": database_config,
                 }
             else:
                 to_update = {}
-                if worker_db.user_schema_pickled is not user_schema_pickled:
-                    to_update["user_schema_pickled"] = user_schema_pickled
+                if worker_db.user_schema_pickle is not user_schema_pickle:
+                    to_update["user_schema_pickle"] = user_schema_pickle
                 if worker_db.reflection_cache is not reflection_cache:
                     to_update["reflection_cache"] = reflection_cache
                 if worker_db.database_config is not database_config:
                     to_update["database_config"] = database_config
             if (
-                tenant_schema.global_schema_pickled
-                is not global_schema_pickled
+                tenant_schema.global_schema_pickle
+                is not global_schema_pickle
             ):
-                to_update["global_schema_pickled"] = global_schema_pickled
+                to_update["global_schema_pickle"] = global_schema_pickle
             if tenant_schema.system_config is not system_config:
                 to_update["instance_config"] = system_config
 
         if to_update:
             pickled = {
-                k.removesuffix("_pickled"): v
-                if k.endswith("_pickled")
+                k.removesuffix("_pickle"): v
+                if k.endswith("_pickle")
                 else _pickle_memoized(v)
                 for k, v in to_update.items()
             }

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -264,7 +264,7 @@ class MultiSchemaPool(pool_mod.FixedPool):
                 (
                     dbname,
                     PickledState(
-                        pickle.dumps(state.user_schema, -1),
+                        state.user_schema_pickled,
                         pickle.dumps(state.reflection_cache, -1),
                         pickle.dumps(state.database_config, -1),
                     ),

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -233,7 +233,7 @@ class MultiSchemaPool(pool_mod.FixedPool):
         (
             std_args_pickled,
             client_args_pickled,
-            global_schema_pickled,
+            global_schema_pickle,
             system_config_pickled,
         ) = init_args_pickled
         dbs, backend_runtime_params = pickle.loads(client_args_pickled)
@@ -263,14 +263,14 @@ class MultiSchemaPool(pool_mod.FixedPool):
                 (
                     dbname,
                     PickledState(
-                        state.user_schema_pickled,
+                        state.user_schema_pickle,
                         pickle.dumps(state.reflection_cache, -1),
                         pickle.dumps(state.database_config, -1),
                     ),
                 )
                 for dbname, state in dbs.items()
             ),
-            global_schema_pickled,
+            global_schema_pickle,
             system_config_pickled,
             (),
         )

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -194,27 +194,26 @@ class MultiSchemaPool(pool_mod.FixedPool):
     _clients: typing.Dict[int, ClientSchema]
 
     def __init__(self, cache_size, *, secret, **kwargs):
-        super().__init__(
-            backend_runtime_params=None,
-            std_schema=None,
-            refl_schema=None,
-            schema_class_layout=None,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
         self._catalog_version = None
         self._inited = asyncio.Event()
         self._cache_size = cache_size
         self._clients = {}
         self._secret = secret
 
-    def _get_init_args_uncached(self):
+    def _init(self, kwargs: dict[str, typing.Any]) -> None:
+        # this is deferred to _init_server()
+        pass
+
+    @functools.cache
+    def _get_init_args(self):
         init_args = (
             self._backend_runtime_params,
             self._std_schema,
             self._refl_schema,
             self._schema_class_layout,
         )
-        return init_args
+        return init_args, pickle.dumps(init_args, -1)
 
     async def _attach_worker(self, pid: int):
         if not self._running:

--- a/edb/server/compiler_pool/state.py
+++ b/edb/server/compiler_pool/state.py
@@ -38,6 +38,12 @@ class DatabaseState(typing.NamedTuple):
 DatabasesState = immutables.Map[str, DatabaseState]
 
 
+class PickledDatabaseState(typing.NamedTuple):
+    user_schema_pickled: bytes
+    reflection_cache: ReflectionCache
+    database_config: immutables.Map[str, config.SettingValue]
+
+
 class FailedStateSync(Exception):
     pass
 

--- a/edb/server/compiler_pool/state.py
+++ b/edb/server/compiler_pool/state.py
@@ -39,7 +39,7 @@ DatabasesState = immutables.Map[str, DatabaseState]
 
 
 class PickledDatabaseState(typing.NamedTuple):
-    user_schema_pickled: bytes
+    user_schema_pickle: bytes
     reflection_cache: ReflectionCache
     database_config: immutables.Map[str, config.SettingValue]
 

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -64,15 +64,32 @@ def __init_worker__(
         std_schema,
         refl_schema,
         schema_class_layout,
-        global_schema,
+        global_schema_pickled,
         system_config,
     ) = pickle.loads(init_args_pickled)
 
     INITED = True
-    DBS = dbs
+    DBS = immutables.Map(
+        [
+            (
+                dbname,
+                state.DatabaseState(
+                    name=dbname,
+                    user_schema=(
+                        None  # type: ignore
+                        if db.user_schema_pickled is None
+                        else pickle.loads(db.user_schema_pickled)
+                    ),
+                    reflection_cache=db.reflection_cache,
+                    database_config=db.database_config,
+                ),
+            )
+            for dbname, db in dbs.items()
+        ]
+    )
     BACKEND_RUNTIME_PARAMS = backend_runtime_params
     STD_SCHEMA = std_schema
-    GLOBAL_SCHEMA = global_schema
+    GLOBAL_SCHEMA = pickle.loads(global_schema_pickled)
     INSTANCE_CONFIG = system_config
 
     COMPILER = compiler.new_compiler(

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -64,7 +64,7 @@ def __init_worker__(
         std_schema,
         refl_schema,
         schema_class_layout,
-        global_schema_pickled,
+        global_schema_pickle,
         system_config,
     ) = pickle.loads(init_args_pickled)
 
@@ -77,8 +77,8 @@ def __init_worker__(
                     name=dbname,
                     user_schema=(
                         None  # type: ignore
-                        if db.user_schema_pickled is None
-                        else pickle.loads(db.user_schema_pickled)
+                        if db.user_schema_pickle is None
+                        else pickle.loads(db.user_schema_pickle)
                     ),
                     reflection_cache=db.reflection_cache,
                     database_config=db.database_config,
@@ -89,7 +89,7 @@ def __init_worker__(
     )
     BACKEND_RUNTIME_PARAMS = backend_runtime_params
     STD_SCHEMA = std_schema
-    GLOBAL_SCHEMA = pickle.loads(global_schema_pickled)
+    GLOBAL_SCHEMA = pickle.loads(global_schema_pickle)
     INSTANCE_CONFIG = system_config
 
     COMPILER = compiler.new_compiler(

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -31,6 +31,7 @@ from .ops import value_from_json, value_to_json_value, coerce_single_value
 from .spec import (
     Spec, FlatSpec, ChainedSpec, Setting,
     load_spec_from_schema, load_ext_spec_from_schema,
+    load_ext_settings_from_schema,
 )
 from .types import ConfigType, CompositeConfigType
 
@@ -43,6 +44,7 @@ __all__ = (
     'ConfigScope', 'OpCode', 'Operation',
     'ConfigType', 'CompositeConfigType',
     'load_spec_from_schema', 'load_ext_spec_from_schema',
+    'load_ext_settings_from_schema',
     'get_compilation_config',
     'coerce_single_value',
 )

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -194,12 +194,18 @@ def load_spec_from_schema(
         cfg = schema.get('cfg::Config', type=s_objtypes.ObjectType)
         settings.extend(_load_spec_from_type(schema, cfg))
 
+    settings.extend(load_ext_settings_from_schema(schema))
+
+    return FlatSpec(*settings)
+
+
+def load_ext_settings_from_schema(schema: s_schema.Schema) -> list[Setting]:
+    settings = []
     ext_cfg = schema.get('cfg::ExtensionConfig', type=s_objtypes.ObjectType)
     for ecfg in ext_cfg.descendants(schema):
         if not ecfg.get_abstract(schema):
             settings.extend(_load_spec_from_type(schema, ecfg))
-
-    return FlatSpec(*settings)
+    return settings
 
 
 def load_ext_spec_from_schema(

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -85,6 +85,7 @@ cdef class Database:
         readonly object dbver
         readonly object db_config
         readonly object user_schema
+        readonly bytes user_schema_pickled
         readonly object reflection_cache
         readonly object backend_ids
         readonly object extensions
@@ -100,7 +101,7 @@ cdef class Database:
     cdef _update_backend_ids(self, new_types)
     cdef _set_and_signal_new_user_schema(
         self,
-        new_schema,
+        new_schema_pickled,
         extensions,
         reflection_cache=?,
         backend_ids=?,

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -110,7 +110,7 @@ cdef class Database:
         db_config=?,
     )
     cdef get_state_serializer(self, protocol_version)
-    cdef set_state_serializer(self, protocol_version, serializer)
+    cpdef set_state_serializer(self, protocol_version, serializer)
 
 
 cdef class DatabaseConnectionView:

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -64,7 +64,7 @@ cdef class DatabaseIndex:
         object _sys_config
         object _comp_sys_config
         object _std_schema
-        object _global_schema_pickled
+        object _global_schema_pickle
         object _default_sysconfig
         object _sys_config_spec
         object _cached_compiler_args
@@ -86,7 +86,7 @@ cdef class Database:
         readonly str name
         readonly object dbver
         readonly object db_config
-        readonly bytes user_schema_pickled
+        readonly bytes user_schema_pickle
         readonly object reflection_cache
         readonly object backend_ids
         readonly object extensions
@@ -100,7 +100,7 @@ cdef class Database:
     cdef _update_backend_ids(self, new_types)
     cdef _set_and_signal_new_user_schema(
         self,
-        new_schema_pickled,
+        new_schema_pickle,
         extensions,
         ext_config_settings,
         reflection_cache=?,
@@ -144,9 +144,9 @@ cdef class DatabaseConnectionView:
         object _txid
         object _in_tx_db_config
         object _in_tx_savepoints
-        object _in_tx_user_schema_pickled
+        object _in_tx_user_schema_pickle
         object _in_tx_user_config_spec
-        object _in_tx_global_schema_pickled
+        object _in_tx_global_schema_pickle
         object _in_tx_new_types
         int _in_tx_dbver
         bint _in_tx

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -80,7 +80,7 @@ cdef class Database:
         object _views
         object _introspection_lock
         object _state_serializers
-        object _user_config_spec
+        object user_config_spec
 
         readonly str name
         readonly object dbver
@@ -92,7 +92,6 @@ cdef class Database:
         readonly object extensions
 
     cdef schedule_config_update(self)
-    cdef get_user_config_spec(self)
 
     cdef _invalidate_caches(self)
     cdef _clear_state_serializers(self)
@@ -104,6 +103,7 @@ cdef class Database:
         self,
         new_schema_pickled,
         extensions,
+        ext_config_settings,
         reflection_cache=?,
         backend_ids=?,
         db_config=?,
@@ -193,6 +193,7 @@ cdef class DatabaseConnectionView:
         self,
         user_schema,
         extensions,
+        ext_config_settings,
         global_schema,
         roles,
         cached_reflection,

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -66,7 +66,6 @@ cdef class DatabaseIndex:
         object _std_schema
         object _global_schema
         object _global_schema_pickled
-        object _factory
         object _default_sysconfig
         object _sys_config_spec
         object _cached_compiler_args
@@ -97,7 +96,6 @@ cdef class Database:
     cdef schedule_config_update(self)
 
     cdef _invalidate_caches(self)
-    cdef _clear_state_serializers(self)
     cdef _cache_compiled_query(self, key, query_unit)
     cdef _new_view(self, query_cache, protocol_version)
     cdef _remove_view(self, view)

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -64,7 +64,6 @@ cdef class DatabaseIndex:
         object _sys_config
         object _comp_sys_config
         object _std_schema
-        object _global_schema
         object _global_schema_pickled
         object _default_sysconfig
         object _sys_config_spec
@@ -87,7 +86,6 @@ cdef class Database:
         readonly str name
         readonly object dbver
         readonly object db_config
-        readonly object user_schema
         readonly bytes user_schema_pickled
         readonly object reflection_cache
         readonly object backend_ids
@@ -147,10 +145,8 @@ cdef class DatabaseConnectionView:
         object _in_tx_db_config
         object _in_tx_savepoints
         object _in_tx_user_schema_pickled
-        object _in_tx_user_schema
         object _in_tx_user_config_spec
         object _in_tx_global_schema_pickled
-        object _in_tx_global_schema
         object _in_tx_new_types
         int _in_tx_dbver
         bint _in_tx

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -69,6 +69,9 @@ cdef class DatabaseIndex:
         object _factory
         object _default_sysconfig
         object _sys_config_spec
+        object _cached_compiler_args
+
+    cdef invalidate_caches(self)
 
 
 cdef class Database:

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -65,6 +65,7 @@ cdef class DatabaseIndex:
         object _comp_sys_config
         object _std_schema
         object _global_schema
+        object _global_schema_pickled
         object _factory
         object _default_sysconfig
         object _sys_config_spec

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -580,14 +580,6 @@ cdef class DatabaseConnectionView:
         else:
             return self._db._index._global_schema_pickled
 
-    def get_schema(self):
-        user_schema = self.get_user_schema()
-        return s_schema.ChainedSchema(
-            self._db._index._std_schema,
-            user_schema,
-            self._db._index._global_schema,
-        )
-
     def resolve_backend_type_id(self, type_id):
         type_id = str(type_id)
 
@@ -1137,6 +1129,15 @@ cdef class DatabaseConnectionView:
         unit_group, self._last_comp_state, self._last_comp_state_id = result
 
         return unit_group
+
+    async def interpret_backend_error(self, exc):
+        compiler_pool = self._db._index._server.get_compiler_pool()
+        return await compiler_pool.interpret_backend_error(
+            self.get_user_schema_pickled(),
+            self.get_global_schema_pickled(),
+            exc.fields,
+            False,
+        )
 
     cdef check_capabilities(
         self,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -567,13 +567,18 @@ cdef class DatabaseConnectionView:
 
     def get_global_schema(self):
         if self._in_tx:
-            if self._in_tx_global_schema_pickled:
+            if self._in_tx_global_schema is None:
                 self._in_tx_global_schema = pickle.loads(
                     self._in_tx_global_schema_pickled)
-                self._in_tx_global_schema_pickled = None
             return self._in_tx_global_schema
         else:
             return self._db._index._global_schema
+
+    def get_global_schema_pickled(self):
+        if self._in_tx:
+            return self._in_tx_global_schema_pickled
+        else:
+            return self._db._index._global_schema_pickled
 
     def get_schema(self):
         user_schema = self.get_user_schema()
@@ -829,6 +834,8 @@ cdef class DatabaseConnectionView:
         self._in_tx_user_schema = self._db.user_schema
         self._in_tx_user_schema_pickled = self._db.user_schema_pickled
         self._in_tx_global_schema = self._db._index._global_schema
+        self._in_tx_global_schema_pickled = \
+            self._db._index._global_schema_pickled
         self._in_tx_user_config_spec = self._db.get_user_config_spec()
         self._in_tx_state_serializer = self._state_serializer
 
@@ -894,8 +901,7 @@ cdef class DatabaseConnectionView:
                 side_effects |= SideEffects.DatabaseChanges
             if query_unit.global_schema is not None:
                 side_effects |= SideEffects.GlobalSchemaChanges
-                self._db._index.update_global_schema(
-                    pickle.loads(query_unit.global_schema))
+                self._db._index.update_global_schema(query_unit.global_schema)
                 self._db.tenant.set_roles(query_unit.roles)
         else:
             if new_types:
@@ -935,8 +941,7 @@ cdef class DatabaseConnectionView:
                 side_effects |= SideEffects.DatabaseConfigChanges
             if query_unit.global_schema is not None:
                 side_effects |= SideEffects.GlobalSchemaChanges
-                self._db._index.update_global_schema(
-                    pickle.loads(query_unit.global_schema))
+                self._db._index.update_global_schema(query_unit.global_schema)
                 self._db.tenant.set_roles(query_unit.roles)
 
             self._reset_tx_state()
@@ -986,8 +991,7 @@ cdef class DatabaseConnectionView:
             side_effects |= SideEffects.DatabaseConfigChanges
         if global_schema is not None:
             side_effects |= SideEffects.GlobalSchemaChanges
-            self._db._index.update_global_schema(
-                pickle.loads(global_schema))
+            self._db._index.update_global_schema(global_schema)
             self._db.tenant.set_roles(roles)
 
         self._reset_tx_state()
@@ -1193,6 +1197,7 @@ cdef class DatabaseIndex:
         self._tenant = tenant
         self._std_schema = std_schema
         self._global_schema = global_schema
+        self._global_schema_pickled = pickle.dumps(global_schema, -1)
         self._default_sysconfig = default_sysconfig
         self._sys_config_spec = sys_config_spec
         # TODO: This factory will probably need to become per-db once
@@ -1239,8 +1244,12 @@ cdef class DatabaseIndex:
     def get_global_schema(self):
         return self._global_schema
 
-    def update_global_schema(self, global_schema):
-        self._global_schema = global_schema
+    def get_global_schema_pickled(self):
+        return self._global_schema_pickled
+
+    def update_global_schema(self, global_schema_pickled):
+        self._global_schema = pickle.loads(global_schema_pickled)
+        self._global_schema_pickled = global_schema_pickled
 
     def register_db(
         self,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -272,7 +272,7 @@ cdef class Database:
     cdef get_state_serializer(self, protocol_version):
         return self._state_serializers.get(protocol_version)
 
-    cdef set_state_serializer(self, protocol_version, serializer):
+    cpdef set_state_serializer(self, protocol_version, serializer):
         old_serializer = self._state_serializers.get(protocol_version)
         if (
             old_serializer is None or
@@ -1272,6 +1272,7 @@ cdef class DatabaseIndex:
                 ext_config_settings=ext_config_settings,
             )
             self._dbs[dbname] = db
+        return db
 
     def unregister_db(self, dbname):
         self._dbs.pop(dbname)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -154,7 +154,7 @@ cdef class Database:
         DatabaseIndex index,
         str name,
         *,
-        object user_schema,
+        bytes user_schema_pickled,
         object db_config,
         object reflection_cache,
         object backend_ids,
@@ -176,7 +176,11 @@ cdef class Database:
             maxsize=defines._MAX_QUERIES_CACHE)
 
         self.db_config = db_config
-        self.user_schema = user_schema
+        if user_schema_pickled is None:
+            self.user_schema = None
+        else:
+            self.user_schema = pickle.loads(user_schema_pickled)
+        self.user_schema_pickled = user_schema_pickled
         self._user_config_spec = None
         self.reflection_cache = reflection_cache
         self.backend_ids = backend_ids
@@ -195,18 +199,19 @@ cdef class Database:
 
     cdef _set_and_signal_new_user_schema(
         self,
-        new_schema,
+        new_schema_pickled,
         extensions,
         reflection_cache=None,
         backend_ids=None,
         db_config=None,
     ):
-        if new_schema is None:
+        if new_schema_pickled is None:
             raise AssertionError('new_schema is not supposed to be None')
 
         self.dbver = next_dbver()
 
-        self.user_schema = new_schema
+        self.user_schema = pickle.loads(new_schema_pickled)
+        self.user_schema_pickled = new_schema_pickled
         self.extensions = extensions
 
         if backend_ids is not None:
@@ -299,9 +304,9 @@ cdef class Database:
         return len(self._eql_to_compiled) + len(self._sql_to_compiled)
 
     async def introspection(self):
-        if self.user_schema is None:
+        if self.user_schema_pickled is None:
             async with self._introspection_lock:
-                if self.user_schema is None:
+                if self.user_schema_pickled is None:
                     await self.tenant.introspect_db(self.name)
 
 
@@ -547,13 +552,18 @@ cdef class DatabaseConnectionView:
 
     def get_user_schema(self):
         if self._in_tx:
-            if self._in_tx_user_schema_pickled:
+            if self._in_tx_user_schema is None:
                 self._in_tx_user_schema = pickle.loads(
                     self._in_tx_user_schema_pickled)
-                self._in_tx_user_schema_pickled = None
             return self._in_tx_user_schema
         else:
             return self._db.user_schema
+
+    def get_user_schema_pickled(self):
+        if self._in_tx:
+            return self._in_tx_user_schema_pickled
+        else:
+            return self._db.user_schema_pickled
 
     def get_global_schema(self):
         if self._in_tx:
@@ -817,6 +827,7 @@ cdef class DatabaseConnectionView:
         self._in_tx_db_config = self._db.db_config
         self._in_tx_modaliases = self._modaliases
         self._in_tx_user_schema = self._db.user_schema
+        self._in_tx_user_schema_pickled = self._db.user_schema_pickled
         self._in_tx_global_schema = self._db._index._global_schema
         self._in_tx_user_config_spec = self._db.get_user_config_spec()
         self._in_tx_state_serializer = self._state_serializer
@@ -865,7 +876,7 @@ cdef class DatabaseConnectionView:
             if query_unit.user_schema is not None:
                 self._in_tx_dbver = next_dbver()
                 self._db._set_and_signal_new_user_schema(
-                    pickle.loads(query_unit.user_schema),
+                    query_unit.user_schema,
                     query_unit.extensions,
                     pickle.loads(query_unit.cached_reflection)
                         if query_unit.cached_reflection is not None
@@ -907,7 +918,7 @@ cdef class DatabaseConnectionView:
                 self._db._update_backend_ids(self._in_tx_new_types)
             if query_unit.user_schema is not None:
                 self._db._set_and_signal_new_user_schema(
-                    pickle.loads(query_unit.user_schema),
+                    query_unit.user_schema,
                     query_unit.extensions,
                     pickle.loads(query_unit.cached_reflection)
                         if query_unit.cached_reflection is not None
@@ -958,7 +969,7 @@ cdef class DatabaseConnectionView:
             self._db._update_backend_ids(self._in_tx_new_types)
         if user_schema is not None:
             self._db._set_and_signal_new_user_schema(
-                pickle.loads(user_schema),
+                user_schema,
                 extensions,
                 pickle.loads(cached_reflection)
                     if cached_reflection is not None
@@ -1235,7 +1246,7 @@ cdef class DatabaseIndex:
         self,
         dbname,
         *,
-        user_schema,
+        user_schema_pickled,
         db_config,
         reflection_cache,
         backend_ids,
@@ -1245,7 +1256,7 @@ cdef class DatabaseIndex:
         db = self._dbs.get(dbname)
         if db is not None:
             db._set_and_signal_new_user_schema(
-                user_schema,
+                user_schema_pickled,
                 extensions,
                 reflection_cache,
                 backend_ids,
@@ -1258,7 +1269,7 @@ cdef class DatabaseIndex:
             db = Database(
                 self,
                 dbname,
-                user_schema=user_schema,
+                user_schema_pickled=user_schema_pickled,
                 db_config=db_config,
                 reflection_cache=reflection_cache,
                 backend_ids=backend_ids,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1184,7 +1184,7 @@ cdef class DatabaseIndex:
         tenant,
         *,
         std_schema,
-        global_schema,
+        global_schema_pickled,
         sys_config,
         default_sysconfig,  # system config without system override
         sys_config_spec,
@@ -1193,8 +1193,8 @@ cdef class DatabaseIndex:
         self._server = tenant.server
         self._tenant = tenant
         self._std_schema = std_schema
-        self._global_schema = global_schema
-        self._global_schema_pickled = pickle.dumps(global_schema, -1)
+        self._global_schema = pickle.loads(global_schema_pickled)
+        self._global_schema_pickled = global_schema_pickled
         self._default_sysconfig = default_sysconfig
         self._sys_config_spec = sys_config_spec
         # TODO: This factory will probably need to become per-db once

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1112,8 +1112,8 @@ cdef class DatabaseConnectionView:
             else:
                 result = await compiler_pool.compile(
                     self.dbname,
-                    self.get_user_schema(),
-                    self.get_global_schema(),
+                    self.get_user_schema_pickled(),
+                    self.get_global_schema_pickled(),
                     self.reflection_cache,
                     self.get_database_config(),
                     self.get_compilation_system_config(),

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -228,9 +228,6 @@ async def _run_server(
             compiler_pool_size=args.compiler_pool_size,
             compiler_pool_mode=args.compiler_pool_mode,
             compiler_pool_addr=args.compiler_pool_addr,
-            compiler_pool_tenant_cache_size=(
-                args.compiler_pool_tenant_cache_size
-            ),
             nethosts=args.bind_addresses,
             netport=args.port,
             listen_sockets=tuple(s for ss in sockets.values() for s in ss),

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -45,6 +45,7 @@ from . import defines
 from . import pgcluster
 from . import server
 from . import tenant as edbtenant
+from .compiler_pool import pool as compiler_pool
 from .pgcon import errors as pgerrors
 
 logger = logging.getLogger("edb.server")
@@ -262,6 +263,10 @@ class MultiTenantServer(server.BaseServer):
             tenant.stop_accepting_connections()
             tenant.stop()
             await tenant.wait_stopped()
+            assert isinstance(
+                self._compiler_pool, compiler_pool.MultiTenantPool
+            )
+            self._compiler_pool.drop_tenant(tenant.client_id)
         finally:
             tenant.terminate_sys_pgcon()
 

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -86,6 +86,7 @@ class MultiTenantServer(server.BaseServer):
         self,
         config_file: pathlib.Path,
         *,
+        compiler_pool_tenant_cache_size: int,
         sys_config: Mapping[str, config.SettingValue],
         backend_settings: Mapping[str, str],
         sys_queries: Mapping[str, bytes],
@@ -96,6 +97,7 @@ class MultiTenantServer(server.BaseServer):
         self._config_file = config_file
         self._sys_config = sys_config
         self._backend_settings = backend_settings
+        self._compiler_pool_tenant_cache_size = compiler_pool_tenant_cache_size
 
         self._tenants_by_sslobj = weakref.WeakKeyDictionary()
         self._tenants_conf = {}
@@ -325,6 +327,11 @@ class MultiTenantServer(server.BaseServer):
             for name, tenant in self._tenants.items()
         }
         return parent
+
+    def _get_compiler_args(self) -> dict[str, Any]:
+        args = super()._get_compiler_args()
+        args["cache_size"] = self._compiler_pool_tenant_cache_size
+        return args
 
 
 async def run_server(

--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -77,8 +77,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
     cdef inline dbview.DatabaseConnectionView get_dbview(self)
 
-    cdef interpret_backend_error(self, exc)
-
     cdef dbview.QueryRequestInfo parse_execute_request(self)
     cdef parse_output_format(self, bytes mode)
     cdef parse_cardinality(self, bytes card)

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1354,7 +1354,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
             user_schema = await tenant.introspect_user_schema(pgcon)
             global_schema = await tenant.introspect_global_schema(pgcon)
-            db_config = await tenant.introspect_db_config(pgcon, user_schema)
+            db_config_json = await server.introspect_db_config(pgcon)
+            db_config = server._parse_db_config(db_config_json, user_schema)
             dump_protocol = self.max_protocol
 
             schema_ddl, schema_dynamic_ddl, schema_ids, blocks = (

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1202,10 +1202,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
             # only use the backend if schema is required
             if static_exc is errormech.SchemaRequired:
-                exc = errormech.interpret_backend_error(
-                    self.get_dbview().get_schema(),
-                    exc.fields
-                )
+                exc = await self.get_dbview().interpret_backend_error(exc)
             elif isinstance(static_exc, (
                     errors.DuplicateDatabaseDefinitionError,
                     errors.UnknownDatabaseError)):

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1352,17 +1352,18 @@ cdef class EdgeConnection(frontend.FrontendConnection):
                 ''',
             )
 
-            user_schema = await tenant.introspect_user_schema(pgcon)
-            global_schema = await tenant.introspect_global_schema(pgcon)
+            user_schema_json = await server.introspect_user_schema_json(pgcon)
+            global_schema_json = (
+                await server.introspect_global_schema_json(pgcon)
+            )
             db_config_json = await server.introspect_db_config(pgcon)
-            db_config = server._parse_db_config(db_config_json, user_schema)
             dump_protocol = self.max_protocol
 
             schema_ddl, schema_dynamic_ddl, schema_ids, blocks = (
                 await compiler_pool.describe_database_dump(
-                    user_schema,
-                    global_schema,
-                    db_config,
+                    user_schema_json,
+                    global_schema_json,
+                    db_config_json,
                     dump_protocol,
                 )
             )

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1535,8 +1535,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         server = self.server
         compiler_pool = server.get_compiler_pool()
 
-        global_schema_pickled = _dbview.get_global_schema_pickled()
-        user_schema_pickled = _dbview.get_user_schema_pickled()
+        global_schema_pickle = _dbview.get_global_schema_pickle()
+        user_schema_pickle = _dbview.get_user_schema_pickle()
 
         dump_server_ver_str = None
         cat_ver = None
@@ -1604,8 +1604,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
             schema_sql_units, restore_blocks, tables = \
                 await compiler_pool.describe_database_restore(
-                    user_schema_pickled,
-                    global_schema_pickled,
+                    user_schema_pickle,
+                    global_schema_pickle,
                     dump_server_ver_str,
                     cat_ver,
                     schema_ddl,

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1526,8 +1526,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         server = self.server
         compiler_pool = server.get_compiler_pool()
 
-        global_schema = _dbview.get_global_schema()
-        user_schema = _dbview.get_user_schema()
+        global_schema_pickled = _dbview.get_global_schema_pickled()
+        user_schema_pickled = _dbview.get_user_schema_pickled()
 
         dump_server_ver_str = None
         cat_ver = None
@@ -1595,8 +1595,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
             schema_sql_units, restore_blocks, tables = \
                 await compiler_pool.describe_database_restore(
-                    user_schema,
-                    global_schema,
+                    user_schema_pickled,
+                    global_schema_pickled,
                     dump_server_ver_str,
                     cat_ver,
                     schema_ddl,

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -208,12 +208,13 @@ async def execute_script(
         bytes state = None, orig_state = None
         ssize_t sent = 0
         bint in_tx, sync, no_sync
-        object user_schema, extensions, cached_reflection, global_schema
+        object user_schema, extensions, ext_config_settings, cached_reflection
+        object global_schema, roles
         WriteBuffer bind_data
         int dbver = dbv.dbver
         bint parse
 
-    user_schema = extensions = cached_reflection = None
+    user_schema = extensions = ext_config_settings = cached_reflection = None
     global_schema = roles = None
     unit_group = compiled.query_unit_group
 
@@ -288,6 +289,7 @@ async def execute_script(
                 if query_unit.user_schema:
                     user_schema = query_unit.user_schema
                     extensions = query_unit.extensions
+                    ext_config_settings = query_unit.ext_config_settings
                     cached_reflection = query_unit.cached_reflection
 
                 if query_unit.global_schema:
@@ -354,6 +356,7 @@ async def execute_script(
             side_effects = dbv.commit_implicit_tx(
                 user_schema,
                 extensions,
+                ext_config_settings,
                 global_schema,
                 roles,
                 cached_reflection,

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -162,8 +162,8 @@ async def execute(db, tenant, queries: list):
     compiler_pool = tenant.server.get_compiler_pool()
     units = await compiler_pool.compile_notebook(
         dbv.dbname,
-        dbv.get_user_schema(),
-        dbv.get_global_schema(),
+        dbv.get_user_schema_pickled(),
+        dbv.get_global_schema_pickled(),
         dbv.reflection_cache,
         dbv.get_database_config(),
         dbv.get_compilation_system_config(),

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -162,8 +162,8 @@ async def execute(db, tenant, queries: list):
     compiler_pool = tenant.server.get_compiler_pool()
     units = await compiler_pool.compile_notebook(
         dbv.dbname,
-        dbv.get_user_schema_pickled(),
-        dbv.get_global_schema_pickled(),
+        dbv.get_user_schema_pickle(),
+        dbv.get_global_schema_pickle(),
         dbv.reflection_cache,
         dbv.get_database_config(),
         dbv.get_compilation_system_config(),

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -1403,8 +1403,8 @@ cdef class PgConnection(frontend.FrontendConnection):
         compiler_pool = self.server.get_compiler_pool()
         result = await compiler_pool.compile_sql(
             self.dbname,
-            self.database.user_schema,
-            self.database._index._global_schema,
+            self.database.user_schema_pickled,
+            self.database._index._global_schema_pickled,
             self.database.reflection_cache,
             self.database.db_config,
             self.database._index.get_compilation_system_config(),

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -1403,8 +1403,8 @@ cdef class PgConnection(frontend.FrontendConnection):
         compiler_pool = self.server.get_compiler_pool()
         result = await compiler_pool.compile_sql(
             self.dbname,
-            self.database.user_schema_pickled,
-            self.database._index._global_schema_pickled,
+            self.database.user_schema_pickle,
+            self.database._index._global_schema_pickle,
             self.database.reflection_cache,
             self.database.db_config,
             self.database._index.get_compilation_system_config(),

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1168,10 +1168,8 @@ class Server(BaseServer):
                 if last_repair:
                     from . import bootstrap
 
-                    global_schema = (
-                        await self._tenant.introspect_global_schema(conn)
-                    )
-                    user_schema = await self._tenant.introspect_user_schema(
+                    global_schema = await self.introspect_global_schema(conn)
+                    user_schema = await self.introspect_user_schema(
                         conn, global_schema)
                     config_json = await self.introspect_db_config(conn)
                     db_config = self._parse_db_config(config_json, user_schema)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -123,7 +123,6 @@ class BaseServer:
         compiler_pool_size,
         compiler_pool_mode: srvargs.CompilerPoolMode,
         compiler_pool_addr,
-        compiler_pool_tenant_cache_size,
         nethosts,
         netport,
         listen_sockets: tuple[socket.socket, ...] = (),
@@ -167,7 +166,6 @@ class BaseServer:
         self._compiler_pool_size = compiler_pool_size
         self._compiler_pool_mode = compiler_pool_mode
         self._compiler_pool_addr = compiler_pool_addr
-        self._compiler_pool_tenant_cache_size = compiler_pool_tenant_cache_size
 
         self._listen_sockets = listen_sockets
         if listen_sockets:
@@ -441,8 +439,6 @@ class BaseServer:
         )
         if self._compiler_pool_mode == srvargs.CompilerPoolMode.Remote:
             args['address'] = self._compiler_pool_addr
-        elif self._compiler_pool_mode == srvargs.CompilerPoolMode.MultiTenant:
-            args["cache_size"] = self._compiler_pool_tenant_cache_size
         return args
 
     async def _destroy_compiler_pool(self):

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -471,7 +471,7 @@ class BaseServer:
     ) -> bytes:
         return await conn.sql_fetch_val(self._local_intro_query)
 
-    async def introspect_user_schema(
+    async def _introspect_user_schema(
         self,
         conn: pgcon.PGConnection,
         global_schema: s_schema.Schema,
@@ -1169,7 +1169,7 @@ class Server(BaseServer):
                     from . import bootstrap
 
                     global_schema = await self.introspect_global_schema(conn)
-                    user_schema = await self.introspect_user_schema(
+                    user_schema = await self._introspect_user_schema(
                         conn, global_schema)
                     config_json = await self.introspect_db_config(conn)
                     db_config = self._parse_db_config(config_json, user_schema)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -826,9 +826,18 @@ class Tenant(ha_base.ClusterProtocol):
             backend_ids = json.loads(backend_ids_json)
 
             db_config_json = await self._server.introspect_db_config(conn)
+
             db_config = self._server._parse_db_config(
                 db_config_json, user_schema
             )  # TODO: will be done in the compiler
+            ext_config_settings = config.load_ext_settings_from_schema(
+                s_schema.ChainedSchema(
+                    self._server.get_std_schema(),
+                    user_schema,
+                    s_schema.EMPTY_SCHEMA,
+                )
+            )  # TODO: will be done in the compiler
+
             extensions = await self._introspect_extensions(conn)
 
             # GOTCHA: we will move introspect_user_schema() to the compiler
@@ -843,6 +852,7 @@ class Tenant(ha_base.ClusterProtocol):
                 reflection_cache=reflection_cache,
                 backend_ids=backend_ids,
                 extensions=extensions,
+                ext_config_settings=ext_config_settings,
             )
         finally:
             self.release_pgcon(dbname, conn)
@@ -872,6 +882,7 @@ class Tenant(ha_base.ClusterProtocol):
                         reflection_cache=None,
                         backend_ids=None,
                         extensions=extensions,
+                        ext_config_settings=None,
                     )
         finally:
             self.release_pgcon(dbname, conn)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -950,9 +950,15 @@ class Tenant(ha_base.ClusterProtocol):
             return
         async with self.use_sys_pgcon() as syscon:
             new_global_schema = await self.introspect_global_schema(syscon)
-            assert self._dbindex is not None
-            self._dbindex.update_global_schema(new_global_schema)
             await self._fetch_roles(syscon)
+
+        assert self._dbindex is not None
+
+        # GOTCHA: we will move introspect_global_schema() to the compiler
+        # so that we don't need this pickle.dumps+loads here.
+        import pickle
+
+        self._dbindex.update_global_schema(pickle.dumps(new_global_schema, -1))
 
     def populate_sys_auth(self) -> None:
         assert self._dbindex is not None

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -264,9 +264,9 @@ class Tenant(ha_base.ClusterProtocol):
         else:
             return self._report_config_data[(1, 0)]
 
-    def get_global_schema_pickled(self) -> bytes:
+    def get_global_schema_pickle(self) -> bytes:
         assert self._dbindex is not None
-        return self._dbindex.get_global_schema_pickled()
+        return self._dbindex.get_global_schema_pickle()
 
     def get_db(self, *, dbname: str) -> dbview.Database:
         assert self._dbindex is not None
@@ -309,7 +309,7 @@ class Tenant(ha_base.ClusterProtocol):
             await self._fetch_roles(syscon)
             if self._server.get_compiler_pool() is None:
                 # Parse global schema in I/O process if this is done only once
-                global_schema_pickled = pickle.dumps(
+                global_schema_pickle = pickle.dumps(
                     await self._server.introspect_global_schema(syscon), -1
                 )
                 data = None
@@ -319,7 +319,7 @@ class Tenant(ha_base.ClusterProtocol):
                 compiler_pool = self._server.get_compiler_pool()
 
         if data is not None:
-            global_schema_pickled = (
+            global_schema_pickle = (
                 await compiler_pool.parse_global_schema(data)
             )
 
@@ -330,7 +330,7 @@ class Tenant(ha_base.ClusterProtocol):
         self._dbindex = dbview.DatabaseIndex(
             self,
             std_schema=self._server.get_std_schema(),
-            global_schema_pickled=global_schema_pickled,
+            global_schema_pickle=global_schema_pickle,
             sys_config=sys_config,
             default_sysconfig=default_sysconfig,
             sys_config_spec=self._server._config_settings,  # TODO
@@ -835,12 +835,12 @@ class Tenant(ha_base.ClusterProtocol):
 
         compiler_pool = self._server.get_compiler_pool()
         parsed_db = await compiler_pool.parse_user_schema_db_config(
-            user_schema_json, db_config_json, self.get_global_schema_pickled()
+            user_schema_json, db_config_json, self.get_global_schema_pickle()
         )
         assert self._dbindex is not None
         db = self._dbindex.register_db(
             dbname,
-            user_schema_pickled=parsed_db.user_schema_pickled,
+            user_schema_pickle=parsed_db.user_schema_pickle,
             db_config=parsed_db.database_config,
             reflection_cache=reflection_cache,
             backend_ids=backend_ids,
@@ -872,7 +872,7 @@ class Tenant(ha_base.ClusterProtocol):
                 if not self._dbindex.has_db(dbname):
                     self._dbindex.register_db(
                         dbname,
-                        user_schema_pickled=None,
+                        user_schema_pickle=None,
                         db_config=None,
                         reflection_cache=None,
                         backend_ids=None,
@@ -938,9 +938,9 @@ class Tenant(ha_base.ClusterProtocol):
             data = await self._server.introspect_global_schema_json(syscon)
             await self._fetch_roles(syscon)
         compiler_pool = self._server.get_compiler_pool()
-        global_schema_pickled = await compiler_pool.parse_global_schema(data)
+        global_schema_pickle = await compiler_pool.parse_global_schema(data)
         assert self._dbindex is not None
-        self._dbindex.update_global_schema(global_schema_pickled)
+        self._dbindex.update_global_schema(global_schema_pickle)
 
     def populate_sys_auth(self) -> None:
         assert self._dbindex is not None

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -834,22 +834,22 @@ class Tenant(ha_base.ClusterProtocol):
             self.release_pgcon(dbname, conn)
 
         compiler_pool = self._server.get_compiler_pool()
-        (
-            user_schema_pickled,
-            db_config,
-            ext_config_settings,
-        ) = await compiler_pool.parse_user_schema_db_config(
+        parsed_db = await compiler_pool.parse_user_schema_db_config(
             user_schema_json, db_config_json, self.get_global_schema_pickled()
         )
         assert self._dbindex is not None
-        self._dbindex.register_db(
+        db = self._dbindex.register_db(
             dbname,
-            user_schema_pickled=user_schema_pickled,
-            db_config=db_config,
+            user_schema_pickled=parsed_db.user_schema_pickled,
+            db_config=parsed_db.database_config,
             reflection_cache=reflection_cache,
             backend_ids=backend_ids,
             extensions=extensions,
-            ext_config_settings=ext_config_settings,
+            ext_config_settings=parsed_db.ext_config_settings,
+        )
+        db.set_state_serializer(
+            parsed_db.protocol_version,
+            parsed_db.state_serializer,
         )
 
     async def _early_introspect_db(self, dbname: str) -> None:

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -43,7 +43,6 @@ from . import dbview
 from . import defines
 from . import metrics
 from . import pgcon
-from .compiler_pool import pool as compiler_pool
 from .ha import adaptive as adaptive_ha
 from .ha import base as ha_base
 from .pgcon import errors as pgcon_errors
@@ -1367,6 +1366,6 @@ class Tenant(ha_base.ClusterProtocol):
 
         return obj
 
-    def attach_to_compiler(self, compiler: compiler_pool.AbstractPool):
+    def get_compiler_args(self) -> dict[str, Any]:
         assert self._dbindex is not None
-        compiler.add_dbindex(self.client_id, self._dbindex)
+        return {"dbindex": self._dbindex}

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -841,10 +841,14 @@ class Tenant(ha_base.ClusterProtocol):
             db_config = await self.introspect_db_config(conn, user_schema)
             extensions = await self._introspect_extensions(conn)
 
+            # GOTCHA: we will move introspect_user_schema() to the compiler
+            # so that we don't need this pickle.dumps+loads here.
+            import pickle
+
             assert self._dbindex is not None
             self._dbindex.register_db(
                 dbname,
-                user_schema=user_schema,
+                user_schema_pickled=pickle.dumps(user_schema, -1),
                 db_config=db_config,
                 reflection_cache=reflection_cache,
                 backend_ids=backend_ids,
@@ -873,7 +877,7 @@ class Tenant(ha_base.ClusterProtocol):
                 if not self._dbindex.has_db(dbname):
                     self._dbindex.register_db(
                         dbname,
-                        user_schema=None,
+                        user_schema_pickled=None,
                         db_config=None,
                         reflection_cache=None,
                         backend_ids=None,

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -269,6 +269,10 @@ class Tenant(ha_base.ClusterProtocol):
         assert self._dbindex is not None
         return self._dbindex.get_global_schema()
 
+    def get_global_schema_pickled(self) -> bytes:
+        assert self._dbindex is not None
+        return self._dbindex.get_global_schema_pickled()
+
     def get_db(self, *, dbname: str) -> dbview.Database:
         assert self._dbindex is not None
         return self._dbindex.get_db(dbname)

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -399,7 +399,7 @@ class TestCompilerPool(tbs.TestCase):
                 dbindex=dbview.DatabaseIndex(
                     unittest.mock.MagicMock(),
                     std_schema=self._std_schema,
-                    global_schema=None,
+                    global_schema_pickled=pickle.dumps(None, -1),
                     sys_config={},
                     default_sysconfig=immutables.Map(),
                     sys_config_spec=config.load_spec_from_schema(

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -399,7 +399,7 @@ class TestCompilerPool(tbs.TestCase):
                 dbindex=dbview.DatabaseIndex(
                     unittest.mock.MagicMock(),
                     std_schema=self._std_schema,
-                    global_schema_pickled=pickle.dumps(None, -1),
+                    global_schema_pickle=pickle.dumps(None, -1),
                     sys_config={},
                     default_sysconfig=immutables.Map(),
                     sys_config_spec=config.load_spec_from_schema(

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -388,7 +388,7 @@ class TestCompilerPool(tbs.TestCase):
 
     async def _test_pool_disconnect_queue(self, pool_class):
         with tempfile.TemporaryDirectory() as td:
-            pool_ = pool.create_compiler_pool(
+            pool_ = await pool.create_compiler_pool(
                 runstate_dir=td,
                 pool_size=2,
                 backend_runtime_params=None,
@@ -396,10 +396,7 @@ class TestCompilerPool(tbs.TestCase):
                 refl_schema=self._refl_schema,
                 schema_class_layout=self._schema_class_layout,
                 pool_class=pool_class,
-            )
-            pool_.add_dbindex(
-                0,
-                dbview.DatabaseIndex(
+                dbindex=dbview.DatabaseIndex(
                     unittest.mock.MagicMock(),
                     std_schema=self._std_schema,
                     global_schema=None,
@@ -409,7 +406,6 @@ class TestCompilerPool(tbs.TestCase):
                         self._std_schema),
                 ),
             )
-            await pool_.start()
             # HACK: For adaptive pool, force the creation of a second
             # worker. This is needed to work around issue #4680, where
             # we won't scale up from a single connection.


### PR DESCRIPTION
- [x] Add pickled user schema
- [x] Add pickled global schema
- [x] Use pickled user/global schema in compiler client
- [x] Move inteprete_backend_error back to the compiler
- [x] Move parsing of JSON schema to the compiler
- [x] Allow compiler initialization with JSON schema
- [x] Edit introspect_user/global_schema
- [x] Deal with state serializer
- [x] Drop unpickled schema in dbview