### PR TITLE
Avoid duplicating outputs for value/serialized for tuples

### DIFF
--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -271,3 +271,13 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             count,
             1,
             f"ORDER BY subquery not optimized out")
+
+    def test_codegen_tuples_no_extra_serialized(self):
+        sql = self._compile('''
+            select (select (1, 'foo'))
+       ''')
+
+        self.assertNotIn(
+            "0_serialized~1", sql,
+            "pointless extra query outputs",
+        )


### PR DESCRIPTION
Tuple queries with extra levels of nesting like
`select (select (1, 'foo'))` currently duplicates some of the query outputs:
```
    "expr-3~2"."0_value~1" AS "0_value~2",
    "expr-3~2"."1_value~1" AS "1_value~2",
    "expr-3~2"."0_value~1" AS "0_serialized~1",
    "expr-3~2"."1_value~1" AS "1_serialized~1"
```

This seemed weird, because we do have machinery for reusing existing
outputs in order to avoid exactly this sort of duplication
(`find_path_output`).

I originally thought that the bug was in `find_path_output`, which worked by
searching through `path_namespace` for an expression that matched and
whose `(path_id, aspect)` key was already present in `path_outputs`.
I thought that the problem was that if the `path_id` got remapped by the
`view_path_id_map`, the existing output would be under a different
path_id, and so we wouldn't find it.

But after thinking about it more, I realized that this didn't really
make sense: we remap path_ids at the start of get_path_output, so
there shouldn't be a mismatch between `path_namespace` and
`path_outputs`: both should use the inner remapped name.

Then, looking at backtraces from where this divergence showed up, I
realized that we were actually going out of our way to make this
happen: we were *reversing* the map on the tuple element path ids and
recursively calling `_get_path_output`, which then called
`get_path_var` which reapplied the map, causing the divergence.

Fortunately I was able to just rip all that code out. I suspect that
it was made unnecessary by #2274 or #3034.