### PR TITLE
Fix link deletion policies on links to union types

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -6563,7 +6563,13 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 target, scls_type=s_links.Link, field_name='target')
 
             # We need to look at all inbound links to all ancestors
-            for ancestor in target.get_ancestors(schema).objects(schema):
+            for ancestor in itertools.chain(
+                target.get_ancestors(schema).objects(schema),
+                schema.get_referrers(
+                    target, scls_type=s_objtypes.ObjectType,
+                    field_name='union_of'
+                ),
+            ):
                 inbound_links |= schema.get_referrers(
                     ancestor, scls_type=s_links.Link, field_name='target')
 

--- a/tests/schemas/link_tgt_del.esdl
+++ b/tests/schemas/link_tgt_del.esdl
@@ -27,9 +27,13 @@ type Target1 extending Named {
      multi link extra_tgt -> Target1;
 };
 type Target1Child extending Target1;
+type Target2 extending Named;
 
 type Source1 extending Named {
     link tgt1_restrict -> Target1 {
+        on target delete restrict;
+    }
+    link tgt_union_restrict -> Target1 | Target2 {
         on target delete restrict;
     }
     link tgt1_allow -> Target1 {
@@ -48,6 +52,9 @@ type Source1 extending Named {
         on target delete allow;
     }
     multi link tgt1_m2m_del_source -> Target1 {
+        on target delete delete source;
+    }
+    multi link tgt_union_m2m_del_source -> Target1 | Target2 {
         on target delete delete source;
     }
 


### PR DESCRIPTION
We were finding the targets properly but not picking up all the
inbound links.

Fixes #6026.