### PR TITLE
Fix object->json casts inside functions

### DIFF
--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -536,8 +536,11 @@ def output_format(
     output_format: OutputFormat,
 ) -> Generator[None, None, None]:
     original_output_format = ctx.env.output_format
+    original_ignore_object_shapes = ctx.env.ignore_object_shapes
     ctx.env.output_format = output_format
+    ctx.env.ignore_object_shapes = False
     try:
         yield
     finally:
         ctx.env.output_format = original_output_format
+        ctx.env.ignore_object_shapes = original_ignore_object_shapes

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -1437,6 +1437,28 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         self.assertTrue('id' not in data)
 
+    async def test_edgeql_json_cast_object_to_json_07(self):
+        await self.con.execute('''
+            create function _get(idx: int64) -> set of json {
+                using (
+                    select <json> (
+                        select JSONTest {
+                            number, edb_string
+                        } filter .number = idx
+                    )
+                )
+            };
+        ''')
+        await self.assert_query_result(
+            r"""
+                SELECT _get(0)
+            """,
+            [
+                {'number': 0, 'edb_string': 'jumps'},
+            ],
+            json_only=True,
+        )
+
     async def test_edgeql_json_cast_tuple_to_json_01(self):
         res = await self.con.query("""
             WITH MODULE schema

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -1663,6 +1663,15 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             for obj in res:
                 self.assertEqual(obj[0], obj[1])
 
+    async def test_edgeql_volatility_in_func_01(self):
+        await self.con.execute('''
+            create function foo() -> float64 using (
+              with Z := Obj { v := random() },
+              select sum(Z.v)
+            );
+        ''')
+        await self.con.query('select foo()')
+
     async def test_edgeql_volatility_errors_01(self):
         async with self._run_and_rollback():
             with self.assertRaisesRegex(


### PR DESCRIPTION
Functions are compiled with object shapes suppressed, so the generated
code was invalid.

Whenever we are switching the output_format for shape serialization
purposes, we should unsuppress object shapes. This also fixes an issue
with materialization.

Fixes #5938.