### PR TITLE
fix typo in doc for reset schema

### DIFF
--- a/docs/reference/ddl/migrations.rst
+++ b/docs/reference/ddl/migrations.rst
@@ -342,7 +342,7 @@ Reset the database schema to its initial state.
 
 .. eql:synopsis::
 
-    reset schema to inital ;
+    reset schema to initial ;
 
 .. warning::
 


### PR DESCRIPTION
Just little typo I found when searching how to reduce migration files.