### PR TITLE
Fix cast of empty set to type with access policy

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2106,7 +2106,7 @@ def _inline_type_computable(
             # we see through that.
             base_stype = stype.get_nearest_non_derived_parent(ctx.env.schema)
             base_ir_set = setgen.ensure_set(
-                ir_set, type_override=base_stype, ctx=ctx)
+                ir_set, type_override=base_stype, ctx=scopectx)
 
             scopectx.anchors[qlast.Source().name] = base_ir_set
             ptr, ptr_set = _normalize_view_ptr_expr(

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -1287,3 +1287,12 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             await self.con.query('''
                 update Base set { name := '!!!' }
             ''')
+
+    async def test_edgeql_policies_empty_cast_01(self):
+        obj = await self.con._fetchall(
+            '''
+                SELECT <Issue>{}
+            ''',
+            __typenames__=True,
+        )
+        self.assertEqual(obj, [])


### PR DESCRIPTION
The bug here was that the _inline_type_computable passed the wrong
context, which could blow up, but only if the type had an access
policy that hadn't been compiled yet (since we would then try to
compile it), which is why it triggered in this case.

Fixes #6070.