### PR TITLE
Do not stack overflow on long arrays and similar

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -891,13 +891,9 @@ class RangeFunction(BaseRangeVar):
     functions: typing.List[FuncCall]
 
 
-class JoinExpr(BaseRangeVar):
-
+class JoinClause(BaseRangeVar):
     # Type of join
     type: str
-
-    # Left subtree
-    larg: BaseRangeVar
     # Right subtree
     rarg: BaseRangeVar
     # USING clause, if any
@@ -905,16 +901,31 @@ class JoinExpr(BaseRangeVar):
     # Qualifiers on join, if any
     quals: typing.Optional[BaseExpr] = None
 
-    def copy(self):
-        result = self.__class__()
-        result.copyfrom(self)
-        return result
 
-    def copyfrom(self, other):
-        self.larg = other.larg
-        self.rarg = other.rarg
-        self.quals = other.quals
-        self.type = other.type
+class JoinExpr(BaseRangeVar):
+    # Left subtree
+    larg: BaseRangeVar
+    # Join clauses
+    # We represent joins as being N-ary to avoid recursing too deeply
+    joins: list[JoinClause]
+
+    @classmethod
+    def make_inplace(
+        cls, *,
+        larg: BaseRangeVar,
+        type: str,
+        rarg: BaseRangeVar,
+        using_clause: typing.Optional[typing.List[ColumnRef]] = None,
+        quals: typing.Optional[BaseExpr] = None,
+    ) -> JoinExpr:
+        clause = JoinClause(
+            type=type, rarg=rarg, using_clause=using_clause, quals=quals
+        )
+        if isinstance(larg, JoinExpr):
+            larg.joins.append(clause)
+            return larg
+        else:
+            return JoinExpr(larg=larg, joins=[clause])
 
 
 class SubLink(ImmutableBaseExpr):

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -693,42 +693,44 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_JoinExpr(self, node: pgast.JoinExpr) -> None:
         self.visit(node.larg)
-        if node.rarg is not None:
+        for join in node.joins:
             self.new_lines = 1
-            if not node.quals and not node.using_clause:
+            if not join.quals and not join.using_clause:
                 join_type = 'CROSS'
             else:
-                join_type = node.type.upper()
+                join_type = join.type.upper()
             if join_type == 'INNER':
                 self.write('JOIN ')
             else:
                 self.write(join_type + ' JOIN ')
+            # XXX
             nested_join = (
-                isinstance(node.rarg, pgast.JoinExpr)
-                and node.rarg.rarg is not None
+                isinstance(join.rarg, pgast.JoinExpr)
+                and join.rarg.joins
+                # and node.rarg.rarg is not None
             )
             if nested_join:
                 self.write('(')
                 self.new_lines = 1
                 self.indentation += 1
-            self.visit(node.rarg)
+            self.visit(join.rarg)
             if nested_join:
                 self.indentation -= 1
                 self.new_lines = 1
                 self.write(')')
-            if node.quals is not None:
+            if join.quals is not None:
                 if not nested_join:
                     self.indentation += 1
                     self.new_lines = 1
                     self.write('ON ')
                 else:
                     self.write(' ON ')
-                self.visit(node.quals)
+                self.visit(join.quals)
                 if not nested_join:
                     self.indentation -= 1
-            elif node.using_clause:
+            elif join.using_clause:
                 self.write(" USING (")
-                self.visit_list(node.using_clause)
+                self.visit_list(join.using_clause)
                 self.write(")")
 
     def visit_Expr(self, node: pgast.Expr) -> None:

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -168,7 +168,8 @@ def each_base_rvar(rvar: pgast.BaseRangeVar) -> Iterator[pgast.BaseRangeVar]:
     while stack:
         rvar = stack.pop()
         if isinstance(rvar, pgast.JoinExpr):
-            stack.append(rvar.rarg)
+            for clause in reversed(rvar.joins):
+                stack.append(clause.rarg)
             stack.append(rvar.larg)
         else:
             yield rvar

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1319,7 +1319,7 @@ def _plain_join(
         larg = query.from_clause[0]
         rarg = right_rvar
 
-        query.from_clause[0] = pgast.JoinExpr(
+        query.from_clause[0] = pgast.JoinExpr.make_inplace(
             type=join_type, larg=larg, rarg=rarg, quals=condition)
 
 
@@ -1362,7 +1362,7 @@ def _lateral_union_join(
         larg = query.from_clause[0]
         rarg = right_rvar
 
-        query.from_clause[0] = pgast.JoinExpr(
+        query.from_clause[0] = pgast.JoinExpr.make_inplace(
             type='cross', larg=larg, rarg=rarg)
 
 

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -843,13 +843,15 @@ def _build_range_function(n: Node, c: Context) -> pgast.RangeFunction:
 def _build_join_expr(n: Node, c: Context) -> pgast.JoinExpr:
     return pgast.JoinExpr(
         alias=_maybe(n, c, "alias", _build_alias) or pgast.Alias(aliasname=""),
-        type=n["jointype"][5:],
         larg=_build_base_range_var(n["larg"], c),
-        rarg=_build_base_range_var(n["rarg"], c),
-        using_clause=_maybe_list(
-            n, c, "usingClause", _build_str, _as_column_ref
-        ),
-        quals=_maybe(n, c, "quals", _build_base_expr),
+        joins=[pgast.JoinClause(
+            type=n["jointype"][5:],
+            rarg=_build_base_range_var(n["rarg"], c),
+            using_clause=_maybe_list(
+                n, c, "usingClause", _build_str, _as_column_ref
+            ),
+            quals=_maybe(n, c, "quals", _build_base_expr),
+        )],
     )
 
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3557,6 +3557,17 @@ class TestExpressions(tb.QueryTestCase):
             [[1]],
         )
 
+    async def test_edgeql_expr_array_27(self):
+        # Big array with nontrivial elements
+        N = 350
+        body = '0+1, ' * N
+
+        await self.assert_query_result(
+            f'select [{body}]',
+            [[1] * N],
+            json_only=True,
+        )
+
     async def test_edgeql_expr_coalesce_01(self):
         await self.assert_query_result(
             r'''SELECT <int64>{} ?? 4 ?? 5;''',


### PR DESCRIPTION
Allow JoinExpr to be flattened, instead of representing an N-ary join
as an N-deep binary tree.

Fixes #4380.

The SQL query performance still seems sometimes pretty bad, though,
for some of these tests. I think it is because pg really doesn't like
to get huge numbers of arguments.

We might consider capping how many constants we are willing to
extract.  And for this particular array case, extracting full arrays
would be good too.