### PR TITLE
Fix collisions between function parameters named id and the property

### DIFF
--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -57,7 +57,7 @@ def compile_ir_to_sql_tree(
     ignore_shapes: bool = False,
     explicit_top_cast: Optional[irast.TypeRef] = None,
     singleton_mode: bool = False,
-    use_named_params: Optional[tuple[str, ...]] = None,
+    named_param_prefix: Optional[tuple[str, ...]] = None,
     expected_cardinality_one: bool = False,
     expand_inhviews: bool = False,
     external_rvars: Optional[
@@ -107,7 +107,7 @@ def compile_ir_to_sql_tree(
         env = context.Environment(
             output_format=output_format,
             expected_cardinality_one=expected_cardinality_one,
-            use_named_params=use_named_params,
+            named_param_prefix=named_param_prefix,
             query_params=list(tuple(query_params) + tuple(query_globals)),
             type_rewrites=type_rewrites,
             ignore_object_shapes=ignore_shapes,

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -57,7 +57,7 @@ def compile_ir_to_sql_tree(
     ignore_shapes: bool = False,
     explicit_top_cast: Optional[irast.TypeRef] = None,
     singleton_mode: bool = False,
-    use_named_params: bool = False,
+    use_named_params: Optional[tuple[str, ...]] = None,
     expected_cardinality_one: bool = False,
     expand_inhviews: bool = False,
     external_rvars: Optional[

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -397,7 +397,7 @@ def fini_toplevel(
     stmt.ctes[:0] = list(ctx.param_ctes.values())
     stmt.ctes[:0] = list(ctx.type_ctes.values())
 
-    if ctx.env.use_named_params is None:
+    if ctx.env.named_param_prefix is None:
         # Adding unused parameters into a CTE
 
         # Find the used parameters by searching the query, so we don't
@@ -438,7 +438,7 @@ def populate_argmap(
     for map_extra in (False, True):
         for param in params:
             if (
-                ctx.env.use_named_params is not None
+                ctx.env.named_param_prefix is not None
                 and not param.name.isdecimal()
             ):
                 continue

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -397,7 +397,7 @@ def fini_toplevel(
     stmt.ctes[:0] = list(ctx.param_ctes.values())
     stmt.ctes[:0] = list(ctx.type_ctes.values())
 
-    if not ctx.env.use_named_params:
+    if ctx.env.use_named_params is None:
         # Adding unused parameters into a CTE
 
         # Find the used parameters by searching the query, so we don't
@@ -437,7 +437,10 @@ def populate_argmap(
     logical_index = 1
     for map_extra in (False, True):
         for param in params:
-            if ctx.env.use_named_params and not param.name.isdecimal():
+            if (
+                ctx.env.use_named_params is not None
+                and not param.name.isdecimal()
+            ):
                 continue
             if param.name.startswith('__edb_arg_') != map_extra:
                 continue

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -475,7 +475,7 @@ class Environment:
 
     aliases: aliases.AliasGenerator
     output_format: Optional[OutputFormat]
-    use_named_params: bool
+    use_named_params: Optional[tuple[str, ...]]
     ptrref_source_visibility: Dict[irast.BasePointerRef, bool]
     expected_cardinality_one: bool
     ignore_object_shapes: bool
@@ -496,7 +496,7 @@ class Environment:
         self,
         *,
         output_format: Optional[OutputFormat],
-        use_named_params: bool,
+        use_named_params: Optional[tuple[str, ...]],
         expected_cardinality_one: bool,
         ignore_object_shapes: bool,
         singleton_mode: bool,

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -475,7 +475,7 @@ class Environment:
 
     aliases: aliases.AliasGenerator
     output_format: Optional[OutputFormat]
-    use_named_params: Optional[tuple[str, ...]]
+    named_param_prefix: Optional[tuple[str, ...]]
     ptrref_source_visibility: Dict[irast.BasePointerRef, bool]
     expected_cardinality_one: bool
     ignore_object_shapes: bool
@@ -496,7 +496,7 @@ class Environment:
         self,
         *,
         output_format: Optional[OutputFormat],
-        use_named_params: Optional[tuple[str, ...]],
+        named_param_prefix: Optional[tuple[str, ...]],
         expected_cardinality_one: bool,
         ignore_object_shapes: bool,
         singleton_mode: bool,
@@ -512,7 +512,7 @@ class Environment:
     ) -> None:
         self.aliases = aliases.AliasGenerator()
         self.output_format = output_format
-        self.use_named_params = use_named_params
+        self.named_param_prefix = named_param_prefix
         self.ptrref_source_visibility = {}
         self.expected_cardinality_one = expected_cardinality_one
         self.ignore_object_shapes = ignore_object_shapes

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -126,9 +126,9 @@ def compile_Parameter(
     params = [p for p in ctx.env.query_params if p.name == expr.name]
     param = params[0] if params else None
 
-    if not is_decimal and ctx.env.use_named_params:
+    if not is_decimal and ctx.env.use_named_params is not None:
         result = pgast.ColumnRef(
-            name=(expr.name, ),
+            name=ctx.env.use_named_params + (expr.name,),
             nullable=not expr.required,
         )
     elif param and param.sub_params:

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -126,9 +126,9 @@ def compile_Parameter(
     params = [p for p in ctx.env.query_params if p.name == expr.name]
     param = params[0] if params else None
 
-    if not is_decimal and ctx.env.use_named_params is not None:
+    if not is_decimal and ctx.env.named_param_prefix is not None:
         result = pgast.ColumnRef(
-            name=ctx.env.use_named_params + (expr.name,),
+            name=ctx.env.named_param_prefix + (expr.name,),
             nullable=not expr.required,
         )
     elif param and param.sub_params:

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1241,7 +1241,7 @@ class FunctionCommand(MetaCommand):
             explicit_top_cast=irtyputils.type_to_typeref(  # note: no cache
                 schema, func.get_return_type(schema)),
             output_format=compiler.OutputFormat.NATIVE,
-            use_named_params=self.get_pgname(func, schema)[-1:],
+            named_param_prefix=self.get_pgname(func, schema)[-1:],
         )
 
         return codegen.generate_source(sql_res.ast)
@@ -1367,7 +1367,7 @@ class FunctionCommand(MetaCommand):
                 explicit_top_cast=irtyputils.type_to_typeref(  # note: no cache
                     schema, func.get_return_type(schema)),
                 output_format=compiler.OutputFormat.NATIVE,
-                use_named_params=self.get_pgname(func, schema)[-1:],
+                named_param_prefix=self.get_pgname(func, schema)[-1:],
                 backend_runtime_params=context.backend_runtime_params,
             )
             body = codegen.generate_source(sql_res.ast)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1241,7 +1241,8 @@ class FunctionCommand(MetaCommand):
             explicit_top_cast=irtyputils.type_to_typeref(  # note: no cache
                 schema, func.get_return_type(schema)),
             output_format=compiler.OutputFormat.NATIVE,
-            use_named_params=True)
+            use_named_params=self.get_pgname(func, schema)[-1:],
+        )
 
         return codegen.generate_source(sql_res.ast)
 
@@ -1366,7 +1367,7 @@ class FunctionCommand(MetaCommand):
                 explicit_top_cast=irtyputils.type_to_typeref(  # note: no cache
                     schema, func.get_return_type(schema)),
                 output_format=compiler.OutputFormat.NATIVE,
-                use_named_params=True,
+                use_named_params=self.get_pgname(func, schema)[-1:],
                 backend_runtime_params=context.backend_runtime_params,
             )
             body = codegen.generate_source(sql_res.ast)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5060,7 +5060,7 @@ def _make_json_caster(
 
     cast_sql_res = compiler.compile_ir_to_sql_tree(
         cast_ir,
-        use_named_params=True,
+        use_named_params=(),
         singleton_mode=True,
     )
     cast_sql = codegen.generate_source(cast_sql_res.ast)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5060,7 +5060,7 @@ def _make_json_caster(
 
     cast_sql_res = compiler.compile_ir_to_sql_tree(
         cast_ir,
-        use_named_params=(),
+        named_param_prefix=(),
         singleton_mode=True,
     )
     cast_sql = codegen.generate_source(cast_sql_res.ast)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4876,6 +4876,25 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 USING (assert_exists(foo));
             """)
 
+    async def test_edgeql_ddl_function_37(self):
+        obj = await self.con.query_single('''
+            create type X;
+            create function getUser(id: uuid) -> set of X {
+                using(
+                    select X filter .id = id
+                )
+            };
+            insert X;
+            insert X;
+        ''')
+        val = await self.con.query_single(
+            '''
+                select count(getUser(<uuid>$0))
+            ''',
+            obj.id,
+        )
+        self.assertEqual(val, 1)
+
     async def test_edgeql_ddl_function_rename_01(self):
         await self.con.execute("""
             CREATE FUNCTION foo(s: str) -> str {


### PR DESCRIPTION
We name function params their actual names, which can collide with the
`id` column in tables and produce bad results. It could maybe collide
with source and target in link tables too. It doesn't collide with
everything, because most columns get uuid names.

Qualify references to params with the function name.

Fixes #5935.