### PR TITLE
Don't persist state in dbview out of transactions

### DIFF
--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -751,7 +751,7 @@ cdef class PGConnection:
                 parse = 0
             else:
                 if self.debug:
-                    self.debug_print(f"discarding ps {stmt_name_to_clean!r}")
+                    self.debug_print(f"discarding ps {stmt_name!r}")
                 outbuf.write_buffer(
                     self.make_clean_stmt_message(stmt_name))
                 del self.prep_stmts[stmt_name]


### PR DESCRIPTION
This is a regression introduced in [#5921](https://github.com/edgedb/edgedb/pull/5921/commits/e2ad279bc8a43c15a7fbe0823185abcbcdeed129)

- [x] Add test in server repo, don't depend on edgedb-python test suite

This should fix the failing CI in edgedb-python on nightly servers.