### PR TITLE
Add `PasswordCredential` type for local IdP

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -1,7 +1,7 @@
 #
 # This source file is part of the EdgeDB open source project.
 #
-# Copyright 2018-present MagicStack Inc. and the EdgeDB authors.
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,11 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create property email: std::str;
 
         create constraint exclusive on ((.iss, .sub))
+    };
+
+    create type ext::auth::LocalIdentity {
+        create property password_hash: std::str;
+        create required link identity: ext::auth::Identity;
     };
 
     create type ext::auth::ClientConfig extending cfg::ConfigObject {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -30,9 +30,11 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create constraint exclusive on ((.iss, .sub))
     };
 
-    create type ext::auth::LocalIdentity {
-        create property password_hash: std::str;
-        create required link identity: ext::auth::Identity;
+    create type ext::auth::PasswordCredential {
+        create required property password_hash: std::str;
+        create required link identity: ext::auth::Identity {
+            create constraint exclusive;
+        };
     };
 
     create type ext::auth::ClientConfig extending cfg::ConfigObject {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -30,7 +30,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create constraint exclusive on ((.iss, .sub))
     };
 
-    create type ext::auth::LocalIdentity {
+    create type ext::auth::LocalIdentity extending ext::auth::Identity {
         create required property handle: std::str {
             create constraint exclusive;
         };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -30,9 +30,15 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create constraint exclusive on ((.iss, .sub))
     };
 
+    create type ext::auth::LocalIdentity {
+        create required property handle: std::str {
+            create constraint exclusive;
+        };
+    };
+
     create type ext::auth::PasswordCredential {
         create required property password_hash: std::str;
-        create required link identity: ext::auth::Identity {
+        create required link identity: ext::auth::LocalIdentity {
             create constraint exclusive;
         };
     };


### PR DESCRIPTION
For cases when the server itself is the Identity Provider, we will store things like password hash, reset password token, magic link tokens, etc.

Opening up for early feedback on the model here: I am imagining creating both an `Identity` and `LocalIdentity` when you sign up.