### PR TITLE
[3.x] Handle RecursionError better and centralize protocol error handling

### DIFF
--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -189,7 +189,7 @@ async def handle_request(
                 )
 
             ex, ex_type = execute.interpret_error(
-                ex, get_schema=_get_schema, server=server
+                ex, get_schema=_get_schema, server=server, from_graphql=True
             )
 
         err_dct = {

--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -180,25 +180,17 @@ async def handle_request(
         if issubclass(ex_type, gql_errors.GraphQLError):
             # XXX Fix this when LSP "location" objects are implemented
             ex_type = errors.QueryError
-        elif issubclass(ex_type, pgerrors.BackendError):
-            static_exc = errormech.static_interpret_backend_error(
-                ex.fields, from_graphql=True)
-
-            # only use the backend if schema is required
-            if static_exc is errormech.SchemaRequired:
-                ex = errormech.interpret_backend_error(
-                    s_schema.ChainedSchema(
-                        server._std_schema,
-                        db.user_schema,
-                        server.get_global_schema(),
-                    ),
-                    ex.fields,
-                    from_graphql=True,
+        else:
+            def _get_schema():
+                return s_schema.ChainedSchema(
+                    server._std_schema,
+                    db.user_schema,
+                    server.get_global_schema(),
                 )
-            else:
-                ex = static_exc
 
-            ex_type = type(ex)
+            ex, ex_type = execute.interpret_error(
+                ex, get_schema=_get_schema, server=server
+            )
 
         err_dct = {
             'message': f'{ex_type.__name__}: {ex}',

--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -176,8 +176,7 @@ async def handle_request(
         if debug.flags.server:
             markup.dump(ex)
 
-        ex_type = type(ex)
-        if issubclass(ex_type, gql_errors.GraphQLError):
+        if isinstance(ex, gql_errors.GraphQLError):
             # XXX Fix this when LSP "location" objects are implemented
             ex_type = errors.QueryError
         else:
@@ -188,9 +187,10 @@ async def handle_request(
                     server.get_global_schema(),
                 )
 
-            ex, ex_type = execute.interpret_error(
+            ex = execute.interpret_error(
                 ex, get_schema=_get_schema, server=server, from_graphql=True
             )
+            ex_type = type(ex)
 
         err_dct = {
             'message': f'{ex_type.__name__}: {ex}',

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -247,6 +247,11 @@ def run_codegen(
     codegen = pgcodegen.SQLSourceGenerator(pretty=pretty, reordered=reordered)
     try:
         codegen.visit(qtree)
+    except RecursionError:
+        # Don't try to wrap and add context to a recursion error,
+        # since the context might easily be too deeply recursive to
+        # process further down the pipe.
+        raise
     except pgcodegen.SQLSourceGeneratorError as e:  # pragma: no cover
         ctx = pgcodegen.SQLSourceGeneratorContext(
             qtree, codegen.result)

--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -77,7 +77,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
     cdef inline dbview.DatabaseConnectionView get_dbview(self)
 
-    cdef interpret_backend_error(self, exc)
+    cdef interpret_error(self, exc)
 
     cdef dbview.QueryRequestInfo parse_execute_request(self)
     cdef parse_output_format(self, bytes mode)

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1160,7 +1160,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         exc_code = None
 
-        exc, exc_type = self.interpret_error(exc)
+        exc = self.interpret_error(exc)
+        exc_type = type(exc)
 
         fields = {}
         if isinstance(exc, errors.EdgeDBError):
@@ -1850,7 +1851,7 @@ async def run_script(
         else:
             await conn._execute(compiled, b'', use_prep_stmt=0)
     except Exception as e:
-        exc, _ = conn.interpret_error(e)
+        exc = conn.interpret_error(e)
         if isinstance(exc, errors.EdgeDBError):
             raise exc from None
         else:

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1160,20 +1160,14 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         exc_code = None
 
-        if isinstance(exc, pgerror.BackendError):
-            exc = self.interpret_backend_error(exc)
+        exc, exc_type = self.interpret_error(exc)
 
         fields = {}
-        if (isinstance(exc, errors.EdgeDBError) and
-                type(exc) is not errors.EdgeDBError):
-            exc_code = exc.get_code()
+        if isinstance(exc, errors.EdgeDBError):
             fields.update(exc._attrs)
 
-        internal_error_code = errors.InternalServerError.get_code()
-        if not exc_code:
-            exc_code = internal_error_code
-
-        if (exc_code == internal_error_code
+        exc_code = exc_type.get_code()
+        if (exc_type is errors.InternalServerError
                 and not fields.get(base_errors.FIELD_HINT)):
             fields[base_errors.FIELD_HINT] = (
                 f'This is most likely a bug in EdgeDB. '
@@ -1207,32 +1201,12 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         self.write(buf)
 
-    cdef interpret_backend_error(self, exc):
-        try:
-            static_exc = errormech.static_interpret_backend_error(
-                exc.fields)
-
-            # only use the backend if schema is required
-            if static_exc is errormech.SchemaRequired:
-                exc = errormech.interpret_backend_error(
-                    self.get_dbview().get_schema(),
-                    exc.fields
-                )
-            elif isinstance(static_exc, (
-                    errors.DuplicateDatabaseDefinitionError,
-                    errors.UnknownDatabaseError)):
-                tenant_id = self.server.get_tenant_id()
-                message = static_exc.args[0].replace(f'{tenant_id}_', '')
-                exc = type(static_exc)(message)
-            else:
-                exc = static_exc
-
-        except Exception:
-            exc = RuntimeError(
-                'unhandled error while calling interpret_backend_error(); '
-                'run with EDGEDB_DEBUG_SERVER to debug.')
-
-        return exc
+    cdef interpret_error(self, exc):
+        return execute.interpret_error(
+            exc,
+            get_schema=lambda: self.get_dbview().get_schema(),
+            server=self.server,
+        )
 
     cdef write_status(self, bytes name, bytes value):
         cdef:
@@ -1875,8 +1849,8 @@ async def run_script(
             await conn._execute_script(compiled, b'')
         else:
             await conn._execute(compiled, b'', use_prep_stmt=0)
-    except pgerror.BackendError as e:
-        exc = conn.interpret_backend_error(e)
+    except Exception as e:
+        exc, _ = conn.interpret_error(e)
         if isinstance(exc, errors.EdgeDBError):
             raise exc from None
         else:

--- a/edb/server/protocol/edgeql_ext.pyx
+++ b/edb/server/protocol/edgeql_ext.pyx
@@ -140,14 +140,14 @@ async def handle_request(
                 db._index._global_schema,
             )
 
-        ex, ex_type = execute.interpret_error(
+        ex = execute.interpret_error(
             ex, get_schema=_get_schema, server=server
         )
 
         err_dct = {
             'message': str(ex),
-            'type': str(ex_type.__name__),
-            'code': ex_type.get_code(),
+            'type': str(type(ex).__name__),
+            'code': ex.get_code(),
         }
 
         response.body = json.dumps({'error': err_dct}).encode()

--- a/edb/server/protocol/edgeql_ext.pyx
+++ b/edb/server/protocol/edgeql_ext.pyx
@@ -29,6 +29,8 @@ from edb import edgeql
 from edb.server import defines as edbdef
 from edb.server.protocol import execute
 
+from edb.schema import schema as s_schema
+
 from edb.common import debug
 from edb.common import markup
 
@@ -44,7 +46,7 @@ from edb.server.pgproto.pgproto cimport WriteBuffer
 async def handle_request(
     object request,
     object response,
-    object db,
+    dbview.Database db,
     list args,
     object server,
 ):
@@ -131,10 +133,16 @@ async def handle_request(
         if debug.flags.server:
             markup.dump(ex)
 
-        ex_type = type(ex)
-        if not issubclass(ex_type, errors.EdgeDBError):
-            # XXX Fix this when LSP "location" objects are implemented
-            ex_type = errors.InternalServerError
+        def _get_schema():
+            return s_schema.ChainedSchema(
+                db._index._std_schema,
+                db.user_schema,
+                db._index._global_schema,
+            )
+
+        ex, ex_type = execute.interpret_error(
+            ex, get_schema=_get_schema, server=server
+        )
 
         err_dct = {
             'message': str(ex),

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -574,7 +574,7 @@ def interpret_error(
     get_schema: object,
     server: object,
     from_graphql: bool=False,
-) -> tuple[Exception, type]:
+) -> Exception:
 
     if isinstance(exc, RecursionError):
         exc = errors.UnsupportedFeatureError(
@@ -609,8 +609,12 @@ def interpret_error(
                 'unhandled error while calling interpret_backend_error(); '
                 'run with EDGEDB_DEBUG_SERVER to debug.')
 
-    exc_type = type(exc)
-    if not issubclass(exc_type, errors.EdgeDBError):
-        exc_type = errors.InternalServerError
+    if not isinstance(exc, errors.EdgeDBError):
+        nexc = errors.InternalServerError(
+            f'{type(exc).__name__}: {exc}').with_traceback(exc.__traceback__)
+        formatted = getattr(exc, '__formatted_error__', None)
+        if formatted:
+            nexc.__formatted_error__ = formatted
+        exc = nexc
 
-    return exc, exc_type
+    return exc

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -584,7 +584,9 @@ def interpret_error(
 
     elif isinstance(exc, pgerror.BackendError):
         try:
-            static_exc = errormech.static_interpret_backend_error(exc.fields)
+            static_exc = errormech.static_interpret_backend_error(
+                exc.fields, from_graphql=from_graphql
+            )
 
             # only use the backend if schema is required
             if static_exc is errormech.SchemaRequired:

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -578,8 +578,12 @@ def interpret_error(
 
     if isinstance(exc, RecursionError):
         exc = errors.UnsupportedFeatureError(
-            "query too deeply nested: the query caused the compiler "
-            "stack to overflow",
+            "The query caused the compiler "
+            "stack to overflow. It is likely too deeply nested.",
+            hint=(
+                "If the query does not contain deep nesting, "
+                "this may be a bug."
+            ),
         )
 
     elif isinstance(exc, pgerror.BackendError):

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -214,7 +214,7 @@ async def execute(db, server, queries: list):
                     if debug.flags.server:
                         markup.dump(ex)
 
-                    ex, ex_type = p_execute.interpret_error(
+                    ex = p_execute.interpret_error(
                         ex,
                         get_schema=lambda: dbv.get_schema(),
                         server=server,
@@ -222,7 +222,7 @@ async def execute(db, server, queries: list):
 
                     result.append({
                         'kind': 'error',
-                        'error': [ex_type.__name__, str(ex), {}],
+                        'error': [type(ex).__name__, str(ex), {}],
                     })
 
                     break

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -214,15 +214,15 @@ async def execute(db, server, queries: list):
                     if debug.flags.server:
                         markup.dump(ex)
 
-                    # TODO: copy proper error reporting from edgecon
-                    if not issubclass(type(ex), errors.EdgeDBError):
-                        ex_type = 'Error'
-                    else:
-                        ex_type = type(ex).__name__
+                    ex, ex_type = p_execute.interpret_error(
+                        ex,
+                        get_schema=lambda: dbv.get_schema(),
+                        server=server,
+                    )
 
                     result.append({
                         'kind': 'error',
-                        'error': [ex_type, str(ex), {}],
+                        'error': [ex_type.__name__, str(ex), {}],
                     })
 
                     break

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -8382,7 +8382,7 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            "query too deeply nested",
+            "caused the compiler stack to overflow",
         ):
             await self.con.query(f'''
                 with x := 1337, select {body}

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -8376,3 +8376,14 @@ aa \
             """,
             [R'aaaa\q\n'],
         )
+
+    async def test_edgeql_overflow_error(self):
+        body = 'x+' * 1600 + '0'
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            "query too deeply nested",
+        ):
+            await self.con.query(f'''
+                with x := 1337, select {body}
+            ''')

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -268,6 +268,14 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
             )
         )
 
+    def test_http_edgeql_query_14(self):
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                r'Minimum allowed value for positive_int_t is 0'):
+            self.edgeql_query(
+                r'''SELECT <positive_int_t>-1''',
+            )
+
     def test_http_edgeql_query_globals_01(self):
         Q = r'''select GlobalTest { gstr, garray, gid, gdef, gdef2 }'''
 

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -189,7 +189,9 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
                     {
                         'kind': 'error',
                         'error': [
-                            'Error', 'array index 2 is out of bounds', {}
+                            'InvalidValueError',
+                            'array index 2 is out of bounds',
+                            {},
                         ]
                     }
                 ]


### PR DESCRIPTION
Make stack overflows consistently produce an UnsupportedFeatureError
instead of producing various ISEs.
They aren't the same class of compiler/server bugs as other ISEs,
typically.

In order to handle this properly for all our protocols, add a
centralized interpret_error function to execute. It turns out that
http and notebook weren't interpreting backend errors at all.

This is the 3.x version. It's close to the original version of #6003,
with some multi-tenant stuff removed, before it was rebased on
top of https://github.com/edgedb/edgedb/pull/5921.

Closes https://github.com/edgedb/edgedb/issues/4677.