### PR TITLE
Add `when` clause to triggers to enable them to be conditional

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_09_27_00_00
+EDGEDB_CATALOG_VERSION = 2023_09_27_00_01
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1330,6 +1330,7 @@ class CreateTrigger(CreateObject, TriggerCommand):
     kinds: typing.List[qltypes.TriggerKind]
     scope: qltypes.TriggerScope
     expr: Expr
+    condition: typing.Optional[Expr]
 
 
 class AlterTrigger(AlterObject, TriggerCommand):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1548,6 +1548,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self._block_ws(0)
             self._write_keywords('FOR ' + str(node.scope) + ' ')
 
+            if node.condition:
+                self._block_ws(1)
+                self._write_keywords('WHEN ')
+                self.write('(')
+                self.visit(node.condition)
+                self.write(')')
+                self._block_ws(-1)
+
             self._write_keywords('DO ')
             self.write('(')
             self.visit(node.expr)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2276,16 +2276,18 @@ class CreateTriggerStmt(Nonterm):
             CREATE TRIGGER UnqualifiedPointerName
             TriggerTiming TriggerKindList
             FOR TriggerScope
+            OptWhenBlock
             DO ParenExpr
             OptCreateTriggerCommandsBlock
         """
-        _, _, name, timing, kinds, _, scope, _, expr, commands = kids
+        _, _, name, timing, kinds, _, scope, when, _, expr, commands = kids
         self.val = qlast.CreateTrigger(
             name=name.val,
             timing=timing.val,
             kinds=kinds.val,
             scope=scope.val,
             expr=expr.val,
+            condition=when.val,
             commands=commands.val,
         )
 
@@ -2298,6 +2300,7 @@ commands_block(
     DropAnnotationValueStmt,
     RenameStmt,
     UsingStmt,
+    AccessWhenStmt,
     SetFieldStmt,
     ResetFieldStmt,
     opt=False

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -1560,16 +1560,18 @@ class TriggerDeclarationBlock(Nonterm):
             TRIGGER NodeName
             TriggerTiming TriggerKindList
             FOR TriggerScope
+            OptWhenBlock
             DO ParenExpr
             CreateTriggerSDLCommandsBlock
         """
-        _, name, timing, kinds, _, scope, _, expr, commands = kids
+        _, name, timing, kinds, _, scope, when, _, expr, commands = kids
         self.val = qlast.CreateTrigger(
             name=name.val,
             timing=timing.val,
             kinds=kinds.val,
             scope=scope.val,
             expr=expr.val,
+            condition=when.val,
             commands=commands.val,
         )
 
@@ -1580,15 +1582,17 @@ class TriggerDeclarationShort(Nonterm):
             TRIGGER NodeName
             TriggerTiming TriggerKindList
             FOR TriggerScope
+            OptWhenBlock
             DO ParenExpr
         """
-        _, name, timing, kinds, _, scope, _, expr = kids
+        _, name, timing, kinds, _, scope, when, _, expr = kids
         self.val = qlast.CreateTrigger(
             name=name.val,
             timing=timing.val,
             kinds=kinds.val,
             scope=scope.val,
             expr=expr.val,
+            condition=when.val,
         )
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -464,6 +464,7 @@ ALTER TYPE schema::Trigger {
   CREATE MULTI PROPERTY kinds -> schema::TriggerKind;
   CREATE REQUIRED PROPERTY scope -> schema::TriggerScope;
   CREATE PROPERTY expr -> std::str;
+  CREATE PROPERTY condition -> std::str;
 };
 
 ALTER TYPE schema::Rewrite {

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -4275,7 +4275,9 @@ class AlterObjectProperty(Command):
             return qlast.SetField(
                 name=self.property,
                 value=expr_ql,
-                special_syntax=(self.property == 'expr'),
+                special_syntax=(
+                    self.property == 'expr' or field.special_ddl_syntax
+                ),
             )
 
     def __repr__(self) -> str:

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -187,7 +187,7 @@ class AccessPolicyCommand(
 
             target = schema.get(sn.QualName('std', 'bool'), type=s_types.Type)
             expr_type = expression.irast.stype
-            if not expr_type.issubclass(schema, target):
+            if not expr_type.issubclass(expression.irast.schema, target):
                 srcctx = self.get_attribute_source_context(field)
                 raise errors.SchemaDefinitionError(
                     f'{vname} expression for {pol_name} is of invalid type: '

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11251,6 +11251,13 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             type Test2 extending Parent;
         """)
 
+        await self.migrate(r"""
+            abstract type Parent {
+                access policy asdf when (true) allow all;
+            }
+            type Test2 extending Parent;
+        """)
+
     async def test_edgeql_migration_access_policy_02(self):
         # Make sure policies don't interfere with constraints or indexes
         await self.migrate(r"""

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11559,7 +11559,8 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
 
             type Person {
                 required name: str;
-                trigger log_delete after insert for each do (
+                trigger log_delete after insert for each
+                when (__new__.name not like "SKIP%") do (
                     insert Log { body := __new__.name }
                 );
             }
@@ -11572,7 +11573,8 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
 
             type Person {
                 required name: str;
-                trigger log_delete after insert for each do (
+                trigger log_delete after insert for each
+                when (false) do (
                     insert Log { body := __new__.name }
                 );
             }
@@ -11669,7 +11671,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }
 
             type Person extending Named {
-                trigger log_insert after insert for each do (
+                trigger log_insert after insert for each when (false) do (
                     insert Log {
                         body := __new__.__type__.name ++ ' ' ++ __new__.name,
                     }
@@ -11689,7 +11691,30 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             abstract type Named {
                 required name: str;
 
-                trigger log_insert after insert for each do (
+                trigger log_insert after insert for each when (false) do (
+                    insert Log {
+                        body := __new__.__type__.name ++ ' ' ++ __new__.name,
+                    }
+                );
+            }
+
+            type Person extending Named {
+            }
+        ''')
+
+        await self.migrate(r'''
+            type Log {
+                body: str;
+                timestamp: datetime {
+                    default := datetime_current();
+                }
+            }
+
+
+            abstract type Named {
+                required name: str;
+
+                trigger log_insert after insert for each when (true) do (
                     insert Log {
                         body := __new__.__type__.name ++ ' ' ++ __new__.name,
                     }


### PR DESCRIPTION
I gave it "filter"-style semantics, where any true value in the
result of the when clause makes it fire. The when clause has
access to all the same variables as the trigger body.

The implementation just is done all at the edgeql-level and
uses a FOR loop.

Fixes #5994.