### PR TITLE
Fix function params whose name collide with SQL type names

### DIFF
--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -212,7 +212,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
             if cte.aliascolnames:
                 self.write('(')
                 for (index, col_name) in enumerate(cte.aliascolnames):
-                    self.write(common.qname(col_name))
+                    self.write(common.qname(col_name, column=True))
                     if index + 1 < len(cte.aliascolnames):
                         self.write(',')
                 self.write(')')
@@ -578,18 +578,18 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         if node.indirection:
             self._visit_indirection_ops(node.indirection)
         if node.name:
-            self.write(' AS ' + common.quote_ident(node.name))
+            self.write(' AS ' + common.quote_col(node.name))
 
     def visit_InsertTarget(self, node: pgast.InsertTarget) -> None:
-        self.write(common.quote_ident(node.name))
+        self.write(common.quote_col(node.name))
 
     def visit_UpdateTarget(self, node: pgast.UpdateTarget) -> None:
         if isinstance(node.name, list):
             self.write('(')
-            self.write(', '.join(common.quote_ident(n) for n in node.name))
+            self.write(', '.join(common.quote_col(n) for n in node.name))
             self.write(')')
         else:
-            self.write(common.quote_ident(node.name))
+            self.write(common.quote_col(node.name))
         if node.indirection:
             self._visit_indirection_ops(node.indirection)
         self.write(' = ')
@@ -599,7 +599,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         self.write(common.quote_ident(node.aliasname))
         if node.colnames:
             self.write('(')
-            self.write(', '.join(common.quote_ident(n) for n in node.colnames))
+            self.write(', '.join(common.quote_col(n) for n in node.colnames))
             self.write(')')
 
     def visit_Keyword(self, node: pgast.Keyword) -> None:
@@ -668,15 +668,15 @@ class SQLSourceGenerator(codegen.SourceGenerator):
                 self.write(names[0])
                 if len(names) > 1:
                     self.write('.')
-                    self.write(common.qname(*names[1:]))
+                    self.write(common.qname(*names[1:], column=True))
             else:
-                self.write(common.qname(*names))
+                self.write(common.qname(*names, column=True))
 
     def visit_ExprOutputVar(self, node: pgast.ExprOutputVar) -> None:
         self.visit(node.expr)
 
     def visit_ColumnDef(self, node: pgast.ColumnDef) -> None:
-        self.write(common.quote_ident(node.name))
+        self.write(common.quote_col(node.name))
         if node.typename:
             self.write(' ')
             self.visit(node.typename)

--- a/edb/pgsql/dbops/functions.py
+++ b/edb/pgsql/dbops/functions.py
@@ -23,7 +23,7 @@ import textwrap
 from typing import *
 
 from ..common import qname as qn
-from ..common import quote_ident as qi
+from ..common import quote_col as qc
 from ..common import quote_literal as ql
 from ..common import quote_type as qt
 
@@ -73,7 +73,7 @@ class FunctionExists(base.Condition):
         self.args = args
 
     def code(self, block: base.PLBlock) -> str:
-        args = f"ARRAY[{','.join(qi(a) for a in self.args)}]"
+        args = f"ARRAY[{','.join(qc(a) for a in self.args)}]"
 
         return textwrap.dedent(f'''\
             SELECT
@@ -111,7 +111,7 @@ class FunctionOperation:
 
             if isinstance(arg, tuple):
                 if arg[0] is not None:
-                    arg_expr += qn(arg[0])
+                    arg_expr += qn(arg[0], column=True)
                 if len(arg) > 1:
                     arg_expr += ' ' + qt(arg[1])
                 if include_defaults:

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4921,6 +4921,18 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
         self.assertEqual(val, 1)
 
+    async def test_edgeql_ddl_function_38(self):
+        await self.con.execute('''
+            create function myFuncFailA(character: int64) -> float64
+            using (
+              select 2.3
+            );
+            create function myFuncFailB(interval: str) -> float64
+            using (
+              select 2.3
+            );
+        ''')
+
     async def test_edgeql_ddl_function_rename_01(self):
         await self.con.execute("""
             CREATE FUNCTION foo(s: str) -> str {


### PR DESCRIPTION
We need to make sure to quote them. Unfortunately we can't
*unconditionally* quote them in quote_ident, because when referring to
them as types or builtin functions they need to not be quoted.

Fixes #6062.