### PR TITLE
Postpone evaluation of function parameter defaults

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8670,6 +8670,18 @@ type default::Foo {
                     create required link identity: ext::auth::Identity;
                     create constraint exclusive on ((.identity, .primary));
                 };
+
+                create scalar type ext::auth::JWTAlgo extending enum<RS256>;
+
+                create function ext::auth::_jwt_check_signature(
+                    algo: ext::auth::JWTAlgo = ext::auth::JWTAlgo.RS256,
+                ) -> bool
+                {
+                    set volatility := 'Immutable';
+                    using (
+                        algo = ext::auth::JWTAlgo.RS256
+                    );
+                };
             }
         """)
 


### PR DESCRIPTION
Currently, the default expression is compiled too early and might fail
if it depends on schema bits that have not been defined yet.
