### PR TITLE
Fix migration incomplete issues with functions that use multiple globals

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1213,8 +1213,8 @@ class Function(
 ):
 
     used_globals = so.SchemaField(
-        so.ObjectList[s_globals.Global],
-        coerce=True, compcoef=0.0, default=so.DEFAULT_CONSTRUCTOR,
+        so.ObjectSet[s_globals.Global],
+        coerce=True, default=so.DEFAULT_CONSTRUCTOR,
         inheritable=False)
 
     # A backend_name that is shared between all overloads of the same
@@ -1672,8 +1672,8 @@ class FunctionCommand(
                     context=body.qlast.context,
                 )
 
-        globs = [schema.get(glob.global_name, type=s_globals.Global)
-                 for glob in ir.globals]
+        globs = {schema.get(glob.global_name, type=s_globals.Global)
+                 for glob in ir.globals}
         self.set_attribute_value('used_globals', globs)
 
         return expr

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2413,6 +2413,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         # different evolution branches.
         base_schema = self.load_schema('')
 
+        schemas = []
         # Evolve a schema in a series of migrations.
         multi_migration = base_schema
         for i, state in enumerate(migrations):
@@ -2432,6 +2433,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
             # Perform incremental migration.
             multi_migration = self.run_ddl(multi_migration, mig_text, 'test')
+            schemas.append(multi_migration)
 
             diff = s_ddl.delta_schemas(multi_migration, cur_state)
 
@@ -2444,6 +2446,8 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                     f'incremental migration on step {i + 1}{note}:\n'
                     f'{markup.dumps(diff)}\n'
                 )
+
+        return schemas
 
     def test_schema_get_migration_01(self):
         schema = r'''
@@ -3785,6 +3789,20 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
               required link user -> User;
               required property action -> str;
             }
+        '''
+
+        self._assert_migration_consistency(schema)
+
+    def test_schema_globals_funcs_01(self):
+        schema = '''
+            required global x1 -> int64 { default := 0 };
+            required global x2 -> int64 { default := 0 };
+            required global x3 -> int64 { default := 0 };
+            required global x4 -> int64 { default := 0 };
+
+            function f1() -> int64 using (
+              global x1 + global x2 + global x3 + global x4);
+            function f2() -> int64 using (f1());
         '''
 
         self._assert_migration_consistency(schema)
@@ -6670,6 +6688,27 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
             alias CurFoo := (select Foo filter .id = global current_foo)
         """])
+
+    def test_schema_migrations_equivalence_globals_funcs_02(self):
+        schema1, schema2, _ = self._assert_migration_equivalence([r"""
+            required global foo -> int64 { default := 0};
+            required global bar -> int64 { default := 0};
+
+            function f1() -> int64 using (global foo);
+            function f2() -> int64 using (f1());
+        """, r"""
+            required global foo -> int64 { default := 0};
+            required global bar -> int64 { default := 0};
+
+            function f1() -> int64 using (global foo + global bar);
+            function f2() -> int64 using (f1());
+        """])
+
+        self.assertEqual(
+            schema1.get_functions('default::f2'),
+            schema2.get_functions('default::f2'),
+            "function got deleted/recreated and should have been altered",
+        )
 
     # NOTE: array<str>, array<int16>, array<json> already exist in std
     # schema, so it's better to use array<float32> or some other


### PR DESCRIPTION
We were treating used_globals as something that needed to perfectly
match (compcoef 0.0) when actually we had meant for it to be
ignored. And to make things worse, it was being compared in an order
sensitive way despite having a set somewhere in its dataflow.

Fixes an ancillary issue from #5641