### PR TITLE
Support marking config variables as "secret"

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_09_05_00_00
+EDGEDB_CATALOG_VERSION = 2023_09_18_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/compiler/config_desc.py
+++ b/edb/edgeql/compiler/config_desc.py
@@ -270,13 +270,15 @@ def _render_config_set(
         return (
             f"'CONFIGURE {scope.to_edgeql()} "
             f"SET { qlquote.quote_ident(name) } := {{' ++ "
-            f"array_join(array_agg({v}), ', ') ++ '}};\\n'"
+            f"array_join(array_agg((select _ := {v} order by _)), ', ') "
+            f"++ '}};\\n'"
         )
     else:
         indent = ' ' * (4 * (level - 1))
         return (
             f"'{indent}{ qlquote.quote_ident(name) } := {{' ++ "
-            f"array_join(array_agg({v}), ', ') ++ '}},'"
+            f"array_join(array_agg((SELECT _ := {v} ORDER BY _)), ', ') "
+            f"++ '}},'"
         )
 
 
@@ -357,12 +359,12 @@ def _render_config_object(
         sli_render = sub_layouts_items[0]
 
     return '\n'.join((
-        f"array_join(array_agg((",
+        f"array_join(array_agg((SELECT _ := (",
         f"  FOR item IN {{ {value_expr} }}",
         f"  UNION (",
         f"{textwrap.indent(sli_render, ' ' * 4)}",
         f"  )",
-        f")), {ql(join_term)})",
+        f") ORDER BY _)), {ql(join_term)})",
     ))
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -530,6 +530,9 @@ class ContextLevel(compiler.ContextLevel):
     defining_view: Optional[s_objtypes.ObjectType]
     """Whether a view is currently being defined (as opposed to be compiled)"""
 
+    current_schema_views: tuple[s_types.Type, ...]
+    """Which schema views are currently being compiled"""
+
     recompiling_schema_alias: bool
     """Whether we are currently recompiling a schema-level expression alias."""
 
@@ -599,6 +602,7 @@ class ContextLevel(compiler.ContextLevel):
             self.special_computables_in_mutation_shape = frozenset()
             self.empty_result_type_hint = None
             self.defining_view = None
+            self.current_schema_views = ()
             self.compiling_update_shape = False
             self.active_computeds = ordered.OrderedSet()
             self.recompiling_schema_alias = False
@@ -641,6 +645,7 @@ class ContextLevel(compiler.ContextLevel):
                 prevlevel.special_computables_in_mutation_shape
             self.empty_result_type_hint = prevlevel.empty_result_type_hint
             self.defining_view = prevlevel.defining_view
+            self.current_schema_views = prevlevel.current_schema_views
             self.compiling_update_shape = prevlevel.compiling_update_shape
             self.active_computeds = prevlevel.active_computeds
             self.recompiling_schema_alias = prevlevel.recompiling_schema_alias

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -69,6 +69,9 @@ class GlobalCompilerOptions:
     #: this contains the type of the schema object.
     schema_object_context: Optional[Type[s_obj.Object]] = None
 
+    #: When compiling a function body, the function name.
+    func_name: Optional[s_name.QualName] = None
+
     #: When compiling a function body, specifies function parameter
     #: definitions.
     func_params: Optional[s_func.ParameterLikeList] = None

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -745,6 +745,7 @@ def _declare_view_from_schema(
     # subcontext to compile in, but it should avoid depending on the
     # context, because of the cache.
     with ctx.detached() as subctx:
+        subctx.current_schema_views += (viewcls,)
         subctx.expr_exposed = context.Exposure.UNEXPOSED
         view_expr = viewcls.get_expr(ctx.env.schema)
         assert view_expr is not None

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -474,9 +474,9 @@ def _process_view(
     # Produce the shape. The main thing here is that we need to fixup
     # all of the rptrs to properly point back at ir_set.
     for _, ptrcls, shape_op, ptr_set in shape_ptrs:
-        srcctx = None
+        psrcctx = None
         if ptrcls in ctx.env.pointer_specified_info:
-            _, _, srcctx = ctx.env.pointer_specified_info[ptrcls]
+            _, _, psrcctx = ctx.env.pointer_specified_info[ptrcls]
 
         if ptr_set:
             src_path_id = path_id
@@ -500,7 +500,7 @@ def _process_view(
             # already has a context, since for explain output that
             # seems nicer, but this is what we want for producing
             # actual error messages.
-            ptr_set.context = srcctx
+            ptr_set.context = psrcctx
 
             _setup_shape_source(ptr_set, ctx=ctx)
 
@@ -510,7 +510,7 @@ def _process_view(
                 ir_set,
                 ptrcls,
                 same_computable_scope=True,
-                srcctx=srcctx,
+                srcctx=psrcctx or srcctx,
                 ctx=ctx,
             )
 
@@ -637,6 +637,8 @@ def _expand_splat(
         path.append(intersection)
     for ptr in pointers.objects(ctx.env.schema):
         if not isinstance(ptr, s_props.Property):
+            continue
+        if ptr.get_secret(ctx.env.schema):
             continue
         sname = ptr.get_shortname(ctx.env.schema)
         if sname.name in skip_ptrs:

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -450,7 +450,11 @@ def object_type_to_spec(
             and any(c.issubclass(schema, exclusive) for c in constraints)
         )
         fields[str_pn] = statypes.CompositeTypeSpecField(
-            name=str_pn, type=pytype, unique=unique, default=default
+            name=str_pn,
+            type=pytype,
+            unique=unique,
+            default=default,
+            secret=p.get_secret(schema),
         )
 
     spec = spec_class(

--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -40,6 +40,7 @@ class CompositeTypeSpecField:
     _: dataclasses.KW_ONLY
     unique: bool = True
     default: Any = MISSING
+    secret: bool = False
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -59,7 +60,7 @@ class CompositeTypeSpec:
 class CompositeType:
     _tspec: CompositeTypeSpec
 
-    def to_json_value(self) -> dict[str, Any]:
+    def to_json_value(self, redacted: bool=False) -> dict[str, Any]:
         raise NotImplementedError
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -133,6 +133,10 @@ create extension package _conf VERSION '1.0' {
         create property opt_value -> std::str {
             set readonly := true;
         };
+        create property secret -> std::str {
+            set readonly := true;
+            set secret := true;
+        };
     };
     create type ext::_conf::SubObj extending ext::_conf::Obj {
         create required property extra -> int64 {
@@ -147,9 +151,16 @@ create extension package _conf VERSION '1.0' {
             set default := "";
         };
         create property opt_value -> std::str;
+        create property secret -> std::str {
+            set secret := true;
+        };
     };
-};
 
+    create function ext::_conf::get_secret(c: ext::_conf::Obj)
+        -> optional std::str using (c.secret);
+    create alias ext::_conf::OK := (
+        cfg::Config.extensions[is ext::_conf::Config].secret ?= 'foobaz');
+};
 
 # std::_gen_series
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -133,14 +133,16 @@ create extension package _conf VERSION '1.0' {
         create property opt_value -> std::str {
             set readonly := true;
         };
-        create property secret -> std::str {
-            set readonly := true;
-            set secret := true;
-        };
     };
     create type ext::_conf::SubObj extending ext::_conf::Obj {
         create required property extra -> int64 {
             set readonly := true;
+        };
+    };
+    create type ext::_conf::SecretObj extending ext::_conf::Obj {
+        create property secret -> std::str {
+            set readonly := true;
+            set secret := true;
         };
     };
 
@@ -156,8 +158,11 @@ create extension package _conf VERSION '1.0' {
         };
     };
 
-    create function ext::_conf::get_secret(c: ext::_conf::Obj)
+    create function ext::_conf::get_secret(c: ext::_conf::SecretObj)
         -> optional std::str using (c.secret);
+    create function ext::_conf::get_top_secret()
+        -> set of std::str using (
+          cfg::Config.extensions[is ext::_conf::Config].secret);
     create alias ext::_conf::OK := (
         cfg::Config.extensions[is ext::_conf::Config].secret ?= 'foobaz');
 };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -70,6 +70,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
         create required property secret: std::str {
             set readonly := true;
+            set secret := true;
             create annotation std::description :=
                 "Secret provided by auth provider";
         };
@@ -91,6 +92,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         };
 
         create property auth_signing_key -> std::str {
+            set secret := true;
             create annotation std::description :=
                 "The signing key used for auth extension. Must be at \
                 least 32 characters long.";

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -385,7 +385,10 @@ def compile_ConfigReset(
 
         rvar = relctx.rvar_for_rel(selector, ctx=ctx)
 
-        assert isinstance(op.selector.expr, irast.SelectStmt)
+        sel_expr = op.selector.expr
+        assert isinstance(sel_expr, irast.SelectStmt)
+        sel_expr = sel_expr.result.expr
+        assert isinstance(sel_expr, irast.SelectStmt)
 
         # Grab all the non-link properties of the object as keys. We
         # could just do the exclusive ones, but this works too and we
@@ -393,7 +396,7 @@ def compile_ConfigReset(
         # XXX: Do we need to consider _tname also?
         keys = [
             el.rptr.ptrref.shortname.name
-            for el, op in op.selector.expr.result.shape
+            for el, op in sel_expr.result.shape
             if el.rptr
             and op == qlast.ShapeOp.ASSIGN
             and not irtyputils.is_object(el.rptr.ptrref.out_target)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1180,6 +1180,7 @@ class FunctionCommand(MetaCommand):
             schema,
             context,
             body=body,
+            func_name=func.get_name(schema),
             params=func.get_params(schema),
             language=ql_ast.Language.EdgeQL,
             return_type=func.get_return_type(schema),

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -37,6 +37,7 @@ from . import modules as s_mod
 from . import name as sn
 from . import objects as so
 from . import schema as s_schema
+from . import types as s_types
 
 
 class ExtensionPackage(
@@ -396,6 +397,10 @@ class DeleteExtension(
                 or (
                     isinstance(obj, so.DerivableObject)
                     and not obj.generic(schema)
+                )
+                or (
+                    isinstance(obj, s_types.Type)
+                    and obj.get_from_alias(schema)
                 )
             ):
                 # Skip any dependent objects, only pick top level

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1625,6 +1625,7 @@ class FunctionCommand(
             schema,
             context,
             body=body,
+            func_name=self.classname,
             params=params,
             language=language,
             return_type=return_type,
@@ -2370,6 +2371,7 @@ def compile_function(
     context: sd.CommandContext,
     *,
     body: s_expr.Expression,
+    func_name: sn.QualName,
     params: FuncParameterList,
     language: qlast.Language,
     return_type: s_types.Type,
@@ -2390,6 +2392,7 @@ def compile_function(
         schema,
         options=qlcompiler.CompilerOptions(
             anchors=param_anchors,
+            func_name=func_name,
             func_params=params,
             apply_query_rewrites=not context.stdmode,
             track_schema_ref_exprs=track_schema_ref_exprs,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -448,6 +448,12 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         merge_fn=merge_readonly,
     )
 
+    secret = so.SchemaField(
+        bool,
+        default=False,
+        compcoef=0.909,
+    )
+
     # For non-derived pointers this is strongly correlated with
     # "expr" below.  Derived pointers might have "computable" set,
     # but expr=None.

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -308,6 +308,26 @@ def generate_structure(
                 $$;
                 SET volatility := 'IMMUTABLE';
             };
+
+            # A strictly-internal get config function that bypasses
+            # the redaction of secrets in the public-facing one.
+            CREATE FUNCTION
+            cfg::_get_config_json_internal(
+                NAMED ONLY sources: OPTIONAL array<std::str> = {},
+                NAMED ONLY max_source: OPTIONAL std::str = {}
+            ) -> std::json
+            {
+                USING SQL $$
+                SELECT
+                    coalesce(jsonb_object_agg(cfg.name, cfg), '{}'::jsonb)
+                FROM
+                    edgedb._read_sys_config(
+                        sources::edgedb._sys_config_source_t[],
+                        max_source::edgedb._sys_config_source_t
+                    ) AS cfg
+                $$;
+            };
+
             ''',
             schema=schema,
             delta=delta,

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1601,7 +1601,7 @@ def compile_sys_queries(
     _, sql = compile_bootstrap_script(
         compiler,
         schema,
-        'SELECT cfg::get_config_json()',
+        'SELECT cfg::_get_config_json_internal()',
         expected_cardinality_one=True,
     )
 
@@ -1610,7 +1610,7 @@ def compile_sys_queries(
     _, sql = compile_bootstrap_script(
         compiler,
         schema,
-        "SELECT cfg::get_config_json(sources := ['database'])",
+        "SELECT cfg::_get_config_json_internal(sources := ['database'])",
         expected_cardinality_one=True,
     )
 
@@ -1619,7 +1619,9 @@ def compile_sys_queries(
     _, sql = compile_bootstrap_script(
         compiler,
         schema,
-        "SELECT cfg::get_config_json(max_source := 'system override')",
+        """
+        SELECT cfg::_get_config_json_internal(max_source := 'system override')
+        """,
         expected_cardinality_one=True,
     )
 
@@ -1628,7 +1630,9 @@ def compile_sys_queries(
     _, sql = compile_bootstrap_script(
         compiler,
         schema,
-        "SELECT cfg::get_config_json(max_source := 'postgres client')",
+        """
+        SELECT cfg::_get_config_json_internal(max_source := 'postgres client')
+        """,
         expected_cardinality_one=True,
     )
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1026,6 +1026,7 @@ class Compiler:
         global_schema_json: bytes,
         db_config_json: bytes,
         protocol_version: defines.ProtocolVersion,
+        with_secrets: bool,
     ) -> DumpDescriptor:
         global_schema = self.parse_json_schema(global_schema_json, None)
         user_schema = self.parse_json_schema(user_schema_json, global_schema)
@@ -1037,7 +1038,7 @@ class Compiler:
         )
 
         sys_config_ddl = config.to_edgeql(
-            self.state.config_spec, database_config, with_secrets=False,
+            self.state.config_spec, database_config, with_secrets=with_secrets,
         )
         # We need to put extension DDL configs *after* we have
         # reloaded the schema
@@ -1045,7 +1046,7 @@ class Compiler:
             config.load_ext_spec_from_schema(
                 user_schema, self.state.std_schema),
             database_config,
-            with_secrets=False,
+            with_secrets=with_secrets,
         )
 
         schema_ddl = s_ddl.ddl_text_from_schema(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1037,7 +1037,7 @@ class Compiler:
         )
 
         sys_config_ddl = config.to_edgeql(
-            self.state.config_spec, database_config
+            self.state.config_spec, database_config, with_secrets=False,
         )
         # We need to put extension DDL configs *after* we have
         # reloaded the schema
@@ -1045,6 +1045,7 @@ class Compiler:
             config.load_ext_spec_from_schema(
                 user_schema, self.state.std_schema),
             database_config,
+            with_secrets=False,
         )
 
         schema_ddl = s_ddl.ddl_text_from_schema(

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -88,3 +88,23 @@ def get_compilation_config(
         if k in spec
         if spec[k].affects_compilation
     ))
+
+
+def _serialize_val(v: object) -> object:
+    if isinstance(v, frozenset):
+        return [_serialize_val(x) for x in v]
+    elif isinstance(v, CompositeConfigType):
+        return v.to_json_value(redacted=True)
+    else:
+        return v
+
+
+def debug_serialize_config(
+    cfg: Mapping[str, SettingValue],
+) -> Any:
+    return {
+        name:
+        {'redacted': True} if value.secret
+        else _serialize_val(value.value)
+        for name, value in cfg.items()
+    }

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -55,6 +55,9 @@ class SettingValue(NamedTuple):
     value: Any
     source: str
     scope: qltypes.ConfigScope
+    # We track this just so that we can redact secret values in our
+    # debug endpoints.
+    secret: bool = False
 
 
 if TYPE_CHECKING:
@@ -414,6 +417,7 @@ def from_json(spec: spec.Spec, js: str | bytes) -> SettingsMap:
                 value=value_from_json_value(spec, setting, value['value']),
                 source=value['source'],
                 scope=qltypes.ConfigScope(value['scope']),
+                secret=setting.secret,
             )
 
     return mm.finish()
@@ -450,7 +454,10 @@ def set_value(
     scope: qltypes.ConfigScope,
 ) -> SettingsMap:
 
+    secret = name in storage and storage[name].secret
+
     return storage.set(
         name,
-        SettingValue(name=name, value=value, source=source, scope=scope),
+        SettingValue(name=name, value=value, source=source, scope=scope,
+                     secret=secret),
     )

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -58,6 +58,7 @@ class Setting:
     affects_compilation: bool = False
     enum_values: Optional[Sequence[str]] = None
     required: bool = True
+    secret: bool = False
 
     def __post_init__(self) -> None:
         if (self.type not in SETTING_TYPES and
@@ -304,6 +305,7 @@ def _load_spec_from_type(
                 else None
             ),
             required=required,
+            secret=p.get_secret(schema),
         )
 
         settings.append(setting)

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -212,16 +212,18 @@ class CompositeConfigType(ConfigType, statypes.CompositeType):
     def from_json_value(cls, s, *, tspec: statypes.CompositeTypeSpec, spec):
         return cls.from_pyvalue(s, tspec=tspec, spec=spec)
 
-    def to_json_value(self):
+    def to_json_value(self, redacted: bool=False):
         dct = {}
         dct['_tname'] = self._tspec.name
 
         for f in self._tspec.fields.values():
             f_type = f.type
             value = getattr(self, f.name)
-            if (isinstance(f_type, statypes.CompositeTypeSpec)
+            if redacted and f.secret and value is not None:
+                value = {'redacted': True}
+            elif (isinstance(f_type, statypes.CompositeTypeSpec)
                     and value is not None):
-                value = value.to_json_value()
+                value = value.to_json_value(redacted=redacted)
             elif typing_inspect.is_generic_type(f_type):
                 value = list(value) if value is not None else []
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -953,9 +953,6 @@ class BaseServer:
         Some tests depend on the exact layout of the returned structure.
         """
 
-        def serialize_config(cfg):
-            return {name: value.value for name, value in cfg.items()}
-
         return dict(
             params=dict(
                 dev_mode=self._devmode,
@@ -964,7 +961,8 @@ class BaseServer:
                 listen_hosts=self._listen_hosts,
                 listen_port=self._listen_port,
             ),
-            instance_config=serialize_config(self._get_sys_config()),
+            instance_config=config.debug_serialize_config(
+                self._get_sys_config()),
             compiler_pool=dict(
                 worker_pids=list(
                     self._compiler_pool._workers.keys()  # type: ignore

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1314,9 +1314,6 @@ class Tenant(ha_base.ClusterProtocol):
             pg_pool=self._pg_pool._build_snapshot(now=time.monotonic()),
         )
 
-        def serialize_config(cfg):
-            return {name: value.value for name, value in cfg.items()}
-
         dbs = {}
         if self._dbindex is not None:
             for db in self._dbindex.iter_dbs():
@@ -1329,7 +1326,7 @@ class Tenant(ha_base.ClusterProtocol):
                     config=(
                         None
                         if db.db_config is None
-                        else serialize_config(db.db_config)
+                        else config.debug_serialize_config(db.db_config)
                     ),
                     extensions=sorted(db.extensions),
                     query_cache_size=db.get_query_cache_size(),
@@ -1337,7 +1334,8 @@ class Tenant(ha_base.ClusterProtocol):
                         dict(
                             in_tx=view.in_tx(),
                             in_tx_error=view.in_tx_error(),
-                            config=serialize_config(view.get_session_config()),
+                            config=config.debug_serialize_config(
+                                view.get_session_config()),
                             module_aliases=view.get_modaliases(),
                         )
                         for view in db.iter_views()

--- a/tests/schemas/dump_v4_setup.edgeql
+++ b/tests/schemas/dump_v4_setup.edgeql
@@ -27,6 +27,8 @@ union (
 
 
 CONFIGURE CURRENT DATABASE SET ext::_conf::Config::config_name := 'ready';
+CONFIGURE CURRENT DATABASE SET ext::_conf::Config::secret := 'secret';
+
 CONFIGURE CURRENT DATABASE INSERT ext::_conf::Obj {
     name := '1',
     value := 'foo',
@@ -39,4 +41,9 @@ CONFIGURE CURRENT DATABASE INSERT ext::_conf::SubObj {
     extra := 42,
     name := '3',
     value := 'baz',
+};
+CONFIGURE CURRENT DATABASE INSERT ext::_conf::SecretObj {
+    name := '4',
+    value := 'spam',
+    secret := '123456',
 };

--- a/tests/test_dump_v4.py
+++ b/tests/test_dump_v4.py
@@ -72,8 +72,17 @@ class DumpTestCaseMixin:
                     dict(name='2', value='bar', tname='ext::_conf::Obj'),
                     dict(name='3', value='baz', extra=42,
                          tname='ext::_conf::SubObj'),
+                    # No SecretObj
                 ],
             ))]
+        )
+
+        # Secret shouldn't make it
+        await self.assert_query_result(
+            '''
+            select ext::_conf::get_top_secret()
+            ''',
+            [],
         )
 
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -291,13 +291,20 @@ class MockAuthProvider:
         self._http_runner = None
 
 
+SIGNING_KEY = 'a' * 32
+GITHUB_SECRET = 'b' * 32
+GOOGLE_SECRET = 'c' * 32
+AZURE_SECRET = 'c' * 32
+APPLE_SECRET = 'c' * 32
+
+
 class TestHttpExtAuth(tb.ExtAuthTestCase):
     TRANSACTION_ISOLATION = False
 
     EXTENSION_SETUP = [
         f"""
         CONFIGURE CURRENT DATABASE SET
-        ext::auth::AuthConfig::auth_signing_key := <str>'{'a' * 32}';
+        ext::auth::AuthConfig::auth_signing_key := <str>'{SIGNING_KEY}';
 
         CONFIGURE CURRENT DATABASE SET
         ext::auth::AuthConfig::token_time_to_live := <duration>'24 hours';
@@ -307,7 +314,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             provider_name := "github",
             url := "https://github.com",
             provider_id := <str>'{uuid.uuid4()}',
-            secret := <str>'{"b" * 32}',
+            secret := <str>'{GITHUB_SECRET}',
             client_id := <str>'{uuid.uuid4()}'
         }};
 
@@ -316,7 +323,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             provider_name := "google",
             url := "https://accounts.google.com",
             provider_id := <str>'{uuid.uuid4()}',
-            secret := <str>'{"c" * 32}',
+            secret := <str>'{GOOGLE_SECRET}',
             client_id := <str>'{uuid.uuid4()}'
         }};
 
@@ -325,7 +332,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             provider_name := "azure",
             url := "https://login.microsoftonline.com/common/v2.0",
             provider_id := <str>'{uuid.uuid4()}',
-            secret := <str>'{"c" * 32}',
+            secret := <str>'{AZURE_SECRET}',
             client_id := <str>'{uuid.uuid4()}'
         }};
 
@@ -334,7 +341,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             provider_name := "apple",
             url := "https://appleid.apple.com",
             provider_id := <str>'{uuid.uuid4()}',
-            secret := <str>'{"c" * 32}',
+            secret := <str>'{APPLE_SECRET}',
             client_id := <str>'{uuid.uuid4()}'
         }};
         """,
@@ -450,7 +457,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         )
 
     async def get_signing_key(self):
-        auth_signing_key = await self.get_auth_config_value("auth_signing_key")
+        auth_signing_key = SIGNING_KEY
         key_bytes = base64.b64encode(auth_signing_key.encode())
         signing_key = jwk.JWK(k=key_bytes.decode(), kty="oct")
         return signing_key
@@ -605,7 +612,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
-            client_secret = provider_config.secret
+            client_secret = GITHUB_SECRET
 
             now = datetime.datetime.utcnow()
             token_request = (
@@ -874,7 +881,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
-            client_secret = provider_config.secret
+            client_secret = GOOGLE_SECRET
 
             now = datetime.datetime.utcnow()
 
@@ -1112,7 +1119,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
-            client_secret = provider_config.secret
+            client_secret = AZURE_SECRET
 
             now = datetime.datetime.utcnow()
 
@@ -1278,7 +1285,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
-            client_secret = provider_config.secret
+            client_secret = APPLE_SECRET
 
             now = datetime.datetime.utcnow()
 


### PR DESCRIPTION
A secret pointer may not be accessed from a query, except via
functions and aliases defined in the same module as the pointer.

A lot of the work here is really in redacting the secret values along
a bunch of different paths.

We still need to decide what to do about dumps.

Fixes #5988.