### PR TITLE
Fix multiplicity inference on operators

### DIFF
--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -149,11 +149,18 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         UNIQUE
         """
 
-    def test_edgeql_ir_mult_inference_14(self):
+    def test_edgeql_ir_mult_inference_14a(self):
         """
         SELECT 1 + {2, 3}
 % OK %
         UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_14b(self):
+        """
+        SELECT 0 * {2, 3}
+% OK %
+        DUPLICATE
         """
 
     def test_edgeql_ir_mult_inference_15(self):


### PR DESCRIPTION
Currently we assume all operators with only one multi argument
are injective in the argument, which is not correct
(for example `0 * {2, 3}` gives back zero twice).

Fix this.

I've kept the old behavior for + and ++, the operators that we
previously tested preserved uniqueness, to avoid making too much of a
compatability break in the cases where the inference /was/ right.  I'm
not sure if this is worth doing, though it seems kind of reasonably
for ++...