### PR TITLE
Fix overloaded indexes/constraints that appear in "wrong order" in SDL

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -301,6 +301,12 @@ class Constraint(
         if (
             ddl_identity is not None
             and self.field_is_inherited(schema, 'subjectexpr')
+            and (bases := self.get_bases(schema).objects(schema))
+            and (
+                bases[0].generic(schema)
+                or 'subjectexpr' not in (
+                    bases[0].get_ddl_identity(schema) or ())
+            )
         ):
             ddl_identity.pop('subjectexpr', None)
 
@@ -1553,6 +1559,10 @@ class RebaseConstraint(
     ConstraintCommand,
     referencing.RebaseReferencedInheritingObject[Constraint],
 ):
+    # finalexpr is fully determined by a bunch of ddl_identity fields,
+    # so it should be inherited by compute_inherited_fields if they are
+    EXTRA_INHERITED_FIELDS = {'finalexpr'}
+
     def _get_bases_for_ast(
         self,
         schema: s_schema.Schema,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8247,6 +8247,40 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             """,
         ])
 
+    def test_schema_migrations_inh_ordering_01(self):
+        self._assert_migration_equivalence([
+            r"""
+            type Tag extending Named {
+              index on (.name);
+              constraint expression on (.name != "");
+              constraint max_value(10) on (.cnt);
+            }
+
+            abstract type Named  {
+              required property name -> str;
+              required property cnt -> int64;
+              index on (.name);
+              constraint expression on (.name != "");
+              constraint max_value(10) on (.cnt);
+            }
+            """,
+            r"""
+            abstract type Named  {
+              required property name -> str;
+              required property cnt -> int64;
+              index on (.name);
+              constraint expression on (.name != "");
+              constraint max_value(10) on (.cnt);
+            }
+
+            type Tag extending Named {
+              index on (.name);
+              constraint expression on (.name != "");
+              constraint max_value(10) on (.cnt);
+            }
+            """,
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
The problem was that fields like `expr` on the constraint weren't
being marked as if the index was recreated in the subtype first and
then rebased when a parent index is created. Fix this by detecting the
rebase and adjusting the inherited statuses.

Fixes #6161

I'm not sure if I'm confident enough in this for a cherry-pick?