### PR TITLE
Add dry run package build workflow variant

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -2,10 +2,15 @@
 
 ROOT = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
-all: workflows/nightly.yml workflows/release.yml workflows/testing.yml \
+all: workflows/nightly.yml \
+	workflows/release.yml \
+	workflows/testing.yml \
+	workflows/dryrun.yml \
 	workflows/tests.yml \
-    workflows/tests-managed-pg.yml workflows/tests-ha.yml \
-    workflows/tests-pg-versions.yml workflows/tests-patches.yml
+    workflows/tests-managed-pg.yml \
+	workflows/tests-ha.yml \
+    workflows/tests-pg-versions.yml \
+	workflows/tests-patches.yml
 
 workflows/%.yml: workflows.src/%.tpl.yml workflows.src/%.targets.yml workflows.src/build.inc.yml
 	$(ROOT)/workflows.src/render.py $* $*.targets.yml

--- a/.github/workflows.src/dryrun.targets.yml
+++ b/.github/workflows.src/dryrun.targets.yml
@@ -1,0 +1,1 @@
+build.targets.yml

--- a/.github/workflows.src/dryrun.tpl.yml
+++ b/.github/workflows.src/dryrun.tpl.yml
@@ -1,0 +1,9 @@
+<% from "build.inc.yml" import workflow -%>
+name: Package Build Dry Run
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  <<- workflow(targets, [], subdist="nightly") ->>

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1,0 +1,1448 @@
+name: Package Build Dry Run
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.whichver.outputs.branch }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Determine package version
+      shell: bash
+      run: |
+        branch=${GITHUB_REF#refs/heads/}
+        echo branch="${branch}" >> $GITHUB_OUTPUT
+      id: whichver
+
+
+
+  build-debian-buster-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-debian-buster-x86_64
+        path: artifacts/debian-buster
+
+
+  build-debian-buster-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-debian-buster-aarch64
+        path: artifacts/debian-buster
+
+
+  build-debian-bullseye-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bullseye"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-debian-bullseye-x86_64
+        path: artifacts/debian-bullseye
+
+
+  build-debian-bullseye-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bullseye"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-debian-bullseye-aarch64
+        path: artifacts/debian-bullseye
+
+
+  build-debian-bookworm-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bookworm"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-debian-bookworm-x86_64
+        path: artifacts/debian-bookworm
+
+
+  build-debian-bookworm-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bookworm"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-debian-bookworm-aarch64
+        path: artifacts/debian-bookworm
+
+
+  build-ubuntu-bionic-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-ubuntu-bionic-x86_64
+        path: artifacts/ubuntu-bionic
+
+
+  build-ubuntu-bionic-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-ubuntu-bionic-aarch64
+        path: artifacts/ubuntu-bionic
+
+
+  build-ubuntu-focal-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-ubuntu-focal-x86_64
+        path: artifacts/ubuntu-focal
+
+
+  build-ubuntu-focal-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-ubuntu-focal-aarch64
+        path: artifacts/ubuntu-focal
+
+
+  build-ubuntu-jammy-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "jammy"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-ubuntu-jammy-x86_64
+        path: artifacts/ubuntu-jammy
+
+
+  build-ubuntu-jammy-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "jammy"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-ubuntu-jammy-aarch64
+        path: artifacts/ubuntu-jammy
+
+
+  build-centos-7-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-centos-7-x86_64
+        path: artifacts/centos-7
+
+
+  build-centos-8-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-centos-8-x86_64
+        path: artifacts/centos-8
+
+
+  build-centos-8-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-centos-8-aarch64
+        path: artifacts/centos-8
+
+
+  build-rockylinux-9-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "rockylinux"
+        PKG_PLATFORM_VERSION: "9"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-rockylinux-9-x86_64
+        path: artifacts/rockylinux-9
+
+
+  build-rockylinux-9-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "rockylinux"
+        PKG_PLATFORM_VERSION: "9"
+        EXTRA_OPTIMIZATIONS: "true"
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-rockylinux-9-aarch64
+        path: artifacts/rockylinux-9
+
+
+  build-linux-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
+        EXTRA_OPTIMIZATIONS: "true"
+
+        BUILD_GENERIC: true
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-linux-x86_64
+        path: artifacts/linux-x86_64
+
+
+  build-linux-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+
+        BUILD_GENERIC: true
+
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-linux-aarch64
+        path: artifacts/linux-aarch64
+
+
+  build-linuxmusl-x86_64:
+    runs-on: ['self-hosted', 'linux', 'x64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
+        EXTRA_OPTIMIZATIONS: "true"
+
+        BUILD_GENERIC: true
+
+
+        PKG_PLATFORM_LIBC: "musl"
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-linuxmusl-x86_64
+        path: artifacts/linuxmusl-x86_64
+
+
+  build-linuxmusl-aarch64:
+    runs-on: ['self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+
+        BUILD_GENERIC: true
+
+
+        PKG_PLATFORM_LIBC: "musl"
+
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-linuxmusl-aarch64
+        path: artifacts/linuxmusl-aarch64
+
+
+
+  build-macos-x86_64:
+    runs-on: ['self-hosted', 'macOS', 'X64']
+    needs: prep
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      if: false
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      if: false
+      with:
+        python-version: "3.x"
+
+    - name: Build
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_PLATFORM_ARCH: "x86_64"
+        METAPKG_GIT_CACHE: disabled
+
+        BUILD_GENERIC: true
+
+      run: |
+        edgedb-pkg/integration/macos/build.sh
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
+
+
+  build-macos-aarch64:
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    needs: prep
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      if: false
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      if: false
+      with:
+        python-version: "3.x"
+
+    - name: Build
+      env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_ARCH: ""
+        METAPKG_GIT_CACHE: disabled
+
+        BUILD_GENERIC: true
+
+      run: |
+        edgedb-pkg/integration/macos/build.sh
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: builds-macos-aarch64
+        path: artifacts/macos-aarch64
+
+
+
+  test-debian-buster-x86_64:
+    needs: [build-debian-buster-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-debian-buster-x86_64
+        path: artifacts/debian-buster
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-debian-buster-aarch64:
+    needs: [build-debian-buster-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-debian-buster-aarch64
+        path: artifacts/debian-buster
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-debian-bullseye-x86_64:
+    needs: [build-debian-bullseye-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-debian-bullseye-x86_64
+        path: artifacts/debian-bullseye
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bullseye"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-debian-bullseye-aarch64:
+    needs: [build-debian-bullseye-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-debian-bullseye-aarch64
+        path: artifacts/debian-bullseye
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bullseye"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-debian-bookworm-x86_64:
+    needs: [build-debian-bookworm-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-debian-bookworm-x86_64
+        path: artifacts/debian-bookworm
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bookworm"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-debian-bookworm-aarch64:
+    needs: [build-debian-bookworm-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-debian-bookworm-aarch64
+        path: artifacts/debian-bookworm
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "bookworm"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-ubuntu-bionic-x86_64:
+    needs: [build-ubuntu-bionic-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-ubuntu-bionic-x86_64
+        path: artifacts/ubuntu-bionic
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-ubuntu-bionic-aarch64:
+    needs: [build-ubuntu-bionic-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-ubuntu-bionic-aarch64
+        path: artifacts/ubuntu-bionic
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-ubuntu-focal-x86_64:
+    needs: [build-ubuntu-focal-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-ubuntu-focal-x86_64
+        path: artifacts/ubuntu-focal
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-ubuntu-focal-aarch64:
+    needs: [build-ubuntu-focal-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-ubuntu-focal-aarch64
+        path: artifacts/ubuntu-focal
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-ubuntu-jammy-x86_64:
+    needs: [build-ubuntu-jammy-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-ubuntu-jammy-x86_64
+        path: artifacts/ubuntu-jammy
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "jammy"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-ubuntu-jammy-aarch64:
+    needs: [build-ubuntu-jammy-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-ubuntu-jammy-aarch64
+        path: artifacts/ubuntu-jammy
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "jammy"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-centos-7-x86_64:
+    needs: [build-centos-7-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-centos-7-x86_64
+        path: artifacts/centos-7
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-centos-8-x86_64:
+    needs: [build-centos-8-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-centos-8-x86_64
+        path: artifacts/centos-8
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-centos-8-aarch64:
+    needs: [build-centos-8-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-centos-8-aarch64
+        path: artifacts/centos-8
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-rockylinux-9-x86_64:
+    needs: [build-rockylinux-9-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-rockylinux-9-x86_64
+        path: artifacts/rockylinux-9
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "rockylinux"
+        PKG_PLATFORM_VERSION: "9"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-rockylinux-9-aarch64:
+    needs: [build-rockylinux-9-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-rockylinux-9-aarch64
+        path: artifacts/rockylinux-9
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "rockylinux"
+        PKG_PLATFORM_VERSION: "9"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-linux-x86_64:
+    needs: [build-linux-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-linux-x86_64
+        path: artifacts/linux-x86_64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-linux-aarch64:
+    needs: [build-linux-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-linux-aarch64
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-linuxmusl-x86_64:
+    needs: [build-linuxmusl-x86_64]
+    runs-on: ['self-hosted', 'linux', 'x64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-linuxmusl-x86_64
+        path: artifacts/linuxmusl-x86_64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_PLATFORM_LIBC: "musl"
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+  test-linuxmusl-aarch64:
+    needs: [build-linuxmusl-aarch64]
+    runs-on: ['self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-linuxmusl-aarch64
+        path: artifacts/linuxmusl-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: "musl"
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+
+
+
+  test-macos-x86_64:
+    needs: [build-macos-x86_64]
+    runs-on: ['self-hosted', 'macOS', 'X64']
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
+
+    - name: Test
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
+      run: |
+        edgedb-pkg/integration/macos/test.sh
+
+
+  test-macos-aarch64:
+    needs: [build-macos-aarch64]
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-macos-aarch64
+        path: artifacts/macos-aarch64
+
+    - name: Test
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "aarch64"
+      run: |
+        edgedb-pkg/integration/macos/test.sh
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  publish-macos-x86_64:
+    needs: [test-macos-x86_64]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
+
+    - uses: actions/checkout@v3
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: macos-x86_64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+
+  publish-macos-aarch64:
+    needs: [test-macos-aarch64]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: builds-macos-aarch64
+        path: artifacts/macos-aarch64
+
+    - uses: actions/checkout@v3
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: macos-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+
+
+
+  publish-docker:
+    needs:
+      
+      - check-published-debian-buster-x86_64
+      
+      - check-published-debian-buster-aarch64
+      
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: dockerfile
+
+    - env:
+        VERSION_SLOT: "${{ needs.check-published-debian-buster-x86_64.outputs.version-slot }}"
+        VERSION_CORE: "${{ needs.check-published-debian-buster-x86_64.outputs.version-core }}"
+        PKG_SUBDIST: "nightly"
+      id: tags
+      run: |
+        set -e
+
+        url='https://registry.hub.docker.com/v2/repositories/edgedb/edgedb/tags?page_size=100'
+        repo_tags=$(
+          while [ -n "$url" ]; do
+            resp=$(curl -L -s "$url")
+            url=$(echo "$resp" | jq -r ".next")
+            if [ "$url" = "null" ] || [ -z "$url" ]; then
+              break
+            fi
+            echo "$resp" | jq -r '."results"[]["name"]'
+          done | grep "^[[:digit:]]\+.*" | grep -v "alpha\|beta\|rc" || :
+        )
+
+        tags=( "$VERSION_CORE" )
+
+        top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
+              | grep "^${VERSION_SLOT}[\.-]" \
+              | sort --version-sort --reverse | head -n 1)
+        if [ "$top" == "$VERSION_CORE" ]; then
+          tags+=( "$VERSION_SLOT" )
+        fi
+
+        if [ -z "$PKG_SUBDIST" ]; then
+          top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
+                | sort --version-sort --reverse | head -n 1)
+          if [ "$top" == "$VERSION_CORE" ]; then
+            tags+=( "latest" )
+          fi
+        fi
+
+        IFS=,
+        echo "tags=${tags[*]}" >> $GITHUB_OUTPUT
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Publish Docker Image (docker.io)
+      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+      with:
+        name: edgedb/edgedb
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "nightly,nightly_${{ needs.check-published-debian-buster-x86_64.outputs.version-slot }}_cv${{ needs.check-published-debian-buster-x86_64.outputs.catalog-version }}"
+        workdir: dockerfile
+        buildargs: version=${{ needs.check-published-debian-buster-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-buster-x86_64.outputs.version-core }},subdist=nightly
+        platforms: linux/amd64,linux/arm64
+
+    - name: Publish Docker Image (ghcr.io)
+      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+      with:
+        registry: ghcr.io
+        name: ${{ github.repository }}
+        username: "edgedb-ci"
+        password: ${{ secrets.GITHUB_CI_BOT_TOKEN }}
+        tags: "nightly,nightly_${{ needs.check-published-debian-buster-x86_64.outputs.version-slot }}_cv${{ needs.check-published-debian-buster-x86_64.outputs.catalog-version }}"
+        workdir: dockerfile
+        buildargs: version=${{ needs.check-published-debian-buster-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-buster-x86_64.outputs.version-core }},subdist=nightly
+        platforms: linux/amd64,linux/arm64
+
+
+  workflow-notifications:
+    if: failure() && github.event_name != 'pull_request'
+    name: Notify in Slack on failures
+
+    needs:
+      - prep
+      - build-debian-buster-x86_64
+      - test-debian-buster-x86_64
+      - build-debian-buster-aarch64
+      - test-debian-buster-aarch64
+      - build-debian-bullseye-x86_64
+      - test-debian-bullseye-x86_64
+      - build-debian-bullseye-aarch64
+      - test-debian-bullseye-aarch64
+      - build-debian-bookworm-x86_64
+      - test-debian-bookworm-x86_64
+      - build-debian-bookworm-aarch64
+      - test-debian-bookworm-aarch64
+      - build-ubuntu-bionic-x86_64
+      - test-ubuntu-bionic-x86_64
+      - build-ubuntu-bionic-aarch64
+      - test-ubuntu-bionic-aarch64
+      - build-ubuntu-focal-x86_64
+      - test-ubuntu-focal-x86_64
+      - build-ubuntu-focal-aarch64
+      - test-ubuntu-focal-aarch64
+      - build-ubuntu-jammy-x86_64
+      - test-ubuntu-jammy-x86_64
+      - build-ubuntu-jammy-aarch64
+      - test-ubuntu-jammy-aarch64
+      - build-centos-7-x86_64
+      - test-centos-7-x86_64
+      - build-centos-8-x86_64
+      - test-centos-8-x86_64
+      - build-centos-8-aarch64
+      - test-centos-8-aarch64
+      - build-rockylinux-9-x86_64
+      - test-rockylinux-9-x86_64
+      - build-rockylinux-9-aarch64
+      - test-rockylinux-9-aarch64
+      - build-linux-x86_64
+      - test-linux-x86_64
+      - build-linux-aarch64
+      - test-linux-aarch64
+      - build-linuxmusl-x86_64
+      - test-linuxmusl-x86_64
+      - build-linuxmusl-aarch64
+      - test-linuxmusl-aarch64
+      - build-macos-x86_64
+      - test-macos-x86_64
+      - build-macos-aarch64
+      - test-macos-aarch64
+      - publish-docker
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read'
+    steps:
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@26a36836c887f260477432e4314ec3490a84f309
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          slack_webhook_url: ${{secrets.ACTIONS_SLACK_WEBHOOK_URL}}
+          name: 'Workflow notifications'
+          icon_emoji: ':hammer:'
+          include_jobs: 'on-failure'


### PR DESCRIPTION
Identical to the nightly workflow, but does not do any publishing, just
builds and tests.
