### PR TITLE
Fix an infinite recursion when casting object->json in some cases

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -108,8 +108,14 @@ def evaluate_TypeCast(
         schema, ir_cast.from_type)
     schema, to_type = irtyputils.ir_typeref_to_type(
         schema, ir_cast.from_type)
-    schema_type_to_python_type(from_type, schema)
-    schema_type_to_python_type(to_type, schema)
+
+    if (
+        not isinstance(from_type, s_scalars.ScalarType)
+        or not isinstance(to_type, s_scalars.ScalarType)
+    ):
+        raise UnsupportedExpressionError('object cast not supported')
+    scalar_type_to_python_type(from_type, schema)
+    scalar_type_to_python_type(to_type, schema)
     evaluate(ir_cast.expr, schema)
     return ir_cast
 
@@ -375,6 +381,10 @@ def scalar_type_to_python_type(
 T_spec = TypeVar('T_spec', bound=statypes.CompositeTypeSpec)
 
 
+class _Missing:
+    pass
+
+
 def object_type_to_spec(
     objtype: s_objtypes.ObjectType,
     schema: s_schema.Schema,
@@ -387,6 +397,9 @@ def object_type_to_spec(
 ) -> T_spec:
     if _memo is None:
         _memo = {}
+    # Prevent infinite recursion
+    _memo[objtype] = _Missing
+
     default: Any
     fields = {}
 
@@ -401,6 +414,8 @@ def object_type_to_spec(
 
         if isinstance(ptype, s_objtypes.ObjectType):
             pytype = _memo.get(ptype)
+            if pytype is _Missing:
+                raise UnsupportedExpressionError()
             if pytype is None:
                 pytype = object_type_to_spec(
                     ptype, schema, spec_class=spec_class,

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2439,6 +2439,17 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             [[]],
         )
 
+    async def test_edgeql_casts_json_15(self):
+        # At one point, a cast from an object inside a binary
+        # operation triggered an infinite loop in staeval if the
+        # object had a self link.
+        await self.con.execute('''
+            create type Z { create link z -> Z; };
+        ''')
+        await self.con.query('''
+            select <json>Z union <json>Z;
+        ''')
+
     async def test_edgeql_casts_assignment_01(self):
         async with self._run_and_rollback():
             await self.con.execute(r"""


### PR DESCRIPTION
When compiling binary operators, we try to constant fold them using
the static evaluator.

When we evaluate a type cast, we just check that the relevant types
support the casting, I think to make sure it is valid?

As part of that, we convert the schema types to python types, but the
function for that will infinite recurse if it hits a self link before
it hits something that makes it fail.

I fix this in two ways:
 * Prevent the infinite recursion in object_type_to_spec
 * Only do the cast checks for scalar types

I am probably going to send up a separate PR to fix this in a third
way by not doing the constant folding thing at all anymore.

Fixes #5569.