### PR TITLE
Avoid using global_schema for roles in I/O process

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2193,7 +2193,6 @@ def _try_compile(
             unit.create_db = comp.create_db
             unit.drop_db = comp.drop_db
             unit.create_db_template = comp.create_db_template
-            unit.has_role_ddl = comp.has_role_ddl
             unit.ddl_stmt_id = comp.ddl_stmt_id
             if comp.user_schema is not None:
                 final_user_schema = comp.user_schema

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -317,6 +317,7 @@ class QueryUnit:
     # If present, represents the future global schema state
     # after the command is run. The schema is pickled.
     global_schema: Optional[bytes] = None
+    roles: immutables.Map[str, immutables.Map[str, Any]] | None = None
 
     is_explain: bool = False
     query_asts: Any = None

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -148,7 +148,6 @@ class DDLQuery(BaseQuery):
     create_db: Optional[str] = None
     drop_db: Optional[str] = None
     create_db_template: Optional[str] = None
-    has_role_ddl: bool = False
     ddl_stmt_id: Optional[str] = None
     config_ops: List[config.Operation] = (
         dataclasses.field(default_factory=list))
@@ -233,9 +232,6 @@ class QueryUnit:
 
     # True if this unit contains SET commands.
     has_set: bool = False
-
-    # True if this unit contains ALTER/DROP/CREATE ROLE commands.
-    has_role_ddl: bool = False
 
     # If tx_id is set, it means that the unit
     # starts a new transaction.

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -273,7 +273,6 @@ def compile_and_apply_ddl_stmt(
         create_db=create_db,
         drop_db=drop_db,
         create_db_template=create_db_template,
-        has_role_ddl=isinstance(stmt, qlast.RoleCommand),
         ddl_stmt_id=ddl_stmt_id,
         user_schema=current_tx.get_user_schema_if_updated(),  # type: ignore
         cached_reflection=current_tx.get_cached_reflection_if_updated(),

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -28,9 +28,8 @@ cpdef enum SideEffects:
     SchemaChanges = 1 << 0
     DatabaseConfigChanges = 1 << 1
     InstanceConfigChanges = 1 << 2
-    RoleChanges = 1 << 3
-    GlobalSchemaChanges = 1 << 4
-    DatabaseChanges = 1 << 5
+    GlobalSchemaChanges = 1 << 3
+    DatabaseChanges = 1 << 4
 
 
 @cython.final
@@ -150,7 +149,6 @@ cdef class DatabaseConnectionView:
         int _in_tx_dbver
         bint _in_tx
         bint _in_tx_with_ddl
-        bint _in_tx_with_role_ddl
         bint _in_tx_with_sysconfig
         bint _in_tx_with_dbconfig
         bint _in_tx_with_set

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -185,7 +185,12 @@ cdef class DatabaseConnectionView:
     cdef on_error(self)
     cdef on_success(self, query_unit, new_types)
     cdef commit_implicit_tx(
-        self, user_schema, extensions, global_schema, cached_reflection
+        self,
+        user_schema,
+        extensions,
+        global_schema,
+        roles,
+        cached_reflection,
     )
 
     cpdef get_config_spec(self)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -345,7 +345,6 @@ cdef class DatabaseConnectionView:
         self._in_tx_modaliases = None
         self._in_tx_savepoints = []
         self._in_tx_with_ddl = False
-        self._in_tx_with_role_ddl = False
         self._in_tx_with_sysconfig = False
         self._in_tx_with_dbconfig = False
         self._in_tx_with_set = False
@@ -804,8 +803,6 @@ cdef class DatabaseConnectionView:
             self._in_tx_with_dbconfig = True
         if query_unit.has_set:
             self._in_tx_with_set = True
-        if query_unit.has_role_ddl:
-            self._in_tx_with_role_ddl = True
         if query_unit.user_schema is not None:
             self._in_tx_user_schema_pickled = query_unit.user_schema
             self._in_tx_user_schema = None
@@ -859,8 +856,6 @@ cdef class DatabaseConnectionView:
                 side_effects |= SideEffects.GlobalSchemaChanges
                 self._db._index.update_global_schema(
                     pickle.loads(query_unit.global_schema))
-            if query_unit.has_role_ddl:
-                side_effects |= SideEffects.RoleChanges
                 self._db.tenant.fetch_roles()
         else:
             if new_types:
@@ -900,8 +895,6 @@ cdef class DatabaseConnectionView:
                 self._db._index.update_global_schema(
                     pickle.loads(query_unit.global_schema))
                 self._db.tenant.fetch_roles()
-            if self._in_tx_with_role_ddl:
-                side_effects |= SideEffects.RoleChanges
 
             self._reset_tx_state()
 
@@ -945,8 +938,6 @@ cdef class DatabaseConnectionView:
             self._db._index.update_global_schema(
                 pickle.loads(global_schema))
             self._db.tenant.fetch_roles()
-        if self._in_tx_with_role_ddl:
-            side_effects |= SideEffects.RoleChanges
 
         self._reset_tx_state()
         return side_effects

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -856,7 +856,7 @@ cdef class DatabaseConnectionView:
                 side_effects |= SideEffects.GlobalSchemaChanges
                 self._db._index.update_global_schema(
                     pickle.loads(query_unit.global_schema))
-                self._db.tenant.fetch_roles()
+                self._db.tenant.set_roles(query_unit.roles)
         else:
             if new_types:
                 self._in_tx_new_types.update(new_types)
@@ -894,7 +894,7 @@ cdef class DatabaseConnectionView:
                 side_effects |= SideEffects.GlobalSchemaChanges
                 self._db._index.update_global_schema(
                     pickle.loads(query_unit.global_schema))
-                self._db.tenant.fetch_roles()
+                self._db.tenant.set_roles(query_unit.roles)
 
             self._reset_tx_state()
 
@@ -908,7 +908,12 @@ cdef class DatabaseConnectionView:
         return side_effects
 
     cdef commit_implicit_tx(
-        self, user_schema, extensions, global_schema, cached_reflection
+        self,
+        user_schema,
+        extensions,
+        global_schema,
+        roles,
+        cached_reflection,
     ):
         assert self._in_tx
         side_effects = 0
@@ -937,7 +942,7 @@ cdef class DatabaseConnectionView:
             side_effects |= SideEffects.GlobalSchemaChanges
             self._db._index.update_global_schema(
                 pickle.loads(global_schema))
-            self._db.tenant.fetch_roles()
+            self._db.tenant.set_roles(roles)
 
         self._reset_tx_state()
         return side_effects

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -207,7 +207,8 @@ async def execute_script(
         int dbver = dbv.dbver
         bint parse
 
-    user_schema = extensions = cached_reflection = global_schema = None
+    user_schema = extensions = cached_reflection = None
+    global_schema = roles = None
     unit_group = compiled.query_unit_group
 
     in_tx = dbv.in_tx()
@@ -278,6 +279,7 @@ async def execute_script(
 
                 if query_unit.global_schema:
                     global_schema = query_unit.global_schema
+                    roles = query_unit.roles
 
                 if query_unit.sql:
                     parse = parse_array[idx]
@@ -332,7 +334,11 @@ async def execute_script(
     else:
         if not in_tx:
             side_effects = dbv.commit_implicit_tx(
-                user_schema, extensions, global_schema, cached_reflection
+                user_schema,
+                extensions,
+                global_schema,
+                roles,
+                cached_reflection,
             )
             if side_effects:
                 signal_side_effects(dbv, side_effects)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -284,6 +284,9 @@ class Tenant(ha_base.ClusterProtocol):
     def get_roles(self) -> Mapping[str, RoleDescriptor]:
         return self._roles
 
+    def set_roles(self, roles: Mapping[str, RoleDescriptor]) -> None:
+        self._roles = roles
+
     def fetch_roles(self) -> None:
         global_schema = self.get_global_schema()
 


### PR DESCRIPTION
* Introspect roles directly without global schema.
* Include `roles` in QueryUnit when global_schema is updated.

This is a partial revert of [this commit](https://github.com/edgedb/edgedb/pull/2183/commits/7c40e2fc306a945dd88dfa1437669ab85cb9efb9#diff-397281e6358a1aadc225ecbf91ee76794703c819aea1faf7913df30561ff0911L336-L347).