### PR TITLE
Adjust error message for some INSERT cases.

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -302,9 +302,29 @@ class SimpleInsert(Nonterm):
                 len(subj_path.steps) == 1 and  \
                 isinstance(subj_path.steps[0], qlast.ObjectRef):
             objtype = subj_path.steps[0]
+        elif isinstance(subj_path, qlast.IfElse):
+            # Insert attempted on something that looks like a conditional
+            # expression. Aside from it being an error, it also seems that
+            # the intent was to insert something conditionally.
+            raise errors.EdgeQLSyntaxError(
+                f"INSERT only works with object types, not conditional "
+                f"expressions",
+                hint=(
+                    f"To resolve this try surrounding the INSERT branch of "
+                    f"the conditional expression with parentheses. This way "
+                    f"the INSERT will be triggered conditionally in one of "
+                    f"the branches."
+                ),
+                context=subj_path.context)
         else:
             raise errors.EdgeQLSyntaxError(
-                "insert expression must be an object type reference",
+                f"INSERT only works with object types, not arbitrary "
+                f"expressions",
+                hint=(
+                    f"To resolve this try to surround the entire INSERT "
+                    f"statement with parentheses in order to separate it "
+                    f"from the rest of the expression."
+                ),
                 context=subj_path.context)
 
         self.val = qlast.InsertQuery(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -32,7 +32,7 @@ class TestInsert(tb.QueryTestCase):
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'insert.esdl')
 
-    async def test_edgeql_insert_fail_1(self):
+    async def test_edgeql_insert_fail_01(self):
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             r"missing value for required property"
@@ -42,7 +42,7 @@ class TestInsert(tb.QueryTestCase):
                 INSERT InsertTest;
             ''')
 
-    async def test_edgeql_insert_fail_2(self):
+    async def test_edgeql_insert_fail_02(self):
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             r"missing value for required property"
@@ -54,7 +54,7 @@ class TestInsert(tb.QueryTestCase):
                 };
             ''')
 
-    async def test_edgeql_insert_fail_3(self):
+    async def test_edgeql_insert_fail_03(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"modification of computed property"
@@ -68,7 +68,7 @@ class TestInsert(tb.QueryTestCase):
                 };
             ''')
 
-    async def test_edgeql_insert_fail_4(self):
+    async def test_edgeql_insert_fail_04(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"mutation queries must specify values with ':='",
@@ -77,16 +77,17 @@ class TestInsert(tb.QueryTestCase):
                 INSERT Person { name };
             ''')
 
-    async def test_edgeql_insert_fail_5(self):
+    async def test_edgeql_insert_fail_05(self):
         with self.assertRaisesRegex(
-            edgedb.EdgeQLSyntaxError,
-            r"insert expression must be an object type reference",
+            edgedb.QueryError,
+            "INSERT only works with object types, not arbitrary "
+            "expressions"
         ):
             await self.con.execute('''
                 INSERT Person.notes { name := "note1" };
             ''')
 
-    async def test_edgeql_insert_fail_6(self):
+    async def test_edgeql_insert_fail_06(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"could not resolve partial path",
@@ -95,7 +96,7 @@ class TestInsert(tb.QueryTestCase):
                 INSERT Person { name := .name };
             ''')
 
-    async def test_edgeql_insert_fail_7(self):
+    async def test_edgeql_insert_fail_07(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"insert standard library type",
@@ -103,6 +104,28 @@ class TestInsert(tb.QueryTestCase):
             await self.con.execute('''
                 INSERT schema::Migration { script := 'foo' };
             ''')
+
+    async def test_edgeql_insert_fail_08(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "INSERT only works with object types, not arbitrary "
+            "expressions"
+        ):
+            await self.con.execute("""
+                insert Note {name := 'bad note'} union DerivedNote;
+            """)
+
+    async def test_edgeql_insert_fail_09(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "INSERT only works with object types, not conditional "
+            "expressions"
+        ):
+            await self.con.execute("""
+                insert Note {
+                    name := 'bad note'
+                } if not exists DerivedNote else DerivedNote;
+            """)
 
     async def test_edgeql_insert_simple_01(self):
         await self.con.execute(r"""

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3021,7 +3021,8 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  'insert expression must be an object type reference',
+                  'INSERT only works with object types, not arbitrary '
+                  'expressions',
                   line=2, col=16)
     def test_edgeql_syntax_insert_05(self):
         """


### PR DESCRIPTION
Inserting an expression can indicate that the intent was to perform a conditional insert. Check the expression and provide more specific error message.