### PR TITLE
Make `SET default` of trivial values much faster

### DIFF
--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -663,7 +663,7 @@ def ptr_default_to_col_default(schema, ptr, expr):
             )
         )
         ir = qlcompiler.compile_ast_to_ir(eql, schema)
-    except errors.SchemaError:
+    except (errors.SchemaError, errors.QueryError):
         # Reference errors mean that is is a non-constant default
         # referring to a not-yet-existing objects.
         return None


### PR DESCRIPTION
Use postgres default values to populate the column, instead of doing
it explicitly. We don't ever actually *use* the default when
INSERTing, but that's fine.