### PR TITLE
Add ext::auth schema and handle auth

### DIFF
--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -163,24 +163,6 @@ ALTER TYPE cfg::AbstractConfig {
             'Whether inserts are allowed to set the \'id\' property.';
     };
 
-    # XXX: Remove these and move to extension config mechanism when ready
-    CREATE PROPERTY xxx_auth_signing_key -> std::str {
-        CREATE ANNOTATION std::description :=
-            'The signing key used for auth extension. Must be at \
-            least 32 characters long.';
-        SET default := '00000000000000000000000000000000';
-    };
-
-    CREATE PROPERTY xxx_github_client_secret -> std::str {
-        CREATE ANNOTATION std::description := 'Secret key provided by GitHub';
-        SET default := '00000000000000000000000000000000';
-    };
-
-    CREATE PROPERTY xxx_github_client_id -> std::str {
-        CREATE ANNOTATION std::description := 'ID provided by GitHub';
-        SET default := '00000000000000000000000000000000';
-    };
-
     # Exposed backend settings follow.
     # When exposing a new setting, remember to modify
     # the _read_sys_config function to select the value

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -35,6 +35,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             set readonly := true;
             create annotation std::description :=
                 "ID of the auth provider";
+            create constraint exclusive;
         };
 
         create required property provider_name: std::str {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -72,5 +72,11 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
                 least 32 characters long.";
             set default := "00000000000000000000000000000000";
         };
+
+        create property token_time_to_live -> std::duration {
+            create annotation std::description :=
+                'The time after which an auth token expires.';
+            set default := <std::duration>'336 hours';
+        };
     };
 };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -71,12 +71,12 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             create annotation std::description :=
                 "The signing key used for auth extension. Must be at \
                 least 32 characters long.";
-            set default := "00000000000000000000000000000000";
         };
 
         create property token_time_to_live -> std::duration {
             create annotation std::description :=
-                'The time after which an auth token expires.';
+                "The time after which an auth token expires. A value of 0 \
+                indicates that the token should never expire.";
             set default := <std::duration>'336 hours';
         };
     };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -17,4 +17,60 @@
 #
 
 
-CREATE EXTENSION PACKAGE auth VERSION '1.0';
+CREATE EXTENSION PACKAGE auth VERSION '1.0' {
+    set ext_module := "ext::auth";
+
+    create module ext::auth;
+
+    create type ext::auth::Identity {
+        create required property iss: std::str;
+        create required property sub: std::str;
+        create property email: std::str;
+
+        create constraint exclusive on ((.iss, .sub))
+    };
+
+    create type ext::auth::ClientConfig extending cfg::ConfigObject {
+        create required property provider_id: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "ID of the auth provider";
+        };
+
+        create required property provider_name: std::str {
+            set readonly := true;
+            create annotation std::description := "Auth provider name";
+        };
+
+        create required property url: std::str {
+            set readonly := true;
+            create annotation std::description := "Authorization server URL";
+        };
+
+        create required property secret: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "Secret provided by auth provider";
+        };
+
+        create required property client_id: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "ID for client provided by auth provider";
+        };
+    };
+
+    create type ext::auth::AuthConfig extending cfg::ExtensionConfig {
+        create multi link providers -> ext::auth::ClientConfig {
+            create annotation std::description :=
+                "Configuration for auth provider clients";
+        };
+
+        create property auth_signing_key -> std::str {
+            create annotation std::description :=
+                "The signing key used for auth extension. Must be at \
+                least 32 characters long.";
+            set default := "00000000000000000000000000000000";
+        };
+    };
+};

--- a/edb/server/protocol/auth_ext/apple.py
+++ b/edb/server/protocol/auth_ext/apple.py
@@ -1,0 +1,41 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import uuid
+import urllib.parse
+
+
+from . import base
+
+
+class AppleProvider(base.OpenIDProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__("apple", "https://appleid.apple.com", *args, **kwargs)
+
+    async def get_code_url(self, state: str, redirect_uri: str) -> str:
+        oidc_config = await self._get_oidc_config()
+        params = {
+            "client_id": self.client_id,
+            "scope": "openid profile name",  # Non-standard "name" scope
+            "state": state,
+            "redirect_uri": redirect_uri,
+            "nonce": str(uuid.uuid4()),
+            "response_type": "code",
+        }
+        encoded = urllib.parse.urlencode(params)
+        return f"{oidc_config.authorization_endpoint}?{encoded}"

--- a/edb/server/protocol/auth_ext/azure.py
+++ b/edb/server/protocol/auth_ext/azure.py
@@ -1,0 +1,30 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from . import base
+
+
+class AzureProvider(base.OpenIDProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            "azure",
+            "https://login.microsoftonline.com/common/v2.0",
+            *args,
+            **kwargs,
+        )

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -16,9 +16,14 @@
 # limitations under the License.
 #
 
+import uuid
+import urllib.parse
+import json
+
+from jwcrypto import jwt, jwk
 from datetime import datetime
 
-from . import data
+from . import data, errors
 
 
 class BaseProvider:
@@ -37,14 +42,103 @@ class BaseProvider:
         self.client_secret = client_secret
         self.http_factory = http_factory
 
-    def get_code_url(self, state: str, redirect_uri: str) -> str:
+    async def get_code_url(self, state: str, redirect_uri: str) -> str:
         raise NotImplementedError
 
-    async def exchange_code(self, code: str) -> str:
+    async def exchange_code(self, code: str) -> data.OAuthAccessTokenResponse:
         raise NotImplementedError
 
-    async def fetch_user_info(self, token: str) -> data.UserInfo:
+    async def fetch_user_info(
+        self, token_response: data.OAuthAccessTokenResponse
+    ) -> data.UserInfo:
         raise NotImplementedError
 
     def _maybe_isoformat_to_timestamp(self, value: str | None) -> float | None:
         return datetime.fromisoformat(value).timestamp() if value else None
+
+
+class OpenIDProvider(BaseProvider):
+    def __init__(self, name: str, issuer_url: str, *args, **kwargs):
+        super().__init__(name, issuer_url, *args, **kwargs)
+
+    async def get_code_url(self, state: str, redirect_uri: str) -> str:
+        oidc_config = await self._get_oidc_config()
+        params = {
+            "client_id": self.client_id,
+            "scope": "openid profile email",
+            "state": state,
+            "redirect_uri": redirect_uri,
+            "nonce": str(uuid.uuid4()),
+            "response_type": "code",
+        }
+        encoded = urllib.parse.urlencode(params)
+        return f"{oidc_config.authorization_endpoint}?{encoded}"
+
+    async def exchange_code(
+        self, code: str
+    ) -> data.OpenIDConnectAccessTokenResponse:
+        oidc_config = await self._get_oidc_config()
+
+        token_endpoint = urllib.parse.urlparse(oidc_config.token_endpoint)
+        async with self.http_factory(
+            base_url=f"{token_endpoint.scheme}://{token_endpoint.netloc}"
+        ) as client:
+            resp = await client.post(
+                token_endpoint.path,
+                json={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+            )
+            json = resp.json()
+
+            return data.OpenIDConnectAccessTokenResponse(**json)
+
+    async def fetch_user_info(
+        self, token_response: data.OAuthAccessTokenResponse
+    ) -> data.UserInfo:
+        if not isinstance(
+            token_response, data.OpenIDConnectAccessTokenResponse
+        ):
+            raise TypeError(
+                "token_response must be of type "
+                "OpenIDConnectAccessTokenResponse"
+            )
+        id_token = token_response.id_token
+
+        # Retrieve JWK Set
+        oidc_config = await self._get_oidc_config()
+        jwks_uri = urllib.parse.urlparse(oidc_config.jwks_uri)
+        async with self.http_factory(
+            base_url=f"{jwks_uri.scheme}://{jwks_uri.netloc}"
+        ) as client:
+            r = await client.get(jwks_uri.path)
+
+        # Load the token as a JWT object and verify it directly
+        try:
+            jwk_set = jwk.JWKSet.from_json(r.text)
+            id_token_verified = jwt.JWT(key=jwk_set, jwt=id_token)
+            payload = json.loads(id_token_verified.claims)
+        except Exception as e:
+            raise errors.MisconfiguredProvider(
+                "Failed to parse ID token with provider keyset"
+            ) from e
+        if payload.get("iss") != self.issuer_url:
+            raise errors.InvalidData("Invalid value for iss in id_token")
+        if payload.get("aud") != self.client_id:
+            raise errors.InvalidData("Invalid value for aud in id_token")
+
+        return data.UserInfo(
+            sub=str(payload["sub"]),
+            name=payload.get("name"),
+            email=payload.get("email"),
+            picture=payload.get("picture"),
+        )
+
+    async def _get_oidc_config(self):
+        client = self.http_factory(base_url=self.issuer_url)
+        response = await client.get('/.well-known/openid-configuration')
+        config = response.json()
+        return data.OpenIDConfig(**config)

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -23,9 +23,16 @@ from . import data
 
 class BaseProvider:
     def __init__(
-        self, name: str, client_id: str, client_secret: str, *, http_factory
+        self,
+        name: str,
+        issuer_url: str,
+        client_id: str,
+        client_secret: str,
+        *,
+        http_factory,
     ):
         self.name = name
+        self.issuer_url = issuer_url
         self.client_id = client_id
         self.client_secret = client_secret
         self.http_factory = http_factory
@@ -39,10 +46,5 @@ class BaseProvider:
     async def fetch_user_info(self, token: str) -> data.UserInfo:
         raise NotImplementedError
 
-    async def fetch_emails(self, token: str) -> list[data.Email]:
-        raise NotImplementedError
-
     def _maybe_isoformat_to_timestamp(self, value: str | None) -> float | None:
-        return (
-            datetime.fromisoformat(value).timestamp() if value else None
-        )
+        return datetime.fromisoformat(value).timestamp() if value else None

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -60,12 +60,3 @@ class UserInfo:
             f"email={self.email!r} "
             f"preferred_username={self.preferred_username!r})"
         )
-
-
-@dataclasses.dataclass
-class Email:
-    """Email address"""
-
-    address: str
-    is_verified: bool
-    is_primary: bool

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -80,3 +80,60 @@ class Identity:
             f"iss={self.iss!r} "
             f"email={self.email!r})"
         )
+
+
+@dataclasses.dataclass
+class OpenIDConfig:
+    """
+    OpenID Connect configuration. Only includes fields actually in use.
+    See:
+    - https://openid.net/specs/openid-connect-discovery-1_0.html
+    - https://accounts.google.com/.well-known/openid-configuration
+    """
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    jwks_uri: str
+
+    def __init__(self, **kwargs):
+        for field in dataclasses.fields(self):
+            setattr(self, field.name, kwargs.get(field.name))
+
+    def __str__(self) -> str:
+        return self.issuer
+
+
+@dataclasses.dataclass(repr=False)
+class OAuthAccessTokenResponse:
+    """
+    Access Token Response.
+    https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4
+    """
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    refresh_token: str
+
+    def __init__(self, **kwargs):
+        for field in dataclasses.fields(self):
+            if field.name in kwargs:
+                setattr(self, field.name, kwargs.pop(field.name))
+        self._extra_fields = kwargs
+
+
+@dataclasses.dataclass(repr=False)
+class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
+    """
+    OpenID Connect Access Token Response.
+    https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse
+    """
+
+    id_token: str
+
+    def __init__(self, **kwargs):
+        for field in dataclasses.fields(self):
+            if field.name in kwargs:
+                setattr(self, field.name, kwargs.pop(field.name))
+        self._extra_fields = kwargs

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -60,3 +60,23 @@ class UserInfo:
             f"email={self.email!r} "
             f"preferred_username={self.preferred_username!r})"
         )
+
+
+@dataclasses.dataclass
+class Identity:
+    id: str
+    sub: str
+    iss: str
+    email: str | None
+
+    def __str__(self) -> str:
+        return self.id
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"id={self.id!r} "
+            f"sub={self.sub!r} "
+            f"iss={self.iss!r} "
+            f"email={self.email!r})"
+        )

--- a/edb/server/protocol/auth_ext/errors.py
+++ b/edb/server/protocol/auth_ext/errors.py
@@ -74,3 +74,20 @@ class InvalidData(AuthExtError):
 
     def __str__(self) -> str:
         return self.description
+
+
+class MisconfiguredProvider(AuthExtError):
+    """Data received from the auth provider is invalid."""
+
+    def __init__(self, description: str):
+        self.description = description
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"description={self.description!r}"
+            ")"
+        )
+
+    def __str__(self) -> str:
+        return self.description

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -75,7 +75,7 @@ class GitHubProvider(base.BaseProvider):
             )
             payload = resp.json()
             return data.UserInfo(
-                sub=payload["id"],
+                sub=str(payload["id"]),
                 preferred_username=payload.get("login"),
                 name=payload.get("name"),
                 email=payload.get("email"),

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -26,8 +26,8 @@ from . import data
 
 class GitHubProvider(base.BaseProvider):
     def __init__(self, *args, **kwargs):
-        super().__init__("github", *args, **kwargs)
-        self.auth_domain = "https://github.com"
+        super().__init__("github", "https://github.com", *args, **kwargs)
+        self.auth_domain = self.issuer_url
         self.api_domain = "https://api.github.com"
         self.auth_client = functools.partial(
             self.http_factory, base_url=self.auth_domain
@@ -84,24 +84,3 @@ class GitHubProvider(base.BaseProvider):
                     payload.get("updated_at")
                 ),
             )
-
-    async def fetch_emails(self, token: str) -> list[data.Email]:
-        async with self.api_client() as client:
-            resp = await client.get(
-                "/user/emails",
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
-            payload = resp.json()
-
-            return [
-                data.Email(
-                    address=d["email"],
-                    is_verified=d["verified"],
-                    is_primary=d["primary"],
-                )
-                for d in payload
-            ]

--- a/edb/server/protocol/auth_ext/google.py
+++ b/edb/server/protocol/auth_ext/google.py
@@ -1,0 +1,27 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from . import base
+
+
+class GoogleProvider(base.OpenIDProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            "google", "https://accounts.google.com", *args, **kwargs
+        )

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -193,11 +193,12 @@ class Router:
         expires_in = auth_expiration_time.to_timedelta()
         expires_at = datetime.datetime.utcnow() + expires_in
 
-        claims = {
+        claims: dict[str, Any] = {
             "iss": self.base_path,
             "sub": identity_id,
-            "exp": expires_at.astimezone().timestamp(),
         }
+        if expires_in.total_seconds() != 0:
+            claims["exp"] = expires_at.astimezone().timestamp()
         session_token = jwt.JWT(
             header={"alg": "HS256"},
             claims=claims,

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -57,18 +57,15 @@ class Router:
         try:
             match args:
                 case ("authorize",):
-                    # TODO: this is ambiguous whether it's a name or ID which
-                    # is useful now, but we'll need to pivot to ID sooner than
-                    # later and then rename all of this to provider_id
-                    provider = _get_search_param(
+                    provider_id = _get_search_param(
                         request.url.query.decode("ascii"), "provider"
                     )
                     client = oauth.Client(
-                        db=self.db, provider=provider, base_url=test_url
+                        db=self.db, provider_id=provider_id, base_url=test_url
                     )
                     authorize_url = client.get_authorize_url(
                         redirect_uri=self._get_callback_url(),
-                        state=self._make_state_claims(provider),
+                        state=self._make_state_claims(provider_id),
                     )
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = authorize_url
@@ -78,11 +75,11 @@ class Router:
                     query = request.url.query.decode("ascii")
                     state = _get_search_param(query, "state")
                     code = _get_search_param(query, "code")
-                    provider = self._get_from_claims(state, "provider")
+                    provider_id = self._get_from_claims(state, "provider")
                     redirect_to = self._get_from_claims(state, "redirect_to")
                     client = oauth.Client(
                         db=self.db,
-                        provider=provider,
+                        provider_id=provider_id,
                         base_url=test_url,
                     )
                     await client.handle_callback(code)
@@ -132,7 +129,7 @@ class Router:
 
     def _get_auth_signing_key(self) -> jwk.JWK:
         auth_signing_key = util.get_config(
-            self.db.db_config, "xxx_auth_signing_key"
+            self.db.db_config, "ext::auth::AuthConfig::auth_signing_key"
         )
         key_bytes = base64.b64encode(auth_signing_key.encode())
 

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -69,7 +69,6 @@ class Router:
                     )
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = authorize_url
-                    response.close_connection = True
 
                 case ("callback",):
                     query = request.url.query.decode("ascii")
@@ -85,7 +84,6 @@ class Router:
                     await client.handle_callback(code)
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = redirect_to
-                    response.close_connection = True
 
                 case _:
                     raise errors.NotFound("Unknown OAuth endpoint")

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -29,6 +29,7 @@ from jwcrypto import jwk, jwt
 from edb import errors as edb_errors
 from edb.common import debug
 from edb.common import markup
+from edb.ir import statypes
 
 from . import oauth
 from . import errors
@@ -81,9 +82,16 @@ class Router:
                         provider_id=provider_id,
                         base_url=test_url,
                     )
-                    await client.handle_callback(code)
+                    identity = await client.handle_callback(code)
+                    session_token = self._make_session_token(identity.id)
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = redirect_to
+                    response.custom_headers[
+                        "Set-Cookie"
+                    ] = (
+                        f"edgedb-session={session_token}; "
+                        f"HttpOnly; Secure; SameSite=Strict"
+                    )
 
                 case _:
                     raise errors.NotFound("Unknown OAuth endpoint")
@@ -148,6 +156,28 @@ class Router:
         )
         state_token.make_signed_token(signing_key)
         return state_token.serialize()
+
+    def _make_session_token(self, identity_id: str) -> str:
+        signing_key = self._get_auth_signing_key()
+        auth_expiration_time = util.get_config(
+            self.db.db_config,
+            "ext::auth::AuthConfig::token_time_to_live",
+            statypes.Duration
+        )
+        expires_in = auth_expiration_time.to_timedelta()
+        expires_at = datetime.datetime.utcnow() + expires_in
+
+        claims = {
+            "iss": self.base_path,
+            "sub": identity_id,
+            "exp": expires_at.astimezone().timestamp(),
+        }
+        session_token = jwt.JWT(
+            header={"alg": "HS256"},
+            claims=claims,
+        )
+        session_token.make_signed_token(signing_key)
+        return session_token.serialize()
 
     def _get_from_claims(self, state: str, key: str) -> str:
         signing_key = self._get_auth_signing_key()

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -37,6 +37,7 @@ bag = assert_data_shape.bag
 
 
 class BaseHttpExtensionTest(server.QueryTestCase):
+    EXTENSION_SETUP: List[str] = []
 
     @classmethod
     def get_extension_name(cls):
@@ -60,6 +61,8 @@ class BaseHttpExtensionTest(server.QueryTestCase):
         cls.loop.run_until_complete(
             cls.con.execute(f'CREATE EXTENSION {extname};')
         )
+        for q in cls.EXTENSION_SETUP:
+            cls.loop.run_until_complete(cls.con.execute(q))
 
     @classmethod
     def tearDownClass(cls):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     'setproctitle~=1.2',
 
     'httpx~=0.24.1',
+    'httpx_cache~=0.12.0',
 ]
 
 [project.optional-dependencies]

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -36,6 +36,141 @@ HTTP_TEST_PORT: contextvars.ContextVar[str] = contextvars.ContextVar(
     'HTTP_TEST_PORT'
 )
 
+GOOGLE_DISCOVERY_DOCUMENT = {
+    "issuer": "https://accounts.google.com",
+    "authorization_endpoint": ("https://accounts.google.com/o/oauth2/v2/auth"),
+    "device_authorization_endpoint": (
+        "https://oauth2.googleapis.com/device/code"
+    ),
+    "token_endpoint": ("https://oauth2.googleapis.com/token"),
+    "userinfo_endpoint": ("https://openidconnect.googleapis.com/v1/userinfo"),
+    "revocation_endpoint": ("https://oauth2.googleapis.com/revoke"),
+    "jwks_uri": ("https://www.googleapis.com/oauth2/v3/certs"),
+    "response_types_supported": [
+        "code",
+        "token",
+        "id_token",
+        "code token",
+        "code id_token",
+        "token id_token",
+        "code token id_token",
+        "none",
+    ],
+    "subject_types_supported": ["public"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "scopes_supported": ["openid", "email", "profile"],
+    "token_endpoint_auth_methods_supported": [
+        "client_secret_post",
+        "client_secret_basic",
+    ],
+    "claims_supported": [
+        "aud",
+        "email",
+        "email_verified",
+        "exp",
+        "family_name",
+        "given_name",
+        "iat",
+        "iss",
+        "locale",
+        "name",
+        "picture",
+        "sub",
+    ],
+    "code_challenge_methods_supported": ["plain", "S256"],
+}
+
+AZURE_DISCOVERY_DOCUMENT = {
+    "token_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    ),
+    "token_endpoint_auth_methods_supported": [
+        "client_secret_post",
+        "private_key_jwt",
+        "client_secret_basic",
+    ],
+    "jwks_uri": "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+    "response_modes_supported": ["query", "fragment", "form_post"],
+    "subject_types_supported": ["pairwise"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "response_types_supported": [
+        "code",
+        "id_token",
+        "code id_token",
+        "id_token token",
+    ],
+    "scopes_supported": ["openid", "profile", "email", "offline_access"],
+    "issuer": "https://login.microsoftonline.com/{tenantid}/v2.0",
+    "request_uri_parameter_supported": False,
+    "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+    "authorization_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    ),
+    "device_authorization_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/devicecode"
+    ),
+    "http_logout_supported": True,
+    "frontchannel_logout_supported": True,
+    "end_session_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/logout"
+    ),
+    "claims_supported": [
+        "sub",
+        "iss",
+        "cloud_instance_name",
+        "cloud_instance_host_name",
+        "cloud_graph_host_name",
+        "msgraph_host",
+        "aud",
+        "exp",
+        "iat",
+        "auth_time",
+        "acr",
+        "nonce",
+        "preferred_username",
+        "name",
+        "tid",
+        "ver",
+        "at_hash",
+        "c_hash",
+        "email",
+    ],
+    "kerberos_endpoint": "https://login.microsoftonline.com/common/kerberos",
+    "tenant_region_scope": None,
+    "cloud_instance_name": "microsoftonline.com",
+    "cloud_graph_host_name": "graph.windows.net",
+    "msgraph_host": "graph.microsoft.com",
+    "rbac_url": "https://pas.windows.net",
+}
+
+APPLE_DISCOVERY_DOCUMENT = {
+    "issuer": "https://appleid.apple.com",
+    "authorization_endpoint": "https://appleid.apple.com/auth/authorize",
+    "token_endpoint": "https://appleid.apple.com/auth/token",
+    "revocation_endpoint": "https://appleid.apple.com/auth/revoke",
+    "jwks_uri": "https://appleid.apple.com/auth/keys",
+    "response_types_supported": ["code"],
+    "response_modes_supported": ["query", "fragment", "form_post"],
+    "subject_types_supported": ["pairwise"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "scopes_supported": ["openid", "email", "name"],
+    "token_endpoint_auth_methods_supported": ["client_secret_post"],
+    "claims_supported": [
+        "aud",
+        "email",
+        "email_verified",
+        "exp",
+        "iat",
+        "is_private_email",
+        "iss",
+        "nonce",
+        "nonce_supported",
+        "real_user_status",
+        "sub",
+        "transfer_sub",
+    ],
+}
+
 
 class MockHttpServerHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
@@ -168,6 +303,36 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             url := "https://github.com",
             provider_id := <str>'{uuid.uuid4()}',
             secret := <str>'{"b" * 32}',
+            client_id := <str>'{uuid.uuid4()}'
+        }};
+        """,
+        f"""
+        CONFIGURE CURRENT DATABASE
+        INSERT ext::auth::ClientConfig {{
+            provider_name := "google",
+            url := "https://accounts.google.com",
+            provider_id := <str>'{uuid.uuid4()}',
+            secret := <str>'{"c" * 32}',
+            client_id := <str>'{uuid.uuid4()}'
+        }};
+        """,
+        f"""
+        CONFIGURE CURRENT DATABASE
+        INSERT ext::auth::ClientConfig {{
+            provider_name := "azure",
+            url := "https://login.microsoftonline.com/common/v2.0",
+            provider_id := <str>'{uuid.uuid4()}',
+            secret := <str>'{"c" * 32}',
+            client_id := <str>'{uuid.uuid4()}'
+        }};
+        """,
+        f"""
+        CONFIGURE CURRENT DATABASE
+        INSERT ext::auth::ClientConfig {{
+            provider_name := "apple",
+            url := "https://appleid.apple.com",
+            provider_id := <str>'{uuid.uuid4()}',
+            secret := <str>'{"c" * 32}',
             client_id := <str>'{uuid.uuid4()}'
         }};
         """,
@@ -608,4 +773,532 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(
                 url.query,
                 "error=access_denied",
+            )
+
+    async def test_http_auth_ext_google_callback_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("google")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+            client_secret = provider_config.secret
+
+            now = datetime.datetime.utcnow()
+
+            discovery_request = (
+                "GET",
+                "https://accounts.google.com",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    GOOGLE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            jwks_request = (
+                "GET",
+                "https://www.googleapis.com",
+                "/oauth2/v3/certs",
+            )
+            # Generate a JWK Set
+            k = jwk.JWK.generate(kty='RSA', size=4096)
+            ks = jwk.JWKSet()
+            ks.add(k)
+            jwk_set: dict[str, Any] = ks.export(
+                private_keys=False, as_dict=True
+            )
+
+            mock_provider.register_route_handler(*jwks_request)(
+                (
+                    jwk_set,
+                    200,
+                )
+            )
+
+            token_request = (
+                "POST",
+                "https://oauth2.googleapis.com",
+                "/token",
+            )
+            id_token_claims = {
+                "iss": "https://accounts.google.com",
+                "sub": "1",
+                "aud": client_id,
+                "exp": (now + datetime.timedelta(minutes=5)).timestamp(),
+                "iat": now.timestamp(),
+                "email": "test@example.com",
+            }
+            id_token = jwt.JWT(header={"alg": "RS256"}, claims=id_token_claims)
+            id_token.make_signed_token(k)
+
+            mock_provider.register_route_handler(*token_request)(
+                (
+                    {
+                        "access_token": "google_access_token",
+                        "id_token": id_token.serialize(),
+                        "scope": "openid",
+                        "token_type": "bearer",
+                    },
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            expires_at = now + datetime.timedelta(minutes=5)
+            state_claims = {
+                "iss": self.http_addr,
+                "provider": str(provider_id),
+                "exp": expires_at.astimezone().timestamp(),
+                "redirect_to": f"{self.http_addr}/some/path",
+            }
+            state_token = self.generate_state_value(state_claims, signing_key)
+
+            data, headers, status = self.http_con_request(
+                http_con,
+                {"state": state_token, "code": "abc123"},
+                path="callback",
+            )
+
+            print(f"data={data}")
+            self.assertEqual(data, b"")
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            server_url = urllib.parse.urlparse(self.http_addr)
+            url = urllib.parse.urlparse(location)
+            self.assertEqual(url.scheme, server_url.scheme)
+            self.assertEqual(url.hostname, server_url.hostname)
+            self.assertEqual(url.path, f"{server_url.path}/some/path")
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 2)
+
+            requests_for_token = mock_provider.requests[token_request]
+            self.assertEqual(len(requests_for_token), 1)
+            self.assertEqual(
+                requests_for_token[0]["body"],
+                json.dumps(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": "abc123",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                    }
+                ),
+            )
+
+            identity = await self.con.query(
+                """
+                SELECT ext::auth::Identity
+                FILTER .sub = '1'
+                AND .iss = 'https://accounts.google.com'
+                AND .email = 'test@example.com'
+                """
+            )
+            self.assertEqual(len(identity), 1)
+
+            set_cookie = headers.get("set-cookie")
+            assert set_cookie is not None
+            (k, v) = set_cookie.split(";")[0].split("=")
+            self.assertEqual(k, "edgedb-session")
+            session_token = jwt.JWT(key=signing_key, jwt=v)
+            session_claims = json.loads(session_token.claims)
+            self.assertEqual(session_claims.get("sub"), str(identity[0].id))
+            self.assertEqual(session_claims.get("iss"), str(self.http_addr))
+            tomorrow = now + datetime.timedelta(hours=25)
+            self.assertTrue(
+                session_claims.get("exp") > now.astimezone().timestamp()
+            )
+            self.assertTrue(
+                session_claims.get("exp") < tomorrow.astimezone().timestamp()
+            )
+
+    async def test_http_auth_ext_google_authorize_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("google")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+
+            discovery_request = (
+                "GET",
+                "https://accounts.google.com",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    GOOGLE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            _, headers, status = self.http_con_request(
+                http_con, {"provider": provider_id}, path="authorize"
+            )
+
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            url = urllib.parse.urlparse(location)
+            qs = urllib.parse.parse_qs(url.query, keep_blank_values=True)
+            self.assertEqual(url.scheme, "https")
+            self.assertEqual(url.hostname, "accounts.google.com")
+            self.assertEqual(url.path, "/o/oauth2/v2/auth")
+            self.assertEqual(qs.get("scope"), ["openid profile email"])
+
+            state = qs.get("state")
+            assert state is not None
+
+            signed_token = jwt.JWT(
+                key=signing_key, algs=["HS256"], jwt=state[0]
+            )
+            claims = json.loads(signed_token.claims)
+            self.assertEqual(claims.get("provider"), provider_id)
+            self.assertEqual(claims.get("iss"), self.http_addr)
+
+            self.assertEqual(
+                qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
+            )
+            self.assertEqual(qs.get("client_id"), [client_id])
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 1)
+
+    async def test_http_auth_ext_azure_authorize_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("azure")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+
+            discovery_request = (
+                "GET",
+                "https://login.microsoftonline.com/common/v2.0",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    AZURE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            _, headers, status = self.http_con_request(
+                http_con, {"provider": provider_id}, path="authorize"
+            )
+
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            url = urllib.parse.urlparse(location)
+            qs = urllib.parse.parse_qs(url.query, keep_blank_values=True)
+            self.assertEqual(url.scheme, "https")
+            self.assertEqual(url.hostname, "login.microsoftonline.com")
+            self.assertEqual(url.path, "/common/oauth2/v2.0/authorize")
+            self.assertEqual(qs.get("scope"), ["openid profile email"])
+
+            state = qs.get("state")
+            assert state is not None
+
+            signed_token = jwt.JWT(
+                key=signing_key, algs=["HS256"], jwt=state[0]
+            )
+            claims = json.loads(signed_token.claims)
+            self.assertEqual(claims.get("provider"), provider_id)
+            self.assertEqual(claims.get("iss"), self.http_addr)
+
+            self.assertEqual(
+                qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
+            )
+            self.assertEqual(qs.get("client_id"), [client_id])
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 1)
+
+    async def test_http_auth_ext_azure_callback_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("azure")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+            client_secret = provider_config.secret
+
+            now = datetime.datetime.utcnow()
+
+            discovery_request = (
+                "GET",
+                "https://login.microsoftonline.com/common/v2.0",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    AZURE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            jwks_request = (
+                "GET",
+                "https://login.microsoftonline.com",
+                "/common/discovery/v2.0/keys",
+            )
+            # Generate a JWK Set
+            k = jwk.JWK.generate(kty='RSA', size=4096)
+            ks = jwk.JWKSet()
+            ks.add(k)
+            jwk_set: dict[str, Any] = ks.export(
+                private_keys=False, as_dict=True
+            )
+
+            mock_provider.register_route_handler(*jwks_request)(
+                (
+                    jwk_set,
+                    200,
+                )
+            )
+
+            token_request = (
+                "POST",
+                "https://login.microsoftonline.com",
+                "/common/oauth2/v2.0/token",
+            )
+            id_token_claims = {
+                "iss": "https://login.microsoftonline.com/common/v2.0",
+                "sub": "1",
+                "aud": client_id,
+                "exp": (now + datetime.timedelta(minutes=5)).timestamp(),
+                "iat": now.timestamp(),
+                "email": "test@example.com",
+            }
+            id_token = jwt.JWT(header={"alg": "RS256"}, claims=id_token_claims)
+            id_token.make_signed_token(k)
+
+            mock_provider.register_route_handler(*token_request)(
+                (
+                    {
+                        "access_token": "azure_access_token",
+                        "id_token": id_token.serialize(),
+                        "scope": "openid",
+                        "token_type": "bearer",
+                    },
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            expires_at = now + datetime.timedelta(minutes=5)
+            state_claims = {
+                "iss": self.http_addr,
+                "provider": str(provider_id),
+                "exp": expires_at.astimezone().timestamp(),
+                "redirect_to": f"{self.http_addr}/some/path",
+            }
+            state_token = self.generate_state_value(state_claims, signing_key)
+
+            data, headers, status = self.http_con_request(
+                http_con,
+                {"state": state_token, "code": "abc123"},
+                path="callback",
+            )
+
+            self.assertEqual(data, b"")
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            server_url = urllib.parse.urlparse(self.http_addr)
+            url = urllib.parse.urlparse(location)
+            self.assertEqual(url.scheme, server_url.scheme)
+            self.assertEqual(url.hostname, server_url.hostname)
+            self.assertEqual(url.path, f"{server_url.path}/some/path")
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 2)
+
+            requests_for_token = mock_provider.requests[token_request]
+            self.assertEqual(len(requests_for_token), 1)
+            self.assertEqual(
+                requests_for_token[0]["body"],
+                json.dumps(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": "abc123",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                    }
+                ),
+            )
+
+    async def test_http_auth_ext_apple_authorize_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("apple")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+
+            discovery_request = (
+                "GET",
+                "https://appleid.apple.com",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    APPLE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            _, headers, status = self.http_con_request(
+                http_con, {"provider": provider_id}, path="authorize"
+            )
+
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            url = urllib.parse.urlparse(location)
+            qs = urllib.parse.parse_qs(url.query, keep_blank_values=True)
+            self.assertEqual(url.scheme, "https")
+            self.assertEqual(url.hostname, "appleid.apple.com")
+            self.assertEqual(url.path, "/auth/authorize")
+            self.assertEqual(qs.get("scope"), ["openid profile name"])
+
+            state = qs.get("state")
+            assert state is not None
+
+            signed_token = jwt.JWT(
+                key=signing_key, algs=["HS256"], jwt=state[0]
+            )
+            claims = json.loads(signed_token.claims)
+            self.assertEqual(claims.get("provider"), provider_id)
+            self.assertEqual(claims.get("iss"), self.http_addr)
+
+            self.assertEqual(
+                qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
+            )
+            self.assertEqual(qs.get("client_id"), [client_id])
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 1)
+
+    async def test_http_auth_ext_apple_callback_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("apple")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+            client_secret = provider_config.secret
+
+            now = datetime.datetime.utcnow()
+
+            discovery_request = (
+                "GET",
+                "https://appleid.apple.com",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    APPLE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            jwks_request = (
+                "GET",
+                "https://appleid.apple.com",
+                "/auth/keys",
+            )
+            # Generate a JWK Set
+            k = jwk.JWK.generate(kty='RSA', size=4096)
+            ks = jwk.JWKSet()
+            ks.add(k)
+            jwk_set: dict[str, Any] = ks.export(
+                private_keys=False, as_dict=True
+            )
+
+            mock_provider.register_route_handler(*jwks_request)(
+                (
+                    jwk_set,
+                    200,
+                )
+            )
+
+            token_request = (
+                "POST",
+                "https://appleid.apple.com",
+                "/auth/token",
+            )
+            id_token_claims = {
+                "iss": "https://appleid.apple.com",
+                "sub": "1",
+                "aud": client_id,
+                "exp": (now + datetime.timedelta(minutes=5)).timestamp(),
+                "iat": now.timestamp(),
+                "email": "test@example.com",
+            }
+            id_token = jwt.JWT(header={"alg": "RS256"}, claims=id_token_claims)
+            id_token.make_signed_token(k)
+
+            mock_provider.register_route_handler(*token_request)(
+                (
+                    {
+                        "access_token": "apple_access_token",
+                        "id_token": id_token.serialize(),
+                        "scope": "openid",
+                        "token_type": "bearer",
+                    },
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            expires_at = now + datetime.timedelta(minutes=5)
+            state_claims = {
+                "iss": self.http_addr,
+                "provider": str(provider_id),
+                "exp": expires_at.astimezone().timestamp(),
+                "redirect_to": f"{self.http_addr}/some/path",
+            }
+            state_token = self.generate_state_value(state_claims, signing_key)
+
+            data, headers, status = self.http_con_request(
+                http_con,
+                {"state": state_token, "code": "abc123"},
+                path="callback",
+            )
+
+            self.assertEqual(data, b"")
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            server_url = urllib.parse.urlparse(self.http_addr)
+            url = urllib.parse.urlparse(location)
+            self.assertEqual(url.scheme, server_url.scheme)
+            self.assertEqual(url.hostname, server_url.hostname)
+            self.assertEqual(url.path, f"{server_url.path}/some/path")
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 2)
+
+            requests_for_token = mock_provider.requests[token_request]
+            self.assertEqual(len(requests_for_token), 1)
+            self.assertEqual(
+                requests_for_token[0]["body"],
+                json.dumps(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": "abc123",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                    }
+                ),
             )

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -455,3 +455,43 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 requests_for_user[0]["headers"]["authorization"],
                 "Bearer github_access_token",
             )
+
+            identity = await self.con.query(
+                """
+                SELECT ext::auth::Identity
+                FILTER .sub = '1'
+                AND .iss = 'https://github.com'
+                AND .email = 'octocat@example.com'
+                """
+            )
+            self.assertEqual(len(identity), 1)
+
+            mock_provider.register_route_handler(*user_request)(
+                (
+                    {
+                        "id": 1,
+                        "login": "octocat",
+                        "name": "monalisa octocat",
+                        "email": "octocat+2@example.com",
+                        "avatar_url": "http://example.com/example.jpg",
+                        "updated_at": now,
+                    },
+                    200,
+                )
+            )
+            self.http_con_request(
+                http_con,
+                {"state": state_token.serialize(), "code": "abc123"},
+                path="callback",
+            )
+
+            same_identity = await self.con.query(
+                """
+                SELECT ext::auth::Identity
+                FILTER .sub = '1'
+                AND .iss = 'https://github.com'
+                AND .email = 'octocat+2@example.com'
+                """
+            )
+            self.assertEqual(len(same_identity), 1)
+            self.assertEqual(identity[0].id, same_identity[0].id)


### PR DESCRIPTION
- Adds a bare-bones schema to the `ext::auth` extension module
- Creates `Identity` objects on successful auth
- Creates a session JWT on successful auth
- Redirect, passing any `error` or `error_description` from the authorization server to the redirect URL if auth fails