### PR TITLE
Support extension-defined config objects

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_08_10_00_00
+EDGEDB_CATALOG_VERSION = 2023_08_23_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -198,9 +198,11 @@ def compile_ConfigInsert(
         shape=expr.shape,
     )
 
-    for el in expr.shape:
-        if isinstance(el.compexpr, qlast.InsertQuery):
-            _inject_tname(el.compexpr, ctx=ctx)
+    # RIGHT? IDK?
+    _inject_tname(insert_stmt, ctx=ctx)
+    # for el in expr.shape:
+    #     if isinstance(el.compexpr, qlast.InsertQuery):
+    #         _inject_tname(el.compexpr, ctx=ctx)
 
     with ctx.newscope(fenced=False) as subctx:
         subctx.expr_exposed = context.Exposure.EXPOSED

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -177,7 +177,9 @@ def compile_ConfigInsert(
 
     info = _validate_op(expr, ctx=ctx)
 
-    if expr.scope is not qltypes.ConfigScope.INSTANCE:
+    if expr.scope not in (
+        qltypes.ConfigScope.INSTANCE, qltypes.ConfigScope.DATABASE
+    ):
         raise errors.UnsupportedFeatureError(
             f'CONFIGURE {expr.scope} INSERT is not supported'
         )

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -313,6 +313,13 @@ def _validate_op(
     cfg_type = None
 
     if isinstance(expr, (qlast.ConfigSet, qlast.ConfigReset)):
+        # TODO: Fix this. The problem is that it gets lost when serializing it
+        if is_ext_config and expr.scope == qltypes.ConfigScope.SESSION:
+            raise errors.UnsupportedFeatureError(
+                'SESSION configuration of extension-defined config variables '
+                'is not yet implemented'
+            )
+
         # expr.name is the actual name of the property.
         ptr = cfg_host_type.maybe_get_ptr(ctx.env.schema, sn.UnqualName(name))
         if ptr is not None:

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -345,15 +345,15 @@ def _validate_op(
 
         cfg_type = ctx.env.get_schema_type_and_track(
             s_utils.ast_ref_to_name(expr.name), default=None)
-        if not cfg_type:
+        if not cfg_type and not expr.name.module:
             # expr.name is the name of the configuration type
             cfg_type = ctx.env.get_schema_type_and_track(
                 sn.QualName('cfg', name), default=None)
-            if cfg_type is None:
-                raise errors.ConfigurationError(
-                    f'unrecognized configuration object {name!r}',
-                    context=expr.context
-                )
+        if not cfg_type:
+            raise errors.ConfigurationError(
+                f'unrecognized configuration object {name!r}',
+                context=expr.context
+            )
 
         assert isinstance(cfg_type, s_objtypes.ObjectType)
         ptr_candidate: Optional[s_pointers.Pointer] = None

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -185,24 +185,12 @@ def compile_ConfigInsert(
         )
 
     subject = info.param_type
-    # subject = ctx.env.get_schema_object_and_track(
-    #     sn.QualName('cfg', expr.name.name), expr.name, default=None)
-    # if subject is None:
-    #     raise errors.ConfigurationError(
-    #         f'{expr.name.name!r} is not a valid configuration item',
-    #         context=expr.context,
-    #     )
-
     insert_stmt = qlast.InsertQuery(
         subject=s_utils.name_to_ast_ref(subject.get_name(ctx.env.schema)),
         shape=expr.shape,
     )
 
-    # RIGHT? IDK?
     _inject_tname(insert_stmt, ctx=ctx)
-    # for el in expr.shape:
-    #     if isinstance(el.compexpr, qlast.InsertQuery):
-    #         _inject_tname(el.compexpr, ctx=ctx)
 
     with ctx.newscope(fenced=False) as subctx:
         subctx.expr_exposed = context.Exposure.EXPOSED
@@ -300,12 +288,6 @@ def _validate_op(
 
     if expr.scope == qltypes.ConfigScope.GLOBAL:
         return _validate_global_op(expr, ctx=ctx)
-
-    # if expr.name.module and expr.name.module != 'cfg':
-    #     raise errors.QueryError(
-    #         'invalid configuration parameter name: module must be either '
-    #         '\'cfg\' or empty', context=expr.name.context,
-    #     )
 
     cfg_host_type = None
     is_ext_config = False

--- a/edb/edgeql/compiler/config_desc.py
+++ b/edb/edgeql/compiler/config_desc.py
@@ -154,13 +154,17 @@ def _describe_config_inner(
                 ' ' * 4,
             )
         else:
+            fn = (
+                pn if actual_name == config_object_name
+                else f'{actual_name}::{pn}'
+            )
             renderer = _render_config_set if mult else _render_config_scalar
             item = textwrap.indent(
                 renderer(
                     schema=schema,
                     valtype=ptype,
                     value_expr=psource,
-                    name=pn,
+                    name=fn,
                     scope=scope,
                     level=1,
                 ),

--- a/edb/edgeql/compiler/config_desc.py
+++ b/edb/edgeql/compiler/config_desc.py
@@ -77,7 +77,9 @@ def _describe_config(
         schema, scope, config_object_name, cfg, testmode
     ))
     ext = schema.get('cfg::ExtensionConfig', type=s_objtypes.ObjectType)
-    for ext_cfg in ext.descendants(schema):
+    for ext_cfg in sorted(
+        ext.descendants(schema), key=lambda x: x.get_name(schema)
+    ):
         items.extend(_describe_config_inner(
             schema, scope, config_object_name, ext_cfg, testmode
         ))
@@ -116,7 +118,10 @@ def _describe_config_inner(
     )
 
     items = []
-    for ptr_name, p in cfg.get_pointers(schema).items(schema):
+    for ptr_name, p in sorted(
+        cfg.get_pointers(schema).items(schema),
+        key=lambda x: x[0],
+    ):
         pn = str(ptr_name)
         if pn in ('id', '__type__') or p.get_computable(schema):
             continue
@@ -348,7 +353,10 @@ def _describe_config_object(
     layouts = {}
     for cfg in cfg_types:
         items = []
-        for ptr_name, p in cfg.get_pointers(schema).items(schema):
+        for ptr_name, p in sorted(
+            cfg.get_pointers(schema).items(schema),
+            key=lambda x: x[0],
+        ):
             pn = str(ptr_name)
             if (
                 pn in ('id', '__type__')

--- a/edb/edgeql/compiler/config_desc.py
+++ b/edb/edgeql/compiler/config_desc.py
@@ -321,6 +321,8 @@ def _describe_config_object(
 
             ptype = p.get_target(schema)
             assert ptype is not None
+            if str(ptype.get_name(schema)) == 'cfg::AbstractConfig':
+                continue
 
             ptr_card = p.get_cardinality(schema)
             mult = ptr_card.is_multi()

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -447,7 +447,7 @@ def object_type_to_spec(
         )
 
     return spec_class(
-        name=objtype.get_name(schema).name,
+        name=str(objtype.get_name(schema)),
         fields=immutables.Map(fields),
         parent=parent,
     )

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -389,7 +389,6 @@ def object_type_to_spec(
         _memo = {}
     default: Any
     fields = {}
-    subclasses = []
 
     for pn, p in objtype.get_pointers(schema).items(schema):
         assert isinstance(p, s_pointers.Pointer)
@@ -407,13 +406,6 @@ def object_type_to_spec(
                     ptype, schema, spec_class=spec_class,
                     parent=parent, _memo=_memo)
                 _memo[ptype] = pytype
-
-                for subtype in ptype.children(schema):
-                    subclasses.append(
-                        object_type_to_spec(
-                            subtype, schema,
-                            spec_class=spec_class,
-                            parent=pytype, _memo=_memo))
         else:
             pytype = scalar_type_to_python_type(ptype, schema)
 
@@ -446,11 +438,20 @@ def object_type_to_spec(
             name=str_pn, type=pytype, unique=unique, default=default
         )
 
-    return spec_class(
+    spec = spec_class(
         name=str(objtype.get_name(schema)),
         fields=immutables.Map(fields),
         parent=parent,
     )
+
+    for subtype in objtype.children(schema):
+        spec.children.append(
+            object_type_to_spec(
+                subtype, schema,
+                spec_class=spec_class,
+                parent=spec, _memo=_memo))
+
+    return spec
 
 
 @functools.singledispatch

--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -50,10 +50,6 @@ class CompositeTypeSpec:
         default_factory=list, hash=False, compare=False
     )
 
-    def __post_init__(self) -> None:
-        if self.parent:
-            self.parent.children.append(self)
-
     @property
     def __name__(self) -> str:
         return self.name

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -83,8 +83,11 @@ CREATE TYPE cfg::Auth EXTENDING cfg::ConfigObject {
     };
 };
 
+CREATE ABSTRACT TYPE cfg::ExtensionConfig EXTENDING cfg::ConfigObject;
 
 CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject {
+    CREATE MULTI LINK exts -> cfg::ExtensionConfig;
+
     CREATE REQUIRED PROPERTY session_idle_timeout -> std::duration {
         CREATE ANNOTATION cfg::system := 'true';
         CREATE ANNOTATION cfg::report := 'true';

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -83,10 +83,16 @@ CREATE TYPE cfg::Auth EXTENDING cfg::ConfigObject {
     };
 };
 
-CREATE ABSTRACT TYPE cfg::ExtensionConfig EXTENDING cfg::ConfigObject;
+CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject;
 
-CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject {
-    CREATE MULTI LINK exts -> cfg::ExtensionConfig;
+CREATE ABSTRACT TYPE cfg::ExtensionConfig EXTENDING cfg::ConfigObject {
+    CREATE REQUIRED SINGLE LINK cfg -> cfg::AbstractConfig {
+        CREATE DELEGATED CONSTRAINT std::exclusive;
+    };
+};
+
+ALTER TYPE cfg::AbstractConfig {
+    CREATE MULTI LINK extensions := .<cfg[IS cfg::ExtensionConfig];
 
     CREATE REQUIRED PROPERTY session_idle_timeout -> std::duration {
         CREATE ANNOTATION cfg::system := 'true';

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -559,7 +559,9 @@ def top_output_as_config_op(
 
     assert isinstance(ir_set.expr, irast.ConfigCommand)
 
-    if ir_set.expr.scope is qltypes.ConfigScope.INSTANCE:
+    if ir_set.expr.scope in (
+        qltypes.ConfigScope.INSTANCE, qltypes.ConfigScope.DATABASE
+    ):
         alias = env.aliases.get('cfg')
         subrvar = pgast.RangeSubselect(
             subquery=stmt,

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -576,8 +576,7 @@ def top_output_as_config_op(
         assert stmt_res.name is not None
     val = pgast.ColumnRef(name=[stmt_res.name])
 
-    # XXX: code duplication?
-    # wait what about _tname??
+    # FIXME: Can the duplication with other db cases be reduced?
     if op.scope is qltypes.ConfigScope.DATABASE:
         sval = pgast.SelectStmt(
             target_list=[pgast.ResTarget(val=val)], from_clause=[subrvar])

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from edb import errors
 from edb.ir import ast as irast
+from edb.ir import typeutils as irtyputils
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -380,10 +381,15 @@ def compile_ConfigReset(
 
         assert isinstance(op.selector.expr, irast.SelectStmt)
 
+        # Grab all the non-link properties of the object as keys. We
+        # could just do the exclusive ones, but this works too and we
+        # have the information at hand.
         keys = [
             el.rptr.ptrref.shortname.name
             for el, op in op.selector.expr.result.shape
-            if el.rptr and op == qlast.ShapeOp.ASSIGN
+            if el.rptr
+            and op == qlast.ShapeOp.ASSIGN
+            and not irtyputils.is_object(el.rptr.ptrref.out_target)
         ]
 
         newval = pgast.SelectStmt(

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -363,7 +363,13 @@ def compile_ConfigReset(
         )
 
     elif op.scope is qltypes.ConfigScope.DATABASE and op.selector is not None:
-        # XXX: some duplication with above
+        # For FILTERed RESET on the database, we have to do a decent
+        # amount of work to actually delete the RESET objects from the
+        # json config blogs.
+        #
+        # This is because the server isn't set up to write back just
+        # the changed parts of the config based on interpreting the output,
+        # so instead we do all the work here.
         with context.output_format(ctx, context.OutputFormat.JSONB):
             selector = dispatch.compile(op.selector, ctx=ctx)
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -2018,8 +2018,12 @@ def rvar_for_rel(
     typeref: Optional[irast.TypeRef] = None,
     lateral: bool = False,
     colnames: Optional[List[str]] = None,
-    ctx: context.CompilerContextLevel,
+    ctx: Optional[context.CompilerContextLevel] = None,
+    env: Optional[context.Environment] = None,
 ) -> pgast.PathRangeVar:
+    if ctx:
+        env = ctx.env
+    assert env
 
     rvar: pgast.PathRangeVar
 
@@ -2027,7 +2031,7 @@ def rvar_for_rel(
         colnames = []
 
     if isinstance(rel, pgast.Query):
-        alias = alias or ctx.env.aliases.get(rel.name or 'q')
+        alias = alias or env.aliases.get(rel.name or 'q')
 
         rvar = pgast.RangeSubselect(
             subquery=rel,
@@ -2036,7 +2040,7 @@ def rvar_for_rel(
             typeref=typeref,
         )
     else:
-        alias = alias or ctx.env.aliases.get(rel.name or '')
+        alias = alias or env.aliases.get(rel.name or '')
 
         rvar = pgast.RelRangeVar(
             relation=rel,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3729,13 +3729,19 @@ class ObjectTypeMetaCommand(AliasCapableMetaCommand,
                 key = 'configspec_ext';
         ''')))
 
-        # FIXME: If this is not a top-level object it is not going to
-        # work right...
-        views = metaschema.get_config_type_views(eff_schema, scls, scope=None)
+        for sub in self.get_subcommands(type=s_pointers.DeletePointer):
+            if has_table(sub.scls, eff_schema):
+                self.pgops.add(dbops.DropView(common.get_backend_name(
+                    eff_schema, sub.scls, catenate=False)))
+
         if isinstance(self, sd.DeleteObject):
-            for cv in views:
-                self.pgops.add(dbops.DropView(cv.view.name))
+            self.pgops.add(dbops.DropView(common.get_backend_name(
+                eff_schema, scls, catenate=False)))
         else:
+            # FIXME: If this is not a top-level object it is not going to
+            # work right...
+            views = metaschema.get_config_type_views(
+                eff_schema, scls, scope=None)
             self.pgops.update(views)
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3729,6 +3729,8 @@ class ObjectTypeMetaCommand(AliasCapableMetaCommand,
                 key = 'configspec_ext';
         ''')))
 
+        # FIXME: If this is not a top-level object it is not going to
+        # work right...
         views = metaschema.get_config_type_views(eff_schema, scls, scope=None)
         if isinstance(self, sd.DeleteObject):
             for cv in views:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3530,7 +3530,10 @@ class ResetSessionConfigFunction(dbops.Function):
         )
 
 
-# XXX: Uh oh.
+# FIXME: Support extension-defined configs that affect the backend
+# Not needed for supporting auth, so can skip temporarily.
+# If perf seems to matter, can hardcode things for base config
+# and consult json for just extension stuff.
 class ApplySessionConfigFunction(dbops.Function):
     """Apply an EdgeDB config setting to the backend, if possible.
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3468,6 +3468,9 @@ class SysConfigFullFunction(dbops.Function):
         )
 
 
+# TODO: Calling this function repeatedly in config introspection
+# queries can lead to performance problems. Could we cache the results
+# in _edgecon_state or something?
 class SysConfigFunction(dbops.Function):
 
     text = f'''

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -6154,49 +6154,47 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
     )
 
 
+def get_config_type_views(
+    schema: s_schema.Schema,
+    conf: s_objtypes.ObjectType,
+    scope: Optional[qltypes.ConfigScope],
+) -> dbops.CommandGroup:
+    commands = dbops.CommandGroup()
+
+    cfg_views, _ = _generate_config_type_view(
+        schema,
+        conf,
+        scope=scope,
+        path=[],
+        rptr=None,
+    )
+    commands.add_commands([
+        dbops.CreateView(dbops.View(name=tn, query=q), or_replace=True)
+        for tn, q in cfg_views
+    ])
+
+    return commands
+
+
 def get_config_views(
     schema: s_schema.Schema,
 ) -> dbops.CommandGroup:
     commands = dbops.CommandGroup()
 
     conf = schema.get('cfg::Config', type=s_objtypes.ObjectType)
-    cfg_views, _ = _generate_config_type_view(
-        schema,
-        conf,
-        scope=None,
-        path=[],
-        rptr=None,
+    commands.add_command(
+        get_config_type_views(schema, conf, scope=None),
     )
-    commands.add_commands([
-        dbops.CreateView(dbops.View(name=tn, query=q), or_replace=True)
-        for tn, q in cfg_views
-    ])
 
     conf = schema.get('cfg::InstanceConfig', type=s_objtypes.ObjectType)
-    cfg_views, _ = _generate_config_type_view(
-        schema,
-        conf,
-        scope=qltypes.ConfigScope.INSTANCE,
-        path=[],
-        rptr=None,
+    commands.add_command(
+        get_config_type_views(schema, conf, scope=qltypes.ConfigScope.INSTANCE),
     )
-    commands.add_commands([
-        dbops.CreateView(dbops.View(name=tn, query=q), or_replace=True)
-        for tn, q in cfg_views
-    ])
 
     conf = schema.get('cfg::DatabaseConfig', type=s_objtypes.ObjectType)
-    cfg_views, _ = _generate_config_type_view(
-        schema,
-        conf,
-        scope=qltypes.ConfigScope.DATABASE,
-        path=[],
-        rptr=None,
+    commands.add_command(
+        get_config_type_views(schema, conf, scope=qltypes.ConfigScope.DATABASE),
     )
-    commands.add_commands([
-        dbops.CreateView(dbops.View(name=tn, query=q), or_replace=True)
-        for tn, q in cfg_views
-    ])
 
     return commands
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3534,7 +3534,7 @@ class ResetSessionConfigFunction(dbops.Function):
         )
 
 
-# FIXME: Support extension-defined configs that affect the backend
+# TODO: Support extension-defined configs that affect the backend
 # Not needed for supporting auth, so can skip temporarily.
 # If perf seems to matter, can hardcode things for base config
 # and consult json for just extension stuff.
@@ -6437,14 +6437,13 @@ def _generate_config_type_view(
 
     ext_cfg = schema.get('cfg::ExtensionConfig', type=s_objtypes.ObjectType)
     is_ext_cfg = stype.issubclass(schema, ext_cfg)
-    if is_ext_cfg:  # XXX? Sure!!
+    if is_ext_cfg:
         rptr = None
     is_rptr_ext_cfg = False
 
     if not path:
         if is_ext_cfg:
             # Extension configs get one object per scope.
-            # Though we skip instance? Maybe we should include it, just because?
             cfg_name = str(stype.get_name(schema))
 
             escaped_name = _escape_like(cfg_name)
@@ -6482,8 +6481,6 @@ def _generate_config_type_view(
                 cfg_name = str(rptr_source.get_name(schema)) + '::' + rptr_name
                 escaped_name = _escape_like(cfg_name)
 
-                # XXX: MAYBE: Have some level of configurability here,
-                # so we don't always duplicate the objects?
                 source0 = f'''
                     (SELECT el.val AS val, s.scope::text AS scope,
                             s.scope_id AS scope_id
@@ -6522,8 +6519,8 @@ def _generate_config_type_view(
         sources.append(source0)
         key_start = 0
     else:
-        # XXX: We want to merge this shit in
         # XXX: The second level is broken
+        # Can we solve this without code duplication?
         key_start = 0
 
         for i, (l, exc_props) in enumerate(path):
@@ -6698,7 +6695,7 @@ def _generate_config_type_view(
             schema, target_exc_props, link, source_idx=link_name)
         sources.append(target_key_source)
 
-        # XXX: that doesn't seem right to *just* use the exc props??
+        # XXX: it doesn't seem right to *just* use the exc props?
         if target_exc_props:
             target_key_components = [f'k{link_name}.key']
         else:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -6636,7 +6636,7 @@ def _generate_config_type_view(
 
         key_expr = 'k.key'
 
-        tname = stype.get_name(schema).name
+        tname = str(stype.get_name(schema))
         where = f"{key_expr} IS NOT NULL AND ({sval}->>'_tname') = {ql(tname)}"
 
     else:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3432,7 +3432,7 @@ class SysConfigFullFunction(dbops.Function):
                 ) AS u
             ) AS q
         WHERE
-            q.n = 1;
+            q.n = 1 AND q.value IS NOT NULL;
     $$;
 
     RETURN QUERY EXECUTE query USING source_filter, max_source;

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3144,11 +3144,9 @@ class SysConfigFullFunction(dbops.Function):
                 (s.value->>'typemod') AS typemod,
                 (s.value->>'backend_setting') AS backend_setting
             FROM
-                jsonb_each(
-                    (SELECT json
-                    FROM edgedbinstdata.instdata
-                    WHERE key = 'configspec')
-                ) AS s
+                edgedbinstdata.instdata as id,
+            LATERAL jsonb_each(id.json) AS s
+            WHERE id.key LIKE 'configspec%'
         ),
 
         config_defaults AS (
@@ -3532,6 +3530,7 @@ class ResetSessionConfigFunction(dbops.Function):
         )
 
 
+# XXX: Uh oh.
 class ApplySessionConfigFunction(dbops.Function):
     """Apply an EdgeDB config setting to the backend, if possible.
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -6572,6 +6572,12 @@ def _generate_config_type_view(
         link_psi = types.get_pointer_storage_info(link, schema=schema)
         link_col = link_psi.column_name
 
+        if str(link_type.get_name(schema)) == 'cfg::AbstractConfig':
+            # XXX: This isn't right at all
+            config_key = f"'{CONFIG_ID[scope]}'::uuid"
+            target_cols[link] = f'({config_key}) AS {qi(link_col)}'
+            continue
+
         if rptr is not None:
             target_path = path + [(rptr, exclusive_props)]
         else:
@@ -6670,6 +6676,12 @@ def _generate_config_type_view(
                     _memo=_memo,
                 )
                 views.extend(desc_views)
+
+        # HACK: For computable links (just extensions hopefully?), we
+        # want to compile the targets as a side effect, but we don't
+        # want to actually include them in the view.
+        if link.get_computable(schema):
+            continue
 
         target_source = _build_data_source(
             schema, link, self_idx, alias=link_name)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3423,7 +3423,8 @@ class SysConfigFullFunction(dbops.Function):
                         SELECT * FROM pg_all_settings
                     ) AS q
                 WHERE
-                    ($1 IS NULL OR
+                    q.value IS NOT NULL
+                    AND ($1 IS NULL OR
                         q.source::edgedb._sys_config_source_t = any($1)
                     )
                     AND ($2 IS NULL OR
@@ -3432,7 +3433,7 @@ class SysConfigFullFunction(dbops.Function):
                 ) AS u
             ) AS q
         WHERE
-            q.n = 1 AND q.value IS NOT NULL;
+            q.n = 1;
     $$;
 
     RETURN QUERY EXECUTE query USING source_filter, max_source;

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1336,7 +1336,7 @@ class CommandContext:
             from *offset* in the stack.
         """
         return any(isinstance(ctx.op, DeleteObject)
-                   for ctx in self.stack[:-offset])
+                   for ctx in self.stack[:-offset if offset else None])
 
     def is_deleting(self, obj: so.Object) -> bool:
         """Return True if *obj* is being deleted in this context.

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -404,6 +404,8 @@ class DeleteExtension(
                 # canonicalization instead.
                 continue
 
+            # This is still kind of sketchy. _canonicalize doesn't
+            # really *fully* canonicalize things.
             drop = obj.init_delta_command(schema, sd.DeleteObject)
             drop.update(drop._canonicalize(schema, context, obj))
             commands.append(drop)

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -1528,7 +1528,11 @@ class DeleteReferencedInheritingObject(
             cmd.add(rebase_cmd)
         else:
             # The ref in child should no longer exist.
-            cmd = child_ref.init_delta_command(schema, sd.DeleteObject)
+            # HACK: Pass if_exists to work around some mismatches in
+            # how canonicalization works when deleting a module as
+            # part of DeleteExtension. It should be harmless though.
+            cmd = child_ref.init_delta_command(
+                schema, sd.DeleteObject, if_exists=True)
 
         return cmd
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -1241,6 +1241,8 @@ def get_config_type_shape(
 
             ptype = p.get_target(schema)
             assert ptype is not None
+            if str(ptype.get_name(schema)) == 'cfg::AbstractConfig':
+                continue
 
             if isinstance(ptype, s_objtypes.ObjectType):
                 subshape = get_config_type_shape(

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1512,6 +1512,11 @@ async def _init_stdlib(
         'configspec',
         config.spec_to_json(config_spec),
     )
+    await _store_static_json_cache(
+        ctx,
+        'configspec_ext',
+        json.dumps({}),
+    )
 
     return stdlib, config_spec, compiler
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2315,11 +2315,11 @@ def _try_compile(
 
                 unit.system_config = True
             elif comp.config_scope is qltypes.ConfigScope.GLOBAL:
-                unit.set_global = True
+                unit.needs_readback = True
 
             elif comp.config_scope is qltypes.ConfigScope.DATABASE:
                 unit.database_config = True
-                unit.set_global = True  # XXX: not really right!
+                unit.needs_readback = True
 
             if comp.is_backend_setting:
                 unit.backend_config = True

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -179,6 +179,10 @@ class CompileContext:
             )
         return mstate
 
+    def get_config_spec(self) -> config.Spec:
+        return self.state.current_tx().get_config_spec(
+            self.compiler_state.config_spec)
+
 
 DEFAULT_MODULE_ALIASES_MAP: immutables.Map[Optional[str], str] = (
     immutables.Map({None: defines.DEFAULT_MODULE_ALIAS}))
@@ -276,6 +280,7 @@ def new_compiler_context(
         database_config=EMPTY_MAP,
         system_config=EMPTY_MAP,
         cached_reflection=EMPTY_MAP,
+        config_spec=config.FlatSpec()
     )
 
     ctx = CompileContext(
@@ -454,6 +459,10 @@ class Compiler:
         ]
     ]:
 
+        # XXX: PERF! DON'T!
+        config_spec = config.load_ext_spec_from_schema(
+            user_schema, self.state.std_schema)
+
         state = dbstate.CompilerConnectionState(
             user_schema=user_schema,
             global_schema=global_schema,
@@ -462,6 +471,7 @@ class Compiler:
             database_config=database_config,
             system_config=system_config,
             cached_reflection=reflection_cache,
+            config_spec=config_spec,
         )
 
         state.start_tx()
@@ -519,6 +529,11 @@ class Compiler:
         current_database: str,
         current_user: str,
     ) -> List[dbstate.SQLQueryUnit]:
+
+        # XXX: PERF! DON'T!
+        config_spec = config.load_ext_spec_from_schema(
+            user_schema, self.state.std_schema)
+
         state = dbstate.CompilerConnectionState(
             user_schema=user_schema,
             global_schema=global_schema,
@@ -527,6 +542,7 @@ class Compiler:
             database_config=database_config,
             system_config=system_config,
             cached_reflection=reflection_cache,
+            config_spec=config_spec,
         )
         schema = state.current_tx().get_schema(self.state.std_schema)
 
@@ -839,6 +855,10 @@ class Compiler:
         if sess_modaliases is None:
             sess_modaliases = DEFAULT_MODULE_ALIASES_MAP
 
+        # XXX: PERF! DON'T!
+        config_spec = config.load_ext_spec_from_schema(
+            user_schema, self.state.std_schema)
+
         state = dbstate.CompilerConnectionState(
             user_schema=user_schema,
             global_schema=global_schema,
@@ -847,6 +867,7 @@ class Compiler:
             database_config=database_config,
             system_config=system_config,
             cached_reflection=reflection_cache,
+            config_spec=config_spec,
         )
 
         ctx = CompileContext(
@@ -1026,6 +1047,7 @@ class Compiler:
             database_config=EMPTY_MAP,
             system_config=EMPTY_MAP,
             cached_reflection=EMPTY_MAP,
+            config_spec=config.FlatSpec(),
         )
 
         ctx = CompileContext(
@@ -1852,25 +1874,6 @@ def _compile_ql_sess_state(
     )
 
 
-def _get_config_spec(
-    ctx: CompileContext, config_op: config.Operation
-) -> config.Spec:
-    config_spec = ctx.compiler_state.config_spec
-    if config_op.setting_name not in config_spec:
-        # We don't typically bother tracking the user config spec in
-        # the compiler workers (to avoid needing to bother with
-        # transmitting, caching, or computing it). If we hit a config
-        # op that needs it, load the spec.
-        config_spec = config.ChainedSpec(
-            config_spec,
-            config.load_ext_spec_from_schema(
-                ctx.state.current_tx().get_user_schema(),
-                ctx.compiler_state.std_schema,
-            ),
-        )
-    return config_spec
-
-
 def _compile_ql_config_op(
     ctx: CompileContext, ql: qlast.ConfigOp
 ) -> dbstate.SessionStateQuery:
@@ -1941,7 +1944,7 @@ def _compile_ql_config_op(
         config_op = ireval.evaluate_to_config_op(ir, schema=schema)
 
         session_config = config_op.apply(
-            _get_config_spec(ctx, config_op),
+            ctx.get_config_spec(),
             session_config,
         )
         current_tx.update_session_config(session_config)
@@ -1950,7 +1953,7 @@ def _compile_ql_config_op(
         config_op = ireval.evaluate_to_config_op(ir, schema=schema)
 
         database_config = config_op.apply(
-            _get_config_spec(ctx, config_op),
+            ctx.get_config_spec(),
             database_config,
         )
         current_tx.update_database_config(database_config)
@@ -2752,17 +2755,16 @@ def _get_config_val(
         current_tx.get_session_config(),
         current_tx.get_database_config(),
         current_tx.get_system_config(),
-        spec=ctx.compiler_state.config_spec,
+        spec=ctx.get_config_spec(),
         allow_unrecognized=True,
     )
 
 
 def _get_compilation_config_vals(ctx: CompileContext) -> Any:
-    assert ctx.compiler_state.config_spec is not None
     return {
         k: _get_config_val(ctx, k)
-        for k in ctx.compiler_state.config_spec
-        if ctx.compiler_state.config_spec[k].affects_compilation
+        for k, s in ctx.get_config_spec().items()
+        if s.affects_compilation
     }
 
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -931,7 +931,6 @@ class Compiler:
             global_schema
         )
 
-        # XXX: ????
         config_spec = config.ChainedSpec(
             self.state.config_spec,
             config.load_ext_spec_from_schema(
@@ -1958,7 +1957,6 @@ def _compile_ql_config_op(
                 _get_config_spec(ctx, config_op),
                 database_config,
             )
-            # HMMMMM
             current_tx.update_database_config(database_config)
 
     elif ql.scope in (

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -298,8 +298,10 @@ class QueryUnit:
     system_config: bool = False
     # Set only when this unit contains a CONFIGURE DATABASE command.
     database_config: bool = False
-    # Set only when this unit contains a SET_GLOBAL command.
-    set_global: bool = False
+    # Set only when this unit contains an operation that needs to have
+    # its results read back in the middle of the script.
+    # (SET GLOBAL, CONFIGURE DATABASE)
+    needs_readback: bool = False
     # Whether any configuration change requires a server restart
     config_requires_restart: bool = False
     # Set only when this unit contains a CONFIGURE command which

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -621,7 +621,6 @@ class TransactionState(NamedTuple):
     system_config: immutables.Map[str, config.SettingValue]
     cached_reflection: immutables.Map[str, Tuple[str, ...]]
     tx: Transaction
-    config_spec: config.Spec
     migration_state: Optional[MigrationState] = None
     migration_rewrite_state: Optional[MigrationRewriteState] = None
 
@@ -642,7 +641,6 @@ class Transaction:
         database_config: immutables.Map[str, config.SettingValue],
         system_config: immutables.Map[str, config.SettingValue],
         cached_reflection: immutables.Map[str, Tuple[str, ...]],
-        config_spec: config.Spec,
         implicit: bool = True,
     ) -> None:
 
@@ -663,7 +661,6 @@ class Transaction:
             database_config=database_config,
             system_config=system_config,
             cached_reflection=cached_reflection,
-            config_spec=config_spec,
             tx=self,
         )
 
@@ -757,12 +754,6 @@ class Transaction:
             std_schema,
             self._current.user_schema,
             self._current.global_schema,
-        )
-
-    def get_config_spec(self, std_spec: config.Spec) -> config.Spec:
-        return config.ChainedSpec(
-            std_spec,
-            self._current.config_spec,
         )
 
     def get_user_schema(self) -> s_schema.FlatSchema:
@@ -871,7 +862,6 @@ class CompilerConnectionState:
         database_config: immutables.Map[str, config.SettingValue],
         system_config: immutables.Map[str, config.SettingValue],
         cached_reflection: immutables.Map[str, Tuple[str, ...]],
-        config_spec: config.Spec,
     ):
         self._tx_count = time.monotonic_ns()
         self._init_current_tx(
@@ -882,7 +872,6 @@ class CompilerConnectionState:
             database_config=database_config,
             system_config=system_config,
             cached_reflection=cached_reflection,
-            config_spec=config_spec,
         )
         self._savepoints_log = {}
 
@@ -900,7 +889,6 @@ class CompilerConnectionState:
         database_config: immutables.Map[str, config.SettingValue],
         system_config: immutables.Map[str, config.SettingValue],
         cached_reflection: immutables.Map[str, Tuple[str, ...]],
-        config_spec: config.Spec,
     ) -> None:
         assert isinstance(user_schema, s_schema.FlatSchema)
         assert isinstance(global_schema, s_schema.FlatSchema)
@@ -913,7 +901,6 @@ class CompilerConnectionState:
             database_config=database_config,
             system_config=system_config,
             cached_reflection=cached_reflection,
-            config_spec=config_spec,
         )
 
     def can_sync_to_savepoint(self, spid: int) -> bool:
@@ -965,7 +952,6 @@ class CompilerConnectionState:
             database_config=prior_state.database_config,
             system_config=prior_state.system_config,
             cached_reflection=prior_state.cached_reflection,
-            config_spec=prior_state.config_spec,
         )
 
         return prior_state
@@ -984,7 +970,6 @@ class CompilerConnectionState:
             database_config=latest_state.database_config,
             system_config=latest_state.system_config,
             cached_reflection=latest_state.cached_reflection,
-            config_spec=latest_state.config_spec,
         )
 
         return latest_state

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -28,18 +28,21 @@ from edb.edgeql.qltypes import ConfigScope
 from .ops import OpCode, Operation, SettingValue
 from .ops import spec_to_json, to_json, from_json, set_value, to_edgeql
 from .ops import value_from_json, value_to_json_value, coerce_single_value
-from .spec import Spec, Setting, load_spec_from_schema
+from .spec import (
+    Spec, FlatSpec, ChainedSpec, Setting,
+    load_spec_from_schema, load_ext_spec_from_schema,
+)
 from .types import ConfigType, CompositeConfigType
 
 
 __all__ = (
     'lookup',
-    'Spec', 'Setting', 'SettingValue',
+    'Spec', 'FlatSpec', 'ChainedSpec', 'Setting', 'SettingValue',
     'spec_to_json', 'to_json', 'to_edgeql', 'from_json', 'set_value',
     'value_from_json', 'value_to_json_value',
     'ConfigScope', 'OpCode', 'Operation',
     'ConfigType', 'CompositeConfigType',
-    'load_spec_from_schema',
+    'load_spec_from_schema', 'load_ext_spec_from_schema',
     'get_compilation_config',
     'coerce_single_value',
 )

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -80,5 +80,6 @@ def get_compilation_config(
     return immutables.Map((
         (k, v)
         for k, v in config.items()
+        if k in spec  # XXX!!!
         if spec[k].affects_compilation
     ))

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -83,6 +83,6 @@ def get_compilation_config(
     return immutables.Map((
         (k, v)
         for k, v in config.items()
-        if k in spec  # XXX!!!
+        if k in spec
         if spec[k].affects_compilation
     ))

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -147,6 +147,10 @@ class Operation(NamedTuple):
             or self.opcode is OpCode.CONFIG_RESET
         )
 
+        # XXX: For now, just fail to track extension config state
+        if '::' in self.setting_name:
+            return storage
+
         if self.scope != qltypes.ConfigScope.GLOBAL:
             setting = self.get_setting(spec)
             value = self.coerce_value(

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -147,10 +147,6 @@ class Operation(NamedTuple):
             or self.opcode is OpCode.CONFIG_RESET
         )
 
-        # XXX: For now, just fail to track extension config state
-        if self.setting_name not in spec and '::' in self.setting_name:
-            return storage
-
         if self.scope != qltypes.ConfigScope.GLOBAL:
             setting = self.get_setting(spec)
             value = self.coerce_value(

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -148,7 +148,7 @@ class Operation(NamedTuple):
         )
 
         # XXX: For now, just fail to track extension config state
-        if '::' in self.setting_name:
+        if self.setting_name not in spec and '::' in self.setting_name:
             return storage
 
         if self.scope != qltypes.ConfigScope.GLOBAL:

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -92,7 +92,6 @@ def coerce_object_set(
     for jv in values:
         new_value = types.CompositeConfigType.from_pyvalue(
             jv, spec=spec, tspec=setting.type,
-            # allow_missing=allow_missing,
         )
 
         if new_value in new_values:

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -199,12 +199,6 @@ class Operation(NamedTuple):
             storage = self._set_value(storage, value)
 
         elif self.opcode is OpCode.CONFIG_RESET:
-            if setting and isinstance(setting.type, types.ConfigTypeSpec):
-                raise errors.InternalServerError(
-                    f'unexpected CONFIGURE RESET on a non-primitive '
-                    f'configuration parameter: {self.setting_name}'
-                )
-
             try:
                 storage = storage.delete(self.setting_name)
             except KeyError:

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -140,7 +140,7 @@ def load_spec_from_schema(schema: s_schema.Schema) -> Spec:
 
     for ptr_name, p in cfg.get_pointers(schema).items(schema):
         pn = str(ptr_name)
-        if pn in ('id', '__type__'):
+        if pn in ('id', '__type__') or p.get_computable(schema):
             continue
 
         ptype = p.get_target(schema)

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -25,7 +25,6 @@ from edb import errors
 from edb.common import typeutils
 from edb.common import typing_inspect
 from edb.schema import objects as s_obj
-from edb.schema import name as s_name
 
 from edb.ir import statypes
 
@@ -117,8 +116,6 @@ class CompositeConfigType(ConfigType):
         data = dict(data)
         tname = data.pop('_tname', None)
         if tname is not None:
-            if '::' in tname:
-                tname = s_name.QualName.from_string(tname).name
             tspec = spec.get_type_by_name(tname)
         assert tspec
 
@@ -171,8 +168,6 @@ class CompositeConfigType(ConfigType):
 
                 tname = value.get('_tname', None)
                 if tname is not None:
-                    if '::' in tname:
-                        tname = s_name.QualName.from_string(tname).name
                     actual_f_type = spec.get_type_by_name(tname)
                 else:
                     actual_f_type = f_type

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -110,6 +110,9 @@ class CompositeConfigType(ConfigType):
                      tspec: statypes.CompositeTypeSpec,
                      spec: spec.Spec,
                      allow_missing=False) -> CompositeConfigType:
+        if allow_missing and data is None:
+            return None  # type: ignore
+
         if not isinstance(data, dict):
             raise cls._err(tspec, f'expected a dict value, got {type(data)!r}')
 

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -80,6 +80,7 @@ cdef class Database:
         object _views
         object _introspection_lock
         object _state_serializers
+        object _user_config_spec
 
         readonly str name
         readonly object dbver
@@ -90,6 +91,7 @@ cdef class Database:
         readonly object extensions
 
     cdef schedule_config_update(self)
+    cdef get_user_config_spec(self)
 
     cdef _invalidate_caches(self)
     cdef _clear_state_serializers(self)
@@ -144,6 +146,7 @@ cdef class DatabaseConnectionView:
         object _in_tx_savepoints
         object _in_tx_user_schema_pickled
         object _in_tx_user_schema
+        object _in_tx_user_config_spec
         object _in_tx_global_schema_pickled
         object _in_tx_global_schema
         object _in_tx_new_types
@@ -190,6 +193,7 @@ cdef class DatabaseConnectionView:
         self, user_schema, extensions, global_schema, cached_reflection
     )
 
+    cdef get_user_config_spec(self)
     cpdef get_config_spec(self)
 
     cpdef get_session_config(self)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -956,7 +956,7 @@ cdef class DatabaseConnectionView:
 
         for op in ops:
             if op.scope is config.ConfigScope.INSTANCE:
-                await self._db._index.apply_system_config_op(conn, op)
+                await self._db._index.apply_system_config_op(conn, op, self)
             elif op.scope is config.ConfigScope.DATABASE:
                 self.set_database_config(
                     op.apply(settings, self.get_database_config()),
@@ -1241,9 +1241,9 @@ cdef class DatabaseIndex:
     def iter_dbs(self):
         return iter(self._dbs.values())
 
-    async def _save_system_overrides(self, conn):
+    async def _save_system_overrides(self, conn, spec):
         data = config.to_json(
-            self._sys_config_spec,
+            spec,
             self._sys_config,
             setting_filter=lambda v: v.source == 'system override',
             include_source=False,
@@ -1263,8 +1263,13 @@ cdef class DatabaseIndex:
             ).generate(block)
         await conn.sql_execute(block.to_string().encode())
 
-    async def apply_system_config_op(self, conn, op):
-        spec = self._sys_config_spec
+    async def apply_system_config_op(self, conn, op, dbv):
+        # spec = self._sys_config_spec
+
+        # XXX: NOT THE RIGHT WAY TO DO THIS!
+        # AND VERY DODGY ON A SYSTEM LEVEL???
+        spec = config.load_spec_from_schema(dbv.get_schema())
+
         op_value = op.get_setting(spec)
         if op.opcode is not None:
             allow_missing = (
@@ -1278,10 +1283,10 @@ cdef class DatabaseIndex:
         # the callbacks below, because certain config changes
         # may cause the backend connection to drop.
         self.update_sys_config(
-            op.apply(self._sys_config_spec, self._sys_config)
+            op.apply(spec, self._sys_config)
         )
 
-        await self._save_system_overrides(conn)
+        await self._save_system_overrides(conn, spec)
 
         if op.opcode is config.OpCode.CONFIG_ADD:
             await self._server._on_system_config_add(op.setting_name, op_value)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -448,7 +448,16 @@ cdef class DatabaseConnectionView:
             )
 
     cpdef get_config_spec(self):
-        return self._db._index._sys_config_spec
+        # XXX: PERF: DO BETTER; absolutely do not reload it every time
+        local_spec = config.load_ext_spec_from_schema(
+            self.get_user_schema(),
+            self._db._index._std_schema,
+        )
+        return config.ChainedSpec(
+            self._db._index._sys_config_spec,
+            local_spec,
+        )
+        # return self._db._index._sys_config_spec
 
     cdef set_session_config(self, new_conf):
         if self._in_tx:

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -922,6 +922,9 @@ cdef class DatabaseConnectionView:
             if self._in_tx_with_sysconfig:
                 side_effects |= SideEffects.InstanceConfigChanges
             if self._in_tx_with_dbconfig:
+                self._db_config_temp = self._in_tx_db_config
+                self._db_config_dbver = self._db.dbver
+
                 self.update_database_config()
                 side_effects |= SideEffects.DatabaseConfigChanges
             if query_unit.global_schema is not None:
@@ -967,6 +970,9 @@ cdef class DatabaseConnectionView:
         if self._in_tx_with_sysconfig:
             side_effects |= SideEffects.InstanceConfigChanges
         if self._in_tx_with_dbconfig:
+            self._db_config_temp = self._in_tx_db_config
+            self._db_config_dbver = self._db.dbver
+
             self.update_database_config()
             side_effects |= SideEffects.DatabaseConfigChanges
         if global_schema is not None:

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -231,11 +231,11 @@ cdef class Database:
     cdef _invalidate_caches(self):
         self._eql_to_compiled.clear()
         self._sql_to_compiled.clear()
+        # XXX: FIXME: Only invalidate when spec actually changes?
+        self._user_config_spec = None
 
     cdef _clear_state_serializers(self):
         self._state_serializers.clear()
-        # XXX: FIXME: Only invalidate when spec actually changes?
-        self._user_config_spec = None
 
     cdef _cache_compiled_query(self, key, compiled: dbstate.QueryUnitGroup):
         assert compiled.cacheable

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -177,6 +177,7 @@ cdef class Database:
 
         self.db_config = db_config
         self.user_schema = user_schema
+        self._user_config_spec = None
         self.reflection_cache = reflection_cache
         self.backend_ids = backend_ids
         self.extensions = extensions
@@ -216,6 +217,14 @@ cdef class Database:
             self.db_config = db_config
         self._invalidate_caches()
 
+    cdef get_user_config_spec(self):
+        if self._user_config_spec is None:
+            self._user_config_spec = config.load_ext_spec_from_schema(
+                self.user_schema,
+                self._index._std_schema,
+            )
+        return self._user_config_spec
+
     cdef _update_backend_ids(self, new_types):
         self.backend_ids.update(new_types)
 
@@ -225,6 +234,8 @@ cdef class Database:
 
     cdef _clear_state_serializers(self):
         self._state_serializers.clear()
+        # XXX: FIXME: Only invalidate when spec actually changes?
+        self._user_config_spec = None
 
     cdef _cache_compiled_query(self, key, compiled: dbstate.QueryUnitGroup):
         assert compiled.cacheable
@@ -354,6 +365,7 @@ cdef class DatabaseConnectionView:
         self._in_tx_global_schema = None
         self._in_tx_global_schema_pickled = None
         self._in_tx_new_types = {}
+        self._in_tx_user_config_spec = None
         self._in_tx_state_serializer = None
         self._tx_error = False
         self._in_tx_dbver = 0
@@ -447,17 +459,22 @@ cdef class DatabaseConnectionView:
                 self._protocol_version, new_serializer
             )
 
+    cdef get_user_config_spec(self):
+        if self._in_tx:
+            if self._in_tx_user_config_spec is None:
+                self._in_tx_user_config_spec = config.load_ext_spec_from_schema(
+                    self.get_user_schema(),
+                    self._db._index._std_schema,
+                )
+            return self._in_tx_user_config_spec
+        else:
+            return self._db.get_user_config_spec()
+
     cpdef get_config_spec(self):
-        # XXX: PERF: DO BETTER; absolutely do not reload it every time
-        local_spec = config.load_ext_spec_from_schema(
-            self.get_user_schema(),
-            self._db._index._std_schema,
-        )
         return config.ChainedSpec(
             self._db._index._sys_config_spec,
-            local_spec,
+            self.get_user_config_spec(),
         )
-        # return self._db._index._sys_config_spec
 
     cdef set_session_config(self, new_conf):
         if self._in_tx:
@@ -802,6 +819,7 @@ cdef class DatabaseConnectionView:
         self._in_tx_modaliases = self._modaliases
         self._in_tx_user_schema = self._db.user_schema
         self._in_tx_global_schema = self._db._index._global_schema
+        self._in_tx_user_config_spec = self._db.get_user_config_spec()
         self._in_tx_state_serializer = self._state_serializer
 
     cdef _apply_in_tx(self, query_unit):
@@ -818,6 +836,8 @@ cdef class DatabaseConnectionView:
         if query_unit.user_schema is not None:
             self._in_tx_user_schema_pickled = query_unit.user_schema
             self._in_tx_user_schema = None
+            # XXX: FIXME: Only invalidate when spec actually changes?
+            self._in_tx_user_config_spec = None
         if query_unit.global_schema is not None:
             self._in_tx_global_schema_pickled = query_unit.global_schema
             self._in_tx_global_schema = None
@@ -1273,11 +1293,9 @@ cdef class DatabaseIndex:
         await conn.sql_execute(block.to_string().encode())
 
     async def apply_system_config_op(self, conn, op, dbv):
-        # spec = self._sys_config_spec
-
-        # XXX: NOT THE RIGHT WAY TO DO THIS!
-        # AND VERY DODGY ON A SYSTEM LEVEL???
-        spec = config.load_spec_from_schema(dbv.get_schema())
+        # XXX: Is it actually legit to have INSTANCE configs of
+        # database local extension configs?
+        spec = dbv.get_config_spec()
 
         op_value = op.get_setting(spec)
         if op.opcode is not None:

--- a/edb/server/pgcon/pgcon.pxd
+++ b/edb/server/pgcon/pgcon.pxd
@@ -159,7 +159,8 @@ cdef class PGConnection:
     cdef make_clean_stmt_message(self, bytes stmt_name)
     cdef make_auth_password_md5_message(self, bytes salt)
     cdef send_query_unit_group(
-        self, object query_unit_group, object bind_datas, bytes state,
+        self, object query_unit_group, bint sync,
+        object bind_datas, bytes state,
         ssize_t start, ssize_t end, int dbver, object parse_array
     )
 

--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -51,6 +51,9 @@ cdef recode_bind_args_for_script(
 ):
     cdef:
         WriteBuffer bind_data
+        ssize_t i
+        ssize_t oidx
+        ssize_t iidx
 
     unit_group = compiled.query_unit_group
 
@@ -76,8 +79,8 @@ cdef recode_bind_args_for_script(
         bind_data.write_int16(<int16_t>num_args)
 
         if query_unit.in_type_args:
-            for arg in query_unit.in_type_args:
-                oidx = arg.outer_idx
+            for iidx, arg in enumerate(query_unit.in_type_args):
+                oidx = arg.outer_idx if arg.outer_idx is not None else iidx
                 barg = recoded[positions[oidx]:positions[oidx+1]]
                 bind_data.write_bytes(barg)
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -971,7 +971,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             self.debug_print('EXECUTE', query_req.source.text())
 
         metrics.edgeql_query_compilations.inc(1.0, 'cache')
-        force_script = any(x.set_global for x in query_unit_group)
+        force_script = any(x.needs_readback for x in query_unit_group)
         if (
             _dbview.in_tx_error()
             or query_unit_group[0].tx_savepoint_rollback

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1356,7 +1356,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
             user_schema = await tenant.introspect_user_schema(pgcon)
             global_schema = await tenant.introspect_global_schema(pgcon)
-            db_config = await tenant.introspect_db_config(pgcon)
+            db_config = await tenant.introspect_db_config(pgcon, user_schema)
             dump_protocol = self.max_protocol
 
             schema_ddl, schema_dynamic_ddl, schema_ids, blocks = (

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -42,6 +42,7 @@ from edb.server.protocol cimport args_ser
 from edb.server.protocol cimport frontend
 from edb.server.pgproto.pgproto cimport WriteBuffer
 from edb.server.pgcon cimport pgcon
+from edb.server.pgcon import errors as pgerror
 
 
 cdef object FMT_NONE = compiler.OutputFormat.NONE
@@ -201,7 +202,7 @@ async def execute_script(
     cdef:
         bytes state = None, orig_state = None
         ssize_t sent = 0
-        bint in_tx
+        bint in_tx, sync, no_sync
         object user_schema, extensions, cached_reflection, global_schema
         WriteBuffer bind_data
         int dbver = dbv.dbver
@@ -210,6 +211,8 @@ async def execute_script(
     user_schema = extensions = cached_reflection = global_schema = None
     unit_group = compiled.query_unit_group
 
+    sync = False
+    no_sync = False
     in_tx = dbv.in_tx()
     if not in_tx:
         orig_state = state = dbv.serialize_state()
@@ -240,19 +243,24 @@ async def execute_script(
                 # execute everything up to that point at once,
                 # finished by a FLUSH.
                 if idx >= sent:
+                    no_sync = False
                     for n in range(idx, len(unit_group)):
                         ng = unit_group[n]
                         if ng.ddl_stmt_id or ng.set_global:
                             sent = n + 1
+                            if ng.set_global:
+                                no_sync = True
                             break
                     else:
                         sent = len(unit_group)
 
+                    sync = sent == len(unit_group) and not no_sync
                     bind_array = args_ser.recode_bind_args_for_script(
                         dbv, compiled, bind_args, idx, sent)
                     dbver = dbv.dbver
                     conn.send_query_unit_group(
                         unit_group,
+                        sync,
                         bind_array,
                         state,
                         idx,
@@ -327,6 +335,11 @@ async def execute_script(
             # Abort the implicit transaction
             dbv.abort_tx()
 
+        # If something went wrong that is *not* on the backend side, force
+        # an error to occur on the SQL side.
+        if not isinstance(e, pgerror.BackendError):
+            await conn.force_error()
+
         raise
 
     else:
@@ -343,7 +356,7 @@ async def execute_script(
             dbv.set_state_serializer(unit_group.state_serializer)
 
     finally:
-        if sent and sent < len(unit_group):
+        if sent and not sync:
             await conn.sync()
 
     return data
@@ -505,7 +518,8 @@ async def execute_json(
 
     bind_args = _encode_args(args)
 
-    if len(qug) > 1:
+    force_script = any(x.set_global for x in qug)
+    if len(qug) > 1 or force_script:
         data = await execute_script(
             be_conn,
             dbv,

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -560,7 +560,7 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         else:
             authmethod = await self.tenant.get_auth_method(
                 user, self._transport_proto)
-            authmethod_name = authmethod._tspec.name
+            authmethod_name = authmethod._tspec.name.split('::')[1]
 
         if authmethod_name == 'SCRAM':
             await self._auth_scram(user)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1150,7 +1150,8 @@ class Server(BaseServer):
                     )
                     user_schema = await self._tenant.introspect_user_schema(
                         conn, global_schema)
-                    config = await self._tenant.introspect_db_config(conn)
+                    config = await self._tenant.introspect_db_config(
+                        conn, user_schema)
                     try:
                         logger.info("repairing database '%s'", dbname)
                         sql += bootstrap.prepare_repair_patch(

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1003,8 +1003,8 @@ class Tenant(ha_base.ClusterProtocol):
         return self._dbindex.remove_view(dbview_)
 
     def schedule_reported_config_if_needed(self, setting_name: str) -> None:
-        setting = self._server._config_settings[setting_name]  # TODO
-        if setting.report and self._accept_new_tasks:
+        setting = self._server._config_settings.get(setting_name)  # TODO
+        if setting and setting.report and self._accept_new_tasks:
             self.create_task(self._load_reported_config(), interruptable=True)
 
     def load_jwcrypto(self) -> None:

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -980,7 +980,7 @@ class Tenant(ha_base.ClusterProtocol):
 
         default_method = self._server.get_default_auth_method(transport)
         auth_type = self._server._config_settings.get_type_by_name(  # TODO
-            default_method.value
+            f'cfg::{default_method.value}'
         )
         return auth_type()
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -371,13 +371,15 @@ class BaseHTTPTestCase(TestCase):
         http_con: http.client.HTTPConnection,
         params: Optional[dict[str, str]] = None,
         *,
+        prefix: Optional[str] = None,
         headers: Optional[dict[str, str]] = None,
         method: str = "GET",
         body: bytes = b"",
         path: str = "",
     ):
         url = f'https://{http_con.host}:{http_con.port}'
-        prefix = self.get_api_prefix()
+        if prefix is None:
+            prefix = self.get_api_prefix()
         if prefix:
             url = f'{url}{prefix}'
         if path:
@@ -402,6 +404,7 @@ class BaseHTTPTestCase(TestCase):
         http_con: http.client.HTTPConnection,
         params: Optional[dict[str, str]] = None,
         *,
+        prefix: Optional[str] = None,
         headers: Optional[dict[str, str]] = None,
         method: str = "GET",
         body: bytes = b"",
@@ -410,6 +413,7 @@ class BaseHTTPTestCase(TestCase):
         self.http_con_send_request(
             http_con,
             params,
+            prefix=prefix,
             headers=headers,
             method=method,
             body=body,
@@ -422,6 +426,7 @@ class BaseHTTPTestCase(TestCase):
         http_con: http.client.HTTPConnection,
         params: Optional[dict[str, str]] = None,
         *,
+        prefix: Optional[str] = None,
         body: Any,
         path: str = "",
     ):
@@ -430,6 +435,7 @@ class BaseHTTPTestCase(TestCase):
             params,
             method="POST",
             body=json.dumps(body).encode(),
+            prefix=prefix,
             headers={"Content-Type": "application/json"},
             path=path,
         )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16040,7 +16040,6 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                 objs=[],
             )
 
-        # TODO: test that users can't create them
         # TODO: redacted annotation?
 
         # TODO: This should all work, instead!

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16136,6 +16136,8 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             describe current database config
         ''')
         test_expected = textwrap.dedent('''\
+        CONFIGURE CURRENT DATABASE SET ext::conf::Config::config_name := \
+'ready';
         CONFIGURE CURRENT DATABASE INSERT ext::conf::Obj {
             name := '1',
             value := 'foo',
@@ -16145,12 +16147,10 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             value := 'bar',
         };
         CONFIGURE CURRENT DATABASE INSERT ext::conf::SubObj {
-            value := 'baz',
-            name := '3',
             extra := 42,
+            name := '3',
+            value := 'baz',
         };
-        CONFIGURE CURRENT DATABASE SET ext::conf::Config::config_name := \
-'ready';
         ''')
         self.assertEqual(val, test_expected)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16042,8 +16042,6 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                 objs=[],
             )
 
-        # TODO: redacted annotation?
-
         # TODO: This should all work, instead!
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError, ""):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16041,7 +16041,6 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             )
 
         # TODO: test that users can't create them
-        # TODO: test describe
         # TODO: redacted annotation?
 
         # TODO: This should all work, instead!
@@ -16093,6 +16092,26 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                 dict(name='3', value='baz', tname='ext::conf::SubObj'),
             ],
         )
+
+        val = await self.con.query_single('''
+            describe current database config
+        ''')
+        test_expected = textwrap.dedent('''\
+        CONFIGURE CURRENT DATABASE INSERT ext::conf::Obj {
+            name := '1',
+            value := 'foo',
+        };
+        CONFIGURE CURRENT DATABASE INSERT ext::conf::Obj {
+            name := '2',
+            value := 'bar',
+        };
+        CONFIGURE CURRENT DATABASE INSERT ext::conf::SubObj {
+            value := 'baz',
+            name := '3',
+        };
+        CONFIGURE CURRENT DATABASE SET config_name := 'test';
+        ''')
+        self.assertEqual(val, test_expected)
 
         await self.con.execute('''
             configure current database reset ext::conf::Obj

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16137,7 +16137,6 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         val = await self.con.query_single('''
             describe current database config
         ''')
-        # XXX! config_name is *wrong* here!!
         test_expected = textwrap.dedent('''\
         CONFIGURE CURRENT DATABASE INSERT ext::conf::Obj {
             name := '1',
@@ -16152,7 +16151,8 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             name := '3',
             extra := 42,
         };
-        CONFIGURE CURRENT DATABASE SET config_name := 'ready';
+        CONFIGURE CURRENT DATABASE SET ext::conf::Config::config_name := \
+'ready';
         ''')
         self.assertEqual(val, test_expected)
 

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -377,3 +377,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                     SET fallback := false;
                 }
             ''')
+
+    async def test_edgeql_userddl_28(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"cannot extend system type"):
+            await self.con.execute(r'''
+            create type Foo extending cfg::ConfigObject;
+            ''')

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -468,6 +468,11 @@ class TestServerConfig(tb.QueryTestCase):
         #     INSERT TestSessionConfig { name := 'foo' };
         # ''')
 
+        # await self.con.query('''
+        #     CONFIGURE CURRENT DATABASE
+        #     RESET TestSessionConfig FILTER .name = 'foo'
+        # ''')
+
         with self.assertRaisesRegex(
                 edgedb.ConfigurationError,
                 'unrecognized configuration object'):

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -460,17 +460,15 @@ class TestServerConfig(tb.QueryTestCase):
                 CONFIGURE SESSION INSERT TestSessionConfig { name := 'foo' };
             ''')
 
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                'CONFIGURE DATABASE INSERT is not supported'):
-            await self.con.query('''
-                CONFIGURE CURRENT DATABASE
-                INSERT TestSessionConfig { name := 'foo' };
-            ''')
+        # XXX: Test this properly?
+        await self.con.query('''
+            CONFIGURE CURRENT DATABASE
+            INSERT TestSessionConfig { name := 'foo' };
+        ''')
 
         with self.assertRaisesRegex(
-                edgedb.QueryError,
-                'module must be either \'cfg\' or empty'):
+                edgedb.ConfigurationError,
+                'unrecognized configuration object'):
             await self.con.query('''
                 CONFIGURE INSTANCE INSERT cf::TestInstanceConfig {
                     name := 'foo'

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -460,11 +460,13 @@ class TestServerConfig(tb.QueryTestCase):
                 CONFIGURE SESSION INSERT TestSessionConfig { name := 'foo' };
             ''')
 
+        # XXX: If this is uncommented... it causes other tests to
+        # bizarrely fail???
         # XXX: Test this properly?
-        await self.con.query('''
-            CONFIGURE CURRENT DATABASE
-            INSERT TestSessionConfig { name := 'foo' };
-        ''')
+        # await self.con.query('''
+        #     CONFIGURE CURRENT DATABASE
+        #     INSERT TestSessionConfig { name := 'foo' };
+        # ''')
 
         with self.assertRaisesRegex(
                 edgedb.ConfigurationError,

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -83,7 +83,7 @@ Port = types.ConfigTypeSpec(
 )
 
 
-testspec1 = spec.Spec(
+testspec1 = spec.FlatSpec(
     spec.Setting(
         'int',
         type=int,


### PR DESCRIPTION
The core user/extension author facing design is that there is a new
config object for extension configs:
```
CREATE ABSTRACT TYPE cfg::ExtensionConfig EXTENDING cfg::ConfigObject {
    CREATE REQUIRED SINGLE LINK cfg -> cfg::AbstractConfig {
        CREATE DELEGATED CONSTRAINT std::exclusive;
    };
};
```
and `AbstractConfig` is updated with a computed back-link:
```
ALTER TYPE cfg::AbstractConfig {
    CREATE MULTI LINK extensions := .<cfg[IS cfg::ExtensionConfig];
};
```

Extension authors can extend ``cfg::ExtensionConfig`` to store
extension specific configuration information. They create a type:
```
CREATE TYPE ext::whatever::WhateverConfig {
    CREATE PROPERTY value -> str { ... }
}
```
The values can then be configured with
```
CONFIGURE CURRENT DATABASE ext::whatever::WhateverConfig::value := ...
```

The config introspection system will generate three `WhateverConfig`
objects, one for each of the `AbstractConfig` subtypes. They can be
fetched directly or via the `extensions` link on
`cfg::AbstractConfig`.

Most of the work in supporting this is in making the config
introspection views understand it properly, and in making sure the
config specs are available where needed.

---

Another change, which probably should have been done separately but
which would be hard to cleanly extract now, is supporting `CONFIGURE
CURRENT DATABASE INSERT`, instead of only supporting it for `INSTANCE`
configs.

This is fairly involved. For `INSTANCE` configs the object-level
operations simply report what changes to make; these changes are then
interpreted by the config system and the entire updated instance
config is written back wholesale as a json blob.
Because we lack the machinery to nicely write back an updated database
config based on changes made in the middle of a script, I instead made
it so that we can do all of the work in SQL, which is kind of a pain because
it is a bunch of jsonb.

I didn't want to try to detect exclusive constraint violations on
those json objects in SQL, so instead we detect the error when
interpreting the returned data from the config operation. This
required adding a new code path to abort

Still TODO:
- [ ] Support extension-defined SESSION configs
- [ ] Support redacting config values?
- [ ] Support a second layer of nesting in extension objects
- [ ] See if introspection performance can be improved
- [ ] Test dumps