### PR TITLE
Make sure block parser is loaded in server

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -186,6 +186,7 @@ def _init_parsers():
         allow_rebuild=devmode.is_in_dev_mode(),
         paralellize=True,
         grammars=[
+            ql_grammar.block,
             ql_grammar.fragment,
         ]
     )


### PR DESCRIPTION
This is a regression from #5856.  The `block` parser is needed to
compile the stdlib when the cache isn't there and for bootstrap scripts.
