### PR TITLE
Fix debug endpoint serialization of object config values

### DIFF
--- a/edb/server/protocol/server_info.py
+++ b/edb/server/protocol/server_info.py
@@ -26,6 +26,7 @@ import immutables
 from edb import errors
 
 from edb.ir import statypes
+from edb.server.config import types as configtypes
 
 from edb.common import debug
 from edb.common import markup
@@ -44,6 +45,8 @@ class ImmutableEncoder(json.JSONEncoder):
             return obj.to_iso8601()
         if isinstance(obj, statypes.ConfigMemory):
             return obj.to_str()
+        if isinstance(obj, configtypes.CompositeConfigType):
+            return obj.to_json_value()
         return super().default(obj)
 
 


### PR DESCRIPTION
I broke it in #5913, when the obects stopped being dataclass
instances.