### PR TITLE
Fix inherited object types in extensions

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -896,8 +896,20 @@ class Command(
             self.add(command)
 
     def replace(self, existing: Command, new: Command) -> None:  # type: ignore
-        i = self.ops.index(existing)
-        self.ops[i] = new
+        try:
+            i = self.ops.index(existing)
+            self.ops[i] = new
+            return
+        except ValueError:
+            pass
+        try:
+            i = self.before_ops.index(existing)
+            self.before_ops[i] = new
+            return
+        except ValueError:
+            pass
+        i = self.caused_ops.index(existing)
+        self.caused_ops[i] = new
 
     def replace_all(self, commands: Iterable[Command]) -> None:
         self.ops.clear()

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -189,9 +189,9 @@ def reconstruct_tree(
             parent_offset = offsets[new_parent] + (offset_within_parent,)
         else:
             parent_offset = (offset_within_parent,)
-        new_parent.add(parent)
         old_parent = parents[parent]
         old_parent.discard(parent)
+        new_parent.add_caused(parent)
         parents[parent] = new_parent
 
         for i in range(slice_start, len(opbranch)):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15990,6 +15990,11 @@ class TestDDLNonIsolated(tb.DDLTestCase):
               set code := ' ((__col__) NULLS FIRST)';
           };
 
+          create type ext::varchar::ParentTest {
+              create property foo -> str;
+          };
+          create type ext::varchar::ChildTest
+              extending ext::varchar::ParentTest;
         };
         ''')
         try:


### PR DESCRIPTION
The child property deletions need to be marked as add_caused when they
get merged into the parent delete nodes.

Should fix the problems in #6032.