### PR TITLE
Small fixes based on end-to-end OAuth testing

### DIFF
--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -20,10 +20,11 @@ import uuid
 import urllib.parse
 import json
 
+from typing import Callable
 from jwcrypto import jwt, jwk
 from datetime import datetime
 
-from . import data, errors
+from . import data, errors, http_client
 
 
 class BaseProvider:
@@ -34,7 +35,7 @@ class BaseProvider:
         client_id: str,
         client_secret: str,
         *,
-        http_factory,
+        http_factory: Callable[..., http_client.HttpClient],
     ):
         self.name = name
         self.issuer_url = issuer_url
@@ -45,7 +46,7 @@ class BaseProvider:
     async def get_code_url(self, state: str, redirect_uri: str) -> str:
         raise NotImplementedError
 
-    async def exchange_code(self, code: str) -> data.OAuthAccessTokenResponse:
+    async def exchange_code(self, code: str, redirect_uri: str) -> data.OAuthAccessTokenResponse:
         raise NotImplementedError
 
     async def fetch_user_info(
@@ -75,7 +76,7 @@ class OpenIDProvider(BaseProvider):
         return f"{oidc_config.authorization_endpoint}?{encoded}"
 
     async def exchange_code(
-        self, code: str
+        self, code: str, redirect_uri: str
     ) -> data.OpenIDConnectAccessTokenResponse:
         oidc_config = await self._get_oidc_config()
 
@@ -90,8 +91,11 @@ class OpenIDProvider(BaseProvider):
                     "code": code,
                     "client_id": self.client_id,
                     "client_secret": self.client_secret,
+                    "redirect_uri": redirect_uri,
                 },
             )
+            if resp.status_code >= 400:
+                raise errors.OAuthProviderFailure(f"Failed to exchange code: {resp.text}")
             json = resp.json()
 
             return data.OpenIDConnectAccessTokenResponse(**json)

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -46,7 +46,9 @@ class BaseProvider:
     async def get_code_url(self, state: str, redirect_uri: str) -> str:
         raise NotImplementedError
 
-    async def exchange_code(self, code: str, redirect_uri: str) -> data.OAuthAccessTokenResponse:
+    async def exchange_code(
+        self, code: str, redirect_uri: str
+    ) -> data.OAuthAccessTokenResponse:
         raise NotImplementedError
 
     async def fetch_user_info(
@@ -95,7 +97,9 @@ class OpenIDProvider(BaseProvider):
                 },
             )
             if resp.status_code >= 400:
-                raise errors.OAuthProviderFailure(f"Failed to exchange code: {resp.text}")
+                raise errors.OAuthProviderFailure(
+                    f"Failed to exchange code: {resp.text}"
+                )
             json = resp.json()
 
             return data.OpenIDConnectAccessTokenResponse(**json)

--- a/edb/server/protocol/auth_ext/errors.py
+++ b/edb/server/protocol/auth_ext/errors.py
@@ -133,3 +133,23 @@ class UserAlreadyRegistered(AuthExtError):
 
     def __str__(self) -> str:
         return self.description
+
+
+class OAuthProviderFailure(AuthExtError):
+    """OAuth Provider returned a non-success for some part of the flow"""
+
+    def __init__(
+        self,
+        description: str,
+    ):
+        self.description = description
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"description={self.description!r}"
+            ")"
+        )
+
+    def __str__(self) -> str:
+        return self.description

--- a/edb/server/protocol/auth_ext/github.py
+++ b/edb/server/protocol/auth_ext/github.py
@@ -45,7 +45,9 @@ class GitHubProvider(base.BaseProvider):
         encoded = urllib.parse.urlencode(params)
         return f"{self.auth_domain}/login/oauth/authorize?{encoded}"
 
-    async def exchange_code(self, code: str) -> data.OAuthAccessTokenResponse:
+    async def exchange_code(
+        self, code: str, redirect_uri: str
+    ) -> data.OAuthAccessTokenResponse:
         async with self.auth_client() as client:
             resp = await client.post(
                 "/login/oauth/access_token",
@@ -54,6 +56,7 @@ class GitHubProvider(base.BaseProvider):
                     "code": code,
                     "client_id": self.client_id,
                     "client_secret": self.client_secret,
+                    "redirect_uri": redirect_uri,
                 },
             )
             json = resp.json()

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -111,7 +111,9 @@ class Router:
                         provider_id=provider_id,
                         base_url=test_url,
                     )
-                    identity = await oauth_client.handle_callback(code)
+                    identity = await oauth_client.handle_callback(
+                        code, self._get_callback_url()
+                    )
                     session_token = self._make_session_token(identity.id)
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = redirect_to

--- a/edb/server/protocol/auth_ext/http_client.py
+++ b/edb/server/protocol/auth_ext/http_client.py
@@ -1,0 +1,26 @@
+import urllib.parse
+import httpx
+import httpx_cache
+
+class HttpClient(httpx.AsyncClient):
+    def __init__(
+        self, *args, edgedb_test_url: str | None, base_url: str, **kwargs
+    ):
+        self.edgedb_orig_base_url = None
+        if edgedb_test_url:
+            self.edgedb_orig_base_url = urllib.parse.quote(base_url, safe='')
+            base_url = edgedb_test_url
+        cache = httpx_cache.AsyncCacheControlTransport()
+        super().__init__(*args, base_url=base_url, transport=cache, **kwargs)
+
+    async def post(self, path, *args, **kwargs):
+        if self.edgedb_orig_base_url:
+            path = f'{self.edgedb_orig_base_url}/{path}'
+        return await super().post(path, *args, **kwargs)
+
+    async def get(self, path, *args, **kwargs):
+        if self.edgedb_orig_base_url:
+            path = f'{self.edgedb_orig_base_url}/{path}'
+        return await super().get(path, *args, **kwargs)
+
+

--- a/edb/server/protocol/auth_ext/http_client.py
+++ b/edb/server/protocol/auth_ext/http_client.py
@@ -1,6 +1,25 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import urllib.parse
 import httpx
 import httpx_cache
+
 
 class HttpClient(httpx.AsyncClient):
     def __init__(
@@ -22,5 +41,3 @@ class HttpClient(httpx.AsyncClient):
         if self.edgedb_orig_base_url:
             path = f'{self.edgedb_orig_base_url}/{path}'
         return await super().get(path, *args, **kwargs)
-
-

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -25,28 +25,7 @@ import httpx_cache
 from typing import Any
 from edb.server.protocol import execute
 
-from . import errors, util, data, base
-
-
-class HttpClient(httpx.AsyncClient):
-    def __init__(
-        self, *args, edgedb_test_url: str | None, base_url: str, **kwargs
-    ):
-        if edgedb_test_url:
-            self.edgedb_orig_base_url = urllib.parse.quote(base_url, safe='')
-            base_url = edgedb_test_url
-        cache = httpx_cache.AsyncCacheControlTransport()
-        super().__init__(*args, base_url=base_url, transport=cache, **kwargs)
-
-    async def post(self, path, *args, **kwargs):
-        if self.edgedb_orig_base_url:
-            path = f'{self.edgedb_orig_base_url}/{path}'
-        return await super().post(path, *args, **kwargs)
-
-    async def get(self, path, *args, **kwargs):
-        if self.edgedb_orig_base_url:
-            path = f'{self.edgedb_orig_base_url}/{path}'
-        return await super().get(path, *args, **kwargs)
+from . import errors, util, data, base, http_client
 
 
 class Client:
@@ -56,7 +35,7 @@ class Client:
         self.db = db
         self.db_config = db.db_config
 
-        http_factory = lambda *args, **kwargs: HttpClient(
+        http_factory = lambda *args, **kwargs: http_client.HttpClient(
             *args, edgedb_test_url=base_url, **kwargs
         )
 

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -82,8 +82,8 @@ class Client:
             state=state, redirect_uri=redirect_uri
         )
 
-    async def handle_callback(self, code: str) -> data.Identity:
-        response = await self.provider.exchange_code(code)
+    async def handle_callback(self, code: str, redirect_uri: str) -> data.Identity:
+        response = await self.provider.exchange_code(code, redirect_uri)
         user_info = await self.provider.fetch_user_info(response)
 
         return await self._handle_identity(user_info)

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -17,10 +17,7 @@
 #
 
 
-import urllib.parse
 import json
-import httpx
-import httpx_cache
 
 from typing import Any
 from edb.server.protocol import execute
@@ -62,6 +59,7 @@ class Client:
                 )
             case "azure":
                 from . import azure
+
                 self.provider = azure.AzureProvider(
                     client_id=client_id,
                     client_secret=client_secret,
@@ -69,6 +67,7 @@ class Client:
                 )
             case "apple":
                 from . import apple
+
                 self.provider = apple.AppleProvider(
                     client_id=client_id,
                     client_secret=client_secret,
@@ -82,7 +81,9 @@ class Client:
             state=state, redirect_uri=redirect_uri
         )
 
-    async def handle_callback(self, code: str, redirect_uri: str) -> data.Identity:
+    async def handle_callback(
+        self, code: str, redirect_uri: str
+    ) -> data.Identity:
         response = await self.provider.exchange_code(code, redirect_uri)
         user_info = await self.provider.fetch_user_info(response)
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -505,7 +505,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             redirect_to = f"{self.http_addr}/some/path"
 
             _, headers, status = self.http_con_request(
-                http_con, {"provider": provider_id, "redirect_to": redirect_to}, path="authorize"
+                http_con,
+                {"provider": provider_id, "redirect_to": redirect_to},
+                path="authorize",
             )
 
             self.assertEqual(status, 302)
@@ -679,15 +681,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_token = mock_provider.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)
             self.assertEqual(
-                requests_for_token[0]["body"],
-                json.dumps(
-                    {
-                        "grant_type": "authorization_code",
-                        "code": "abc123",
-                        "client_id": client_id,
-                        "client_secret": client_secret,
-                    }
-                ),
+                json.loads(requests_for_token[0]["body"]),
+                {
+                    "grant_type": "authorization_code",
+                    "code": "abc123",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "redirect_uri": f"{self.http_addr}/callback",
+                },
             )
 
             requests_for_user = mock_provider.requests[user_request]
@@ -980,15 +981,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_token = mock_provider.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)
             self.assertEqual(
-                requests_for_token[0]["body"],
-                json.dumps(
-                    {
-                        "grant_type": "authorization_code",
-                        "code": "abc123",
-                        "client_id": client_id,
-                        "client_secret": client_secret,
-                    }
-                ),
+                json.loads(requests_for_token[0]["body"]),
+                {
+                    "grant_type": "authorization_code",
+                    "code": "abc123",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "redirect_uri": f"{self.http_addr}/callback",
+                },
             )
 
             identity = await self.con.query(
@@ -1031,8 +1031,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
+            redirect_to = f"{self.http_addr}/some/path"
             _, headers, status = self.http_con_request(
-                http_con, {"provider": provider_id}, path="authorize"
+                http_con,
+                {
+                    "provider": provider_id,
+                    "redirect_to": redirect_to,
+                },
+                path="authorize",
             )
 
             self.assertEqual(status, 302)
@@ -1052,6 +1058,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             claims = await self.extract_jwt_claims(state[0])
             self.assertEqual(claims.get("provider"), provider_id)
             self.assertEqual(claims.get("iss"), self.http_addr)
+            self.assertEqual(claims.get("redirect_to"), redirect_to)
 
             self.assertEqual(
                 qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
@@ -1081,8 +1088,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
+            redirect_to = f"{self.http_addr}/some/path"
             _, headers, status = self.http_con_request(
-                http_con, {"provider": provider_id}, path="authorize"
+                http_con,
+                {
+                    "provider": provider_id,
+                    "redirect_to": redirect_to,
+                },
+                path="authorize",
             )
 
             self.assertEqual(status, 302)
@@ -1102,6 +1115,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             claims = await self.extract_jwt_claims(state[0])
             self.assertEqual(claims.get("provider"), provider_id)
             self.assertEqual(claims.get("iss"), self.http_addr)
+            self.assertEqual(claims.get("redirect_to"), redirect_to)
 
             self.assertEqual(
                 qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
@@ -1216,15 +1230,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_token = mock_provider.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)
             self.assertEqual(
-                requests_for_token[0]["body"],
-                json.dumps(
-                    {
-                        "grant_type": "authorization_code",
-                        "code": "abc123",
-                        "client_id": client_id,
-                        "client_secret": client_secret,
-                    }
-                ),
+                json.loads(requests_for_token[0]["body"]),
+                {
+                    "grant_type": "authorization_code",
+                    "code": "abc123",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "redirect_uri": f"{self.http_addr}/callback",
+                },
             )
 
     async def test_http_auth_ext_apple_authorize_01(self):
@@ -1247,8 +1260,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
+            redirect_to = f"{self.http_addr}/some/path"
             _, headers, status = self.http_con_request(
-                http_con, {"provider": provider_id}, path="authorize"
+                http_con,
+                {
+                    "provider": provider_id,
+                    "redirect_to": redirect_to,
+                },
+                path="authorize",
             )
 
             self.assertEqual(status, 302)
@@ -1268,6 +1287,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             claims = await self.extract_jwt_claims(state[0])
             self.assertEqual(claims.get("provider"), provider_id)
             self.assertEqual(claims.get("iss"), self.http_addr)
+            self.assertEqual(claims.get("redirect_to"), redirect_to)
 
             self.assertEqual(
                 qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
@@ -1382,15 +1402,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_token = mock_provider.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)
             self.assertEqual(
-                requests_for_token[0]["body"],
-                json.dumps(
-                    {
-                        "grant_type": "authorization_code",
-                        "code": "abc123",
-                        "client_id": client_id,
-                        "client_secret": client_secret,
-                    }
-                ),
+                json.loads(requests_for_token[0]["body"]),
+                {
+                    "grant_type": "authorization_code",
+                    "code": "abc123",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "redirect_uri": f"{self.http_addr}/callback",
+                },
             )
 
     async def test_http_auth_ext_local_password_register_form_01(self):

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -502,9 +502,10 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
+            redirect_to = f"{self.http_addr}/some/path"
 
             _, headers, status = self.http_con_request(
-                http_con, {"provider": provider_id}, path="authorize"
+                http_con, {"provider": provider_id, "redirect_to": redirect_to}, path="authorize"
             )
 
             self.assertEqual(status, 302)
@@ -524,6 +525,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             claims = await self.extract_jwt_claims(state[0])
             self.assertEqual(claims.get("provider"), provider_id)
             self.assertEqual(claims.get("iss"), self.http_addr)
+            self.assertEqual(claims.get("redirect_to"), redirect_to)
 
             self.assertEqual(
                 qs.get("redirect_uri"), [f"{self.http_addr}/callback"]


### PR DESCRIPTION
A few random bits came up when actually testing the OAuth flow end-to-end:

- Accidentally forgot to include the `redirect_to` in the initial `state` claims that are generated by the `authorize` endpoint.
- Forgot to send the `redirect_uri` in the final code-exchange request.
- Added some better logging when code-exchange fails.