### PR TITLE
Add conversion from Duration to timedelta

### DIFF
--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -24,6 +24,7 @@ import dataclasses
 import functools
 import re
 import struct
+import datetime
 
 import immutables
 

--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -336,6 +336,9 @@ class Duration(ScalarType):
             ret.append('0S')
         return ''.join(ret)
 
+    def to_timedelta(self) -> datetime.timedelta:
+        return datetime.timedelta(microseconds=self.to_microseconds())
+
     def to_backend_str(self) -> str:
         return f'{self.to_microseconds()}us'
 


### PR DESCRIPTION
Adds a useful conversion method to the `edb.ir.statypes.Duration` class.