### PR TITLE
Fix drop of union links when source has a subtype

### DIFF
--- a/edb/schema/reflection/__init__.py
+++ b/edb/schema/reflection/__init__.py
@@ -20,11 +20,11 @@
 from .reader import parse_into, SchemaClassLayout
 from .structure import generate_structure
 from .structure import SchemaTypeLayout, SchemaReflectionParts
-from .writer import write_meta
+from .writer import generate_metadata_write_edgeql
 
 __all__ = (
     'generate_structure',
-    'write_meta',
+    'generate_metadata_write_edgeql',
     'parse_into',
     'SchemaTypeLayout',
     'SchemaClassLayout',

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -41,6 +41,63 @@ from edb.schema.reflection import structure as sr_struct
 
 
 @functools.singledispatch
+def generate_metadata_write_edgeql(
+    cmd: sd.Command,
+    *,
+    classlayout: Dict[Type[so.Object], sr_struct.SchemaTypeLayout],
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+    blocks: List[Tuple[str, Dict[str, Any]]],
+    internal_schema_mode: bool,
+    stdmode: bool,
+) -> None:
+
+    _hoist_if_unused_deletes(cmd)
+
+    return write_meta(
+        cmd,
+        classlayout=classlayout, schema=schema, context=context,
+        blocks=blocks, internal_schema_mode=internal_schema_mode,
+        stdmode=stdmode)
+
+
+def _hoist_if_unused_deletes(
+    cmd: sd.Command,
+    target: Optional[sd.DeleteObject[so.Object]] = None,
+) -> None:
+    """Hoist up if_unused deletes higher in the tree.
+
+    if_unused deletes for things like union and collection types need
+    to be done *after* the referring object that triggered the
+    deletion is deleted. There is special handling in the write_meta
+    case for DeleteObject to support this, but we need to also handle
+    the case where the delete of the union/collection happens down in
+    a nested delete of a child.
+
+    Work around this by hoisting up if_unused to the outermost enclosing
+    delete.  (We can't just hoist to the actual toplevel, because that
+    might move the command after something that needs to go *after*,
+    like a delete of one of the union components.)
+
+    FIXME: Could we instead *generate* the deletions at the outermost point?
+    """
+    new_target = target
+    if not new_target and isinstance(cmd, sd.DeleteObject):
+        new_target = cmd
+
+    for sub in cmd.get_subcommands():
+        if (
+            isinstance(sub, sd.DeleteObject)
+            and target
+            and sub.if_unused
+        ):
+            cmd.discard(sub)
+            target.add_caused(sub)
+        else:
+            _hoist_if_unused_deletes(sub, new_target)
+
+
+@functools.singledispatch
 def write_meta(
     cmd: sd.Command,
     *,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1370,7 +1370,7 @@ def compile_schema_storage_in_delta(
         context.renames.clear()
         context.early_renames.clear()
 
-    s_refl.write_meta(
+    s_refl.generate_metadata_write_edgeql(
         delta,
         classlayout=ctx.compiler_state.schema_class_layout,
         schema=schema,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10200,6 +10200,21 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 }
             ''')
 
+    async def test_edgeql_migration_union_02(self):
+        await self.migrate('''
+            type Target1;
+            type Target1Child extending Target1;
+            type Target2;
+
+            type Source1 {
+                link tgt_union_restrict -> Target1 | Target2;
+                multi link tgt_union_m2m_del_source -> Target1 | Target2;
+            }
+
+            type Source3 extending Source1;
+        ''')
+        await self.migrate('')
+
     async def test_edgeql_migration_backlink_01(self):
         await self.migrate('''
             type User {


### PR DESCRIPTION
Ran into when I added a test for another issue I fixed.