### PR TITLE
rv arrows to match new schema

### DIFF
--- a/docs/changelog/3_x.rst
+++ b/docs/changelog/3_x.rst
@@ -614,8 +614,8 @@ EdgeQL
   .. code-block:: sdl
 
     type User {
-      required property email -> str { constraint exclusive; };
-      required property is_admin -> bool { default := false };
+      required email: str { constraint exclusive; };
+      required is_admin: bool { default := false };
       access policy admin_only
         allow all
         using (global current_user.is_admin ?? false) {
@@ -679,7 +679,7 @@ EdgeQL
   .. code-block:: sdl
 
       type User {
-        required property name -> str;
+        required name: str;
         index pg::spgist on (.name);
       };
 

--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -193,7 +193,7 @@ You can use them like this:
 .. code-block:: sdl
 
     type User {
-      required property name -> str;
+      required name: str;
       index pg::spgist on (.name);
     };
 


### PR DESCRIPTION
I noticed a rogue arrow on the page for indexes and ironically some other arrows that survived Order 66 right under our nose, on the very page announcing the new syntax!