### PR TITLE
Fix loading extensions with constraints via SDL

### DIFF
--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -483,8 +483,6 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase[ReferencedT]):
                             astnode: qlast.NamedDDL,
                             context: sd.CommandContext
                             ) -> sn.QualName:
-        name = super()._classname_from_ast(schema, astnode, context)
-
         parent_ctx = cls.get_referrer_context(context)
         if parent_ctx is not None:
             assert isinstance(parent_ctx.op, sd.QualifiedObjectCommand)
@@ -492,6 +490,8 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase[ReferencedT]):
             name = cls._classname_from_ast_and_referrer(
                 schema, referrer_name, astnode, context
             )
+        else:
+            name = super()._classname_from_ast(schema, astnode, context)
 
         assert isinstance(name, sn.QualName)
         return name


### PR DESCRIPTION
There was a bug where ReferencedObjectCommand only worked if a fully
qualified name coudl be found for the object using modaliases to
resolve the module. If it was actually a nested object, though, then
we would discard that name.

Don't require that we be able to compute a wrong name before computing
the right one.

I don't have a test here, because the simplest test is loading the
auth extension via SDL, and that only works 50% of the time because we
don't have ext dependencies yet.