### PR TITLE
Fix schema ordering bugs with rewrites

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -879,14 +879,14 @@ def trace_Rewrite(
 ) -> None:
     exprs = [ExprDependency(expr=node.expr)]
 
-    obj = ctx.depstack[-1][1]
+    obj = ctx.depstack[-2][1]
     _register_item(
         node,
         deps=set(),
         hard_dep_exprs=exprs,
         source=obj,
         subject=obj,
-        anchors={'__specified__': obj},
+        anchors={'__old__': obj},
         ctx=ctx,
     )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1459,6 +1459,28 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """
 
+    def test_schema_rewrite_order_01(self):
+        """
+            type EventSession extending Timed {
+
+              lastSeen: datetime {
+                rewrite update using (
+                  __old__.foo
+                )
+              }
+              lastSeen2: datetime {
+                rewrite insert using (
+                  __subject__.foo
+                )
+              }
+            }
+            abstract type Timed {
+              required foo: datetime {
+                default := datetime_current();
+              }
+            }
+        """
+
     def test_schema_property_cardinality_alter_01(self):
         schema = self.load_schema('''
             type Foo {


### PR DESCRIPTION
Rewrites were grabbing the wrong object as the source