### PR TITLE
Function to check if auth signing key exists

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -106,6 +106,13 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         };
     };
 
+    create function ext::auth::signing_key_exists() -> std::bool {
+        using (
+            select exists cfg::Config.extensions[is ext::auth::AuthConfig]
+                .auth_signing_key
+        );
+    };
+
     create scalar type ext::auth::JWTAlgo extending enum<RS256, HS256>;
 
     create function ext::auth::_jwt_check_signature(


### PR DESCRIPTION
Now that `auth_signing_key` is a #5988 secret, expose a function that checks if it has been set.