### PR TITLE
Support functional-style if/then/else syntax

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -385,6 +385,8 @@ class IfElse(Expr):
     condition: Expr
     if_expr: Expr
     else_expr: Expr
+    # Just affects pretty-printing
+    python_style: bool = False
 
 
 class TupleElement(Base):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -460,11 +460,19 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_IfElse(self, node: qlast.IfElse) -> None:
         self.write('(')
-        self.visit(node.if_expr)
-        self._write_keywords(' IF ')
-        self.visit(node.condition)
-        self._write_keywords(' ELSE ')
-        self.visit(node.else_expr)
+        if node.python_style:
+            self.visit(node.if_expr)
+            self._write_keywords(' IF ')
+            self.visit(node.condition)
+            self._write_keywords(' ELSE ')
+            self.visit(node.else_expr)
+        else:
+            self._write_keywords(' IF ')
+            self.visit(node.condition)
+            self._write_keywords(' THEN ')
+            self.visit(node.if_expr)
+            self._write_keywords(' ELSE ')
+            self.visit(node.else_expr)
         self.write(')')
 
     def visit_Tuple(self, node: qlast.Tuple) -> None:

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1389,8 +1389,21 @@ class Expr(Nonterm):
         )
 
     def reduce_Expr_IF_Expr_ELSE_Expr(self, *kids):
+        if_expr, _, condition, _, else_expr = kids
         self.val = qlast.IfElse(
-            if_expr=kids[0].val, condition=kids[2].val, else_expr=kids[4].val)
+            if_expr=if_expr.val,
+            condition=condition.val,
+            else_expr=else_expr.val,
+            python_style=True,
+        )
+
+    def reduce_IF_Expr_THEN_Expr_ELSE_Expr(self, *kids):
+        _, condition, _, if_expr, _, else_expr = kids
+        self.val = qlast.IfElse(
+            condition=condition.val,
+            if_expr=if_expr.val,
+            else_expr=else_expr.val,
+        )
 
     def reduce_Expr_UNION_Expr(self, *kids):
         self.val = qlast.BinOp(left=kids[0].val, op='UNION',

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -812,6 +812,24 @@ aa';
         SELECT (User IS (Named, Text));
         """
 
+    def test_edgeql_syntax_ops_27(self):
+        """
+        WITH x := {'b', 'a', 't'}
+        SELECT
+            IF x = 'a' THEN 1 ELSE
+            IF x = 'b' THEN 10 ELSE
+            IF x = 'c' THEN 100 ELSE
+            0;
+
+% OK %
+
+        WITH x := {'b', 'a', 't'}
+        SELECT
+            (IF (x = 'a') THEN 1 ELSE
+            (IF (x = 'b') THEN 10 ELSE
+            (IF (x = 'c') THEN 100 ELSE
+            0)));
+        """
     def test_edgeql_syntax_required_01(self):
         """
         SELECT REQUIRED (User.groups.description);
@@ -933,7 +951,7 @@ aa';
         SELECT event;
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=17)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=19)
     def test_edgeql_syntax_name_08(self):
         """
         SELECT (event::if);
@@ -1910,7 +1928,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected keyword 'IF'", line=4, col=13)
+                  r"Missing '\('", line=4, col=15)
     def test_edgeql_syntax_struct_08(self):
         """
         SELECT (


### PR DESCRIPTION
In addition to our current "Python-style"
`then_expr if cond_expr else else_expr`, add support for
Haskell/SML/OCaml-style
`if cond_expr then then_expr else else_expr`.

The Python-style syntax did a great job fitting a conditional
expression into Python under a lot of tough syntactic constraints, but
non-Python people tend to hate it and it will look pretty bad once we
have conditional DML.

There aren't any grammar conflicts, so this is fully backward
compatible, and both syntaxes can coexist peacefully, though we should
change all of our documentation to prefer the new syntax.