### PR TITLE
Support listen_ports greater than 32767

### DIFF
--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -118,11 +118,14 @@ ALTER TYPE cfg::AbstractConfig {
             'How long an individual query can run before being aborted.';
     };
 
-    CREATE REQUIRED PROPERTY listen_port -> std::int16 {
+    CREATE REQUIRED PROPERTY listen_port -> std::int32 {
         CREATE ANNOTATION cfg::system := 'true';
         CREATE ANNOTATION std::description :=
             'The TCP port the server listens on.';
         SET default := 5656;
+        # Really we want a uint16, but oh well
+        CREATE CONSTRAINT std::min_value(0);
+        CREATE CONSTRAINT std::max_value(65535);
     };
 
     CREATE MULTI PROPERTY listen_addresses -> std::str {

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1953,7 +1953,7 @@ class TestStaticServerConfig(tb.TestCase):
         "cannot use CONFIGURE INSTANCE in multi-tenant mode",
     )
     async def test_server_config_default(self):
-        p1 = tb.find_available_port(max_value=32767)
+        p1 = tb.find_available_port(max_value=50000)
         async with tb.start_edgedb_server(
             extra_args=["--port", str(p1)]
         ) as sd:


### PR DESCRIPTION
The problem is that listen_port had a type of int16, but it really
should be an *unsigned* int16. We don't have those, so approximate.

I ran into this because it turns out that if the server is told to
automatically pick a port, *then* it works outside the int16
(... possibly because it is failing to reflect the value into config).
The `edb test --use-db-cache` flow would stop a server and then
restart it on its previous port, and it was failing.