### PR TITLE
Update debug log for precise compile cache key

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -608,15 +608,30 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         self,
         dbview.QueryRequestInfo query_req,
     ) -> dbview.CompiledQuery:
+        cdef dbview.DatabaseConnectionView dbv
+        dbv = self.get_dbview()
         if self.debug:
             source = query_req.source
             text = source.text()
             self.debug_print('PARSE', text)
-            self.debug_print('Cache key', source.cache_key())
+            self.debug_print(
+                'Cache key',
+                source.cache_key(),
+                f"protocol_version={query_req.protocol_version}",
+                f"output_format={query_req.output_format}",
+                f"expect_one={query_req.expect_one}",
+                f"implicit_limit={query_req.implicit_limit}",
+                f"inline_typeids={query_req.inline_typeids}",
+                f"inline_typenames={query_req.inline_typenames}",
+                f"inline_objectids={query_req.inline_objectids}",
+                f"allow_capabilities={query_req.allow_capabilities}",
+                f"modaliazes={dbv.get_modaliases()}",
+                f"session_config={dbv.get_session_config()}",
+            )
             self.debug_print('Extra variables', source.variables(),
                              'after', source.first_extra())
 
-        return await self.get_dbview().parse(query_req)
+        return await dbv.parse(query_req)
 
     cdef parse_cardinality(self, bytes card):
         if card[0] == CARD_MANY.value:


### PR DESCRIPTION
hint: debug with `EDGEDB_DEBUG_SERVER_PROTO=1`

sample log:

`::EDGEPROTO:: id:1 in_tx:0 tx_error:0 Cache key b'\x06\xf6\x80\x80\x86\x12P*N\xdb\xd6\xfdkP\x1cu\xeb]\x95K\x11\xc3!G\xf0\x0f\xccn\xf7\x93\x86At\xfb.=\x98\xd6\xe6[\xf5/\xb7<\xc5\xe3w\xe8\x10\xa9;1\x9cC\xfes_\x18\xfe\x1f\xaa#\xe7' protocol_version=(2, 0) output_format=BINARY expect_one=False implicit_limit=0 inline_typeids=False inline_typenames=False inline_objectids=True allow_capabilities=18446744073709551609 modaliazes=immutables.Map({None: 'default'}) session_config=immutables.Map({})`