### PR TITLE
Implement `blocked` readiness state

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -150,6 +150,7 @@
 0x_08_00_00_01   BackendUnavailableError  #SHOULD_RETRY
 0x_08_00_00_02   ServerOfflineError  #SHOULD_RECONNECT #SHOULD_RETRY
 0x_08_00_00_03   UnknownTenantError  #SHOULD_RECONNECT #SHOULD_RETRY
+0x_08_00_00_04   ServerBlockedError
 
 ####
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -91,6 +91,7 @@ __all__ = base.__all__ + (  # type: ignore
     'BackendUnavailableError',
     'ServerOfflineError',
     'UnknownTenantError',
+    'ServerBlockedError',
     'BackendError',
     'UnsupportedBackendFeatureError',
     'LogMessage',
@@ -424,6 +425,10 @@ class ServerOfflineError(AvailabilityError):
 
 class UnknownTenantError(AvailabilityError):
     _code = 0x_08_00_00_03
+
+
+class ServerBlockedError(AvailabilityError):
+    _code = 0x_08_00_00_04
 
 
 class BackendError(EdgeDBError):

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -103,7 +103,12 @@ class ReadinessState(enum.StrEnum):
 
     Offline = "offline"
     """Any existing connections are gracefully terminated and no new
-    connections are allowed."""
+    connections are accepted."""
+
+    Blocked = "blocked"
+    """Any existing connections are gracefully terminated and all
+    new connections are accepted but are immediately terminated
+    with a ServerBlockedError."""
 
 
 class ServerAuthMethod(enum.StrEnum):

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1090,13 +1090,6 @@ cdef class DatabaseConnectionView:
         error_constructor,
         reason,
     ):
-        if not self.tenant.is_online():
-            readiness_reason = self.tenant.get_readiness_reason()
-            msg = "the server is going offline"
-            if readiness_reason:
-                msg = f"{msg}: {readiness_reason}"
-            raise errors.ServerOfflineError(msg)
-
         if query_capabilities & ~self._capability_mask:
             # _capability_mask is currently only used for system database
             raise query_capabilities.make_error(

--- a/edb/server/pgcon/errors.py
+++ b/edb/server/pgcon/errors.py
@@ -181,6 +181,13 @@ class ProtocolViolation(BackendError):
         ))
 
 
+class CannotConnectNowError(BackendError):
+    def __init__(self, message="cannot connect now", **kwargs):
+        super().__init__(fields=_build_fields(
+            ERROR_CANNOT_CONNECT_NOW, message, **kwargs
+        ))
+
+
 class InvalidAuthSpec(BackendError):
     def __init__(
         self, message="invalid authorization specification", **kwargs

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -239,6 +239,9 @@ class Tenant(ha_base.ClusterProtocol):
     def is_online(self) -> bool:
         return self._readiness is not srvargs.ReadinessState.Offline
 
+    def is_blocked(self) -> bool:
+        return self._readiness is srvargs.ReadinessState.Blocked
+
     def is_ready(self) -> bool:
         return (
             self._readiness is srvargs.ReadinessState.Default


### PR DESCRIPTION
The difference from the `offline` state is that the server still accepts
connections, but immediately closes them with a protocol-appropriate
error.
