### PR TITLE
Return the delta dump to the user when we hit "not complete but no proposed"

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -195,6 +195,11 @@ def dump(*args, **kwargs):
     _markup.dump(*args, **kwargs)
 
 
+def dumps(*args, **kwargs):
+    from . import markup as _markup
+    return _markup.dumps(*args, **kwargs)
+
+
 def dump_code(*args, **kwargs):
     from . import markup as _markup
     _markup.dump_code(*args, **kwargs)

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -689,6 +689,8 @@ def _describe_current_migration(
             else:
                 proposed_desc = None
 
+        extra = {}
+
         complete = False
         if proposed_desc is None:
             diff = s_ddl.delta_schemas(schema, mstate.target_schema)
@@ -696,6 +698,8 @@ def _describe_current_migration(
             if debug.flags.delta_plan and not complete:
                 debug.header('DESCRIBE CURRENT MIGRATION AS JSON mismatch')
                 debug.dump(diff)
+            if not complete:
+                extra['debug_diff'] = debug.dumps(diff)
 
         desc = (
             json.dumps(
@@ -708,6 +712,7 @@ def _describe_current_migration(
                     'complete': complete,
                     'confirmed': confirmed,
                     'proposed': proposed_desc,
+                    **extra,
                 }
             )
             .encode('unicode_escape')


### PR DESCRIPTION
It will probably always be inscrutable to users but I'll be able to
ask users for it when they are hitting certain nasty schema errors,
and it will be much easier for them to give it to me if they don't
need to restart the server with logging.

We can give the cli a flag to include the data.

I tested this using the bug in #5714.