### PR TITLE
Make consul watching more robust

### DIFF
--- a/edb/common/asyncwatcher.py
+++ b/edb/common/asyncwatcher.py
@@ -41,6 +41,7 @@ class AsyncWatcherProtocol(asyncio.Protocol):
         self.request()
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
+        self._watcher.incr_metrics_counter("watch-disconnect")
         self._watcher.on_connection_lost()
 
     def request(self) -> None:
@@ -66,6 +67,7 @@ class AsyncWatcher:
                 self._protocol = await self._start_watching()
                 return True
             except BaseException:
+                self.incr_metrics_counter("watch-start-err")
                 self._watching = False
                 raise
         return False
@@ -119,3 +121,6 @@ class AsyncWatcher:
         # For rate limit - tries to consume the given number of tokens, returns
         # non-zero values as seconds to wait if unsuccessful
         return 0
+
+    def incr_metrics_counter(self, event: str, value: float = 1.0) -> None:
+        pass

--- a/edb/common/asyncwatcher.py
+++ b/edb/common/asyncwatcher.py
@@ -20,8 +20,12 @@ from __future__ import annotations
 from typing import *
 
 import asyncio
+import logging
 
 from . import retryloop
+
+
+logger = logging.getLogger("edb.server.asyncwatcher")
 
 
 class AsyncWatcherProtocol(asyncio.Protocol):
@@ -70,7 +74,15 @@ class AsyncWatcher:
         self._retry_attempt += 1
         delay = self._backoff(self._retry_attempt)
         await asyncio.sleep(delay)
-        await self.start_watching()
+        try:
+            await self.start_watching()
+        except Exception:
+            logger.warning(
+                "%s failed to start watching, will retry.",
+                type(self).__name__,
+                exc_info=True,
+            )
+            asyncio.create_task(self.retry_watching())
 
     def stop_watching(self) -> None:
         self._watching = False
@@ -94,6 +106,10 @@ class AsyncWatcher:
                 waiter.set_result(None)
 
     def on_update(self, data: bytes) -> None:
+        self._retry_attempt = 0
+        self._on_update(data)
+
+    def _on_update(self, data: bytes) -> None:
         raise NotImplementedError
 
     async def _start_watching(self) -> AsyncWatcherProtocol:

--- a/edb/common/asyncwatcher.py
+++ b/edb/common/asyncwatcher.py
@@ -114,3 +114,8 @@ class AsyncWatcher:
 
     async def _start_watching(self) -> AsyncWatcherProtocol:
         raise NotImplementedError
+
+    def consume_tokens(self, tokens: int) -> float:
+        # For rate limit - tries to consume the given number of tokens, returns
+        # non-zero values as seconds to wait if unsuccessful
+        return 0

--- a/edb/common/prometheus.py
+++ b/edb/common/prometheus.py
@@ -145,7 +145,7 @@ class Registry:
         desc: str,
         /,
         *,
-        labels: tuple[str],
+        labels: tuple[str, ...],
         unit: Unit | None = None,
     ) -> LabeledCounter:
         counter = LabeledCounter(self, name, desc, unit, labels=labels)

--- a/edb/common/token_bucket.py
+++ b/edb/common/token_bucket.py
@@ -1,0 +1,46 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import time
+
+
+class TokenBucket:
+    _capacity: float
+    _token_per_sec: float
+    _tokens: float
+    _last_fill_time: float
+
+    def __init__(self, capacity: float, token_per_sec: float):
+        self._capacity = capacity
+        self._token_per_sec = token_per_sec
+        self._tokens = capacity
+        self._last_fill_time = time.monotonic()
+
+    def consume(self, tokens: int) -> float:
+        if tokens <= 0:
+            return True
+        now = time.monotonic()
+        tokens_to_add = (now - self._last_fill_time) * self._token_per_sec
+        self._tokens = min(self._capacity, self._tokens + tokens_to_add)
+        self._last_fill_time = now
+        left = self._tokens - tokens
+        if left >= 0:
+            self._tokens -= tokens
+            return 0
+        else:
+            return -left / (tokens * self._token_per_sec)

--- a/edb/server/ha/base.py
+++ b/edb/server/ha/base.py
@@ -22,6 +22,7 @@ from typing import *
 import urllib.parse
 
 from edb.common import asyncwatcher
+from edb.server import metrics
 
 
 class ClusterProtocol:
@@ -49,6 +50,9 @@ class HABackend(asyncwatcher.AsyncWatcher):
     @property
     def dsn(self) -> str:
         raise NotImplementedError
+
+    def incr_metrics_counter(self, event: str, value: float = 1.0) -> None:
+        metrics.ha_events_total.inc(value, self.dsn, event)
 
 
 def get_backend(parsed_dsn: urllib.parse.ParseResult) -> Optional[HABackend]:

--- a/edb/server/ha/stolon.py
+++ b/edb/server/ha/stolon.py
@@ -105,6 +105,7 @@ class StolonBackend(base.HABackend):
                 )
                 self._master_addr = master_addr
                 if self._failover_cb is not None:
+                    self.incr_metrics_counter("failover")
                     self._failover_cb()
 
         if self._waiter is not None:
@@ -149,7 +150,7 @@ class StolonConsulBackend(StolonBackend):
         )
         return pr  # type: ignore [return-value]
 
-    @property
+    @functools.cached_property
     def dsn(self) -> str:
         proto = "http" if self._ssl is None else "https"
         return (

--- a/edb/server/ha/stolon.py
+++ b/edb/server/ha/stolon.py
@@ -59,7 +59,7 @@ class StolonBackend(base.HABackend):
     def get_master_addr(self) -> Optional[Tuple[str, int]]:
         return self._master_addr
 
-    def on_update(self, payload: bytes) -> None:
+    def _on_update(self, payload: bytes) -> None:
         try:
             data = json.loads(base64.b64decode(payload))
         except (TypeError, ValueError):

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -97,3 +97,9 @@ background_errors = registry.new_labeled_counter(
     'Number of unhandled errors in background server routines.',
     labels=('source',)
 )
+
+ha_events_total = registry.new_labeled_counter(
+    "ha_events_total",
+    "Number of each high-availability watch event.",
+    labels=("dsn", "event"),
+)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -135,7 +135,9 @@ class Tenant(ha_base.ClusterProtocol):
         # Increase-only counter to reject outdated attempts to connect
         self._ha_master_serial = 0
         if backend_adaptive_ha:
-            self._backend_adaptive_ha = adaptive_ha.AdaptiveHASupport(self)
+            self._backend_adaptive_ha = adaptive_ha.AdaptiveHASupport(
+                self, self._instance_name
+            )
         else:
             self._backend_adaptive_ha = None
         self._readiness_state_file = readiness_state_file

--- a/tests/common/test_token_bucket.py
+++ b/tests/common/test_token_bucket.py
@@ -1,0 +1,48 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import unittest.mock
+
+from edb.common.token_bucket import TokenBucket
+
+
+class ManualClock:
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+class WindowedSumTests(unittest.TestCase):
+    def test_common_token_bucket(self) -> None:
+        monotonic = ManualClock(0)
+        with unittest.mock.patch("time.monotonic", monotonic):
+            tb = TokenBucket(10, 0.1)
+            self.assertEqual(tb.consume(5), 0)
+
+            monotonic.value += 12
+            self.assertEqual(tb.consume(6), 0)
+            self.assertGreater(tb.consume(1), 0)
+            self.assertGreater(tb.consume(2), tb.consume(1))
+
+            monotonic.value += 30
+            self.assertEqual(tb.consume(2), 0)
+            self.assertEqual(tb.consume(1), 0)
+            self.assertGreater(tb.consume(1), 0)

--- a/tests/test_backend_ha.py
+++ b/tests/test_backend_ha.py
@@ -503,13 +503,9 @@ class TestBackendHA(tb.TestCase):
                 backend_dsn=(
                     f"stolon+consul+http://127.0.0.1:{consul.http_port}"
                     f"/{pg1.cluster_name}"
+                    f"?pguser=suname&pgpassword=supass&pgdatabase=postgres"
                 ),
                 runstate_dir=str(pathlib.Path(consul.tmp_dir.name) / "edb"),
-                env=dict(
-                    PGUSER="suname",
-                    PGPASSWORD="supass",
-                    PGDATABASE="postgres",
-                ),
                 reset_auth=True,
                 debug=debug,
             ) as sd:


### PR DESCRIPTION
Refs https://developer.hashicorp.com/consul/api-docs/features/blocking

- [x] [CRITICAL] Retry if failed to start watching
- [x] Reset backoff after recovered
- [x] On timeout (5 minutes), issue a non-blocking query to handle the index going backwards issue
- [x] Add metrics about number of udpates/retries
- [x] Add rate limit
- [x] Manual test
- [x] Fix issue passing PGPASSWORD down to multi-tenant backend DSNs
- [ ] Add unit test
