### PR TITLE
Make ids of schema objects stable

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2946,7 +2946,8 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
         metaclass = self.get_schema_metaclass()
 
         props = self.get_resolved_attributes(schema, context)
-        schema, self.scls = metaclass.create_in_schema(schema, **props)
+        schema, self.scls = metaclass.create_in_schema(
+            schema, stdmode=context.stdmode, **props)
 
         if not props.get('id'):
             # Record the generated ID.
@@ -3108,7 +3109,7 @@ class CreateExternalObject(
 
         obj_id = props.get('id')
         if obj_id is None:
-            obj_id = metaclass._prepare_id(schema, props)
+            obj_id = metaclass._prepare_id(schema, context.stdmode, props)
             self.set_attribute_value('id', obj_id)
 
         self.scls = metaclass._create_from_id(obj_id)

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -83,6 +83,15 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             '_irast': None,
         }
 
+    def __eq__(self, rhs: object) -> bool:
+        if not isinstance(rhs, Expression):
+            return NotImplemented
+        return (
+            self.text == rhs.text
+            and self.refs == rhs.refs
+            and self.origin == rhs.origin
+        )
+
     @property
     def qlast(self) -> qlast_.Expr:
         if self._qlast is None:

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -56,6 +56,9 @@ if TYPE_CHECKING:
     ParameterLike_T = TypeVar("ParameterLike_T", bound="ParameterLike")
 
 
+FUNC_NAMESPACE = uuidgen.UUID('80cd3b19-bb51-4659-952d-6bb03e3347d7')
+
+
 def param_as_str(
     schema: s_schema.Schema,
     param: Union[ParameterDesc, Parameter],
@@ -1721,6 +1724,8 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
             elif others := schema.get_functions(
                     sn.QualName(fullname.module, shortname.name), ()):
                 backend_name = others[0].get_backend_name(schema)
+            elif context.stdmode:
+                backend_name = uuidgen.uuid5(FUNC_NAMESPACE, str(fullname))
             else:
                 backend_name = uuidgen.uuid1mc()
             if not self.has_attribute_value('backend_name'):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1084,14 +1084,6 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         return hash(self.id)
 
     @classmethod
-    def generate_id(
-        cls,
-        schema: s_schema.Schema,
-        data: Dict[str, Any],
-    ) -> uuid.UUID:
-        return uuidgen.uuid1mc()
-
-    @classmethod
     def _prepare_id(
         cls,
         schema: s_schema.Schema,
@@ -1112,7 +1104,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
                 return uuidgen.uuid5(
                     TYPE_ID_NAMESPACE, f'{name}-{cls.__name__}')
             else:
-                return cls.generate_id(schema, data)
+                return uuidgen.uuid1mc()
 
     @classmethod
     def _create_from_id(cls: Type[Object_T], id: uuid.UUID) -> Object_T:

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -100,6 +100,8 @@ ObjectCollection_T = TypeVar(
 )
 HashCriterion = Union[Type["Object"], Tuple[str, Any]]
 
+TYPE_ID_NAMESPACE = uuidgen.UUID('00e50276-2502-11e7-97f2-27fe51238dbd')
+
 
 class ReflectionMethod(enum.Enum):
     """Annotation on schema classes telling how to reflect in metaschema."""
@@ -1093,6 +1095,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
     def _prepare_id(
         cls,
         schema: s_schema.Schema,
+        stdmode: bool,
         data: Dict[str, Any],
     ) -> uuid.UUID:
         name = data.get('name')
@@ -1101,7 +1104,15 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         try:
             return get_known_type_id(name)
         except errors.SchemaError:
-            return cls.generate_id(schema, data)
+            if stdmode:
+                # When compiling the standard library, we generate
+                # stable ids based on the internal name and the type's
+                # name. This keeps std schemas compatible across
+                # minor versions at least.
+                return uuidgen.uuid5(
+                    TYPE_ID_NAMESPACE, f'{name}-{cls.__name__}')
+            else:
+                return cls.generate_id(schema, data)
 
     @classmethod
     def _create_from_id(cls: Type[Object_T], id: uuid.UUID) -> Object_T:
@@ -1112,6 +1123,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
     def create_in_schema(
         cls: Type[Object_T],
         schema: s_schema.Schema_T,
+        stdmode: bool = False,
         *,
         id: Optional[uuid.UUID] = None,
         **data: Any,
@@ -1131,7 +1143,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
             obj_data[field.index] = value
 
         if id is None:
-            id = cls._prepare_id(schema, data)
+            id = cls._prepare_id(schema, stdmode, data)
         scls = cls._create_from_id(id)
         schema = schema.add(id, cls, tuple(obj_data))
 

--- a/edb/schema/std.py
+++ b/edb/schema/std.py
@@ -90,25 +90,31 @@ def load_std_module(
     )
 
 
+BASE_VERSION = uuidgen.UUID('013d1e23-51ce-11ee-a29d-e1f01853d332')
+GLOBAL_BASE_VERSION = uuidgen.UUID('013d235b-51ce-11ee-be76-bf15d10edfe5')
+
+
 def make_schema_version(
     schema: s_schema.Schema,
 ) -> Tuple[s_schema.Schema, s_ver.CreateSchemaVersion]:
+    context = sd.CommandContext(stdmode=True)
     sv = sn.UnqualName('__schema_version__')
     schema_version = s_ver.CreateSchemaVersion(classname=sv)
     schema_version.set_attribute_value('name', sv)
-    schema_version.set_attribute_value('version', uuidgen.uuid1mc())
+    schema_version.set_attribute_value('version', BASE_VERSION)
     schema_version.set_attribute_value('internal', True)
-    schema = sd.apply(schema_version, schema=schema)
+    schema = sd.apply(schema_version, schema=schema, context=context)
     return schema, schema_version
 
 
 def make_global_schema_version(
     schema: s_schema.Schema,
 ) -> Tuple[s_schema.Schema, s_ver.CreateGlobalSchemaVersion]:
+    context = sd.CommandContext(stdmode=True)
     sv = sn.UnqualName('__global_schema_version__')
     schema_version = s_ver.CreateGlobalSchemaVersion(classname=sv)
     schema_version.set_attribute_value('name', sv)
-    schema_version.set_attribute_value('version', uuidgen.uuid1mc())
+    schema_version.set_attribute_value('version', GLOBAL_BASE_VERSION)
     schema_version.set_attribute_value('internal', True)
-    schema = sd.apply(schema_version, schema=schema)
+    schema = sd.apply(schema_version, schema=schema, context=context)
     return schema, schema_version

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -28,7 +28,6 @@ import uuid
 from edb import errors
 
 from edb.common import checked
-from edb.common import uuidgen
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -53,7 +52,6 @@ if typing.TYPE_CHECKING:
     from edb.common import parsing
 
 
-TYPE_ID_NAMESPACE = uuidgen.UUID('00e50276-2502-11e7-97f2-27fe51238dbd')
 MAX_TYPE_DISTANCE = 1_000_000_000
 
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -532,8 +532,7 @@ def _process_delta_params(delta, schema, params):
         debug.header('Delta Plan')
         debug.dump(delta, schema=schema)
 
-    context = sd.CommandContext()
-    context.stdmode = True
+    context = sd.CommandContext(stdmode=True)
 
     if not delta.canonical:
         # Canonicalize
@@ -961,6 +960,7 @@ async def _make_stdlib(
     schema, _ = s_mod.Module.create_in_schema(
         schema,
         name=sn.UnqualName('__derived__'),
+        stdmode=True,
     )
 
     current_block = dbops.PLTopBlock()
@@ -1019,7 +1019,7 @@ async def _make_stdlib(
         if not schema.has_object(obj.id):
             delta = sd.DeltaRoot()
             delta.add(obj.as_shell(reflschema).as_create_delta(reflschema))
-            schema = delta.apply(schema, sd.CommandContext())
+            schema = delta.apply(schema, sd.CommandContext(stdmode=True))
     assert isinstance(schema, s_schema.ChainedSchema)
 
     assert current_block is not None
@@ -1098,8 +1098,7 @@ async def _amend_stdlib(
     topblock = dbops.PLTopBlock()
     plans = []
 
-    context = sd.CommandContext()
-    context.stdmode = True
+    context = sd.CommandContext(stdmode=True)
 
     for ddl_cmd in edgeql.parse_block(ddl_text):
         assert isinstance(ddl_cmd, qlast.DDLCommand)

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -213,7 +213,7 @@ def _get_collection_type_id(
     string_id = f'{coll_type}\x00{":".join(map(str, subtypes))}'
     if element_names:
         string_id += f'\x00{":".join(element_names)}'
-    return uuidgen.uuid5(s_types.TYPE_ID_NAMESPACE, string_id)
+    return uuidgen.uuid5(s_obj.TYPE_ID_NAMESPACE, string_id)
 
 
 def _get_object_shape_id(
@@ -234,12 +234,12 @@ def _get_object_shape_id(
         parts.append(":".join(chr(c._value_) for c in cardinalities))
     string_id = "\x00".join(parts)
     string_id += f'{has_implicit_fields!r};{links_props!r};{links!r}'
-    return uuidgen.uuid5(s_types.TYPE_ID_NAMESPACE, string_id)
+    return uuidgen.uuid5(s_obj.TYPE_ID_NAMESPACE, string_id)
 
 
 def _get_set_type_id(basetype_id: uuid.UUID) -> uuid.UUID:
     return uuidgen.uuid5(
-        s_types.TYPE_ID_NAMESPACE, 'set-of::' + str(basetype_id))
+        s_obj.TYPE_ID_NAMESPACE, 'set-of::' + str(basetype_id))
 
 
 def _register_type_id(


### PR DESCRIPTION
Instead of generating them randomly, use a uuid5 generated using the
name/type of the object.

Does the implementation work of #6054, but I don't want to close that
(and we shouldn't depend on this) until we have a testing setup.

I tested this using:
```
import pickle
from edb.common import devmode
devmode.enable_dev_mode()

p1 = pickle.loads(open('backend-stdlib.pickle', mode='rb').read()[20:])
p2 = pickle.loads(open('build/cache/backend-stdlib.pickle', mode='rb').read()[20:])

mismatched = [k for k in p1.reflschema._id_to_data if p1.reflschema._id_to_data.get(k) != p2.reflschema._id_to_data.get(k)]

print("reflschema:", p1.reflschema.__dict__ == p2.reflschema.__dict__)
print("stdschema:", p1.stdschema.__dict__ == p2.stdschema.__dict__)
```