### PR TITLE
Add Google, Azure/MS, Apple OIDC providers

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -35,6 +35,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             set readonly := true;
             create annotation std::description :=
                 "ID of the auth provider";
+            create constraint exclusive;
         };
 
         create required property provider_name: std::str {

--- a/edb/server/protocol/auth_ext/apple.py
+++ b/edb/server/protocol/auth_ext/apple.py
@@ -1,0 +1,41 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import uuid
+import urllib.parse
+
+
+from . import base
+
+
+class AppleProvider(base.OpenIDProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__("apple", "https://appleid.apple.com", *args, **kwargs)
+
+    async def get_code_url(self, state: str, redirect_uri: str) -> str:
+        oidc_config = await self._get_oidc_config()
+        params = {
+            "client_id": self.client_id,
+            "scope": "openid profile name",  # Non-standard "name" scope
+            "state": state,
+            "redirect_uri": redirect_uri,
+            "nonce": str(uuid.uuid4()),
+            "response_type": "code",
+        }
+        encoded = urllib.parse.urlencode(params)
+        return f"{oidc_config.authorization_endpoint}?{encoded}"

--- a/edb/server/protocol/auth_ext/azure.py
+++ b/edb/server/protocol/auth_ext/azure.py
@@ -1,0 +1,30 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from . import base
+
+
+class AzureProvider(base.OpenIDProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            "azure",
+            "https://login.microsoftonline.com/common/v2.0",
+            *args,
+            **kwargs,
+        )

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -89,7 +89,6 @@ class OpenIDProvider(BaseProvider):
                 token_endpoint.path,
                 json=data,
             )
-            from edb.common import markup
             token = resp.json()["id_token"]
 
             return token

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -37,7 +37,7 @@ class BaseProvider:
         self.client_secret = client_secret
         self.http_factory = http_factory
 
-    def get_code_url(self, state: str, redirect_uri: str) -> str:
+    async def get_code_url(self, state: str, redirect_uri: str) -> str:
         raise NotImplementedError
 
     async def exchange_code(self, code: str) -> str:

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -116,4 +116,7 @@ class OpenIDProvider(BaseProvider):
         )
 
     async def _get_oidc_config(self):
-        raise NotImplementedError
+        client = self.http_factory(base_url=self.issuer_url)
+        response = await client.get('/.well-known/openid-configuration')
+        config = response.json()
+        return data.OpenIDConfig(**config)

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -20,7 +20,6 @@ import uuid
 import urllib.parse
 import json
 
-from typing import Union
 from jwcrypto import jwt, jwk
 from datetime import datetime
 

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -16,9 +16,14 @@
 # limitations under the License.
 #
 
+import uuid
+import urllib
+import json
+
+from jwcrypto import jwt, jwk
 from datetime import datetime
 
-from . import data
+from . import data, errors
 
 
 class BaseProvider:
@@ -48,3 +53,67 @@ class BaseProvider:
 
     def _maybe_isoformat_to_timestamp(self, value: str | None) -> float | None:
         return datetime.fromisoformat(value).timestamp() if value else None
+
+
+class OpenIDProvider(BaseProvider):
+    def __init__(self, name: str, issuer_url: str, *args, **kwargs):
+        super().__init__(name, issuer_url, *args, **kwargs)
+
+    async def get_code_url(self, state: str, redirect_uri: str) -> str:
+        oidc_config = await self._get_oidc_config()
+        params = {
+            "client_id": self.client_id,
+            "scope": "openid profile email",
+            "state": state,
+            "redirect_uri": redirect_uri,
+            "nonce": str(uuid.uuid4()),
+            "response_type": "code",
+        }
+        encoded = urllib.parse.urlencode(params)
+        return f"{oidc_config.authorization_endpoint}?{encoded}"
+
+    async def exchange_code(self, code: str) -> str:
+        oidc_config = await self._get_oidc_config()
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+        token_endpoint = urllib.parse.urlparse(oidc_config.token_endpoint)
+        async with self.http_factory(base_url=token_endpoint.netloc) as client:
+            resp = await client.post(
+                token_endpoint.path,
+                json=data,
+            )
+            token = resp.json()["id_token"]
+
+            return token
+
+    async def fetch_user_info(self, token: str) -> data.UserInfo:
+        # Retrieve JWK Set
+        oidc_config = await self._get_oidc_config()
+        jwks_uri = urllib.parse.urlparse(oidc_config.jwks_uri)
+        async with self.http_factory(base_url=jwks_uri.netloc) as client:
+            r = await client.get(jwks_uri.path)
+        keyset = r.json()
+
+        # Load the token as a JWT object and verify it directly
+        jwk_set = jwk.JWKSet.from_json(keyset)
+        id_token_verified = jwt.JWT(key=jwk_set, jwt=token)
+        payload = json.loads(id_token_verified.claims)
+        if payload["iss"] != self.issuer_url:
+            raise errors.InvalidData("Invalid value for iss in id_token")
+        if payload["aud"] != self.client_id:
+            raise errors.InvalidData("Invalid value for aud in id_token")
+
+        return data.UserInfo(
+            sub=str(payload["sub"]),
+            name=payload.get("name"),
+            email=payload.get("email"),
+            picture=payload.get("picture"),
+        )
+
+    async def _get_oidc_config(self):
+        raise NotImplementedError

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -146,3 +146,60 @@ class OpenIDConfig:
             "id_token_signing_alg_values_supported="
             f"{self.id_token_signing_alg_values_supported!r})"
         )
+
+
+@dataclasses.dataclass
+class OAuthAccessTokenResponse:
+    """
+    Access Token Response.
+    https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4
+    """
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    refresh_token: str
+
+    def __init__(self, **kwargs):
+        for field in dataclasses.fields(self):
+            setattr(self, field.name, kwargs.get(field.name))
+
+    def __str__(self) -> str:
+        return self.access_token
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"access_token={self.access_token!r}, "
+            f"token_type={self.token_type!r}, "
+            f"expires_in={self.expires_in!r}, "
+            f"refresh_token={self.refresh_token!r})"
+        )
+
+
+@dataclasses.dataclass
+class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
+    """
+    OpenID Connect Access Token Response.
+    https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse
+    """
+
+    id_token: str
+
+    def __init__(self, **kwargs):
+        for field in dataclasses.fields(self):
+            setattr(self, field.name, kwargs.get(field.name))
+
+    def __str__(self) -> str:
+        return self.id_token
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"access_token={self.access_token!r}, "
+            f"token_type={self.token_type!r}, "
+            f"expires_in={self.expires_in!r}, "
+            f"refresh_token={self.refresh_token!r}, "
+            f"example_parameter={self.example_parameter!r}, "
+            f"id_token={self.id_token!r})"
+        )

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -85,7 +85,7 @@ class Identity:
 @dataclasses.dataclass
 class OpenIDConfig:
     """
-    OpenID Connect configuration.
+    OpenID Connect configuration. Only includes fields actually in use.
     See:
     - https://openid.net/specs/openid-connect-discovery-1_0.html
     - https://accounts.google.com/.well-known/openid-configuration
@@ -94,38 +94,7 @@ class OpenIDConfig:
     issuer: str
     authorization_endpoint: str
     token_endpoint: str
-    userinfo_endpoint: Optional[str]
     jwks_uri: str
-    registration_endpoint: Optional[str]
-    scopes_supported: Optional[list[str]]
-    response_types_supported: list[str]
-    response_modes_supported: Optional[list[str]]
-    grant_types_supported: Optional[list[str]]
-    acr_values_supported: Optional[list[str]]
-    subject_types_supported: list[str]
-    id_token_signing_alg_values_supported: list[str]
-    id_token_encryption_alg_values_supported: Optional[list[str]]
-    id_token_encryption_enc_values_supported: Optional[list[str]]
-    userinfo_signing_alg_values_supported: Optional[list[str]]
-    userinfo_encryption_alg_values_supported: Optional[list[str]]
-    userinfo_encryption_enc_values_supported: Optional[list[str]]
-    request_object_signing_alg_values_supported: Optional[list[str]]
-    request_object_encryption_alg_values_supported: Optional[list[str]]
-    request_object_encryption_enc_values_supported: Optional[list[str]]
-    token_endpoint_auth_methods_supported: Optional[list[str]]
-    token_endpoint_auth_signing_alg_values_supported: Optional[list[str]]
-    display_values_supported: Optional[list[str]]
-    claim_types_supported: Optional[list[str]]
-    claims_supported: Optional[list[str]]
-    service_documentation: Optional[str]
-    claims_locales_supported: Optional[list[str]]
-    ui_locales_supported: Optional[list[str]]
-    claims_parameter_supported: Optional[bool]
-    request_parameter_supported: Optional[bool]
-    request_uri_parameter_supported: Optional[bool]
-    require_request_uri_registration: Optional[bool]
-    op_policy_uri: Optional[str]
-    op_tos_uri: Optional[str]
 
     def __init__(self, **kwargs):
         for field in dataclasses.fields(self):
@@ -133,19 +102,6 @@ class OpenIDConfig:
 
     def __str__(self) -> str:
         return self.issuer
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f"issuer={self.issuer!r}, "
-            f"authorization_endpoint={self.authorization_endpoint!r}, "
-            f"token_endpoint={self.token_endpoint!r}, "
-            f"jwks_uri={self.jwks_uri!r}, "
-            f"response_types_supported={self.response_types_supported!r}, "
-            f"subject_types_supported={self.subject_types_supported!r}, "
-            "id_token_signing_alg_values_supported="
-            f"{self.id_token_signing_alg_values_supported!r})"
-        )
 
 
 @dataclasses.dataclass

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -117,11 +117,10 @@ class OAuthAccessTokenResponse:
     refresh_token: str
 
     def __init__(self, **kwargs):
-        self._extra_fields = {}
         for field in dataclasses.fields(self):
             if field.name in kwargs:
                 setattr(self, field.name, kwargs.pop(field.name))
-        self._extra_fields.update(kwargs)
+        self._extra_fields = kwargs
 
 
 @dataclasses.dataclass(repr=False)
@@ -134,8 +133,7 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
     id_token: str
 
     def __init__(self, **kwargs):
-        self._extra_fields = {}
         for field in dataclasses.fields(self):
             if field.name in kwargs:
                 setattr(self, field.name, kwargs.pop(field.name))
-        self._extra_fields.update(kwargs)
+        self._extra_fields = kwargs

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -200,6 +200,5 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
             f"token_type={self.token_type!r}, "
             f"expires_in={self.expires_in!r}, "
             f"refresh_token={self.refresh_token!r}, "
-            f"example_parameter={self.example_parameter!r}, "
             f"id_token={self.id_token!r})"
         )

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -117,8 +117,11 @@ class OAuthAccessTokenResponse:
     refresh_token: str
 
     def __init__(self, **kwargs):
+        self._extra_fields = {}
         for field in dataclasses.fields(self):
-            setattr(self, field.name, kwargs.get(field.name))
+            if field.name in kwargs:
+                setattr(self, field.name, kwargs.pop(field.name))
+        self._extra_fields.update(kwargs)
 
 
 @dataclasses.dataclass(repr=False)
@@ -131,6 +134,8 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
     id_token: str
 
     def __init__(self, **kwargs):
+        self._extra_fields = {}
         for field in dataclasses.fields(self):
-            setattr(self, field.name, kwargs.get(field.name))
-
+            if field.name in kwargs:
+                setattr(self, field.name, kwargs.pop(field.name))
+        self._extra_fields.update(kwargs)

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -127,6 +127,10 @@ class OpenIDConfig:
     op_policy_uri: Optional[str]
     op_tos_uri: Optional[str]
 
+    def __init__(self, **kwargs):
+        for field in dataclasses.fields(self):
+            setattr(self, field.name, kwargs.get(field.name))
+
     def __str__(self) -> str:
         return self.issuer
 

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -86,22 +86,46 @@ class Identity:
 class OpenIDConfig:
     """
     OpenID Connect configuration.
-    See: https://accounts.google.com/.well-known/openid-configuration
+    See:
+    - https://openid.net/specs/openid-connect-discovery-1_0.html
+    - https://accounts.google.com/.well-known/openid-configuration
     """
 
     issuer: str
     authorization_endpoint: str
     token_endpoint: str
-    userinfo_endpoint: str
-    revocation_endpoint: str
+    userinfo_endpoint: Optional[str]
     jwks_uri: str
+    registration_endpoint: Optional[str]
+    scopes_supported: Optional[list[str]]
     response_types_supported: list[str]
+    response_modes_supported: Optional[list[str]]
+    grant_types_supported: Optional[list[str]]
+    acr_values_supported: Optional[list[str]]
     subject_types_supported: list[str]
     id_token_signing_alg_values_supported: list[str]
-    scopes_supported: list[str]
-    token_endpoint_auth_methods_supported: list[str]
-    claims_supported: list[str]
-    code_challenge_methods_supported: list[str]
+    id_token_encryption_alg_values_supported: Optional[list[str]]
+    id_token_encryption_enc_values_supported: Optional[list[str]]
+    userinfo_signing_alg_values_supported: Optional[list[str]]
+    userinfo_encryption_alg_values_supported: Optional[list[str]]
+    userinfo_encryption_enc_values_supported: Optional[list[str]]
+    request_object_signing_alg_values_supported: Optional[list[str]]
+    request_object_encryption_alg_values_supported: Optional[list[str]]
+    request_object_encryption_enc_values_supported: Optional[list[str]]
+    token_endpoint_auth_methods_supported: Optional[list[str]]
+    token_endpoint_auth_signing_alg_values_supported: Optional[list[str]]
+    display_values_supported: Optional[list[str]]
+    claim_types_supported: Optional[list[str]]
+    claims_supported: Optional[list[str]]
+    service_documentation: Optional[str]
+    claims_locales_supported: Optional[list[str]]
+    ui_locales_supported: Optional[list[str]]
+    claims_parameter_supported: Optional[bool]
+    request_parameter_supported: Optional[bool]
+    request_uri_parameter_supported: Optional[bool]
+    require_request_uri_registration: Optional[bool]
+    op_policy_uri: Optional[str]
+    op_tos_uri: Optional[str]
 
     def __str__(self) -> str:
         return self.issuer
@@ -109,8 +133,12 @@ class OpenIDConfig:
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}("
-            f"issuer={self.issuer!r} "
-            f"authorization_endpoint={self.authorization_endpoint!r} "
-            f"token_endpoint={self.token_endpoint!r} "
-            f"userinfo_endpoint={self.userinfo_endpoint!r})"
+            f"issuer={self.issuer!r}, "
+            f"authorization_endpoint={self.authorization_endpoint!r}, "
+            f"token_endpoint={self.token_endpoint!r}, "
+            f"jwks_uri={self.jwks_uri!r}, "
+            f"response_types_supported={self.response_types_supported!r}, "
+            f"subject_types_supported={self.subject_types_supported!r}, "
+            "id_token_signing_alg_values_supported="
+            f"{self.id_token_signing_alg_values_supported!r})"
         )

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -104,7 +104,7 @@ class OpenIDConfig:
         return self.issuer
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(repr=False)
 class OAuthAccessTokenResponse:
     """
     Access Token Response.
@@ -120,20 +120,8 @@ class OAuthAccessTokenResponse:
         for field in dataclasses.fields(self):
             setattr(self, field.name, kwargs.get(field.name))
 
-    def __str__(self) -> str:
-        return self.access_token
 
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f"access_token={self.access_token!r}, "
-            f"token_type={self.token_type!r}, "
-            f"expires_in={self.expires_in!r}, "
-            f"refresh_token={self.refresh_token!r})"
-        )
-
-
-@dataclasses.dataclass
+@dataclasses.dataclass(repr=False)
 class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
     """
     OpenID Connect Access Token Response.
@@ -146,15 +134,3 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
         for field in dataclasses.fields(self):
             setattr(self, field.name, kwargs.get(field.name))
 
-    def __str__(self) -> str:
-        return self.id_token
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f"access_token={self.access_token!r}, "
-            f"token_type={self.token_type!r}, "
-            f"expires_in={self.expires_in!r}, "
-            f"refresh_token={self.refresh_token!r}, "
-            f"id_token={self.id_token!r})"
-        )

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -80,3 +80,37 @@ class Identity:
             f"iss={self.iss!r} "
             f"email={self.email!r})"
         )
+
+
+@dataclasses.dataclass
+class OpenIDConfig:
+    """
+    OpenID Connect configuration.
+    See: https://accounts.google.com/.well-known/openid-configuration
+    """
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    userinfo_endpoint: str
+    revocation_endpoint: str
+    jwks_uri: str
+    response_types_supported: list[str]
+    subject_types_supported: list[str]
+    id_token_signing_alg_values_supported: list[str]
+    scopes_supported: list[str]
+    token_endpoint_auth_methods_supported: list[str]
+    claims_supported: list[str]
+    code_challenge_methods_supported: list[str]
+
+    def __str__(self) -> str:
+        return self.issuer
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"issuer={self.issuer!r} "
+            f"authorization_endpoint={self.authorization_endpoint!r} "
+            f"token_endpoint={self.token_endpoint!r} "
+            f"userinfo_endpoint={self.userinfo_endpoint!r})"
+        )

--- a/edb/server/protocol/auth_ext/errors.py
+++ b/edb/server/protocol/auth_ext/errors.py
@@ -74,3 +74,20 @@ class InvalidData(AuthExtError):
 
     def __str__(self) -> str:
         return self.description
+
+
+class MisconfiguredProvider(AuthExtError):
+    """Data received from the auth provider is invalid."""
+
+    def __init__(self, description: str):
+        self.description = description
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"description={self.description!r}"
+            ")"
+        )
+
+    def __str__(self) -> str:
+        return self.description

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -20,8 +20,7 @@
 import urllib.parse
 import functools
 
-from . import base
-from . import data
+from . import base, data
 
 
 class GitHubProvider(base.BaseProvider):
@@ -46,29 +45,29 @@ class GitHubProvider(base.BaseProvider):
         encoded = urllib.parse.urlencode(params)
         return f"{self.auth_domain}/login/oauth/authorize?{encoded}"
 
-    async def exchange_code(self, code: str) -> str:
-        data = {
-            "grant_type": "authorization_code",
-            "code": code,
-            "client_id": self.client_id,
-            "client_secret": self.client_secret,
-        }
-
+    async def exchange_code(self, code: str) -> data.OAuthAccessTokenResponse:
         async with self.auth_client() as client:
             resp = await client.post(
                 "/login/oauth/access_token",
-                json=data,
+                json={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
             )
-            token = resp.json()["access_token"]
+            json = resp.json()
 
-            return token
+            return data.OAuthAccessTokenResponse(**json)
 
-    async def fetch_user_info(self, token: str) -> data.UserInfo:
+    async def fetch_user_info(
+        self, token_response: data.OAuthAccessTokenResponse
+    ) -> data.UserInfo:
         async with self.api_client() as client:
             resp = await client.get(
                 "/user",
                 headers={
-                    "Authorization": f"Bearer {token}",
+                    "Authorization": f"Bearer {token_response.access_token}",
                     "Accept": "application/vnd.github+json",
                     "X-GitHub-Api-Version": "2022-11-28",
                     "Cache-Control": "no-store",

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -36,7 +36,7 @@ class GitHubProvider(base.BaseProvider):
             self.http_factory, base_url=self.api_domain
         )
 
-    def get_code_url(self, state: str, redirect_uri: str) -> str:
+    async def get_code_url(self, state: str, redirect_uri: str) -> str:
         params = {
             "client_id": self.client_id,
             "scope": "read:user user:email",

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -71,6 +71,7 @@ class GitHubProvider(base.BaseProvider):
                     "Authorization": f"Bearer {token}",
                     "Accept": "application/vnd.github+json",
                     "X-GitHub-Api-Version": "2022-11-28",
+                    "Cache-Control": "no-store",
                 },
             )
             payload = resp.json()

--- a/edb/server/protocol/auth_ext/google.py
+++ b/edb/server/protocol/auth_ext/google.py
@@ -1,0 +1,93 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import urllib.parse
+import functools
+import uuid
+import json
+
+from jwcrypto import jwt, jwk
+from . import base, data, errors
+
+
+class GoogleProvider(base.BaseProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            "google", "https://accounts.google.com", *args, **kwargs
+        )
+        self.auth_domain = "https://oauth2.googleapis.com/"
+        self.api_domain = "https://www.googleapis.com"
+        self.auth_client = functools.partial(
+            self.http_factory, base_url=self.auth_domain
+        )
+        self.api_client = functools.partial(
+            self.http_factory, base_url=self.api_domain
+        )
+
+    def get_code_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "client_id": self.client_id,
+            "scope": "openid profile email",
+            "state": state,
+            "redirect_uri": redirect_uri,
+            "nonce": str(uuid.uuid4()),
+            "response_type": "code",
+        }
+        encoded = urllib.parse.urlencode(params)
+        return f"{self.issuer}/o/oauth2/v2/auth?{encoded}"
+
+    async def exchange_code(self, code: str) -> str:
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+        async with self.auth_client() as client:
+            resp = await client.post(
+                "/token",
+                json=data,
+            )
+            token = resp.json()["access_token"]
+            self.id_token = resp.json()["id_token"]
+
+            return token
+
+    async def fetch_user_info(self, token: str) -> data.UserInfo:
+        # Retrieve Google's JWKs
+        async with self.api_client() as client:
+            r = await client.get('/oauth2/v3/certs')
+        keyset = r.json()
+
+        # Load the token as a JWT object and verify it directly
+        jwk_set = jwk.JWKSet.from_json(keyset)
+        id_token_verified = jwt.JWT(key=jwk_set, jwt=self.id_token)
+        payload = json.loads(id_token_verified.claims)
+        if payload["iss"] != self.issuer_url:
+            raise errors.InvalidData("Invalid value for iss in id_token")
+        if payload["aud"] != self.client_id:
+            raise errors.InvalidData("Invalid value for aud in id_token")
+
+        return data.UserInfo(
+            sub=str(payload["sub"]),
+            name=payload.get("name"),
+            email=payload.get("email"),
+            picture=payload.get("picture"),
+        )

--- a/edb/server/protocol/auth_ext/google.py
+++ b/edb/server/protocol/auth_ext/google.py
@@ -17,7 +17,7 @@
 #
 
 
-from . import base, data
+from . import base
 
 
 class GoogleProvider(base.OpenIDProvider):
@@ -25,9 +25,3 @@ class GoogleProvider(base.OpenIDProvider):
         super().__init__(
             "google", "https://accounts.google.com", *args, **kwargs
         )
-
-    async def _get_oidc_config(self):
-        client = self.http_factory(base_url=self.issuer_url)
-        response = await client.get('/.well-known/openid-configuration')
-        config = response.json()
-        return data.OpenIDConfig(**config)

--- a/edb/server/protocol/auth_ext/google.py
+++ b/edb/server/protocol/auth_ext/google.py
@@ -50,7 +50,7 @@ class GoogleProvider(base.BaseProvider):
             "response_type": "code",
         }
         encoded = urllib.parse.urlencode(params)
-        return f"{self.issuer}/o/oauth2/v2/auth?{encoded}"
+        return f"{self.issuer_url}/o/oauth2/v2/auth?{encoded}"
 
     async def exchange_code(self, code: str) -> str:
         data = {
@@ -65,8 +65,7 @@ class GoogleProvider(base.BaseProvider):
                 "/token",
                 json=data,
             )
-            token = resp.json()["access_token"]
-            self.id_token = resp.json()["id_token"]
+            token = resp.json()["id_token"]
 
             return token
 
@@ -78,7 +77,7 @@ class GoogleProvider(base.BaseProvider):
 
         # Load the token as a JWT object and verify it directly
         jwk_set = jwk.JWKSet.from_json(keyset)
-        id_token_verified = jwt.JWT(key=jwk_set, jwt=self.id_token)
+        id_token_verified = jwt.JWT(key=jwk_set, jwt=token)
         payload = json.loads(id_token_verified.claims)
         if payload["iss"] != self.issuer_url:
             raise errors.InvalidData("Invalid value for iss in id_token")

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -64,7 +64,7 @@ class Router:
                     client = oauth.Client(
                         db=self.db, provider_id=provider_id, base_url=test_url
                     )
-                    authorize_url = client.get_authorize_url(
+                    authorize_url = await client.get_authorize_url(
                         redirect_uri=self._get_callback_url(),
                         state=self._make_state_claims(provider_id),
                     )

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -76,11 +76,15 @@ class Router:
                     state = _get_search_param(query, "state")
                     try:
                         code = _get_search_param(query, "code")
-                    except errors.InvalidData:
-                        error = _get_search_param(query, "error")
-                        error_description = _maybe_get_search_param(
-                            query, "error_description"
-                        )
+                    except (errors.InvalidData, errors.MisconfiguredProvider) as ex:
+                        if isinstance(ex, errors.MisconfiguredProvider):
+                            error = "misconfigured_provider"
+                            error_description = ex.description
+                        else:
+                            error = _get_search_param(query, "error")
+                            error_description = _maybe_get_search_param(
+                                query, "error_description"
+                            )
                         redirect_to = self._get_from_claims(
                             state, "redirect_to"
                         )
@@ -94,6 +98,7 @@ class Router:
                             "Location"
                         ] = f"{redirect_to}?{urllib.parse.urlencode(params)}"
                         return
+
 
                     provider_id = self._get_from_claims(state, "provider")
                     redirect_to = self._get_from_claims(state, "redirect_to")

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -76,7 +76,11 @@ class Router:
                     state = _get_search_param(query, "state")
                     try:
                         code = _get_search_param(query, "code")
-                    except (errors.InvalidData, errors.MisconfiguredProvider) as ex:
+                    except (
+                        errors.InvalidData,
+                        errors.MisconfiguredProvider,
+                    ) as ex:
+                        error_description = None
                         if isinstance(ex, errors.MisconfiguredProvider):
                             error = "misconfigured_provider"
                             error_description = ex.description
@@ -98,7 +102,6 @@ class Router:
                             "Location"
                         ] = f"{redirect_to}?{urllib.parse.urlencode(params)}"
                         return
-
 
                     provider_id = self._get_from_claims(state, "provider")
                     redirect_to = self._get_from_claims(state, "redirect_to")

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -74,8 +74,8 @@ class Client:
             case _:
                 raise errors.InvalidData("Invalid provider: {provider}")
 
-    def get_authorize_url(self, state: str, redirect_uri: str) -> str:
-        return self.provider.get_code_url(
+    async def get_authorize_url(self, state: str, redirect_uri: str) -> str:
+        return await self.provider.get_code_url(
             state=state, redirect_uri=redirect_uri
         )
 

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -90,8 +90,8 @@ class Client:
         )
 
     async def handle_callback(self, code: str) -> data.Identity:
-        token = await self.provider.exchange_code(code)
-        user_info = await self.provider.fetch_user_info(token)
+        response = await self.provider.exchange_code(code)
+        user_info = await self.provider.fetch_user_info(response)
 
         return await self._handle_identity(user_info)
 

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -88,6 +88,13 @@ class Client:
                     client_secret=client_secret,
                     http_factory=http_factory,
                 )
+            case "apple":
+                from . import apple
+                self.provider = apple.AppleProvider(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    http_factory=http_factory,
+                )
             case _:
                 raise errors.InvalidData(f"Invalid provider: {provider_name}")
 

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -25,7 +25,7 @@ import httpx_cache
 from typing import Any
 from edb.server.protocol import execute
 
-from . import errors, util, data
+from . import errors, util, data, base
 
 
 class HttpClient(httpx.AsyncClient):
@@ -50,6 +50,8 @@ class HttpClient(httpx.AsyncClient):
 
 
 class Client:
+    provider: base.BaseProvider
+
     def __init__(self, db: Any, provider_id: str, base_url: str | None = None):
         self.db = db
         self.db_config = db.db_config

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -81,6 +81,13 @@ class Client:
                     client_secret=client_secret,
                     http_factory=http_factory,
                 )
+            case "azure":
+                from . import azure
+                self.provider = azure.AzureProvider(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    http_factory=http_factory,
+                )
             case _:
                 raise errors.InvalidData(f"Invalid provider: {provider_name}")
 

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -71,8 +71,16 @@ class Client:
                     client_secret=client_secret,
                     http_factory=http_factory,
                 )
+            case "google":
+                from . import google
+
+                self.provider = google.GoogleProvider(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    http_factory=http_factory,
+                )
             case _:
-                raise errors.InvalidData("Invalid provider: {provider}")
+                raise errors.InvalidData(f"Invalid provider: {provider_name}")
 
     async def get_authorize_url(self, state: str, redirect_uri: str) -> str:
         return await self.provider.get_code_url(
@@ -134,5 +142,6 @@ select (insert ext::auth::Identity {
                 return r
             case _:
                 raise errors.InvalidData(
-                    f"Invalid provider configuration: {provider_id}"
+                    f"Invalid provider configuration: {provider_id}\n"
+                    f"providers={provider_client_config!r}"
                 )

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -20,6 +20,7 @@
 import urllib.parse
 import json
 import httpx
+import httpx_cache
 
 from typing import Any
 from edb.server.protocol import execute
@@ -34,7 +35,8 @@ class HttpClient(httpx.AsyncClient):
         if edgedb_test_url:
             self.edgedb_orig_base_url = urllib.parse.quote(base_url, safe='')
             base_url = edgedb_test_url
-        super().__init__(*args, base_url=base_url, **kwargs)
+        cache = httpx_cache.AsyncCacheControlTransport()
+        super().__init__(*args, base_url=base_url, transport=cache, **kwargs)
 
     async def post(self, path, *args, **kwargs):
         if self.edgedb_orig_base_url:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     'setproctitle~=1.2',
 
     'httpx~=0.24.1',
+    'httpx_cache~=0.12.0',
 ]
 
 [project.optional-dependencies]

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -638,12 +638,24 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 (
                     {
                         "issuer": "https://accounts.google.com",
-                        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-                        "device_authorization_endpoint": "https://oauth2.googleapis.com/device/code",
-                        "token_endpoint": "https://oauth2.googleapis.com/token",
-                        "userinfo_endpoint": "https://openidconnect.googleapis.com/v1/userinfo",
-                        "revocation_endpoint": "https://oauth2.googleapis.com/revoke",
-                        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+                        "authorization_endpoint": (
+                            "https://accounts.google.com/o/oauth2/v2/auth"
+                        ),
+                        "device_authorization_endpoint": (
+                            "https://oauth2.googleapis.com/device/code"
+                        ),
+                        "token_endpoint": (
+                            "https://oauth2.googleapis.com/token"
+                        ),
+                        "userinfo_endpoint": (
+                            "https://openidconnect.googleapis.com/v1/userinfo"
+                        ),
+                        "revocation_endpoint": (
+                            "https://oauth2.googleapis.com/revoke"
+                        ),
+                        "jwks_uri": (
+                            "https://www.googleapis.com/oauth2/v3/certs"
+                        ),
                         "response_types_supported": [
                             "code",
                             "token",
@@ -712,7 +724,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 "aud": client_id,
                 "exp": (now + datetime.timedelta(minutes=5)).timestamp(),
                 "iat": now.timestamp(),
-                "email": "test@example.com"
+                "email": "test@example.com",
             }
             id_token = jwt.JWT(header={"alg": "RS256"}, claims=id_token_claims)
             id_token.make_signed_token(k)

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -80,6 +80,69 @@ GOOGLE_DISCOVERY_DOCUMENT = {
     "code_challenge_methods_supported": ["plain", "S256"],
 }
 
+AZURE_DISCOVERY_DOCUMENT = {
+    "token_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    ),
+    "token_endpoint_auth_methods_supported": [
+        "client_secret_post",
+        "private_key_jwt",
+        "client_secret_basic",
+    ],
+    "jwks_uri": "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+    "response_modes_supported": ["query", "fragment", "form_post"],
+    "subject_types_supported": ["pairwise"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "response_types_supported": [
+        "code",
+        "id_token",
+        "code id_token",
+        "id_token token",
+    ],
+    "scopes_supported": ["openid", "profile", "email", "offline_access"],
+    "issuer": "https://login.microsoftonline.com/{tenantid}/v2.0",
+    "request_uri_parameter_supported": False,
+    "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+    "authorization_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    ),
+    "device_authorization_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/devicecode"
+    ),
+    "http_logout_supported": True,
+    "frontchannel_logout_supported": True,
+    "end_session_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/logout"
+    ),
+    "claims_supported": [
+        "sub",
+        "iss",
+        "cloud_instance_name",
+        "cloud_instance_host_name",
+        "cloud_graph_host_name",
+        "msgraph_host",
+        "aud",
+        "exp",
+        "iat",
+        "auth_time",
+        "acr",
+        "nonce",
+        "preferred_username",
+        "name",
+        "tid",
+        "ver",
+        "at_hash",
+        "c_hash",
+        "email",
+    ],
+    "kerberos_endpoint": "https://login.microsoftonline.com/common/kerberos",
+    "tenant_region_scope": None,
+    "cloud_instance_name": "microsoftonline.com",
+    "cloud_graph_host_name": "graph.windows.net",
+    "msgraph_host": "graph.microsoft.com",
+    "rbac_url": "https://pas.windows.net",
+}
+
 
 class MockHttpServerHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
@@ -220,6 +283,16 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         INSERT ext::auth::ClientConfig {{
             provider_name := "google",
             url := "https://accounts.google.com",
+            provider_id := <str>'{uuid.uuid4()}',
+            secret := <str>'{"c" * 32}',
+            client_id := <str>'{uuid.uuid4()}'
+        }};
+        """,
+        f"""
+        CONFIGURE CURRENT DATABASE
+        INSERT ext::auth::ClientConfig {{
+            provider_name := "azure",
+            url := "https://login.microsoftonline.com/common/v2.0",
             provider_id := <str>'{uuid.uuid4()}',
             secret := <str>'{"c" * 32}',
             client_id := <str>'{uuid.uuid4()}'
@@ -857,3 +930,170 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             requests_for_discovery = mock_provider.requests[discovery_request]
             self.assertEqual(len(requests_for_discovery), 1)
+
+    async def test_http_auth_ext_azure_authorize_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("azure")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+
+            discovery_request = (
+                "GET",
+                "https://login.microsoftonline.com/common/v2.0",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    AZURE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            _, headers, status = self.http_con_request(
+                http_con, {"provider": provider_id}, path="authorize"
+            )
+
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            url = urllib.parse.urlparse(location)
+            qs = urllib.parse.parse_qs(url.query, keep_blank_values=True)
+            self.assertEqual(url.scheme, "https")
+            self.assertEqual(url.hostname, "login.microsoftonline.com")
+            self.assertEqual(url.path, "/common/oauth2/v2.0/authorize")
+            self.assertEqual(qs.get("scope"), ["openid profile email"])
+
+            state = qs.get("state")
+            assert state is not None
+
+            signed_token = jwt.JWT(
+                key=signing_key, algs=["HS256"], jwt=state[0]
+            )
+            claims = json.loads(signed_token.claims)
+            self.assertEqual(claims.get("provider"), provider_id)
+            self.assertEqual(claims.get("iss"), self.http_addr)
+
+            self.assertEqual(
+                qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
+            )
+            self.assertEqual(qs.get("client_id"), [client_id])
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 1)
+
+    async def test_http_auth_ext_azure_callback_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("azure")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+            client_secret = provider_config.secret
+
+            now = datetime.datetime.utcnow()
+
+            discovery_request = (
+                "GET",
+                "https://login.microsoftonline.com/common/v2.0",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    AZURE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            jwks_request = (
+                "GET",
+                "https://login.microsoftonline.com",
+                "/common/discovery/v2.0/keys",
+            )
+            # Generate a JWK Set
+            k = jwk.JWK.generate(kty='RSA', size=4096)
+            ks = jwk.JWKSet()
+            ks.add(k)
+            jwk_set: dict[str, Any] = ks.export(
+                private_keys=False, as_dict=True
+            )
+
+            mock_provider.register_route_handler(*jwks_request)(
+                (
+                    jwk_set,
+                    200,
+                )
+            )
+
+            token_request = (
+                "POST",
+                "https://login.microsoftonline.com",
+                "/common/oauth2/v2.0/token",
+            )
+            id_token_claims = {
+                "iss": "https://login.microsoftonline.com/common/v2.0",
+                "sub": "1",
+                "aud": client_id,
+                "exp": (now + datetime.timedelta(minutes=5)).timestamp(),
+                "iat": now.timestamp(),
+                "email": "test@example.com",
+            }
+            id_token = jwt.JWT(header={"alg": "RS256"}, claims=id_token_claims)
+            id_token.make_signed_token(k)
+
+            mock_provider.register_route_handler(*token_request)(
+                (
+                    {
+                        "access_token": "azure_access_token",
+                        "id_token": id_token.serialize(),
+                        "scope": "openid",
+                        "token_type": "bearer",
+                    },
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            expires_at = now + datetime.timedelta(minutes=5)
+            state_claims = {
+                "iss": self.http_addr,
+                "provider": str(provider_id),
+                "exp": expires_at.astimezone().timestamp(),
+                "redirect_to": f"{self.http_addr}/some/path",
+            }
+            state_token = self.generate_state_value(state_claims, signing_key)
+
+            data, headers, status = self.http_con_request(
+                http_con,
+                {"state": state_token, "code": "abc123"},
+                path="callback",
+            )
+
+            self.assertEqual(data, b"")
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            server_url = urllib.parse.urlparse(self.http_addr)
+            url = urllib.parse.urlparse(location)
+            self.assertEqual(url.scheme, server_url.scheme)
+            self.assertEqual(url.hostname, server_url.hostname)
+            self.assertEqual(url.path, f"{server_url.path}/some/path")
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 2)
+
+            requests_for_token = mock_provider.requests[token_request]
+            self.assertEqual(len(requests_for_token), 1)
+            self.assertEqual(
+                requests_for_token[0]["body"],
+                json.dumps(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": "abc123",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                    }
+                ),
+            )


### PR DESCRIPTION
Support Google as an OAuth provider using their [OpenID Connect authorization flow.](https://developers.google.com/identity/openid-connect/openid-connect)

A few things of note:

- Abstracted the common OpenID Connect functionality into it's own base provider.
- Added a caching transport (https://github.com/obendidi/httpx-cache) to avoid refetching the very cacheable contents of the discovery endpoint and JWKS endpoint.
- Updated the `get_code` function to be async even though in the normal OAuth flow, it doesn't need it. Didn't feel worth caring about the Coroutine overhead to try to do something more specialized like an Async Sentinel or something.