### PR TITLE
Prevent user modifications to extension modules

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2391,14 +2391,15 @@ class ObjectCommand(Command, Generic[so.Object_T]):
 
             if (
                 isinstance(self.classname, sn.QualName)
+                and (modname := self.classname.get_module_name())
                 and (
-                    (modname := self.classname.get_module_name())
+                    (modroot := sn.UnqualName(modname.name.partition('::')[0]))
                     in s_schema.STD_MODULES
                 )
             ):
                 raise errors.SchemaDefinitionError(
                     f'cannot {self._delta_action} {self.get_verbosename()}: '
-                    f'module {modname} is read-only',
+                    f'module {modroot} is read-only',
                     context=self.source_context)
 
     def get_verbosename(self, parent: Optional[str] = None) -> str:

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -66,8 +66,10 @@ class ModuleCommand(
         super()._validate_legal_command(schema, context)
 
         last = str(self.classname)
+        first = last
         enclosing = None
         if '::' in str(self.classname):
+            first, _, _ = str(self.classname).partition('::')
             enclosing, _, last = str(self.classname).rpartition('::')
             if not schema.has_module(enclosing):
                 raise errors.UnknownModuleError(
@@ -79,18 +81,11 @@ class ModuleCommand(
 
         if (
             not context.stdmode and not context.testmode
-            and (
-                (modname := self.classname) in s_schema.STD_MODULES
-                or (
-                    enclosing
-                    and (modname := sn.UnqualName(enclosing))
-                    in s_schema.STD_MODULES
-                )
-            )
+            and sn.UnqualName(first) in s_schema.STD_MODULES
         ):
             raise errors.SchemaDefinitionError(
                 f'cannot {self._delta_action} {self.get_verbosename()}: '
-                f'module {modname} is read-only',
+                f'module {first} is read-only',
                 context=self.source_context)
 
 

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -385,3 +385,35 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             await self.con.execute(r'''
             create type Foo extending cfg::ConfigObject;
             ''')
+
+    async def test_edgeql_userddl_29(self):
+        await self.con.execute('''
+            configure session set __internal_testmode := true;
+            create module ext::_test;
+            create type ext::_test::X;
+            configure session reset __internal_testmode;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.SchemaDefinitionError, "module ext is read-only"):
+            await self.con.execute('''
+                create module ext::_test::foo;
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.SchemaDefinitionError, "module ext is read-only"):
+            await self.con.execute('''
+                create type ext::_test::foo;
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.SchemaDefinitionError, "module ext is read-only"):
+            await self.con.execute('''
+                alter type ext::_test::X { create property x -> str };
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.SchemaDefinitionError, "module ext is read-only"):
+            await self.con.execute('''
+                drop type ext::_test::X;
+            ''')


### PR DESCRIPTION
We need to check the *first* component of a module name against the
std module list, not the full thing.

Fixes #5989.