### PR TITLE
Add JWT parsing functions to ext::auth

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2408,6 +2408,10 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                     (modroot := sn.UnqualName(modname.name.partition('::')[0]))
                     in s_schema.STD_MODULES
                 )
+                and not (
+                    modroot == s_schema.EXT_MODULE
+                    and context.transient_derivation
+                )
             ):
                 raise errors.SchemaDefinitionError(
                     f'cannot {self._delta_action} {self.get_verbosename()}: '

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
         ],
     ]
 
+EXT_MODULE = sn.UnqualName('ext')
+
 STD_MODULES = (
     sn.UnqualName('std'),
     sn.UnqualName('schema'),
@@ -65,7 +67,7 @@ STD_MODULES = (
     sn.UnqualName('pg'),
     sn.UnqualName('std::_test'),
     sn.UnqualName('fts'),
-    sn.UnqualName('ext'),
+    EXT_MODULE,
     sn.UnqualName('std::enc'),
 )
 

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -54,15 +54,14 @@ class BaseHttpExtensionTest(server.QueryTestCase):
         return f'/db/{dbname}/{extpath}'
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def get_setup_script(cls):
+        script = super().get_setup_script()
 
         extname = cls.get_extension_name()
-        cls.loop.run_until_complete(
-            cls.con.execute(f'CREATE EXTENSION {extname};')
-        )
-        for q in cls.EXTENSION_SETUP:
-            cls.loop.run_until_complete(cls.con.execute(q))
+        script += f'\nCREATE EXTENSION pgcrypto;\n'
+        script += f'\nCREATE EXTENSION {extname};\n'
+        script += "\n".join(cls.EXTENSION_SETUP)
+        return script
 
     @classmethod
     def tearDownClass(cls):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -667,16 +667,7 @@ class ClusterTestCase(BaseHTTPTestCase):
 
     @classmethod
     async def tearDownSingleDB(cls):
-        await cls.con.execute(
-            'START MIGRATION TO {};\n'
-            'POPULATE MIGRATION;\n'
-            'COMMIT MIGRATION;'
-        )
-        while m := await cls.con.query_single(
-            "SELECT schema::Migration { name } "
-            "FILTER NOT EXISTS .<parents LIMIT 1"
-        ):
-            await cls.con.execute(f"DROP MIGRATION {m.name}")
+        await cls.con.execute("RESET SCHEMA TO initial;")
 
     @classmethod
     def fetch_metrics(cls) -> str:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -342,8 +342,9 @@ class BaseHTTPTestCase(TestCase):
     def get_api_prefix(cls):
         return ''
 
+    @classmethod
     @contextlib.contextmanager
-    def http_con(self, server, keep_alive=True):
+    def http_con(cls, server, keep_alive=True):
         conn_args = server.get_connect_args()
         tls_context = ssl.create_default_context(
             ssl.Purpose.SERVER_AUTH,
@@ -366,8 +367,9 @@ class BaseHTTPTestCase(TestCase):
         finally:
             con.true_close()
 
+    @classmethod
     def http_con_send_request(
-        self,
+        cls,
         http_con: http.client.HTTPConnection,
         params: Optional[dict[str, str]] = None,
         *,
@@ -379,7 +381,7 @@ class BaseHTTPTestCase(TestCase):
     ):
         url = f'https://{http_con.host}:{http_con.port}'
         if prefix is None:
-            prefix = self.get_api_prefix()
+            prefix = cls.get_api_prefix()
         if prefix:
             url = f'{url}{prefix}'
         if path:
@@ -390,8 +392,9 @@ class BaseHTTPTestCase(TestCase):
             headers = {}
         http_con.request(method, url, body=body, headers=headers)
 
+    @classmethod
     def http_con_read_response(
-        self,
+        cls,
         http_con: http.client.HTTPConnection,
     ) -> tuple[bytes, dict[str, str], int]:
         resp = http_con.getresponse()
@@ -399,8 +402,9 @@ class BaseHTTPTestCase(TestCase):
         resp_headers = {k.lower(): v for k, v in resp.getheaders()}
         return resp_body, resp_headers, resp.status
 
+    @classmethod
     def http_con_request(
-        self,
+        cls,
         http_con: http.client.HTTPConnection,
         params: Optional[dict[str, str]] = None,
         *,
@@ -410,7 +414,7 @@ class BaseHTTPTestCase(TestCase):
         body: bytes = b"",
         path: str = "",
     ) -> tuple[bytes, dict[str, str], int]:
-        self.http_con_send_request(
+        cls.http_con_send_request(
             http_con,
             params,
             prefix=prefix,
@@ -419,10 +423,11 @@ class BaseHTTPTestCase(TestCase):
             body=body,
             path=path,
         )
-        return self.http_con_read_response(http_con)
+        return cls.http_con_read_response(http_con)
 
+    @classmethod
     def http_con_json_request(
-        self,
+        cls,
         http_con: http.client.HTTPConnection,
         params: Optional[dict[str, str]] = None,
         *,
@@ -430,7 +435,7 @@ class BaseHTTPTestCase(TestCase):
         body: Any,
         path: str = "",
     ):
-        response, headers, status = self.http_con_request(
+        response, headers, status = cls.http_con_request(
             http_con,
             params,
             method="POST",
@@ -745,10 +750,11 @@ class ClusterTestCase(BaseHTTPTestCase):
             finally:
                 await tx.rollback()
 
+    @classmethod
     @contextlib.contextmanager
-    def http_con(self, server=None):
+    def http_con(cls, server=None):
         if server is None:
-            server = self
+            server = cls
         with super().http_con(server) as http_con:
             yield http_con
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -185,6 +185,9 @@ class MockHttpServerHandler(http.server.BaseHTTPRequestHandler):
         server = urllib.parse.unquote(server)
         self.server.owner.handle_request('POST', server, path, self)
 
+    def log_message(self, *args):
+        pass
+
 
 ResponseType = tuple[dict[str, Any] | list[dict[str, Any]], int]
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -339,6 +339,29 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         """,
     ]
 
+    @classmethod
+    def get_setup_script(cls):
+        res = super().get_setup_script()
+
+        import os.path
+
+        # HACK: As a debugging cycle hack, when RELOAD is true, we reload the
+        # extension package from the file, so we can test without a bootstrap.
+        RELOAD = True
+
+        if RELOAD:
+            root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            with open(os.path.join(root, 'edb/lib/ext/auth.edgeql')) as f:
+                contents = f.read()
+            to_add = '''
+                drop extension package auth version '1.0';
+                create extension pgcrypto;
+            ''' + contents
+            splice = '__internal_testmode := true;'
+            res = res.replace(splice, splice + to_add)
+
+        return res
+
     def http_con_send_request(self, *args, headers=None, **kwargs):
         """Inject a test header.
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -347,7 +347,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
         # HACK: As a debugging cycle hack, when RELOAD is true, we reload the
         # extension package from the file, so we can test without a bootstrap.
-        RELOAD = True
+        RELOAD = False
 
         if RELOAD:
             root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -355,7 +355,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 contents = f.read()
             to_add = '''
                 drop extension package auth version '1.0';
-                create extension pgcrypto;
+                create extension auth;
             ''' + contents
             splice = '__internal_testmode := true;'
             res = res.replace(splice, splice + to_add)


### PR DESCRIPTION
With this, setting the `ext::auth::client_token` global will yield an
identity via the `ext::auth::ClientTokenIdentity` global if the token is
valid.
