### PR TITLE
Fix schema confusion with objects that shadow std objects

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -101,6 +101,7 @@ class TraceContextBase:
     def get_local_name(
         self,
         ref: qlast.ObjectRef,
+        declaration: bool=False,
     ) -> s_name.QualName:
         return qltracer.resolve_name(
             ref,
@@ -109,6 +110,7 @@ class TraceContextBase:
             objects=self.objects,
             modaliases=None,
             local_modules=self.local_modules,
+            declaration=declaration,
         )
 
     def get_ref_name(self, ref: qlast.BaseObjectRef) -> s_name.QualName:
@@ -130,6 +132,7 @@ class TraceContextBase:
     def get_fq_name(
         self,
         decl: qlast.DDLOperation,
+        declaration: bool=False,
     ) -> Tuple[str, s_name.QualName]:
         # Get the basic name form.
         if isinstance(decl, qlast.CreateConcretePointer):
@@ -139,7 +142,7 @@ class TraceContextBase:
             name = decl.name
             parent_expected = True
         elif isinstance(decl, qlast.ObjectDDL):
-            fq_name = self.get_local_name(decl.name)
+            fq_name = self.get_local_name(decl.name, declaration=declaration)
             name = str(fq_name)
             parent_expected = False
         else:
@@ -363,7 +366,7 @@ def sdl_to_ddl(
         ctx.set_module(module_name)
         for decl_ast in declarations:
             if isinstance(decl_ast, qlast.CreateObject):
-                _, fq_name = ctx.get_fq_name(decl_ast)
+                _, fq_name = ctx.get_fq_name(decl_ast, declaration=True)
 
                 if isinstance(decl_ast, qlast.CreateObjectType):
                     ctx.objects[fq_name] = qltracer.ObjectType(fq_name)

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -352,6 +352,7 @@ def resolve_name(
     objects: Dict[sn.QualName, Optional[ObjectLike]],
     modaliases: Optional[Dict[Optional[str], str]],
     local_modules: AbstractSet[str],
+    declaration: bool=False,
 ) -> sn.QualName:
     """Resolve a name into a fully-qualified one.
 
@@ -359,7 +360,7 @@ def resolve_name(
     """
     module = ref.module
 
-    no_std = False
+    no_std = declaration
     if module and module.startswith('__current__::'):
         no_std = True
         module = f'{current_module}::{module.removeprefix("__current__::")}'
@@ -377,15 +378,13 @@ def resolve_name(
             module = fq_module + sep + rest
 
     qname = sn.QualName(module=module, name=ref.name)
-    if type is None:
-        return qname
 
     # check if there's a name in default module
-    # actually registered to the right type
+    # that matches
     if not no_std and not (
         ref.module and ref.module in local_modules
     ) and not (
-        isinstance(objects.get(qname), type)
+        objects.get(qname)
         or schema.get(
             qname, default=None, type=so.Object) is not None
     ):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9755,6 +9755,75 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 """,
             )
 
+    def test_schema_describe_name_override_01(self):
+        self._assert_describe(
+            """
+            type Other {
+                obj: Object;
+            }
+            type Object;
+            """,
+
+            'DESCRIBE MODULE test',
+
+            """
+            create type test::Object;
+            create type test::Other {
+                create link obj: test::Object;
+            };
+            """
+        )
+
+    def test_schema_describe_name_override_02(self):
+        self._assert_describe(
+            """
+            type Object;
+            type Other {
+                obj: test::Object;
+            }
+            """,
+
+            'DESCRIBE MODULE test',
+
+            """
+            create type test::Object;
+            create type test::Other {
+                create link obj: test::Object;
+            };
+            """
+        )
+
+    def test_schema_describe_name_override_03(self):
+        self._assert_describe(
+            """
+            type User {
+              single link identity: Identity;
+            }
+
+            abstract type BaseObject {}
+
+            type Identity extending BaseObject {
+              link user := .<identity[is User];
+            }
+
+            type IdentityCredential extending BaseObject {}
+            """,
+
+            'DESCRIBE MODULE test',
+
+            """
+            create abstract type test::BaseObject;
+            create type test::Identity extending test::BaseObject;
+            create type test::IdentityCredential extending test::BaseObject;
+            create type test::User {
+                create single link identity: test::Identity;
+            };
+            alter type test::Identity {
+                create link user := (.<identity[is test::User]);
+            };
+            """
+        )
+
 
 class TestCreateMigration(tb.BaseSchemaTest):
 


### PR DESCRIPTION
We were actually inferring the names of the *objects themselves*
as being std::Object when we declared a type named Object,
because we didn't understand that you never need to fall back
to looking in std when actually *declaring* the object.

Once that was fixed, there was also some impossibly confused code I
had apparently written that accidentally preferred names in std over
local ones as a result of a bad refactor.