### PR TITLE
Start a new server for JWT auth test

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -34,7 +34,6 @@ from jwcrypto import jwk
 
 from edb import buildmeta
 from edb.common import devmode
-from edb.common import secretkey
 from edb.edgeql import quote
 
 from edb.server import args as edgedb_args
@@ -424,26 +423,6 @@ class Cluster(BaseCluster):
     def get_data_dir(self) -> pathlib.Path:
         return self._data_dir
 
-    def get_runstate_dir(self) -> pathlib.Path:
-        return self._runstate_dir
-
-    def get_jws_key(self) -> jwk.JWK:
-        if self._jws_key is None:
-            self._jws_key = self._load_jws_key()
-        return self._jws_key
-
-    def _load_jws_key(self) -> jwk.JWK:
-        try:
-            return secretkey.load_secret_key(self._get_jws_key_path())
-        except secretkey.SecretKeyReadError as e:
-            raise ClusterError(e.args[0]) from e
-
-    def _get_jws_key_path(self) -> pathlib.Path:
-        if path := os.environ.get("EDGEDB_SERVER_JWS_KEY_FILE"):
-            return pathlib.Path(path)
-        else:
-            return self.get_runstate_dir() / edgedb_args.JWS_KEY_FILE_NAME
-
     async def init(
         self,
         *,
@@ -501,12 +480,6 @@ class TempCluster(Cluster):
 class RunningCluster(BaseCluster):
     def __init__(self, **conn_args: Any) -> None:
         self.conn_args = conn_args
-        if path := os.environ.get("EDGEDB_SERVER_JWS_KEY_FILE"):
-            try:
-                jws_key = secretkey.load_secret_key(pathlib.Path(path))
-            except secretkey.SecretKeyReadError as e:
-                raise ClusterError(e.args[0]) from e
-            self.get_jws_key = lambda: jws_key
 
     def is_managed(self) -> bool:
         return False

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -28,6 +28,7 @@ import jwcrypto.jwk
 import edgedb
 
 from edb.common import secretkey
+from edb.server import args
 from edb.schema import defines as s_def
 from edb.testbase import server as tb
 
@@ -236,33 +237,28 @@ class TestServerAuth(tb.ConnectedTestCase):
             await self.con.execute(
                 f'CREATE SUPERUSER ROLE myrole_{"x" * s_def.MAX_NAME_LENGTH};')
 
+    @unittest.skipIf(
+        "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
+        "cannot use CONFIGURE INSTANCE in multi-tenant mode",
+    )
     async def test_server_auth_jwt_1(self):
-        if not self.has_create_role:
-            self.skipTest("create role is not supported by the backend")
+        jwk_fd, jwk_file = tempfile.mkstemp()
 
-        if not hasattr(self.cluster, "get_jws_key"):
-            raise unittest.SkipTest("test not supported on remote cluster")
-
-        jwk = self.cluster.get_jws_key()
-
-        try:
-            # enable JWT
-            await self.con.query("""
-                CONFIGURE INSTANCE INSERT Auth {
-                    comment := 'test',
-                    priority := 0,
-                    method := (INSERT JWT {
-                        transports := cfg::ConnectionTransport.TCP
-                    }),
-                }
-            """)
-
+        key = jwcrypto.jwk.JWK(generate='EC')
+        with open(jwk_fd, "wb") as f:
+            f.write(key.export_to_pem(private_key=True, password=None))
+        jwk = secretkey.load_secret_key(pathlib.Path(jwk_file))
+        async with tb.start_edgedb_server(
+            jws_key_file=pathlib.Path(jwk_file),
+            default_auth_method=args.ServerAuthMethod.JWT,
+            extra_args=["--instance-name=localtest"],
+        ) as sd:
             # bad secret keys
             with self.assertRaisesRegex(
                 edgedb.AuthenticationError,
                 'authentication failed: malformed JWT',
             ):
-                await self.connect(secret_key='wrong')
+                await sd.connect(secret_key='wrong')
 
             sk = secretkey.generate_secret_key(jwk)
             corrupt_sk = sk[:50] + "0" + sk[51:]
@@ -271,7 +267,7 @@ class TestServerAuth(tb.ConnectedTestCase):
                 edgedb.AuthenticationError,
                 'authentication failed: Verification failed',
             ):
-                await self.connect(secret_key=corrupt_sk)
+                await sd.connect(secret_key=corrupt_sk)
 
             good_keys = [
                 [],
@@ -284,7 +280,7 @@ class TestServerAuth(tb.ConnectedTestCase):
                 params_dict = dict(params)
                 with self.subTest(**params_dict):
                     sk = secretkey.generate_secret_key(jwk, **params_dict)
-                    conn = await self.connect(secret_key=sk)
+                    conn = await sd.connect(secret_key=sk)
                     await conn.aclose()
 
             bad_keys = {
@@ -307,12 +303,7 @@ class TestServerAuth(tb.ConnectedTestCase):
                         edgedb.AuthenticationError,
                         "authentication failed: " + msg,
                     ):
-                        await self.connect(secret_key=sk)
-
-        finally:
-            await self.con.query("""
-                CONFIGURE INSTANCE RESET Auth FILTER .comment = 'test'
-            """)
+                        await sd.connect(secret_key=sk)
 
     @unittest.skipIf(
         "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,


### PR DESCRIPTION
Unfortunately we'll have to start a separate server for JWT auth test because the "system" test parallelism granularity doesn't prevent non-system tests running on the same cluster.

Partially reverts:

* [#5928@b66246](https://github.com/edgedb/edgedb/pull/5928/commits/b66246f291aa67df4c31acedf71fb6243f44fa05)
* [#5197@73d3f2](https://github.com/edgedb/edgedb/pull/5197/commits/73d3f27ac6e4b0b71c693bb50ac05540772d67b1)