### PR TITLE
Improve FTS weights

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -1003,7 +1003,7 @@ def compile_fts_with_options(
     weight_expr = call.args[1].expr
     if not irutils.is_const(weight_expr):
         raise errors.InvalidValueError(
-            f"fts::search weight_category must be a literal",
+            f"fts::search weight_category must be a constant",
             context=weight_expr.context,
         )
     weight_const = irutils.as_const(weight_expr)
@@ -1011,6 +1011,7 @@ def compile_fts_with_options(
         weight = str(weight_const.value)
     else:
         weight = None
+        assert weight
 
     return irast.FTSDocument(
         text=call.args[2].expr,

--- a/edb/lib/fts.edgeql
+++ b/edb/lib/fts.edgeql
@@ -51,6 +51,13 @@ CREATE SCALAR TYPE fts::Language
     ';
 };
 
+CREATE SCALAR TYPE fts::Weight EXTENDING enum<A, B, C, D> {
+    CREATE ANNOTATION std::description := "
+        Weight category.
+        Weight values for each category can be provided in fts::search.
+    ";
+};
+
 CREATE ABSTRACT INDEX fts::index {
     CREATE ANNOTATION std::description :=
         "Full-text search index based on the Postgres's GIN index.";
@@ -64,7 +71,7 @@ CREATE SCALAR TYPE fts::document {
 CREATE FUNCTION fts::with_options(
     text: std::str,
     NAMED ONLY language: anyenum,
-    NAMED ONLY weight_category: optional std::str = <std::str>{},
+    NAMED ONLY weight_category: optional fts::Weight = fts::Weight.A,
 ) -> fts::document {
     CREATE ANNOTATION std::description := '
         Adds language and weight category information to a string,

--- a/tests/schemas/fts1.esdl
+++ b/tests/schemas/fts1.esdl
@@ -21,7 +21,7 @@ type Text {
     required text: str;
     index fts::index on (fts::with_options(.text,
         language := fts::Language.eng,
-        weight_category := 'A'
+        weight_category := fts::Weight.A
     ));
 }
 
@@ -42,11 +42,11 @@ type Post {
     index fts::index on ((
         fts::with_options(.title,
             language := fts::Language.eng,
-            weight_category := 'A'
+            weight_category := fts::Weight.A
         ),
         fts::with_options(.body,
             language := fts::Language.eng,
-            weight_category := 'B'
+            weight_category := fts::Weight.B
         )
     ));
 }
@@ -59,7 +59,7 @@ type Description {
     index fts::index on (
         fts::with_options(.text,
             language := fts::Language.eng,
-            weight_category := 'A'
+            weight_category := fts::Weight.A
         )
     );
 }

--- a/tests/test_edgeql_fts.py
+++ b/tests/test_edgeql_fts.py
@@ -737,7 +737,6 @@ class TestEdgeQLFTSFeatures(tb.QueryTestCase):
             ["angry reply", "random stuff"],
         )
 
-
     async def test_edgeql_fts_updating(self):
         # test that adding an fts index, existing objects are also indexed
 

--- a/tests/test_edgeql_fts.py
+++ b/tests/test_edgeql_fts.py
@@ -141,7 +141,7 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
             )
             select x.object {
                 number,
-                rank := x.score,
+                score := x.score,
             };
             ''',
             [
@@ -151,21 +151,21 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
                     # "dressed, with a pair of <b>white</b> kid <b>gloves</b> "
                     # "in one hand",
                     "number": 8,
-                    "rank": 0.6037054,
+                    "score": 0.6037054,
                 },
                 {
                     # "hl":
                     # "<b>Rabbit</b>’s little <b>white</b> kid <b>gloves</b> "
                     # "while she was talking. “How _can_ I have done",
                     "number": 14,
-                    "rank": 0.4559453,
+                    "score": 0.4559453,
                 },
                 {
                     # "hl":
                     # "<b>Rabbit</b> actually _took a <b>watch</b> out of its "
                     # "waistcoat-pocket_, and looked at it, and then",
                     "number": 3,
-                    "rank": 0.40634018,
+                    "score": 0.40634018,
                 },
             ],
         )
@@ -691,7 +691,7 @@ class TestEdgeQLFTSFeatures(tb.QueryTestCase):
                 Post,
                 'angry',
                 language := 'eng',
-                weights := [0.0, 0.0, 0.0, 1.0]
+                weights := [1.0, 0.0]
             )
             select res.object.title
             order by res.score desc
@@ -704,13 +704,39 @@ class TestEdgeQLFTSFeatures(tb.QueryTestCase):
                 Post,
                 'angry',
                 language := 'eng',
-                weights := [0.0, 0.0, 1.0, 0.0]
+                weights := [0.0, 1.0]
             )
             select res.object.title
             order by res.score desc
             ''',
             ["random stuff", "angry reply"],
         )
+        await self.assert_query_result(
+            r'''
+            with res := fts::search(
+                Post,
+                'angry',
+                language := 'eng',
+                weights := [1.0, 0.0, 0.0, 0.0, 1.0, 1.0]
+            )
+            select res.object.title
+            order by res.score desc
+            ''',
+            ["angry reply", "random stuff"],
+        )
+        await self.assert_query_result(
+            r'''
+            with res := fts::search(
+                Post,
+                'angry',
+                language := 'eng'
+            )
+            select res.object.title
+            order by res.score desc
+            ''',
+            ["angry reply", "random stuff"],
+        )
+
 
     async def test_edgeql_fts_updating(self):
         # test that adding an fts index, existing objects are also indexed


### PR DESCRIPTION
Limits what's accepted into `weight_category`.

Ideally, `with_options(weight_category)` would be an `anyenum`,
similar to language, so people can use their own enum,
with their own naming.
It would ignore the names of the enum variants and instead only
use their ordering which would have to match the ordering of
the weight values in the `fts::search`.

Right now, we cannot have it be an `anyenum`,
because the `anyenum` type would get conflated with `language: anyenum`.

Naive option would be to stick with `str` for now, but the future change
to enums would be backward in-compatible.

This PR adds `fts::Weight` enum that must be used in
`with_options(weight_category: fts::WeightCategory)`.
In the future, we can implement proper generics and change it
to `weight_category: anyenum`.

The category now also defaults to 'A',
instead of inheriting Postgres's behavior of defaulting to 'D'.

---

This PR also adjust `fts:search`'s `weights` parameter':
- it now defaults to `[1.0, 0.5, 0.25, 0.125]` (as agreed in the RFC),
- if less than four values are provided, it pads the array with zeros,
- if more than four values are provided, it ignores them,
- the four values of the array correspond to categories A, B, C and D, respectively.
  (instead of inheriting Postgres's behavior of D, C, B and A)
