### PR TITLE
Disallow INSTANCE config of extension-defined config values

### DIFF
--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -332,6 +332,13 @@ def _validate_op(
                 'is not yet implemented'
             )
 
+        # This error is legit, though
+        if is_ext_config and expr.scope == qltypes.ConfigScope.INSTANCE:
+            raise errors.ConfigurationError(
+                'INSTANCE configuration of extension-defined config variables '
+                'is not allowed'
+            )
+
         # expr.name is the actual name of the property.
         ptr = cfg_host_type.maybe_get_ptr(ctx.env.schema, sn.UnqualName(name))
         if ptr is not None:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -6569,9 +6569,7 @@ def _generate_config_type_view(
                     FROM (VALUES
                         (NULL, '{CONFIG_ID[None]}'::uuid),
                         ('database',
-                         '{CONFIG_ID[qltypes.ConfigScope.DATABASE]}'::uuid),
-                        ('system override',
-                         '{CONFIG_ID[qltypes.ConfigScope.INSTANCE]}'::uuid)
+                         '{CONFIG_ID[qltypes.ConfigScope.DATABASE]}'::uuid)
                     ) AS s(scope, scope_id)
                 ) AS q0
             '''
@@ -6594,9 +6592,7 @@ def _generate_config_type_view(
                      FROM (VALUES
                          (NULL, '{CONFIG_ID[None]}'::uuid),
                          ('database',
-                          '{CONFIG_ID[qltypes.ConfigScope.DATABASE]}'::uuid),
-                         ('system override',
-                          '{CONFIG_ID[qltypes.ConfigScope.INSTANCE]}'::uuid)
+                          '{CONFIG_ID[qltypes.ConfigScope.DATABASE]}'::uuid)
                      ) AS s(scope, scope_id),
                      LATERAL (
                          SELECT (value::jsonb) AS val

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -947,7 +947,7 @@ cdef class DatabaseConnectionView:
 
         for op in ops:
             if op.scope is config.ConfigScope.INSTANCE:
-                await self._db._index.apply_system_config_op(conn, op, self)
+                await self._db._index.apply_system_config_op(conn, op)
             elif op.scope is config.ConfigScope.DATABASE:
                 self.set_database_config(
                     op.apply(settings, self.get_database_config()),
@@ -1261,10 +1261,8 @@ cdef class DatabaseIndex:
             ).generate(block)
         await conn.sql_execute(block.to_string().encode())
 
-    async def apply_system_config_op(self, conn, op, dbv):
-        # XXX: Is it actually legit to have INSTANCE configs of
-        # database local extension configs?
-        spec = dbv.get_config_spec()
+    async def apply_system_config_op(self, conn, op):
+        spec = self._sys_config_spec
 
         op_value = op.get_setting(spec)
         if op.opcode is not None:


### PR DESCRIPTION
The main reason it was ever supported is that it was an implementation
stepping stone, since originally DATABASE didn't support CONFIGURE
INSERT. It doesn't really make sense, and it also doesn't work
currently, because if there is a config value from an extension set,
CONFIGURE INSTANCE operations will ISE if performed from other
databases, since they don't know how to serialize the config back to
json without a complete spec.

Drop the INSTANCE version of the extension config objects, too,
since it can never be populated.