### PR TITLE
Expose digest functions from pgcrypto in `ext::pgcrypto`

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_08_23_00_00
+EDGEDB_CATALOG_VERSION = 2023_08_24_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/lib/ext/pgcrypto.edgeql
+++ b/edb/lib/ext/pgcrypto.edgeql
@@ -1,0 +1,59 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+create extension package pgcrypto version '1.3' {
+    set ext_module := "ext::pgcrypto";
+    set sql_extensions := ["pgcrypto >=1.3"];
+
+    create module ext::pgcrypto;
+
+    create function ext::pgcrypto::digest(
+        data: std::str,
+        type: std::str,
+    ) -> std::bytes {
+        set volatility := 'Immutable';
+        using sql function 'edgedb.digest';
+    };
+
+    create function ext::pgcrypto::digest(
+        data: std::bytes,
+        type: std::str,
+    ) -> std::bytes {
+        set volatility := 'Immutable';
+        using sql function 'edgedb.digest';
+    };
+
+    create function ext::pgcrypto::hmac(
+        data: std::str,
+        key: std::str,
+        type: std::str,
+    ) -> std::bytes {
+        set volatility := 'Immutable';
+        using sql function 'edgedb.hmac';
+    };
+
+    create function ext::pgcrypto::hmac(
+        data: std::bytes,
+        key: std::bytes,
+        type: std::str,
+    ) -> std::bytes {
+        set volatility := 'Immutable';
+        using sql function 'edgedb.hmac';
+    };
+};

--- a/tests/test_edgeql_ext_pgcrypto.py
+++ b/tests/test_edgeql_ext_pgcrypto.py
@@ -1,0 +1,105 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from edb.testbase import server as tb
+
+
+class TestEdgeQLExtPgCrypto(tb.QueryTestCase):
+    EXTENSIONS = ['pgcrypto']
+    BACKEND_SUPERUSER = True
+
+    async def test_edgeql_ext_pgcrypto_digest(self):
+        CASES = [
+            ("md5", "rL0Y20zC+Fzt72VPzMSk2A=="),
+            ("sha1", "C+7Hteo/D9vJXQ3UfzxbwnXaijM="),
+            ("sha224", "CAj2TmDViXn8tnbJbsk4Jw3qQkRa7vzTpOb42w=="),
+            ("sha256", "LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564="),
+            ("sha384", "mMEf/f3VQGdrGhN8saIrKnA1DJpEFx1rEYDGvly7LuP3n"
+                       + "VMsih3Z7y6OCOdSo7q7"),
+            ("sha512", "9/u6bgY2+JDlb7vzKD5STG+jIErimDgtYkdB0NxmODJuK"
+                       + "CxBvl5CVNiCB3LFUYosWowMf37aGVlK\nfrU5RT4e1w=="),
+        ]
+
+        for hash_type, result in CASES:
+            with self.subTest(hash_type):
+                await self.assert_query_result(
+                    """
+                        select ext::pgcrypto::digest(<str>$data, <str>$type)
+                    """,
+                    [result],
+                    variables={
+                        "data": "foo",
+                        "type": hash_type,
+                    },
+                    json_only=True,
+                )
+
+                await self.assert_query_result(
+                    """
+                        select ext::pgcrypto::digest(<bytes>$data, <str>$type)
+                    """,
+                    [result],
+                    variables={
+                        "data": b"foo",
+                        "type": hash_type,
+                    },
+                    json_only=True,
+                )
+
+    async def test_edgeql_ext_pgcrypto_hmac(self):
+        CASES = [
+            ("md5", "Mbbbnl60rdtC8abKBzZ63A=="),
+            ("sha1", "hdFVxV7ShqMAvRzxJN4I2H6RTzo="),
+            ("sha224", "1/UIN19LWxwjbS3xuFDeJHSpE2RIdnBeYr14zA=="),
+            ("sha256", "FHkzIYqqvAuLEKKzpcNGhMjZQ0G88QpHNtxycPd0GFE="),
+            ("sha384", "HZBw0Hy3dG4GZMzMbOwfqZbcf0Y2iYKs+iCV7o1z/iW1"
+                       + "tuMieZAM2w/TcqNlTkHF"),
+            ("sha512", "JCV9chBYKmXHMexVFZyBhMwkwCSJRT5YWH9x9EwjotYb"
+                       + "S3IVSonRey1JRIqEUuoGb0/FaivOrUXA\niFcv/M2z2A=="),
+        ]
+
+        for hash_type, result in CASES:
+            with self.subTest(hash_type):
+                await self.assert_query_result(
+                    """
+                        select ext::pgcrypto::hmac(
+                            <str>$data, <str>$key, <str>$type)
+                    """,
+                    [result],
+                    variables={
+                        "data": "foo",
+                        "key": "bar",
+                        "type": hash_type,
+                    },
+                    json_only=True,
+                )
+
+                await self.assert_query_result(
+                    """
+                        select ext::pgcrypto::hmac(
+                            <bytes>$data, <bytes>$key, <str>$type)
+                    """,
+                    [result],
+                    variables={
+                        "data": b"foo",
+                        "key": b"bar",
+                        "type": hash_type,
+                    },
+                    json_only=True,
+                )


### PR DESCRIPTION
This adds a bundled `pgcrypto` extension that exposes two overloaded
functions: `ext::pgcrypto::digest` and `ext::pgcrypto::hmac`, which map
1:1 to the functions provided by the extension.

Fixes: #5065
