### PR TITLE
Disallow more broken sorts of function overloads

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1417,6 +1417,39 @@ class Function(
                         )
                     )
 
+                if not all(
+                    new_p.get_typemod(schema)
+                    == ext_p.get_typemod(schema)
+                    for new_p, ext_p in zip(new_params, ext_params)
+                ):
+                    # And also _all_ parameter names must match due to
+                    # current implementation constraints.
+                    my_sig = self.get_signature_as_str(schema)
+                    other_sig = f.get_signature_as_str(schema)
+                    raise errors.UnsupportedFeatureError(
+                        f'cannot create the `{my_sig}` '
+                        f'function: overloading an object type-receiving '
+                        f'function with differences in the type modifiers of '
+                        f'parameters is not supported',
+                        context=srcctx,
+                        details=(
+                            f"Other function is defined as `{other_sig}`"
+                        )
+                    )
+
+                if (
+                    new_params[this_diff_param].get_typemod(schema) !=
+                    ft.TypeModifier.SingletonType
+                ):
+                    my_sig = self.get_signature_as_str(schema)
+                    raise errors.UnsupportedFeatureError(
+                        f'cannot create the `{my_sig}` function: '
+                        f'object type-receiving '
+                        f'functions may not be overloaded on an OPTIONAL '
+                        f'parameter',
+                        context=srcctx,
+                    )
+
                 diff_param = this_diff_param
                 overloads.append(f)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4707,6 +4707,32 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     USING ('bar');
             """)
 
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            r"cannot create the .* function: overloading an object "
+            r"type-receiving function with differences in the type modifiers "
+            r"of parameters is not supported",
+        ):
+            await self.con.execute(r"""
+                CREATE FUNCTION func32_a(obj: Foo, a: int32) -> str
+                    USING ('foo');
+                CREATE FUNCTION func32_a(obj: Bar, a: OPTIONAL int32) -> str
+                    USING ('bar');
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            r"cannot create the .* function: object "
+            r"type-receiving functions may not be overloaded on an OPTIONAL "
+            r"parameter"
+        ):
+            await self.con.execute(r"""
+                CREATE FUNCTION func32_a(obj: OPTIONAL Foo) -> str
+                    USING ('foo');
+                CREATE FUNCTION func32_a(obj: OPTIONAL Bar) -> str
+                    USING ('bar');
+            """)
+
     async def test_edgeql_ddl_function_33(self):
         await self.con.execute(r"""
             CREATE TYPE Parent;


### PR DESCRIPTION
* Disallow changing type modifiers between overloaded versions
 * Disallow overloading on an OPTIONAL argument

Fixes #5980.