### PR TITLE
Fix instance-name JWT test without devmode

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -72,6 +72,7 @@ class BaseCluster:
     ):
         self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
 
+        self._edgedb_cmd.append('--instance-name=_localtest')
         self._edgedb_cmd.append('--tls-cert-mode=generate_self_signed')
         self._edgedb_cmd.append('--jose-key-mode=generate')
 

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -72,7 +72,9 @@ class BaseCluster:
     ):
         self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
 
-        self._edgedb_cmd.append('--instance-name=_localtest')
+        if "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" not in os.environ:
+            self._edgedb_cmd.append('--instance-name=localtest')
+
         self._edgedb_cmd.append('--tls-cert-mode=generate_self_signed')
         self._edgedb_cmd.append('--jose-key-mode=generate')
 

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -277,7 +277,7 @@ class TestServerAuth(tb.ConnectedTestCase):
                 [],
                 [("roles", ["edgedb"])],
                 [("databases", ["edgedb"])],
-                [("instances", ["_localdev"])],
+                [("instances", ["_localtest"])],
             ]
 
             for params in good_keys:

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -277,7 +277,7 @@ class TestServerAuth(tb.ConnectedTestCase):
                 [],
                 [("roles", ["edgedb"])],
                 [("databases", ["edgedb"])],
-                [("instances", ["_localtest"])],
+                [("instances", ["localtest"])],
             ]
 
             for params in good_keys:


### PR DESCRIPTION
Fixes `test_server_auth_jwt_1()` added in #5197, which is failing in nightly builds.