### PR TITLE
Make patches tests able to catch busted migrations

### DIFF
--- a/.github/scripts/patches/create-databases.py
+++ b/.github/scripts/patches/create-databases.py
@@ -18,6 +18,23 @@ try:
     for name in ['json', 'functions', 'expressions', 'casts', 'policies', 'vector', 'scope']:
         db.execute(f'create database {name};')
 
+    # For the scope database, let's actually migration to it.  This
+    # will test that the migrations can still work after the upgrade.
+    db2 = edgedb.create_client(
+        host='localhost', port=10000, tls_security='insecure', database='scope'
+    )
+    with open("tests/schemas/cards.esdl") as f:
+        body = f.read()
+    db2.execute(f'''
+        START MIGRATION TO {{
+            module default {{
+                {body}
+            }}
+        }};
+        POPULATE MIGRATION;
+        COMMIT MIGRATION;
+    ''')
+
 finally:
     proc.terminate()
     proc.wait()

--- a/.github/workflows.src/tests-patches.tpl.yml
+++ b/.github/workflows.src/tests-patches.tpl.yml
@@ -67,7 +67,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -468,7 +468,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -280,5 +280,10 @@ std::__range_validate_json(v: std::json) -> OPTIONAL std::json
         ) j
     $$;
 };
-''')
+'''),
+    # Repair only if the database was originally created with rc1 or
+    # rc2, prior to pgvector being added. This catches a schema
+    # problem caused by adding prefer_subquery_args, where we
+    # distinguish between None (from old dbs) and False (the default).
+    ('repair', 'from {3.0-rc.1, 3.0-rc.2}'),
 ])


### PR DESCRIPTION
Upgrading from rc.1/rc.2 to later versions leaves user schemas in a bad state, since
the `prefer_subquery_args` field is `None` on old versions and `False` on new ones.
 
To make sure we won't miss issues like this again, fix the patches tests to
create an instance of the database for the `scope` tests (probably the most complex
of the test schemas). If the schema state is corrupted, then the (now no-op) migration
when running the tests will fail.

Also fix the object-level issue by adding a repair pass that only runs if the database 
was created with rc1 or rc2. We'll maybe want to add a mechanism to properly detect
that, but since we don't have one, we have to be a bit hacky.
We could also skip the auto-repair and just document that affected users should run
`administer schema_repair()`.