### PR TITLE
Fix unclosed socket warning from http_ext_auth tests

### DIFF
--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -142,6 +142,7 @@ class MockAuthProvider:
         self._address = self._http_server.server_address
         self.has_started.set()
         self._http_server.serve_forever(poll_interval=0.01)
+        self._http_server.server_close()
 
     def __exit__(self, *exc):
         self._http_server.shutdown()


### PR DESCRIPTION
Apparently while `HTTPServer.shutdown` knocks the serving thread out
of `serve_forever`, it does not actually close the server socket.
Explicitly call `server_close` to do that.