### PR TITLE
Fix use of certain empty sets from multiple optional arguments

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -416,7 +416,6 @@ def new_empty_rvar(
     nullrel = pgast.NullRelation(
         path_id=ir_set.path_id, type_or_ptr_ref=ir_set.typeref)
     rvar = rvar_for_rel(nullrel, ctx=ctx)
-    pathctx.put_rvar_path_bond(rvar, ir_set.path_id)
     return rvar
 
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -413,12 +413,51 @@ def _get_set_rvar(
     return process_set_as_root(ir_set, ctx=ctx)
 
 
+def _get_source_rvar(
+    ir_set: irast.Set,
+    scope_stmt: pgast.SelectStmt,
+    *,
+    ctx: context.CompilerContextLevel,
+) -> pgast.PathRangeVar:
+    is_optional = (
+        ctx.scope_tree.is_optional(ir_set.path_id) or
+        ir_set.path_id in ctx.force_optional
+    )
+
+    if not is_optional:
+        rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
+        relctx.include_rvar(
+            scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx
+        )
+    else:
+        # If the path is optional in the context we are in, then we
+        # need to put optional wrapping around the join with the base table.
+        with ctx.subrel() as subctx:
+            stmt, optrel = prepare_optional_rel(
+                ir_set=ir_set, stmt=subctx.rel, ctx=subctx)
+            subctx.pending_query = subctx.rel = stmt
+
+            rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=subctx)
+            rvars = new_source_set_rvar(ir_set, rvar)
+            rvars = finalize_optional_rel(
+                ir_set, optrel=optrel, rvars=rvars, ctx=subctx)
+
+            rvar = _include_rvars(rvars, scope_stmt=scope_stmt, ctx=ctx)
+
+    return rvar
+
+
 def ensure_source_rvar(
     ir_set: irast.Set,
     stmt: pgast.Query,
     *,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
+    """Make sure that a source aspect is available for ir_set.
+
+    If no aspect is available, compile it. If value/identity is available
+    but source is not, select from the base relation and join it in.
+    """
 
     rvar = relctx.maybe_get_path_rvar(
         stmt, ir_set.path_id, aspect='source', ctx=ctx)
@@ -442,10 +481,7 @@ def ensure_source_rvar(
                 rvar = relctx.get_path_rvar(
                     scope_stmt, ir_set.path_id, aspect='value', ctx=ctx)
             else:
-                rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
-                relctx.include_rvar(
-                    scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx
-                )
+                rvar = _get_source_rvar(ir_set, scope_stmt, ctx=ctx)
             pathctx.put_path_rvar(stmt, ir_set.path_id, rvar, aspect='source')
 
     return rvar


### PR DESCRIPTION
The problem is that if a source aspect was missing for some set (like
because it came from an array_unpack, or was a function argument),
when ensure_source_rvar is run at the common binding point, it
unconditionally joined against the bare object table, which causes us
to lose our NULL values and get no rows returned instead, which means
our optional functions don't work.

We need to put an optional wrapping around it. Fortunately all the
optional wrapping machinery is easy to reuse here.

I also needed to new_empty_rvar to not ask to be joined against its
path_id, which will obviously never work.

Fixes #5979