### PR TITLE
Add Azure OIDC compatible OAuth provider

### DIFF
--- a/edb/server/protocol/auth_ext/azure.py
+++ b/edb/server/protocol/auth_ext/azure.py
@@ -1,0 +1,30 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from . import base
+
+
+class AzureProvider(base.OpenIDProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            "azure",
+            "https://login.microsoftonline.com/common/v2.0",
+            *args,
+            **kwargs,
+        )

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -81,6 +81,13 @@ class Client:
                     client_secret=client_secret,
                     http_factory=http_factory,
                 )
+            case "azure":
+                from . import azure
+                self.provider = azure.AzureProvider(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    http_factory=http_factory,
+                )
             case _:
                 raise errors.InvalidData(f"Invalid provider: {provider_name}")
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -80,6 +80,69 @@ GOOGLE_DISCOVERY_DOCUMENT = {
     "code_challenge_methods_supported": ["plain", "S256"],
 }
 
+AZURE_DISCOVERY_DOCUMENT = {
+    "token_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    ),
+    "token_endpoint_auth_methods_supported": [
+        "client_secret_post",
+        "private_key_jwt",
+        "client_secret_basic",
+    ],
+    "jwks_uri": "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+    "response_modes_supported": ["query", "fragment", "form_post"],
+    "subject_types_supported": ["pairwise"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "response_types_supported": [
+        "code",
+        "id_token",
+        "code id_token",
+        "id_token token",
+    ],
+    "scopes_supported": ["openid", "profile", "email", "offline_access"],
+    "issuer": "https://login.microsoftonline.com/{tenantid}/v2.0",
+    "request_uri_parameter_supported": False,
+    "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+    "authorization_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    ),
+    "device_authorization_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/devicecode"
+    ),
+    "http_logout_supported": True,
+    "frontchannel_logout_supported": True,
+    "end_session_endpoint": (
+        "https://login.microsoftonline.com/common/oauth2/v2.0/logout"
+    ),
+    "claims_supported": [
+        "sub",
+        "iss",
+        "cloud_instance_name",
+        "cloud_instance_host_name",
+        "cloud_graph_host_name",
+        "msgraph_host",
+        "aud",
+        "exp",
+        "iat",
+        "auth_time",
+        "acr",
+        "nonce",
+        "preferred_username",
+        "name",
+        "tid",
+        "ver",
+        "at_hash",
+        "c_hash",
+        "email",
+    ],
+    "kerberos_endpoint": "https://login.microsoftonline.com/common/kerberos",
+    "tenant_region_scope": None,
+    "cloud_instance_name": "microsoftonline.com",
+    "cloud_graph_host_name": "graph.windows.net",
+    "msgraph_host": "graph.microsoft.com",
+    "rbac_url": "https://pas.windows.net",
+}
+
 
 class MockHttpServerHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
@@ -220,6 +283,16 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         INSERT ext::auth::ClientConfig {{
             provider_name := "google",
             url := "https://accounts.google.com",
+            provider_id := <str>'{uuid.uuid4()}',
+            secret := <str>'{"c" * 32}',
+            client_id := <str>'{uuid.uuid4()}'
+        }};
+        """,
+        f"""
+        CONFIGURE CURRENT DATABASE
+        INSERT ext::auth::ClientConfig {{
+            provider_name := "azure",
+            url := "https://login.microsoftonline.com/common/v2.0",
             provider_id := <str>'{uuid.uuid4()}',
             secret := <str>'{"c" * 32}',
             client_id := <str>'{uuid.uuid4()}'
@@ -857,3 +930,170 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             requests_for_discovery = mock_provider.requests[discovery_request]
             self.assertEqual(len(requests_for_discovery), 1)
+
+    async def test_http_auth_ext_azure_authorize_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("azure")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+
+            discovery_request = (
+                "GET",
+                "https://login.microsoftonline.com/common/v2.0",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    AZURE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            _, headers, status = self.http_con_request(
+                http_con, {"provider": provider_id}, path="authorize"
+            )
+
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            url = urllib.parse.urlparse(location)
+            qs = urllib.parse.parse_qs(url.query, keep_blank_values=True)
+            self.assertEqual(url.scheme, "https")
+            self.assertEqual(url.hostname, "login.microsoftonline.com")
+            self.assertEqual(url.path, "/common/oauth2/v2.0/authorize")
+            self.assertEqual(qs.get("scope"), ["openid profile email"])
+
+            state = qs.get("state")
+            assert state is not None
+
+            signed_token = jwt.JWT(
+                key=signing_key, algs=["HS256"], jwt=state[0]
+            )
+            claims = json.loads(signed_token.claims)
+            self.assertEqual(claims.get("provider"), provider_id)
+            self.assertEqual(claims.get("iss"), self.http_addr)
+
+            self.assertEqual(
+                qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
+            )
+            self.assertEqual(qs.get("client_id"), [client_id])
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 1)
+
+    async def test_http_auth_ext_azure_callback_01(self):
+        with MockAuthProvider() as mock_provider, self.http_con() as http_con:
+            provider_config = await self.get_client_config_by_provider("azure")
+            provider_id = provider_config.provider_id
+            client_id = provider_config.client_id
+            client_secret = provider_config.secret
+
+            now = datetime.datetime.utcnow()
+
+            discovery_request = (
+                "GET",
+                "https://login.microsoftonline.com/common/v2.0",
+                "/.well-known/openid-configuration",
+            )
+            mock_provider.register_route_handler(*discovery_request)(
+                (
+                    AZURE_DISCOVERY_DOCUMENT,
+                    200,
+                )
+            )
+
+            jwks_request = (
+                "GET",
+                "https://login.microsoftonline.com",
+                "/common/discovery/v2.0/keys",
+            )
+            # Generate a JWK Set
+            k = jwk.JWK.generate(kty='RSA', size=4096)
+            ks = jwk.JWKSet()
+            ks.add(k)
+            jwk_set: dict[str, Any] = ks.export(
+                private_keys=False, as_dict=True
+            )
+
+            mock_provider.register_route_handler(*jwks_request)(
+                (
+                    jwk_set,
+                    200,
+                )
+            )
+
+            token_request = (
+                "POST",
+                "https://login.microsoftonline.com",
+                "/common/oauth2/v2.0/token",
+            )
+            id_token_claims = {
+                "iss": "https://login.microsoftonline.com/common/v2.0",
+                "sub": "1",
+                "aud": client_id,
+                "exp": (now + datetime.timedelta(minutes=5)).timestamp(),
+                "iat": now.timestamp(),
+                "email": "test@example.com",
+            }
+            id_token = jwt.JWT(header={"alg": "RS256"}, claims=id_token_claims)
+            id_token.make_signed_token(k)
+
+            mock_provider.register_route_handler(*token_request)(
+                (
+                    {
+                        "access_token": "azure_access_token",
+                        "id_token": id_token.serialize(),
+                        "scope": "openid",
+                        "token_type": "bearer",
+                    },
+                    200,
+                )
+            )
+
+            signing_key = await self.get_signing_key()
+
+            expires_at = now + datetime.timedelta(minutes=5)
+            state_claims = {
+                "iss": self.http_addr,
+                "provider": str(provider_id),
+                "exp": expires_at.astimezone().timestamp(),
+                "redirect_to": f"{self.http_addr}/some/path",
+            }
+            state_token = self.generate_state_value(state_claims, signing_key)
+
+            data, headers, status = self.http_con_request(
+                http_con,
+                {"state": state_token, "code": "abc123"},
+                path="callback",
+            )
+
+            self.assertEqual(data, b"")
+            self.assertEqual(status, 302)
+
+            location = headers.get("location")
+            assert location is not None
+            server_url = urllib.parse.urlparse(self.http_addr)
+            url = urllib.parse.urlparse(location)
+            self.assertEqual(url.scheme, server_url.scheme)
+            self.assertEqual(url.hostname, server_url.hostname)
+            self.assertEqual(url.path, f"{server_url.path}/some/path")
+
+            requests_for_discovery = mock_provider.requests[discovery_request]
+            self.assertEqual(len(requests_for_discovery), 2)
+
+            requests_for_token = mock_provider.requests[token_request]
+            self.assertEqual(len(requests_for_token), 1)
+            self.assertEqual(
+                requests_for_token[0]["body"],
+                json.dumps(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": "abc123",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                    }
+                ),
+            )


### PR DESCRIPTION
Add Azure/Microsoft "common" tenant OpenID Connect compatible provider.

`common` means:

> Users with both a personal Microsoft account and a work or school account from Azure AD can sign in to the application.

[Source](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#find-your-apps-openid-configuration-document-uri)