### PR TITLE
Refactor auth schema

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -23,29 +23,46 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
     create module ext::auth;
 
-    create type ext::auth::Identity {
-        create required property iss: std::str;
-        create required property sub: std::str;
-        create property email: std::str;
+    create abstract type ext::auth::Auditable {
+        create required property created_at: std::datetime {
+            set default := std::datetime_current();
+            set readonly := true;
+        };
+        create required property modified_at: std::datetime {
+            create rewrite insert, update using (
+                std::datetime_current()
+            );
+        };
+    };
 
-        create constraint exclusive on ((.iss, .sub))
+    create type ext::auth::Identity extending ext::auth::Auditable {
+        create required property issuer: std::str;
+        create required property subject: std::str;
+
+        create constraint exclusive on ((.issuer, .subject));
     };
 
     create type ext::auth::LocalIdentity extending ext::auth::Identity {
-        create required property handle: std::str {
-            create constraint exclusive;
-        };
-
-        alter property sub {
+        alter property subject {
             create rewrite insert using (<str>.id);
         };
     };
 
-    create type ext::auth::PasswordCredential {
-        create required property password_hash: std::str;
+    create abstract type ext::auth::Factor extending ext::auth::Auditable {
         create required link identity: ext::auth::LocalIdentity {
             create constraint exclusive;
         };
+    };
+
+    create type ext::auth::EmailFactor extending ext::auth::Factor {
+        create required property email: str {
+            create delegated constraint exclusive;
+        };
+    };
+
+    create type ext::auth::EmailPasswordFactor
+        extending ext::auth::EmailFactor {
+        create required property password_hash: std::str;
     };
 
     create type ext::auth::ClientConfig extending cfg::ConfigObject {

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -18,6 +18,7 @@
 
 
 import dataclasses
+import datetime
 from typing import Optional
 
 
@@ -65,9 +66,10 @@ class UserInfo:
 @dataclasses.dataclass
 class Identity:
     id: str
-    sub: str
-    iss: str
-    email: str | None
+    subject: str
+    issuer: str
+    created_at: datetime.datetime
+    modified_at: datetime.datetime
 
     def __str__(self) -> str:
         return self.id
@@ -75,10 +77,7 @@ class Identity:
 
 @dataclasses.dataclass
 class LocalIdentity(Identity):
-    handle: str
-
-    def __str__(self) -> str:
-        return self.handle
+    pass
 
 
 @dataclasses.dataclass

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -118,21 +118,16 @@ class Client:
 with
   iss := <str>$issuer_url,
   sub := <str>$provider_id,
-  email := <optional str>$email,
 
 select (insert ext::auth::Identity {
-  iss := iss,
-  sub := sub,
-  email := email,
-} unless conflict on ((.iss, .sub)) else (
-  update ext::auth::Identity set {
-    email := email
-  }
+  issuer := iss,
+  subject := sub,
+} unless conflict on ((.issuer, .subject)) else (
+  select ext::auth::Identity
 )) { * };""",
             variables={
                 "issuer_url": self.provider.issuer_url,
                 "provider_id": user_info.sub,
-                "email": user_info.email,
             },
         )
         result_json = json.loads(r.decode())


### PR DESCRIPTION
Based on an in-person review of the UI and schema, we've made the following changes:

- We renamed the concept of "credential" to "factor".
- The existence and value of an "email" is now a concern of factors that deal with email instead of the `Identity`.
- Use expanded names for `iss` (`issuer`) and `sub` (`subject`) for better readability.
- Add an `Auditable` abstract class that for now just has ctime and mtime, but will eventually also multi-link to `Audit` objects.
- Drop support for a "username"-like authentication (formerly `handle`) in favor of an `EmailPasswordFactor` that requires an email and uses the email for both uniquely identifying an `Identity` (which the `handle` used to do) and also for communicating things like reset tokens and mutli-factor authentication codes (which the `Identity.email` used to do).