### PR TITLE
Get global Identity by ID and use HMAC verification

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -225,7 +225,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         select
             ext::auth::Identity
         filter
-            .iss = <str>json_get(jwt.claims, "iss")
-            and .sub = <str>json_get(jwt.claims, "sub")
+            .id = <uuid>json_get(jwt.claims, "sub")
     );
 };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -119,7 +119,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     create function ext::auth::_jwt_check_signature(
         jwt: tuple<header: std::str, payload: std::str, signature: std::str>,
         key: std::str,
-        algo: ext::auth::JWTAlgo = ext::auth::JWTAlgo.RS256,
+        algo: ext::auth::JWTAlgo = ext::auth::JWTAlgo.HS256,
     ) -> std::json
     {
         set volatility := 'Stable';
@@ -176,7 +176,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     create function ext::auth::_jwt_verify(
         token: std::str,
         key: std::str,
-        algo: ext::auth::JWTAlgo = ext::auth::JWTAlgo.RS256,
+        algo: ext::auth::JWTAlgo = ext::auth::JWTAlgo.HS256,
     ) -> std::json
     {
         set volatility := 'Stable';

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -145,9 +145,7 @@ class Router:
                     )
                     try:
                         identity = await local_client.register(data)
-                        session_token = self._make_session_token(
-                            identity.id, "local"
-                        )
+                        session_token = self._make_session_token(identity.id)
                         response.custom_headers["Set-Cookie"] = (
                             f"edgedb-session={session_token}; "
                             f"HttpOnly; Secure; SameSite=Strict"
@@ -220,9 +218,7 @@ class Router:
                     try:
                         identity = await local_client.authenticate(data)
 
-                        session_token = self._make_session_token(
-                            identity.id, "local"
-                        )
+                        session_token = self._make_session_token(identity.id)
                         response.custom_headers["Set-Cookie"] = (
                             f"edgedb-session={session_token}; "
                             f"HttpOnly; Secure; SameSite=Strict"
@@ -346,7 +342,7 @@ class Router:
         state_token.make_signed_token(signing_key)
         return state_token.serialize()
 
-    def _make_session_token(self, identity_id: str, iss: str | None) -> str:
+    def _make_session_token(self, identity_id: str) -> str:
         signing_key = self._get_auth_signing_key()
         auth_expiration_time = util.get_config(
             self.db.db_config,
@@ -357,7 +353,7 @@ class Router:
         expires_at = datetime.datetime.utcnow() + expires_in
 
         claims: dict[str, Any] = {
-            "iss": iss or self.base_path,
+            "iss": self.base_path,
             "sub": identity_id,
         }
         if expires_in.total_seconds() != 0:

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -145,7 +145,9 @@ class Router:
                     )
                     try:
                         identity = await local_client.register(data)
-                        session_token = self._make_session_token(identity.id)
+                        session_token = self._make_session_token(
+                            identity.id, "local"
+                        )
                         response.custom_headers["Set-Cookie"] = (
                             f"edgedb-session={session_token}; "
                             f"HttpOnly; Secure; SameSite=Strict"
@@ -218,7 +220,9 @@ class Router:
                     try:
                         identity = await local_client.authenticate(data)
 
-                        session_token = self._make_session_token(identity.id)
+                        session_token = self._make_session_token(
+                            identity.id, "local"
+                        )
                         response.custom_headers["Set-Cookie"] = (
                             f"edgedb-session={session_token}; "
                             f"HttpOnly; Secure; SameSite=Strict"
@@ -342,7 +346,7 @@ class Router:
         state_token.make_signed_token(signing_key)
         return state_token.serialize()
 
-    def _make_session_token(self, identity_id: str) -> str:
+    def _make_session_token(self, identity_id: str, iss: str | None) -> str:
         signing_key = self._get_auth_signing_key()
         auth_expiration_time = util.get_config(
             self.db.db_config,
@@ -353,7 +357,7 @@ class Router:
         expires_at = datetime.datetime.utcnow() + expires_in
 
         claims: dict[str, Any] = {
-            "iss": self.base_path,
+            "iss": iss or self.base_path,
             "sub": identity_id,
         }
         if expires_in.total_seconds() != 0:


### PR DESCRIPTION
Based on testing this in client-side code:

1. The JWT that we use for our locally-issued auth token after authenticating will have the _server_ as the `iss` (Issuer) instead of the original identity provider. And the `sub` (Subject) of the JWT will be the `Identity.id` already, so the filter is just simply `.id = <uuid>json_get(jwt.claims, "sub")`.
2. We use a symmetric key and sign with HMAC instead of RSA, so update the defaults in the JWT functions to reflect that.