### PR TITLE
Allow computed pointers on types to omit link/property kind specification

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1049,6 +1049,10 @@ class CreateConcreteUnknownPointer(CreateConcretePointer):
     pass
 
 
+class AlterConcreteUnknownPointer(AlterObject, PropertyCommand):
+    pass
+
+
 class CreateConcreteProperty(CreateConcretePointer, PropertyCommand):
     pass
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1647,7 +1647,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def _process_AlterConcretePointer_for_SDL(
         self,
-        node: Union[qlast.AlterConcreteProperty, qlast.AlterConcreteLink],
+        node: qlast.AlterObject,
     ) -> Tuple[List[str], FrozenSet[qlast.DDLOperation]]:
         keywords = []
         specials = set()
@@ -1668,36 +1668,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self,
         node: qlast.AlterConcreteProperty
     ) -> None:
-        keywords = []
-        ignored_cmds: Set[qlast.DDLOperation] = set()
-        after_name: Optional[Callable[[], None]] = None
-
-        if self.sdlmode:
-            if not self.descmode:
-                keywords.append('OVERLOADED')
-            quals, ignored_cmds_r = self._process_AlterConcretePointer_for_SDL(
-                node)
-            keywords.extend(quals)
-            ignored_cmds.update(ignored_cmds_r)
-
-            type_cmd = None
-            for cmd in node.commands:
-                if isinstance(cmd, qlast.SetPointerType):
-                    ignored_cmds.add(cmd)
-                    type_cmd = cmd
-                    break
-
-            def after_name() -> None:
-                if type_cmd is not None:
-                    self.write(' -> ')
-                    assert type_cmd.value
-                    self.visit(type_cmd.value)
-
-        keywords.append('PROPERTY')
-        self._visit_AlterObject(
-            node, *keywords, ignored_cmds=ignored_cmds,
-            allow_short=False, unqualified=True,
-            after_name=after_name)
+        self.visit_AlterConcretePointer(node, kind='PROPERTY')
 
     def visit_DropConcreteProperty(
         self,
@@ -1770,13 +1741,23 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     ) -> None:
         self.visit_CreateConcretePointer(node, kind=None)
 
+    def visit_AlterConcreteUnknownPointer(
+        self,
+        node: qlast.AlterConcreteLink
+    ) -> None:
+        self.visit_AlterConcretePointer(node, kind=None)
+
     def visit_CreateConcreteLink(
         self,
         node: qlast.CreateConcreteLink
     ) -> None:
         self.visit_CreateConcretePointer(node, kind='LINK')
 
-    def visit_AlterConcreteLink(self, node: qlast.AlterConcreteLink) -> None:
+    def visit_AlterConcretePointer(
+        self,
+        node: qlast.AlterObject,
+        kind: Optional[str],
+    ) -> None:
         keywords = []
         ignored_cmds: Set[qlast.DDLOperation] = set()
 
@@ -1812,10 +1793,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         else:
             after_name = None
 
-        keywords.append('LINK')
+        if kind:
+            keywords.append(kind)
         self._visit_AlterObject(
             node, *keywords, ignored_cmds=ignored_cmds,
             allow_short=False, unqualified=True, after_name=after_name)
+
+    def visit_AlterConcreteLink(self, node: qlast.AlterConcreteLink) -> None:
+        self.visit_AlterConcretePointer(node, kind='LINK')
 
     def visit_DropConcreteLink(self, node: qlast.DropConcreteLink) -> None:
         self._visit_DropObject(node, 'LINK', unqualified=True)

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -38,6 +38,7 @@ from . import referencing
 from . import rewrites as s_rewrites
 from . import sources
 from . import types as s_types
+from . import unknown_pointers
 from . import utils
 
 if TYPE_CHECKING:
@@ -209,6 +210,7 @@ class LinkCommandContext(
     pointers.PointerCommandContext[Link],
     constraints.ConsistencySubjectCommandContext,
     properties.PropertySourceContext[Link],
+    unknown_pointers.UnknownPointerSourceContext[Link],
     sources.SourceCommandContext[Link],
     s_rewrites.RewriteSubjectCommandContext,
 ):

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -44,6 +44,7 @@ from . import schema as s_schema
 from . import sources
 from . import triggers
 from . import types as s_types
+from . import unknown_pointers
 from . import utils
 
 
@@ -471,6 +472,7 @@ def get_or_create_intersection_type(
 class ObjectTypeCommandContext(
     links.LinkSourceCommandContext[ObjectType],
     properties.PropertySourceContext[ObjectType],
+    unknown_pointers.UnknownPointerSourceContext[ObjectType],
     policies.AccessPolicySourceCommandContext[ObjectType],
     triggers.TriggerSourceCommandContext[ObjectType],
     sd.ObjectCommandContext[ObjectType],

--- a/edb/schema/unknown_pointers.py
+++ b/edb/schema/unknown_pointers.py
@@ -1,0 +1,174 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Machinery for handling pointers with an unspecified kind.
+
+Most of the DDL/delta machinery really requires that we know whether
+we are operating on a link or a property, but our SDL syntax allows
+omitting the specifier. Because the pointer might be computed, it's
+not possible to resolve this ahead of time, so we build just enough
+machinery for compiling unknown pointer operations to make
+ddl.apply_sdl work.
+
+"""
+
+from __future__ import annotations
+from typing import *
+
+
+from edb.common import struct
+
+from edb.edgeql import ast as qlast
+from edb.edgeql import parser as qlparser
+
+from . import delta as sd
+from . import objects as so
+from . import properties as s_props
+from . import pointers
+from . import sources
+from . import schema as s_schema
+
+
+class UnknownPointerSourceContext(
+    sources.SourceCommandContext[sources.Source_T]
+):
+    pass
+
+
+class UnknownPointerCommand(
+    pointers.PointerCommand[pointers.Pointer],
+    context_class=pointers.PointerCommandContext,
+    referrer_context_class=UnknownPointerSourceContext,
+):
+    _schema_metaclass = pointers.Pointer
+
+    def _propagate_ref_creation(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        referrer: so.InheritingObject,
+    ) -> None:
+        pass
+
+
+class CreateUnknownPointer(
+    UnknownPointerCommand,
+    pointers.CreatePointer[pointers.Pointer],
+):
+    astnode = qlast.CreateConcreteUnknownPointer
+    referenced_astnode = qlast.CreateConcreteUnknownPointer
+
+    # We stash the original AST node here, so we can reuse it in apply
+    # after we've figured out the type.
+    node = struct.Field(qlast.CreateConcreteUnknownPointer, default=None)
+
+    @classmethod
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
+        assert isinstance(astnode, qlast.CreateConcreteUnknownPointer)
+
+        # We don't need any of the subcommands in order to figure out
+        # the kind, and we avoid needing to get the contexts right if
+        # we skip them.
+        fakenode = astnode.replace(commands=[])
+        cmd = super()._cmd_tree_from_ast(schema, fakenode, context)
+        assert isinstance(cmd, CreateUnknownPointer)
+        cmd._process_create_or_alter_ast(schema, fakenode, context)
+
+        if context.modaliases:
+            astnode = astnode.replace()
+            qlparser.append_module_aliases(astnode, context.modaliases)
+
+        cmd.node = astnode
+
+        return cmd
+
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        # We don't know what the real type of this pointer is, so this
+        # is a two step process:
+        # 1. Apply it using purely generic Pointer code. This doesn't produce
+        #    a fully legitimate result, but will resolve the target.
+        # 2. Check whether the target is an object, and construct a new
+        #    create AST node specialized to pointer or link. Then compile
+        #    that to a delta tree and apply it.
+
+        nschema = super().apply(schema, context)
+        target = self.scls.get_target(nschema)
+        assert target
+
+        astnode = self.node
+        assert astnode
+        astcls = (
+            qlast.CreateConcreteLink
+            if target.is_object_type()
+            else qlast.CreateConcreteProperty
+        )
+        astnode = astnode.replace(__class__=astcls)
+
+        ncmd = sd.compile_ddl(schema, astnode, context=context)
+        assert isinstance(ncmd, pointers.CreatePointer)
+
+        rschema = ncmd.apply(schema, context)
+        return rschema
+
+
+class AlterUnknownPointer(
+    UnknownPointerCommand,
+    pointers.AlterPointer[pointers.Pointer],
+):
+    astnode = qlast.AlterConcreteUnknownPointer
+    referenced_astnode = qlast.AlterConcreteUnknownPointer
+
+    @classmethod
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> pointers.AlterPointer[pointers.Pointer]:
+        # For alters that get run as part of apply_sdl, the relevant
+        # object should exist in the schema when _cmd_tree_from_ast is
+        # called, so we can resolve whether it is a link or a property
+        # right away and never need to return an AlterUnknownPointer
+        # object.
+
+        # We don't need any of the subcommands in order to figure out
+        # the kind, and we avoid needing to get the contexts right if
+        # we skip them.
+        fakenode = astnode.replace(commands=[])
+        cmd = super()._cmd_tree_from_ast(schema, fakenode, context)
+
+        obj = cmd.get_object(schema, context)
+        astcls = (
+            qlast.AlterConcreteProperty
+            if isinstance(obj, s_props.Property)
+            else qlast.AlterConcreteLink
+        )
+        astnode = astnode.replace(__class__=astcls)
+        qlparser.append_module_aliases(astnode, context.modaliases)
+        res = sd.compile_ddl(schema, astnode, context=context)
+        assert isinstance(res, pointers.AlterPointer)
+        return res

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -54,12 +54,12 @@ type Bot extending User;
 type Card extending Named {
     required element: str;
     required cost: int64;
-    multi link owners := .<deck[IS User];
+    multi owners := .<deck[IS User];
     # computable property
-    property elemental_cost := <str>.cost ++ ' ' ++ .element;
+    elemental_cost := <str>.cost ++ ' ' ++ .element;
     multi awards: Award;
-    multi link good_awards := (SELECT .awards FILTER .name != '3rd');
-    single link best_award := (select .awards order by .name limit 1);
+    multi good_awards := (SELECT .awards FILTER .name != '3rd');
+    single best_award := (select .awards order by .name limit 1);
 }
 
 type SpecialCard extending Card;

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -124,12 +124,12 @@ type URL extending Named {
 type Publication {
     required title: str;
 
-    property title1 := (SELECT ident(.title));
-    required property title2 := (SELECT ident(.title));
-    required single property title3 := (SELECT ident(.title));
-    optional single property title4 := (SELECT ident(.title));
-    optional multi property title5 := (SELECT ident(.title));
-    required multi property title6 := (SELECT ident(.title));
+    title1 := (SELECT ident(.title));
+    required title2 := (SELECT ident(.title));
+    required single title3 := (SELECT ident(.title));
+    optional single title4 := (SELECT ident(.title));
+    optional multi title5 := (SELECT ident(.title));
+    required multi title6 := (SELECT ident(.title));
 
     multi authors: User {
         list_order: int64;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13730,7 +13730,7 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
             "'ha' is not a valid field",
         ):
             await self.con.execute(r"""
-                CREATE TYPE Lol {SET ha := "crash"};
+                CREATE SCALAR TYPE Lol extending str {SET ha := "crash"};
             """)
 
     async def test_edgeql_ddl_bad_field_02(self):
@@ -13740,7 +13740,7 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
         ):
             await self.con.execute(r"""
                 START MIGRATION TO {
-                    type default::Lol {
+                    scalar type default::Lol extending str {
                         ha := "crash"
                     }
                 }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -368,12 +368,12 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
             module default {
                 type Person {
-                    required name : str {
+                    required name: str {
                         constraint exclusive;
                     }
 
                     multi friends : Person {
-                        note : str {
+                        note: str {
                             default := .name
                         }
                     }
@@ -3770,25 +3770,62 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         };
         type Foo {
             name: str;
+            required address: str {
+                default := "n" ++ "/a";
+            }
             foo: Foo;
+            multi foos: Foo;
             bar: Bar;
             bar2 extending friendship: Bar;
+            bar3: Bar {
+               lprop: str {
+                   default := "foo" ++ "bar";
+               }
+            };
             or_: Foo | Bar;
             array1: array<str>;
             array2: array<scl>;
+
+            cprop1 := .name;
+            multi cprop2 := (
+              with us := .name,
+              select (select .foos filter .name != us).name
+            );
+            required cprop3 := assert_exists(.name);
+
+            clink1 := (select .foo filter .name != 'Elvis');
         };
+        type Child extending Foo {
+            overloaded foo {
+                lprop: str;
+            };
+        }
         '''
 
         schema = self._assert_migration_consistency(tschema)
 
         obj = schema.get('default::Foo')
         obj.getptr(schema, s_name.UnqualName('name'), type=s_props.Property)
+        obj.getptr(schema, s_name.UnqualName('address'), type=s_props.Property)
         obj.getptr(schema, s_name.UnqualName('array1'), type=s_props.Property)
         obj.getptr(schema, s_name.UnqualName('array2'), type=s_props.Property)
         obj.getptr(schema, s_name.UnqualName('foo'), type=s_links.Link)
         obj.getptr(schema, s_name.UnqualName('bar'), type=s_links.Link)
         obj.getptr(schema, s_name.UnqualName('bar2'), type=s_links.Link)
         obj.getptr(schema, s_name.UnqualName('or_'), type=s_links.Link)
+
+        obj.getptr(schema, s_name.UnqualName('cprop1'), type=s_props.Property)
+        obj.getptr(schema, s_name.UnqualName('cprop2'), type=s_props.Property)
+        obj.getptr(schema, s_name.UnqualName('cprop3'), type=s_props.Property)
+
+        obj.getptr(schema, s_name.UnqualName('clink1'), type=s_links.Link)
+
+        ptr = obj.getptr(schema, s_name.UnqualName('bar3'), type=s_links.Link)
+        ptr.getptr(schema, s_name.UnqualName('lprop'), type=s_props.Property)
+
+        obj2 = schema.get('default::Child')
+        ptr = obj2.getptr(schema, s_name.UnqualName('foo'), type=s_links.Link)
+        ptr.getptr(schema, s_name.UnqualName('lprop'), type=s_props.Property)
 
     def test_schema_migrations_equivalence_01(self):
         self._assert_migration_equivalence([r"""


### PR DESCRIPTION
This requires dropping the field setting syntax from object types, but
that's mostly OK because object types don't have any fields that can
be set from SDL.
This introduces some inconsistency but it is probably acceptable.

If we want to add fields to object types in the future, probably
we'll just want to allow writing `SET foo := ...`.
Technically, id can be set on object types, but it only works
now in DDL, so there is no breakage.

The implementation is a pile of hacks, where we run creation using
only the generic Pointer code, determine whether the target is an
object, then reinterpret the original ast node with that information
and run the resulting delta. Oh well.