### PR TITLE
Implement extension dependencies

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_09_20_00_00
+EDGEDB_CATALOG_VERSION = 2023_09_21_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -904,7 +904,11 @@ class ExtensionCommand(UnqualifiedObjectCommand):
 
 
 class CreateExtension(CreateObject, ExtensionCommand):
-    pass
+    # HACK: I think there is a bug in our plugin that made us not
+    # understand that this was overridden in ExtensionCommand.
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.EXTENSION
+    )
 
 
 class DropExtension(DropObject, ExtensionCommand):

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -769,7 +769,9 @@ class CreateExtensionPackageBodyBlock(NestedQLBlock):
 
     @property
     def allowed_fields(self) -> typing.FrozenSet[str]:
-        return frozenset({'internal', 'ext_module', 'sql_extensions'})
+        return frozenset({
+            'internal', 'ext_module', 'sql_extensions', 'dependencies'
+        })
 
     @property
     def result(self) -> typing.Any:

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -19,6 +19,7 @@
 
 CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     set ext_module := "ext::auth";
+    set dependencies := ["pgcrypto==1.3"];
 
     create module ext::auth;
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -7167,6 +7167,7 @@ class CreateExtensionPackage(
                 'internal': self.scls.get_internal(schema),
                 'ext_module': ext_module and str(ext_module),
                 'sql_extensions': list(self.scls.get_sql_extensions(schema)),
+                'dependencies': list(self.scls.get_dependencies(schema)),
             }
         }
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4669,6 +4669,15 @@ def _generate_extension_views(schema: s_schema.Schema) -> List[dbops.View]:
                 ARRAY[]::text[]
             )
         ''',
+        'dependencies': '''
+            COALESCE(
+                (SELECT array_agg(edgedb.jsonb_extract_scalar(q.v, 'string'))
+                FROM jsonb_array_elements(
+                    e.value->'dependencies'
+                ) AS q(v)),
+                ARRAY[]::text[]
+            )
+        ''',
         'ext_module': "(e.value->>'ext_module')",
         'computed_fields': 'ARRAY[]::text[]',
         'builtin': "(e.value->>'builtin')::bool",

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8680,7 +8680,7 @@ type default::Foo {
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
-            "extension 'MyExtension' already exists",
+            "version 1.0 is already installed",
         ):
             await self.con.execute(r"""
                 CREATE EXTENSION MyExtension VERSION '2.0';
@@ -16470,6 +16470,143 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         finally:
             await self.con.execute('''
                 drop type Test;
+            ''')
+
+    async def _extension_test_06b(self):
+        await self.con.execute(r"""
+            START MIGRATION TO {
+                using extension bar version "1.1";
+                module default {
+                    function lol() -> str using (ext::bar::fubar())
+                }
+            };
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)
+
+        await self.assert_query_result(
+            'select lol()',
+            ['foobar'],
+        )
+
+        # Try dropping everything that uses it but not the extension
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                START MIGRATION TO {
+                    using extension bar version "1.1";
+                    module default {
+                    }
+                };
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
+
+        # Try dropping it but adding bar
+        async with self._run_and_rollback():
+            await self.con.execute(r"""
+                START MIGRATION TO {
+                    using extension bar version "1.1";
+                    module default {
+                    }
+                };
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
+
+        # Try dropping everything including the extension
+        await self.con.execute(r"""
+            START MIGRATION TO {
+                module default {
+                }
+            };
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)
+
+        # Try it explicitly specifying an old version. Note
+        # that we don't *yet* support upgrading between extension
+        # versions; you need to drop it and recreate everything, which
+        # obviously is not great.
+
+        await self.con.execute(r"""
+            START MIGRATION TO {
+                using extension bar version '1.0';
+                module default {
+                    function lol() -> str using (ext::bar::fubar())
+                }
+            };
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)
+
+        await self.assert_query_result(
+            'select lol()',
+            ['foo?bar'],
+        )
+
+        # Try dropping everything including the extension
+        await self.con.execute(r"""
+            START MIGRATION TO {
+                module default {
+                }
+            };
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)
+
+        with self.assertRaisesRegex(
+            edgedb.SchemaError,
+            "cannot install extension 'foo' version 1.1: "
+            "version 1.0 is already installed"
+        ):
+            await self.con.execute(r"""
+                START MIGRATION TO {
+                    using extension bar version '1.0';
+                    using extension foo version '1.1';
+                    module default {
+                    }
+                };
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
+
+    async def test_edgeql_ddl_extensions_06(self):
+        # Make an extension with dependencies
+        await self.con.execute('''
+            create extension package foo VERSION '1.0' {
+              set ext_module := "ext::foo";
+              create module ext::foo;
+              create function ext::foo::test() -> str using ("foo?");
+            };
+            create extension package foo VERSION '1.1' {
+              set ext_module := "ext::foo";
+              create module ext::foo;
+              create function ext::foo::test() -> str using ("foo");
+            };
+            create extension package bar VERSION '1.0' {
+              set ext_module := "ext::bar";
+              set dependencies := ["foo==1.0"];
+              create module ext::bar;
+              create function ext::bar::fubar() -> str using (
+                ext::foo::test() ++ "bar"
+              );
+            };
+            create extension package bar VERSION '1.1' {
+              set ext_module := "ext::bar";
+              set dependencies := ["foo==1.1"];
+              create module ext::bar;
+              create function ext::bar::fubar() -> str using (
+                ext::foo::test() ++ "bar"
+              );
+            };
+        ''')
+        try:
+            async with self._run_and_rollback():
+                await self._extension_test_06b()
+        finally:
+            await self.con.execute('''
+                drop extension package bar VERSION '1.0';
+                drop extension package foo VERSION '1.0';
             ''')
 
     async def test_edgeql_ddl_reindex(self):


### PR DESCRIPTION
Extensions specify a specific version of their
depdendencies. Eventually we will probably want to be more lenient.

Transitive dependencies will automatically be created when using SDL.

Work on #5954.