### PR TITLE
Get rid of constant folding in the compiler

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -27,7 +27,6 @@ from typing import *
 from edb import errors
 
 from edb.common import context as ctx_utils
-from edb.edgeql import qltypes as ft
 
 from edb.ir import ast as irast
 from edb.ir import staeval as ireval
@@ -39,7 +38,6 @@ from edb.schema import globals as s_globals
 from edb.schema import indexes as s_indexes
 from edb.schema import name as sn
 from edb.schema import objtypes as s_objtypes
-from edb.schema import scalars as s_scalars
 from edb.schema import types as s_types
 from edb.schema import utils as s_utils
 
@@ -130,12 +128,6 @@ def compile_BinOp(
 
     op_node = func.compile_operator(
         expr, op_name=expr.op, qlargs=[expr.left, expr.right], ctx=ctx)
-
-    if ctx.env.options.constant_folding:
-        op_node.expr = cast(irast.OperatorCall, op_node.expr)
-        folded = try_fold_binop(op_node.expr, ctx=ctx)
-        if folded is not None:
-            return folded
 
     return op_node
 
@@ -254,113 +246,6 @@ def compile_BaseConstant(
         env=ctx.env,
     )
     return setgen.ensure_set(node_cls(value=value, typeref=ct), ctx=ctx)
-
-
-def try_fold_binop(
-        opcall: irast.OperatorCall, *,
-        ctx: context.ContextLevel) -> Optional[irast.Set]:
-    try:
-        const = ireval.evaluate(opcall, schema=ctx.env.schema)
-    except ireval.UnsupportedExpressionError:
-        anyreal = ctx.env.schema.get('std::anyreal', type=s_scalars.ScalarType)
-
-        if (str(opcall.func_shortname) in ('std::+', 'std::*') and
-                opcall.operator_kind is ft.OperatorKind.Infix and
-                all(setgen.get_set_type(a.expr, ctx=ctx).issubclass(
-                    ctx.env.schema, anyreal)
-                    for a in opcall.args)):
-            return try_fold_associative_binop(opcall, ctx=ctx)
-        else:
-            return None
-    else:
-        return setgen.ensure_set(const, ctx=ctx)
-
-
-def try_fold_associative_binop(
-        opcall: irast.OperatorCall, *,
-        ctx: context.ContextLevel) -> Optional[irast.Set]:
-
-    # Let's check if we have (CONST + (OTHER_CONST + X))
-    # tree, which can be optimized to ((CONST + OTHER_CONST) + X)
-
-    op = opcall.func_shortname
-    my_const = opcall.args[0].expr
-    other_binop = opcall.args[1].expr
-    folded = None
-
-    if isinstance(other_binop.expr, irast.BaseConstant):
-        my_const, other_binop = other_binop, my_const
-
-    if (isinstance(my_const.expr, irast.BaseConstant) and
-            isinstance(other_binop.expr, irast.OperatorCall) and
-            other_binop.expr.func_shortname == op and
-            other_binop.expr.operator_kind is ft.OperatorKind.Infix):
-
-        other_const = other_binop.expr.args[0].expr
-        other_binop_node = other_binop.expr.args[1].expr
-
-        if isinstance(other_binop_node.expr, irast.BaseConstant):
-            other_binop_node, other_const = \
-                other_const, other_binop_node
-
-        if isinstance(other_const.expr, irast.BaseConstant):
-            try:
-                new_const = ireval.evaluate(
-                    irast.OperatorCall(
-                        args=[
-                            irast.CallArg(
-                                expr=other_const,
-                            ),
-                            irast.CallArg(
-                                expr=my_const,
-                            ),
-                        ],
-                        func_shortname=op,
-                        func_polymorphic=opcall.func_polymorphic,
-                        sql_function=opcall.sql_function,
-                        func_sql_expr=opcall.func_sql_expr,
-                        sql_operator=opcall.sql_operator,
-                        force_return_cast=opcall.force_return_cast,
-                        operator_kind=opcall.operator_kind,
-                        params_typemods=opcall.params_typemods,
-                        context=opcall.context,
-                        typeref=opcall.typeref,
-                        typemod=opcall.typemod,
-                        tuple_path_ids=opcall.tuple_path_ids,
-                        volatility=opcall.volatility,
-                    ),
-                    schema=ctx.env.schema,
-                )
-            except ireval.UnsupportedExpressionError:
-                pass
-            else:
-                folded_binop = irast.OperatorCall(
-                    args=[
-                        irast.CallArg(
-                            expr=setgen.ensure_set(new_const, ctx=ctx),
-                        ),
-                        irast.CallArg(
-                            expr=other_binop_node,
-                        ),
-                    ],
-                    func_shortname=op,
-                    func_polymorphic=opcall.func_polymorphic,
-                    sql_function=opcall.sql_function,
-                    func_sql_expr=opcall.func_sql_expr,
-                    sql_operator=opcall.sql_operator,
-                    force_return_cast=opcall.force_return_cast,
-                    operator_kind=opcall.operator_kind,
-                    params_typemods=opcall.params_typemods,
-                    context=opcall.context,
-                    typeref=opcall.typeref,
-                    typemod=opcall.typemod,
-                    tuple_path_ids=opcall.tuple_path_ids,
-                    volatility=opcall.volatility,
-                )
-
-                folded = setgen.ensure_set(folded_binop, ctx=ctx)
-
-    return folded
 
 
 @dispatch.compile.register(qlast.NamedTuple)

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -29,7 +29,6 @@ from edb import errors
 from edb.common import context as ctx_utils
 
 from edb.ir import ast as irast
-from edb.ir import staeval as ireval
 from edb.ir import typeutils as irtyputils
 
 from edb.schema import abc as s_abc
@@ -316,18 +315,8 @@ def compile_IfElse(
 def compile_UnaryOp(
         expr: qlast.UnaryOp, *, ctx: context.ContextLevel) -> irast.Set:
 
-    result = func.compile_operator(
+    return func.compile_operator(
         expr, op_name=expr.op, qlargs=[expr.operand], ctx=ctx)
-
-    try:
-        result = setgen.ensure_set(
-            ireval.evaluate(result, schema=ctx.env.schema),
-            ctx=ctx,
-        )
-    except ireval.UnsupportedExpressionError:
-        pass
-
-    return result
 
 
 @dispatch.compile.register(qlast.GlobalExpr)

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -489,7 +489,16 @@ def __infer_const_set(
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
 ) -> inf_ctx.MultiplicityInfo:
-    if len(ir.elements) == len({el.value for el in ir.elements}):
+    # Is it worth doing this? It won't trigger in the common case of having
+    # performed constant extraction.
+    els = set()
+    for el in ir.elements:
+        if isinstance(el, irast.BaseConstant):
+            els.add(el.value)
+        else:
+            return DUPLICATE
+
+    if len(ir.elements) == len(els):
         return UNIQUE
     else:
         return DUPLICATE

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -52,9 +52,6 @@ class GlobalCompilerOptions:
     #: Whether to allow specifying 'id' explicitly in INSERT
     allow_user_specified_id: bool = False
 
-    #: Enables constant folding optimization (enabled by default).
-    constant_folding: bool = True
-
     #: Force types of all parameters to std::json
     json_parameters: bool = False
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -783,7 +783,7 @@ class BytesConstant(BaseConstant):
 
 class ConstantSet(ConstExpr, ImmutableExpr):
 
-    elements: typing.Tuple[BaseConstant, ...]
+    elements: typing.Tuple[BaseConstant | Parameter, ...]
 
 
 class Parameter(ImmutableExpr):

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -217,7 +217,12 @@ def _evaluate_union(
     for arg in opcall.args:
         val = evaluate(arg.expr, schema=schema)
         if isinstance(val, irast.ConstantSet):
-            elements.extend(val.elements)
+            for el in val.elements:
+                if isinstance(el, irast.Parameter):
+                    raise UnsupportedExpressionError(
+                        f'{el!r} not supported in UNION',
+                        context=opcall.context)
+                elements.append(el)
         elif isinstance(val, irast.EmptySet):
             empty_set = val
         elif isinstance(val, irast.BaseConstant):

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -73,13 +73,6 @@ ALTER TYPE cfg::AbstractConfig {
         SET default := 0;
     };
 
-
-    CREATE PROPERTY __internal_no_const_folding -> std::bool {
-        CREATE ANNOTATION cfg::internal := 'true';
-        CREATE ANNOTATION cfg::affects_compilation := 'true';
-        SET default := false;
-    };
-
     CREATE PROPERTY __internal_testmode -> std::bool {
         CREATE ANNOTATION cfg::internal := 'true';
         SET default := false;

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1169,7 +1169,7 @@ def _get_path_output(
         # The VALUES() construct seems to always expose its
         # value as "column1".
         alias = 'column1'
-        ref = pgast.ColumnRef(name=[alias])
+        ref = pgast.ColumnRef(name=[alias], nullable=rel.nullable)
     else:
         ref = get_path_var(rel, path_id, aspect=aspect, flavor=flavor, env=env)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2202,6 +2202,7 @@ def process_set_as_const_set(
         vals = [dispatch.compile(v, ctx=subctx) for v in expr.elements]
         vals_rel = subctx.rel
         vals_rel.values = [pgast.ImplicitRowExpr(args=[v]) for v in vals]
+        vals_rel.nullable = any(v.nullable for v in vals)
 
     vals_rvar = relctx.new_rel_rvar(ir_set, vals_rel, ctx=ctx)
     relctx.include_rvar(ctx.rel, vals_rvar, ir_set.path_id, ctx=ctx)

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1510,11 +1510,6 @@ def _get_compile_options(
     can_have_implicit_fields = (
         ctx.output_format is enums.OutputFormat.BINARY)
 
-    disable_constant_folding = _get_config_val(
-        ctx,
-        '__internal_no_const_folding',
-    )
-
     return qlcompiler.CompilerOptions(
         modaliases=ctx.state.current_tx().get_modaliases(),
         implicit_tid_in_shapes=(
@@ -1526,7 +1521,6 @@ def _get_compile_options(
         implicit_id_in_shapes=(
             can_have_implicit_fields and ctx.inline_objectids
         ),
-        constant_folding=not disable_constant_folding,
         json_parameters=ctx.json_parameters,
         implicit_limit=ctx.implicit_limit,
         bootstrap_mode=ctx.bootstrap_mode,

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3223,6 +3223,15 @@ class TestExpressions(tb.QueryTestCase):
             [1, 2, 2, 3],
         )
 
+    async def test_edgeql_expr_set_07(self):
+        await self.assert_query_result(
+            r"""
+                select {<optional int64>$0, <optional int64>$0};
+            """,
+            [],
+            variables=(None,)
+        )
+
     async def test_edgeql_expr_array_01(self):
         await self.assert_query_result(
             r'''SELECT [1];''',

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -9608,11 +9608,7 @@ aa \
             FOR Z IN {(Object,)} UNION Z;
         """, __typenames__=True)
 
-    async def test_edgeql_no_const_folding_str_concat(self):
-        await self.con.execute("""
-            CONFIGURE SESSION SET __internal_no_const_folding := true;
-        """)
-
+    async def test_edgeql_str_concat(self):
         await self.assert_query_result(
             r"""
                 SELECT 'aaaa' ++ 'bbbb';

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -151,7 +151,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_14(self):
         """
-        SELECT 1 + (distinct {2, 3})
+        SELECT 1 + {2, 3}
 % OK %
         UNIQUE
         """
@@ -179,7 +179,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_18(self):
         """
-        SELECT (1, distinct {'a', 'b'})
+        SELECT (1, {'a', 'b'})
 % OK %
         UNIQUE
         """
@@ -193,7 +193,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_20(self):
         """
-        SELECT [1, distinct {1, 2}]
+        SELECT [1, {1, 2}]
 % OK %
         UNIQUE
         """
@@ -293,7 +293,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_32(self):
         """
-        SELECT <str>(distinct {1, 2, 3})
+        SELECT <str>{1, 2, 3}
 % OK %
         UNIQUE
         """
@@ -477,7 +477,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_55a(self):
         """
-        FOR x IN (distinct {'fire', 'water'})
+        FOR x IN {'fire', 'water'}
         UNION (
             SELECT Card
             FILTER .element = x
@@ -488,7 +488,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_55b(self):
         """
-        FOR letter IN (distinct {'I', 'B'})
+        FOR letter IN {'I', 'B'}
         UNION (
             SELECT Card
             FILTER .name[0] = letter
@@ -501,7 +501,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         """
         SELECT User {
             wishlist := (
-                FOR x IN (distinct {'fire', 'water'})
+                FOR x IN {'fire', 'water'}
                 UNION (
                     SELECT Card
                     FILTER .element = x
@@ -739,7 +739,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_77(self):
         """
-        for x in (distinct {1, 2}) union { foo := 10 }
+        for x in {1, 2} union { foo := 10 }
 % OK %
         UNIQUE
         """
@@ -747,28 +747,28 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_mult_inference_78(self):
         """
         with F := { foo := 10 }
-        for x in (distinct {1, 2}) union F
+        for x in {1, 2} union F
 % OK %
         DUPLICATE
         """
 
     def test_edgeql_ir_mult_inference_79(self):
         """
-        for x in (distinct {1, 2, 3}) union (with z := x, select z)
+        for x in {1, 2, 3} union (with z := x, select z)
 % OK %
         UNIQUE
         """
 
     def test_edgeql_ir_mult_inference_80(self):
         """
-        for x in (distinct {1,2}) union (for y in (distinct {3, 4}) union x)
+        for x in {1,2} union (for y in {3, 4} union x)
 % OK %
         DUPLICATE
         """
 
     def test_edgeql_ir_mult_inference_81(self):
         """
-        for x in (distinct {1,2}) union (for y in (distinct {3, 4}) union y)
+        for x in {1,2} union (for y in {3, 4} union y)
 % OK %
         DUPLICATE
         """

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -151,7 +151,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_14(self):
         """
-        SELECT 1 + {2, 3}
+        SELECT 1 + (distinct {2, 3})
 % OK %
         UNIQUE
         """
@@ -179,7 +179,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_18(self):
         """
-        SELECT (1, {'a', 'b'})
+        SELECT (1, distinct {'a', 'b'})
 % OK %
         UNIQUE
         """
@@ -193,7 +193,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_20(self):
         """
-        SELECT [1, {1, 2}]
+        SELECT [1, distinct {1, 2}]
 % OK %
         UNIQUE
         """
@@ -293,7 +293,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_32(self):
         """
-        SELECT <str>{1, 2, 3}
+        SELECT <str>(distinct {1, 2, 3})
 % OK %
         UNIQUE
         """
@@ -477,7 +477,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_55a(self):
         """
-        FOR x IN {'fire', 'water'}
+        FOR x IN (distinct {'fire', 'water'})
         UNION (
             SELECT Card
             FILTER .element = x
@@ -488,7 +488,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_55b(self):
         """
-        FOR letter IN {'I', 'B'}
+        FOR letter IN (distinct {'I', 'B'})
         UNION (
             SELECT Card
             FILTER .name[0] = letter
@@ -501,7 +501,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         """
         SELECT User {
             wishlist := (
-                FOR x IN {'fire', 'water'}
+                FOR x IN (distinct {'fire', 'water'})
                 UNION (
                     SELECT Card
                     FILTER .element = x
@@ -739,7 +739,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_77(self):
         """
-        for x in {1, 2} union { foo := 10 }
+        for x in (distinct {1, 2}) union { foo := 10 }
 % OK %
         UNIQUE
         """
@@ -747,28 +747,28 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_mult_inference_78(self):
         """
         with F := { foo := 10 }
-        for x in {1, 2} union F
+        for x in (distinct {1, 2}) union F
 % OK %
         DUPLICATE
         """
 
     def test_edgeql_ir_mult_inference_79(self):
         """
-        for x in {1, 2, 3} union (with z := x, select z)
+        for x in (distinct {1, 2, 3}) union (with z := x, select z)
 % OK %
         UNIQUE
         """
 
     def test_edgeql_ir_mult_inference_80(self):
         """
-        for x in {1,2} union (for y in {3, 4} union x)
+        for x in (distinct {1,2}) union (for y in (distinct {3, 4}) union x)
 % OK %
         DUPLICATE
         """
 
     def test_edgeql_ir_mult_inference_81(self):
         """
-        for x in {1,2} union (for y in {3, 4} union y)
+        for x in (distinct {1,2}) union (for y in (distinct {3, 4}) union y)
 % OK %
         DUPLICATE
         """

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -426,14 +426,14 @@ class TestServerConfig(tb.QueryTestCase):
                 edgedb.ConfigurationError,
                 'invalid setting value type'):
             await self.con.execute('''
-                CONFIGURE SESSION SET __internal_no_const_folding := 1;
+                CONFIGURE SESSION SET __internal_sess_testvalue := 'test';
             ''')
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 'cannot be executed in a transaction block'):
             await self.con.execute('''
-                CONFIGURE SESSION SET __internal_no_const_folding := false;
+                CONFIGURE SESSION SET __internal_sess_testvalue := 10;
                 CONFIGURE INSTANCE SET __internal_testvalue := 1;
             ''')
 
@@ -442,7 +442,7 @@ class TestServerConfig(tb.QueryTestCase):
                 'cannot be executed in a transaction block'):
             await self.con.execute('''
                 CONFIGURE INSTANCE SET __internal_testvalue := 1;
-                CONFIGURE SESSION SET __internal_no_const_folding := false;
+                CONFIGURE SESSION SET __internal_sess_testvalue := 10;
             ''')
 
         with self.assertRaisesRegex(


### PR DESCRIPTION
It activates approximately never, since it can't fold very many things
and we typically extract constants before running queries.

Mostly it just is some extra code that takes time to run but doesn't
do much except occasionally cause weird bugs like #5569.