### PR TITLE
Support DML in IF/THEN/ELSE expressions

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -182,6 +182,10 @@ class Anchor(Expr):
     name: str
 
 
+class IRAnchor(Anchor):
+    has_dml: bool = False
+
+
 class SpecialAnchor(Anchor):
     pass
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -781,6 +781,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_Anchor(self, node: qlast.Anchor) -> None:
         self.write(node.name)
 
+    def visit_IRAnchor(self, node: qlast.IRAnchor) -> None:
+        self.write(node.name)
+
     def visit_SpecialAnchor(self, node: qlast.SpecialAnchor) -> None:
         self.write(node.name)
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -734,11 +734,13 @@ class ContextLevel(compiler.ContextLevel):
     def detached(self) -> compiler.CompilerContextManager[ContextLevel]:
         return self.new(ContextSwitchMode.DETACHED)
 
-    def create_anchor(self, ir: irast.Set, name: str='v') -> qlast.Path:
+    def create_anchor(
+        self, ir: irast.Set, name: str='v', *, has_dml: bool=False
+    ) -> qlast.Path:
         alias = self.aliases.get(name)
         self.anchors[alias] = ir
         return qlast.Path(
-            steps=[qlast.ObjectRef(name=alias)],
+            steps=[qlast.IRAnchor(name=alias, has_dml=has_dml)],
         )
 
     def maybe_create_anchor(

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -37,6 +37,7 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
 from edb.ir import ast as irast
+from edb.ir import utils as irutils
 from edb.ir import typeutils as irtyputils
 
 from edb.schema import expraliases as s_aliases
@@ -735,9 +736,12 @@ class ContextLevel(compiler.ContextLevel):
         return self.new(ContextSwitchMode.DETACHED)
 
     def create_anchor(
-        self, ir: irast.Set, name: str='v', *, has_dml: bool=False
+        self, ir: irast.Set, name: str='v', *, check_dml: bool=False
     ) -> qlast.Path:
         alias = self.aliases.get(name)
+        # TODO: We should probably always check for DML, but I'm
+        # concerned about perf, since we don't cache it at all.
+        has_dml = check_dml and irutils.contains_dml(ir)
         self.anchors[alias] = ir
         return qlast.Path(
             steps=[qlast.IRAnchor(name=alias, has_dml=has_dml)],

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -351,7 +351,7 @@ def _compile_dml_ifelse(
                     result=qlast.Tuple(elements=[]),
                     where=cond_path,
                 ),
-                result=subctx.create_anchor(if_ir, has_dml=True),
+                result=subctx.create_anchor(if_ir, check_dml=True),
             )
             els.append(if_b)
 
@@ -362,7 +362,7 @@ def _compile_dml_ifelse(
                     result=qlast.Tuple(elements=[]),
                     where=qlast.UnaryOp(op='NOT', operand=cond_path),
                 ),
-                result=subctx.create_anchor(else_ir, has_dml=True),
+                result=subctx.create_anchor(else_ir, check_dml=True),
             )
             els.append(else_b)
 

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -42,6 +42,7 @@ from edb.schema import types as s_types
 from edb.schema import utils as s_utils
 
 from edb.edgeql import ast as qlast
+from edb.edgeql import utils
 
 from . import astutils
 from . import casts
@@ -306,13 +307,87 @@ def compile_Array(
     return setgen.new_array_set(elements, ctx=ctx, srcctx=expr.context)
 
 
+def _compile_dml_ifelse(
+        ir: irast.Set, *, ctx: context.ContextLevel) -> irast.Set:
+    """Transform an IF/ELSE that contains DML into FOR loops
+
+    The basic approach is to extract the pieces from the if/then/else and
+    rewrite them into:
+        for b in COND union (
+          {
+            (for _ in (select () filter b) union (IF_BRANCH)),
+            (for _ in (select () filter not b) union (ELSE_BRANCH)),
+          }
+        )
+    """
+
+    # Extract the IR parts from the IF/THEN/ELSE
+    # Note that cond_ir will be unfenced while if_ir and else_ir
+    # will have been compiled under fences.
+    match ir.expr:
+        case irast.OperatorCall(args=[
+            irast.CallArg(expr=if_ir),
+            irast.CallArg(expr=cond_ir),
+            irast.CallArg(expr=else_ir),
+        ]):
+            pass
+        case _:
+            raise AssertionError('malformed DML IF/ELSE')
+
+    with ctx.new() as subctx:
+        subctx.anchors = subctx.anchors.copy()
+
+        alias = ctx.aliases.get('b')
+        cond_path = qlast.Path(
+            steps=[qlast.ObjectRef(name=alias)],
+        )
+
+        if_b = qlast.ForQuery(
+            iterator_alias='__',
+            iterator=qlast.SelectQuery(
+                result=qlast.Tuple(elements=[]),
+                where=cond_path,
+            ),
+            result=subctx.create_anchor(if_ir, has_dml=True),
+        )
+        else_b = qlast.ForQuery(
+            iterator_alias='__',
+            iterator=qlast.SelectQuery(
+                result=qlast.Tuple(elements=[]),
+                where=qlast.UnaryOp(op='NOT', operand=cond_path),
+            ),
+            result=subctx.create_anchor(else_ir, has_dml=True),
+        )
+
+        full = qlast.ForQuery(
+            iterator_alias=alias,
+            iterator=subctx.create_anchor(cond_ir, 'b'),
+            result=qlast.Set(elements=[if_b, else_b]),
+        )
+
+        res = dispatch.compile(full, ctx=subctx)
+        # Indicate that the original IF/ELSE code should determine the
+        # cardinality/multiplicity.
+        res.card_inference_override = ir
+
+        return res
+
+
 @dispatch.compile.register(qlast.IfElse)
 def compile_IfElse(
         expr: qlast.IfElse, *, ctx: context.ContextLevel) -> irast.Set:
 
-    return func.compile_operator(
+    res = func.compile_operator(
         expr, op_name='std::IF',
         qlargs=[expr.if_expr, expr.condition, expr.else_expr], ctx=ctx)
+
+    if (
+        utils.contains_dml(expr.if_expr)
+        or utils.contains_dml(expr.else_expr)
+    ):
+        res = _compile_dml_ifelse(res, ctx=ctx)
+
+    return res
 
 
 @dispatch.compile.register(qlast.UnaryOp)

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -476,7 +476,6 @@ def compile_GlobalExpr(
 def compile_TypeCast(
         expr: qlast.TypeCast, *, ctx: context.ContextLevel) -> irast.Set:
     target_stype = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
-    target_typeref = typegen.type_to_typeref(target_stype, env=ctx.env)
     ir_expr: Union[irast.Set, irast.Expr]
 
     if isinstance(expr.expr, qlast.Parameter):
@@ -567,14 +566,7 @@ def compile_TypeCast(
             subctx.implicit_tid_in_shapes = False
             subctx.implicit_tname_in_shapes = False
 
-        if (
-            isinstance(expr.expr, qlast.Array)
-            and not expr.expr.elements
-            and irtyputils.is_array(target_typeref)
-        ):
-            ir_expr = irast.Array(elements=[], typeref=target_typeref)
-        else:
-            ir_expr = dispatch.compile(expr.expr, ctx=subctx)
+        ir_expr = dispatch.compile(expr.expr, ctx=subctx)
 
         res = casts.compile_cast(
             ir_expr,

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -341,7 +341,6 @@ def _special_case(name: str) -> Callable[[_SpecialCaseFunc], _SpecialCaseFunc]:
 #: A dictionary of conditional callables and the indices
 #: of the arguments that are evaluated conditionally.
 CONDITIONAL_OPS = {
-    sn.QualName('std', 'IF'): {0, 2},
     sn.QualName('std', '??'): {1},
 }
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -519,6 +519,12 @@ def _infer_set(
             ir, is_mutation=is_mutation,
             scope_tree=scope_tree, ctx=ctx)
 
+        # But actually! Check if it is overridden
+        if ir.card_inference_override:
+            result = _infer_set_inner(
+                ir.card_inference_override, is_mutation=is_mutation,
+                scope_tree=scope_tree, ctx=ctx)
+
         # We need to cache the main result before doing the shape,
         # since sometimes the shape will refer to the enclosing set.
         ctx.inferred_cardinality[ir] = result

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -226,6 +226,11 @@ def _infer_set(
     result = _infer_set_inner(
         ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx
     )
+    if ir.card_inference_override:
+        result = _infer_set_inner(
+            ir.card_inference_override, is_mutation=is_mutation,
+            scope_tree=scope_tree, ctx=ctx)
+
     ctx.inferred_multiplicity[ir, scope_tree, ctx.distinct_iterator] = result
 
     # The shape doesn't affect multiplicity, but requires validation.

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -262,6 +262,18 @@ def try_bind_call_args(
                 # refine our resolved_poly_base_type to be that as the
                 # more general case.
                 resolved_poly_base_type = ct
+            else:
+                # Try resolving a polymorphic argument type against the
+                # resolved base type. This lets us handle cases like
+                #  - if b then x else {}
+                #  - if b then [1] else []
+                # Though it is still unfortunately not smart enough
+                # to handle the reverse case.
+                if resolved.is_polymorphic(schema):
+                    ct = resolved.resolve_polymorphic(
+                        schema, resolved_poly_base_type)
+
+            if ct is not None:
                 return s_types.MAX_TYPE_DISTANCE if is_abstract else 0
             else:
                 return -1

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -286,6 +286,13 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         if isinstance(step, qlast.SpecialAnchor):
             path_tip = resolve_special_anchor(step, ctx=ctx)
 
+        elif isinstance(step, qlast.IRAnchor):
+            # Check if the starting path label is a known anchor
+            refnode = anchors.get(step.name)
+            if not refnode:
+                raise AssertionError(f'anchor {step.name} is missing')
+            path_tip = new_set_from_set(refnode, ctx=ctx)
+
         elif isinstance(step, qlast.ObjectRef):
             if i > 0:  # pragma: no cover
                 raise RuntimeError(

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -882,8 +882,8 @@ def trace_Path(
 
 
 @trace.register
-def trace_SpecialAnchor(
-    node: qlast.SpecialAnchor, *, ctx: TracerContext
+def trace_Anchor(
+    node: qlast.Anchor, *, ctx: TracerContext
 ) -> Optional[ObjectLike]:
     if name := ctx.anchors.get(node.name):
         return ctx.objects[name]

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -204,8 +204,13 @@ def contains_dml(ql_expr: qlast.Base) -> bool:
     if isinstance(ql_expr, dml_types):
         return True
 
-    res = ast.find_children(ql_expr, qlast.Query,
-                            lambda x: isinstance(x, dml_types),
-                            terminate_early=True)
+    res = ast.find_children(
+        ql_expr, qlast.Base,
+        lambda x: (
+            isinstance(x, dml_types)
+            or (isinstance(x, qlast.IRAnchor) and x.has_dml)
+        ),
+        terminate_early=True,
+    )
 
     return bool(res)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -533,6 +533,12 @@ class Set(Base):
     # insertions to BaseObject.
     ignore_rewrites: bool = False
 
+    # An expression to use instead of this one for the purpose of
+    # cardinality/multiplicity inference. This is used for when something
+    # is desugared in a way that doesn't preserve cardinality, but we
+    # need to anyway.
+    card_inference_override: typing.Optional[Set] = None
+
     def __repr__(self) -> str:
         return f'<ir.Set \'{self.path_id}\' at 0x{id(self):x}>'
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -76,7 +76,7 @@ def is_union_expr(ir: irast.Base) -> bool:
     )
 
 
-def is_empty_array_expr(ir: irast.Base) -> bool:
+def is_empty_array_expr(ir: Optional[irast.Base]) -> TypeGuard[irast.Array]:
     """Return True if the given *ir* expression is an empty array expression.
     """
     return (
@@ -85,14 +85,16 @@ def is_empty_array_expr(ir: irast.Base) -> bool:
     )
 
 
-def is_untyped_empty_array_expr(ir: irast.Base) -> bool:
+def is_untyped_empty_array_expr(
+    ir: Optional[irast.Base]
+) -> TypeGuard[irast.Array]:
     """Return True if the given *ir* expression is an empty
        array expression of an uknown type.
     """
     return (
         is_empty_array_expr(ir)
-        and (ir.typeref is None                    # type: ignore
-             or typeutils.is_generic(ir.typeref))  # type: ignore
+        and (ir.typeref is None
+             or typeutils.is_generic(ir.typeref))
     )
 
 

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -491,21 +491,6 @@ class TestDelete(tb.QueryTestCase):
                     (DELETE DeleteTest2);
             ''')
 
-    async def test_edgeql_delete_in_conditional_bad_02(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                'DELETE statements cannot be used'):
-            await self.con.execute(r'''
-                SELECT
-                    (SELECT DeleteTest FILTER .name = 'foo')
-                    IF EXISTS DeleteTest
-                    ELSE (
-                        (SELECT DeleteTest)
-                        UNION
-                        (DELETE DeleteTest)
-                    );
-            ''')
-
     async def test_edgeql_delete_abstract_01(self):
         await self.con.execute(r"""
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3500,14 +3500,12 @@ class TestExpressions(tb.QueryTestCase):
             """)
 
     async def test_edgeql_expr_array_21(self):
-        # it should be technically possible to infer the type of the array
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r"operator 'UNION' cannot be applied to operands.*anytype.*"):
-
-            await self.con.execute("""
+        await self.assert_query_result(
+            """
                 SELECT [1, 2] UNION [];
-            """)
+            """,
+            [[1, 2], []],
+        )
 
     async def test_edgeql_expr_array_22(self):
         await self.assert_query_result(
@@ -8253,6 +8251,43 @@ aa \
             r"""
                 with test := ['']
                 select test if false else <array<str>>[];
+            """,
+            [[]],
+        )
+
+    async def test_edgeql_expr_if_else_10(self):
+        await self.assert_query_result(
+            r"""
+                select if true then 10 else {}
+            """,
+            [10],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select if false then 10 else {}
+            """,
+            [],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select if true then [10] else []
+            """,
+            [[10]],
+        )
+
+        await self.assert_query_result(
+            r"""
+                select if false then [10] else []
+            """,
+            [[]],
+        )
+
+        await self.assert_query_result(
+            r"""
+                with test := ['']
+                select test if false else [];
             """,
             [[]],
         )

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -6053,11 +6053,22 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             '''
+            select if <bool>$0 then (
+                insert InsertTest { l2 := 100 }
+            ) else {}
+            ''',
+            [{}],
+            variables=(True,)
+        )
+
+        await self.assert_query_result(
+            '''
             select InsertTest { l2, tname := .__type__.name } order by  .l2
             ''',
             [
                 {"l2": 2, "tname": "default::InsertTest"},
                 {"l2": 2, "tname": "default::InsertTest"},
+                {"l2": 100, "tname": "default::InsertTest"},
                 {"l2": 200, "tname": "default::DerivedTest"},
                 {"l2": 200, "tname": "default::DerivedTest"},
             ],

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -6053,7 +6053,8 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             '''
-            select if <bool>$0 then (
+            with go := <bool>$0
+            select if go then (
                 insert InsertTest { l2 := 100 }
             ) else {}
             ''',

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2532,22 +2532,6 @@ class TestInsert(tb.QueryTestCase):
                     (INSERT Subordinate { name := 'no way' });
             ''')
 
-    async def test_edgeql_insert_in_conditional_bad_02(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                'INSERT statements cannot be used inside '
-                'conditional expressions'):
-            await self.con.execute(r'''
-                SELECT
-                    (SELECT Subordinate FILTER .name = 'foo')
-                    IF EXISTS Subordinate
-                    ELSE (
-                        (SELECT Subordinate)
-                        UNION
-                        (INSERT Subordinate { name := 'no way' })
-                    );
-            ''')
-
     async def test_edgeql_insert_correlated_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
@@ -6010,3 +5994,84 @@ class TestInsert(tb.QueryTestCase):
             ''',
             [{"sub": {"name": str, "@note": "!"}}] * 10,
         )
+
+    async def test_edgeql_insert_conditional_01(self):
+        await self.assert_query_result(
+            '''
+            select if <bool>$0 then (
+                insert InsertTest { l2 := 2 }
+            ) else (
+                insert DerivedTest { l2 := 200 }
+            )
+            ''',
+            [{}],
+            variables=(True,)
+        )
+
+        await self.assert_query_result(
+            '''
+            select InsertTest { l2, tname := .__type__.name }
+            ''',
+            [
+                {"l2": 2, "tname": "default::InsertTest"},
+            ],
+        )
+
+        await self.assert_query_result(
+            '''
+            select if <bool>$0 then (
+                insert InsertTest { l2 := 2 }
+            ) else (
+                insert DerivedTest { l2 := 200 }
+            )
+            ''',
+            [{}],
+            variables=(False,)
+        )
+
+        await self.assert_query_result(
+            '''
+            select InsertTest { l2, tname := .__type__.name } order by  .l2
+            ''',
+            [
+                {"l2": 2, "tname": "default::InsertTest"},
+                {"l2": 200, "tname": "default::DerivedTest"},
+            ],
+        )
+
+        await self.assert_query_result(
+            '''
+            select if array_unpack(<array<bool>>$0) then (
+                insert InsertTest { l2 := 2 }
+            ) else (
+                insert DerivedTest { l2 := 200 }
+            )
+            ''',
+            [{}, {}],
+            variables=([True, False],)
+        )
+
+        await self.assert_query_result(
+            '''
+            select InsertTest { l2, tname := .__type__.name } order by  .l2
+            ''',
+            [
+                {"l2": 2, "tname": "default::InsertTest"},
+                {"l2": 2, "tname": "default::InsertTest"},
+                {"l2": 200, "tname": "default::DerivedTest"},
+                {"l2": 200, "tname": "default::DerivedTest"},
+            ],
+        )
+
+    async def test_edgeql_insert_conditional_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.QueryError,
+            "cannot reference correlated set",
+        ):
+            await self.con.execute('''
+                select ((if ExceptTest.deleted then (
+                    insert InsertTest { l2 := 2 }
+                ) else (
+                    insert DerivedTest { l2 := 200 }
+                )), (select ExceptTest.deleted limit 1));
+            ''')

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1175,3 +1175,33 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         AT_LEAST_ONE
         """
+
+    def test_edgeql_ir_card_inference_139(self):
+        """
+        if <bool>$0 then
+            (insert User { name := "test" })
+        else
+            (insert User { name := "???" })
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_140(self):
+        """
+        if <bool>$0 then
+            (insert User { name := "test" })
+        else
+            {(insert User { name := "???" }), (insert User { name := "!!!" })}
+% OK %
+        AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_141(self):
+        """
+        if <bool>$0 then
+            (insert User { name := "test" })
+        else
+            <User>{}
+% OK %
+        AT_MOST_ONE
+        """

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -835,3 +835,33 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         DUPLICATE
         """
+
+    def test_edgeql_ir_mult_inference_90(self):
+        """
+        if <bool>$0 then
+            (insert User { name := "test" })
+        else
+            (insert User { name := "???" })
+% OK %
+        UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_91(self):
+        """
+        if <bool>$0 then
+            (insert User { name := "test" })
+        else
+            {(insert User { name := "???" }), (insert User { name := "!!!" })}
+% OK %
+        UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_92(self):
+        """
+        if <bool>$0 then
+            (insert User { name := "test" })
+        else
+            <User>{}
+% OK %
+        UNIQUE
+        """

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2171,21 +2171,6 @@ class TestUpdate(tb.QueryTestCase):
                     (UPDATE UpdateTest SET { name := 'no way' });
             ''')
 
-    async def test_edgeql_update_in_conditional_bad_02(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                'UPDATE statements cannot be used'):
-            await self.con.execute(r'''
-                SELECT
-                    (SELECT UpdateTest FILTER .name = 'foo')
-                    IF EXISTS UpdateTest
-                    ELSE (
-                        (SELECT UpdateTest)
-                        UNION
-                        (UPDATE UpdateTest SET { name := 'no way' })
-                    );
-            ''')
-
     async def test_edgeql_update_correlated_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,


### PR DESCRIPTION
As we've discussed (and, tragically, recommended to users), we can
rewrite the conditionals into for loops:
```
    for b in COND union (
      {
	(for _ in (select () filter b) union (IF_BRANCH)),
	(for _ in (select () filter not b) union (ELSE_BRANCH)),
      }
    )
```

The main fiddly part is preserving the correct
cardinality/multiplicity inference. I did this by adding a
card_inference_override field to Set that specifies another set that
should determine the cardinality.

I don't love this, but I haven't thought of a cleaner approach that
doesn't give up the benefits of the desugaring approach.

We need more testing but I wanted to get something up for people to
look at / we can catch up on testing after the feature freeze if
needed.

Fixes #4437.