### PR TITLE
Allow optional signing key

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -70,7 +70,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             create annotation std::description :=
                 "The signing key used for auth extension. Must be at \
                 least 32 characters long.";
-            set default := "00000000000000000000000000000000";
         };
 
         create property token_time_to_live -> std::duration {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -74,7 +74,8 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
         create property token_time_to_live -> std::duration {
             create annotation std::description :=
-                'The time after which an auth token expires.';
+                "The time after which an auth token expires. A value of 0 \
+                indicates that the token should never expire.";
             set default := <std::duration>'336 hours';
         };
     };

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -185,11 +185,12 @@ class Router:
         expires_in = auth_expiration_time.to_timedelta()
         expires_at = datetime.datetime.utcnow() + expires_in
 
-        claims = {
+        claims: dict[str, Any] = {
             "iss": self.base_path,
             "sub": identity_id,
-            "exp": expires_at.astimezone().timestamp(),
         }
+        if expires_in.total_seconds() != 0:
+            claims["exp"] = expires_at.astimezone().timestamp()
         session_token = jwt.JWT(
             header={"alg": "HS256"},
             claims=claims,


### PR DESCRIPTION
The signing key needs to be optional to allow the extension to be enabled and the secret to be set via some UI.

While I was in here, I wanted to also update the token TTL to treat `0` as non-expiring.