### PR TITLE
Fix named-tuple params that also appear in the schema

### DIFF
--- a/edb/edgeql/compiler/tuple_args.py
+++ b/edb/edgeql/compiler/tuple_args.py
@@ -95,6 +95,7 @@ import dataclasses
 from typing import *
 
 from edb import errors
+from edb.common.typeutils import not_none
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtypeutils
@@ -121,7 +122,7 @@ MAX_NESTING = 20
 
 def _lmost_is_array(typ: irast.ParamTransType) -> bool:
     while isinstance(typ, irast.ParamTuple):
-        typ = typ.typs[0]
+        _, typ = typ.typs[0]
     return isinstance(typ, irast.ParamArray)
 
 
@@ -166,13 +167,14 @@ def translate_type(
             )
 
         elif irtypeutils.is_tuple(typ):
-            # HACK: We don't bother dealing with named tuples. We just
-            # generate anonymous tuples and it all still works out.
             return irast.ParamTuple(
                 typeref=typ,
                 idx=start,
                 typs=tuple(
-                    trans(t, in_array=in_array, depth=depth + 1)
+                    (
+                        t.element_name,
+                        trans(t, in_array=in_array, depth=depth + 1),
+                    )
                     for t in typ.subtypes
                 ),
             )
@@ -222,6 +224,21 @@ def _index(expr: qlast.Expr, idx: qlast.Expr) -> qlast.Indirection:
     return qlast.Indirection(arg=expr, indirection=[qlast.Index(index=idx)])
 
 
+def _make_tuple(
+    fields: Sequence[tuple[Optional[str], qlast.Expr]]
+) -> qlast.NamedTuple | qlast.Tuple:
+    is_named = fields and fields[0][0]
+    if is_named:
+        return qlast.NamedTuple(elements=[
+            qlast.TupleElement(name=qlast.ObjectRef(name=not_none(f)), val=e)
+            for f, e in fields
+        ])
+    else:
+        return qlast.Tuple(
+            elements=[e for _, e in fields]
+        )
+
+
 def make_decoder(
     ptyp: irast.ParamTransType,
     qparams: tuple[irast.Param, ...],
@@ -252,7 +269,7 @@ def make_decoder(
             return expr
 
         elif isinstance(typ, irast.ParamTuple):
-            return qlast.Tuple(elements=[mk(t, idx=idx) for t in typ.typs])
+            return _make_tuple([(f, mk(t, idx=idx)) for f, t in typ.typs])
 
         elif isinstance(typ, irast.ParamArray):
             inner_idx_alias, inner_idx = _get_alias('idx', ctx=ctx)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -612,12 +612,12 @@ class ParamScalar(ParamTransType):
 
 @dataclasses.dataclass(eq=False)
 class ParamTuple(ParamTransType):
-    typs: tuple[ParamTransType, ...]
+    typs: tuple[tuple[typing.Optional[str], ParamTransType], ...]
 
     def flatten(self) -> tuple[typing.Any, ...]:
         return (
             (int(qltypes.TypeTag.TUPLE), self.idx)
-            + tuple(x.flatten() for x in self.typs)
+            + tuple(x.flatten() for _, x in self.typs)
         )
 
 

--- a/tests/schemas/casts.esdl
+++ b/tests/schemas/casts.esdl
@@ -39,6 +39,7 @@ type Test {
     property p_float64 -> float64;
     property p_bigint -> bigint;
     property p_decimal -> decimal;
+    property p_tup -> tuple<test: str>;
 }
 
 type JSONTest {

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2883,6 +2883,43 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             variables=(None, 11111),
         )
 
+    async def test_edgeql_casts_tuple_params_09(self):
+        await self.con.query('''
+            WITH
+              p := <tuple<test: str>>$0
+            insert Test { p_tup := p };
+        ''', ('foo',))
+
+        await self.assert_query_result(
+            '''
+            select Test { p_tup } filter exists .p_tup
+            ''',
+            [{'p_tup': {'test': 'foo'}}],
+        )
+        await self.assert_query_result(
+            '''
+            WITH
+              p := <tuple<test: str>>$0
+            select p
+            ''',
+            [{'test': 'foo'}],
+            variables=(('foo',),),
+        )
+        await self.assert_query_result(
+            '''
+            select <tuple<test: str>>$0
+            ''',
+            [{'test': 'foo'}],
+            variables=(('foo',),),
+        )
+        await self.assert_query_result(
+            '''
+            select <array<tuple<test: str>>>$0
+            ''',
+            [[{'test': 'foo'}, {'test': 'bar'}]],
+            variables=([('foo',), ('bar',)],),
+        )
+
     async def test_edgeql_cast_empty_set_to_array_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
The tuple argument decoder code simply ignores whether a tuple is
named, figuring that named tuples and unnamed tuples have the same
representation in the generated SQL, so why bother. (It was called out
as a "HACK" in the comments.)

But they only have the same representation when they are represented
as a `record`. If the tuple type appears in the schema, it gets
represented as a named composite type and we no longer have the right
representation.

Just do it right. Fixes #5789.