### PR TITLE
Transient types

### DIFF
--- a/edb/lib/fts.edgeql
+++ b/edb/lib/fts.edgeql
@@ -25,6 +25,10 @@ CREATE ABSTRACT INDEX fts::textsearch(named only language: std::str) {
     SET code := 'gin (to_tsvector(__kw_language__, __col__))';
 };
 
+CREATE SCALAR TYPE fts::searchable_str {
+    SET transient := true;
+};
+
 ## Functions
 ## ---------
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2393,6 +2393,9 @@ class CreateScalarType(ScalarTypeMetaCommand,
         else:
             ops = dbops.CommandGroup()
 
+            if scalar.get_transient(schema):
+                return ops
+
             base = types.get_scalar_base(schema, scalar)
 
             new_domain_name = types.pg_type_from_scalar(schema, scalar)

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -469,6 +469,7 @@ def _build_object_mutation_shape(
             issubclass(mcls, (s_scalars.ScalarType, s_types.Collection))
             and not issubclass(mcls, s_types.CollectionExprAlias)
             and not cmd.get_attribute_value('abstract')
+            and not cmd.get_attribute_value('transient')
         ):
             kind = f'"schema::{mcls.__name__}"'
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -138,6 +138,10 @@ class Type(
         int,
         default=None, inheritable=False)
 
+    # True for types that cannot be persistently stored.
+    # See fts::searchable_str for an example.
+    transient = so.SchemaField(bool, default=False)
+
     def compare(
         self,
         other: so.Object,

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1480,6 +1480,7 @@ async def _init_stdlib(
             FILTER
                 .builtin
                 AND NOT (.abstract ?? False)
+                AND NOT (.transient ?? False)
                 AND schema::Type IS schema::ScalarType | schema::Tuple
             SET {
                 backend_id := sys::_get_pg_type_for_edgedb_type(
@@ -1503,6 +1504,7 @@ async def _init_stdlib(
             FILTER
                 .builtin
                 AND NOT (.abstract ?? False)
+                AND NOT (.transient ?? False)
             SET {
                 backend_id := sys::_get_pg_type_for_edgedb_type(
                     .id,


### PR DESCRIPTION
For fts::searchable_str we need a type that will never
be stored in the database or returned in a query result.

This is similar to the type being abstract, but not in
the terms of polymorhism.

TODO:
- check that transient types are not returned in a query result
  or stored in a database
