### PR TITLE
Fix remote compiler unpickling None bug

### DIFF
--- a/edb/server/compiler_pool/multitenant_worker.py
+++ b/edb/server/compiler_pool/multitenant_worker.py
@@ -97,7 +97,11 @@ def __sync__(client_id, pickled_schema, invalidation) -> None:
                 dbs = {
                     dbname: state.DatabaseState(
                         dbname,
-                        pickle.loads(pickled_state.user_schema),
+                        (
+                            None
+                            if pickled_state.user_schema is None
+                            else pickle.loads(pickled_state.user_schema)
+                        ),
                         pickle.loads(pickled_state.reflection_cache),
                         pickle.loads(pickled_state.database_config),
                     )

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -131,7 +131,9 @@ class MultiTenantServer(server.BaseServer):
     async def _before_start_servers(self) -> None:
         assert self._task_group is not None
         await self._task_group.__aenter__()
-        await asyncio.wait(self.reload_tenants())
+        fs = self.reload_tenants()
+        if fs:
+            await asyncio.wait(fs)
 
     def _get_status(self) -> dict[str, Any]:
         status = super()._get_status()

--- a/edb/server/protocol/system_api.py
+++ b/edb/server/protocol/system_api.py
@@ -49,7 +49,7 @@ async def handle_request(
         if path_parts == ['status', 'ready'] and request.method == b'GET':
             if tenant is None:
                 # TODO(fantix): test the compiler pool
-                _response_ok(response, "OK")
+                _response_ok(response, b"OK")
             else:
                 await tenant.create_task(
                     handle_readiness_query(request, response, tenant),
@@ -58,7 +58,7 @@ async def handle_request(
         elif path_parts == ['status', 'alive'] and request.method == b'GET':
             if tenant is None:
                 # TODO(fantix): test the compiler pool
-                _response_ok(response, "OK")
+                _response_ok(response, b"OK")
             else:
                 await tenant.create_task(
                     handle_liveness_query(request, response, tenant),


### PR DESCRIPTION
This bug was introduced in [#5921#diff](https://github.com/edgedb/edgedb/pull/5921/commits/4bde3adc1075ce4acee66f53655f9f8c41bac662#diff-cb023165d37a6f71ee27d63c154a2ad31c6c0509668ec482846db124ab1b5bec)

Before that change, we used to pickle and unpickle `None`. But now we no longer pickle/unpickle the user schema in remote compiler server, so the `None` literal is passed to the worker.

This also fixed 2 multi-tenant server issues when 0 tenant configured.