### PR TITLE
Add a PKCE flow to end of OAuth

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -65,6 +65,11 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property password_hash: std::str;
     };
 
+    create type ext::auth::PKCE extending ext::auth::Auditable {
+        create required property challenge: std::str;
+        create link identity: ext::auth::Identity;
+    };
+
     create type ext::auth::ClientConfig extending cfg::ConfigObject {
         create required property provider_id: std::str {
             set readonly := true;

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -66,7 +66,9 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     };
 
     create type ext::auth::PKCE extending ext::auth::Auditable {
-        create required property challenge: std::str;
+        create required property challenge: std::str {
+            create constraint exclusive;
+        };
         create link identity: ext::auth::Identity;
     };
 

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -65,7 +65,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property password_hash: std::str;
     };
 
-    create type ext::auth::PKCE extending ext::auth::Auditable {
+    create type ext::auth::PKCEChallenge extending ext::auth::Auditable {
         create required property challenge: std::str {
             create constraint exclusive;
         };

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -135,3 +135,14 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
             if field.name in kwargs:
                 setattr(self, field.name, kwargs.pop(field.name))
         self._extra_fields = kwargs
+
+
+@dataclasses.dataclass(repr=False)
+class PKCE:
+    """
+    Object that represents the ext::auth::PKCE type
+    """
+
+    id: str
+    challenge: str
+    identity_id: str | None

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -135,14 +135,3 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
             if field.name in kwargs:
                 setattr(self, field.name, kwargs.pop(field.name))
         self._extra_fields = kwargs
-
-
-@dataclasses.dataclass(repr=False)
-class PKCE:
-    """
-    Object that represents the ext::auth::PKCE type
-    """
-
-    id: str
-    challenge: str
-    identity_id: str | None

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -149,11 +149,12 @@ class Router:
 
                     if verifier_size < 43:
                         raise errors.InvalidData(
-                            "Verifier token must be at least 43 characters long"
+                            "Verifier must be at least 43 characters long"
                         )
                     if verifier_size > 128:
                         raise errors.InvalidData(
-                            "Verifier token must be shorter than 128 characters long"
+                            "Verifier must be shorter than 128 "
+                            "characters long"
                         )
                     try:
                         pkce_object = await pkce.get_by_id(self.db, code)

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -148,7 +148,12 @@ class Router:
                     verifier = _get_search_param(query, "verifier")
 
                     pkce_client = pkce.PKCE(self.db)
-                    pkce_object = await pkce_client.get_by_id(code)
+                    try:
+                        pkce_object = await pkce_client.get_by_id(code)
+                    except Exception:
+                        raise errors.NoIdentityFound(
+                            "Could not find a matching PKCE code"
+                        )
 
                     if pkce_object.identity_id is None:
                         raise errors.InvalidData(
@@ -177,7 +182,7 @@ class Router:
                             }
                         ).encode()
                     else:
-                        response.status = http.HTTPStatus.UNAUTHORIZED
+                        response.status = http.HTTPStatus.FORBIDDEN
 
                 case ("register",):
                     content_type = request.content_type

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -22,6 +22,7 @@ import http
 import json
 import urllib.parse
 import base64
+import hashlib
 
 from typing import *
 from jwcrypto import jwk, jwt
@@ -31,7 +32,7 @@ from edb.common import debug
 from edb.common import markup
 from edb.ir import statypes
 
-from . import oauth, local, errors, util
+from . import oauth, local, errors, util, pkce
 
 
 class Router:
@@ -56,18 +57,20 @@ class Router:
         try:
             match args:
                 case ("authorize",):
-                    provider_id = _get_search_param(
-                        request.url.query.decode("ascii"), "provider"
-                    )
-                    redirect_to = _get_search_param(
-                        request.url.query.decode("ascii"), "redirect_to"
-                    )
+                    query = request.url.query.decode("ascii")
+                    provider_id = _get_search_param(query, "provider")
+                    redirect_to = _get_search_param(query, "redirect_to")
+                    challenge = _get_search_param(query, "challenge")
                     oauth_client = oauth.Client(
                         db=self.db, provider_id=provider_id, base_url=test_url
                     )
+                    pkce_client = pkce.PKCE(self.db)
+                    await pkce_client.create(challenge)
                     authorize_url = await oauth_client.get_authorize_url(
                         redirect_uri=self._get_callback_url(),
-                        state=self._make_state_claims(provider_id, redirect_to),
+                        state=self._make_state_claims(
+                            provider_id, redirect_to, challenge
+                        ),
                     )
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = authorize_url
@@ -110,6 +113,7 @@ class Router:
                         claims = self._verify_and_extract_claims(state)
                         provider_id = claims["provider"]
                         redirect_to = claims["redirect_to"]
+                        challenge = claims["challenge"]
                     except Exception:
                         raise errors.InvalidData("Invalid state token")
                     oauth_client = oauth.Client(
@@ -120,13 +124,60 @@ class Router:
                     identity = await oauth_client.handle_callback(
                         code, self._get_callback_url()
                     )
+                    pkce_client = pkce.PKCE(self.db)
+                    pkce_code = await pkce_client.link_identity_challenge(
+                        identity.id, challenge
+                    )
+                    parsed_url = urllib.parse.urlparse(redirect_to)
+                    query_params = urllib.parse.parse_qs(parsed_url.query)
+                    query_params["code"] = [pkce_code]
+                    new_query = urllib.parse.urlencode(query_params, doseq=True)
+                    new_url = parsed_url._replace(query=new_query).geturl()
+
                     session_token = self._make_session_token(identity.id)
                     response.status = http.HTTPStatus.FOUND
-                    response.custom_headers["Location"] = redirect_to
+                    response.custom_headers["Location"] = new_url
                     response.custom_headers["Set-Cookie"] = (
                         f"edgedb-session={session_token}; "
                         f"HttpOnly; Secure; SameSite=Strict"
                     )
+
+                case ("token",):
+                    query = request.url.query.decode("ascii")
+                    code = _get_search_param(query, "code")
+                    verifier = _get_search_param(query, "verifier")
+
+                    pkce_client = pkce.PKCE(self.db)
+                    pkce_object = await pkce_client.get_by_id(code)
+
+                    if pkce_object.identity_id is None:
+                        raise errors.InvalidData(
+                            "Code is not associated with an Identity"
+                        )
+
+                    hashed_verifier = hashlib.sha256(verifier.encode()).digest()
+                    base64_url_encoded_verifier = base64.urlsafe_b64encode(
+                        hashed_verifier
+                    ).rstrip(b'=')
+
+                    if (
+                        base64_url_encoded_verifier.decode()
+                        == pkce_object.challenge
+                    ):
+                        await pkce_client.delete(code)
+                        session_token = self._make_session_token(
+                            pkce_object.identity_id
+                        )
+                        response.status = http.HTTPStatus.OK
+                        response.content_type = b"application/json"
+                        response.body = json.dumps(
+                            {
+                                "auth_token": session_token,
+                                "identity_id": pkce_object.identity_id,
+                            }
+                        ).encode()
+                    else:
+                        response.status = http.HTTPStatus.UNAUTHORIZED
 
                 case ("register",):
                     content_type = request.content_type
@@ -337,7 +388,9 @@ class Router:
 
         return jwk.JWK(kty="oct", k=key_bytes.decode())
 
-    def _make_state_claims(self, provider: str, redirect_to: str) -> str:
+    def _make_state_claims(
+        self, provider: str, redirect_to: str, challenge: str
+    ) -> str:
         signing_key = self._get_auth_signing_key()
         expires_at = datetime.datetime.utcnow() + datetime.timedelta(minutes=5)
 
@@ -346,6 +399,7 @@ class Router:
             "provider": provider,
             "exp": expires_at.astimezone().timestamp(),
             "redirect_to": redirect_to,
+            "challenge": challenge,
         }
         state_token = jwt.JWT(
             header={"alg": "HS256"},

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -145,6 +145,16 @@ class Router:
                     code = _get_search_param(query, "code")
                     verifier = _get_search_param(query, "verifier")
 
+                    verifier_size = len(verifier)
+
+                    if verifier_size < 43:
+                        raise errors.InvalidData(
+                            "Verifier token must be at least 43 characters long"
+                        )
+                    if verifier_size > 128:
+                        raise errors.InvalidData(
+                            "Verifier token must be shorter than 128 characters long"
+                        )
                     try:
                         pkce_object = await pkce.get_by_id(self.db, code)
                     except Exception:

--- a/edb/server/protocol/auth_ext/pkce.py
+++ b/edb/server/protocol/auth_ext/pkce.py
@@ -69,7 +69,9 @@ class PKCE:
               id,
               challenge,
               identity_id := .identity.id
-            } filter .id = <uuid>$id
+            }
+            filter .id = <uuid>$id
+            and (datetime_current() - .created_at) < <duration>'10 minutes';
             """,
             variables={"id": id},
         )

--- a/edb/server/protocol/auth_ext/pkce.py
+++ b/edb/server/protocol/auth_ext/pkce.py
@@ -1,0 +1,92 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import json
+
+from edb.server.protocol import execute
+from . import data
+
+
+class PKCE:
+    def __init__(self, db):
+        self.db = db
+
+    async def create(self, challenge: str):
+        await execute.parse_execute_json(
+            self.db,
+            """
+            insert ext::auth::PKCE {
+              challenge := <str>$challenge,
+            }
+            """,
+            variables={
+                "challenge": challenge,
+            },
+        )
+
+    async def link_identity_challenge(
+        self, identity_id: str, challenge: str
+    ) -> str:
+        r = await execute.parse_execute_json(
+            self.db,
+            """
+            update ext::auth::PKCE
+            filter .challenge = <str>$challenge
+            set { identity := <ext::auth::Identity><uuid>$identity_id }
+            """,
+            variables={
+                "challenge": challenge,
+                "identity_id": identity_id,
+            },
+        )
+
+        result_json = json.loads(r.decode())
+        assert len(result_json) == 1
+
+        return result_json[0]["id"]
+
+    async def get_by_id(self, id: str) -> data.PKCE:
+        r = await execute.parse_execute_json(
+            self.db,
+            """
+            select ext::auth::PKCE {
+              id,
+              challenge,
+              identity_id := .identity.id
+            } filter .id = <uuid>$id
+            """,
+            variables={"id": id},
+        )
+
+        result_json = json.loads(r.decode())
+        assert len(result_json) == 1
+
+        return data.PKCE(**result_json[0])
+
+    async def delete(self, id: str) -> None:
+        r = await execute.parse_execute_json(
+            self.db,
+            """
+            delete ext::auth::PKCE filter .id = <uuid>$id
+            """,
+            variables={"id": id},
+        )
+
+        result_json = json.loads(r.decode())
+        assert len(result_json) == 1

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -551,7 +551,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             pkce = await self.con.query(
                 """
-                select ext::auth::PKCE
+                select ext::auth::PKCEChallenge
                 filter .challenge = <str>$challenge
                 """,
                 challenge=challenge,
@@ -685,7 +685,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             await self.con.query(
                 """
-                insert ext::auth::PKCE {
+                insert ext::auth::PKCEChallenge {
                     challenge := <str>$challenge,
                 }
                 """,
@@ -1000,7 +1000,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             await self.con.query(
                 """
-                insert ext::auth::PKCE {
+                insert ext::auth::PKCEChallenge {
                     challenge := <str>$challenge,
                 }
                 """,
@@ -1142,7 +1142,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             pkce = await self.con.query(
                 """
-                select ext::auth::PKCE
+                select ext::auth::PKCEChallenge
                 filter .challenge = <str>$challenge
                 """,
                 challenge=challenge,
@@ -1210,7 +1210,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             pkce = await self.con.query(
                 """
-                select ext::auth::PKCE
+                select ext::auth::PKCEChallenge
                 filter .challenge = <str>$challenge
                 """,
                 challenge=challenge,
@@ -1299,7 +1299,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             await self.con.query(
                 """
-                insert ext::auth::PKCE {
+                insert ext::auth::PKCEChallenge {
                     challenge := <str>$challenge,
                 }
                 """,
@@ -1420,7 +1420,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             pkce = await self.con.query(
                 """
-                select ext::auth::PKCE
+                select ext::auth::PKCEChallenge
                 filter .challenge = <str>$challenge
                 """,
                 challenge=challenge,
@@ -1509,7 +1509,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             await self.con.query(
                 """
-                insert ext::auth::PKCE {
+                insert ext::auth::PKCEChallenge {
                     challenge := <str>$challenge,
                 }
                 """,
@@ -2081,7 +2081,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             pkce = await self.con.query_single(
                 """
                 select (
-                    insert ext::auth::PKCE {
+                    insert ext::auth::PKCEChallenge {
                         challenge := <str>$challenge,
                         identity := (
                             insert ext::auth::Identity {

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -508,7 +508,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
-                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                        base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
                     ).digest()
                 )
                 .rstrip(b'=')
@@ -677,7 +677,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
-                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                        base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
                     ).digest()
                 )
                 .rstrip(b'=')
@@ -992,7 +992,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
-                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                        base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
                     ).digest()
                 )
                 .rstrip(b'=')
@@ -1083,7 +1083,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
-                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                        base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
                     ).digest()
                 )
                 .rstrip(b'=')
@@ -1291,7 +1291,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
-                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                        base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
                     ).digest()
                 )
                 .rstrip(b'=')
@@ -1361,7 +1361,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
-                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                        base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
                     ).digest()
                 )
                 .rstrip(b'=')
@@ -1501,7 +1501,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
-                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                        base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
                     ).digest()
                 )
                 .rstrip(b'=')
@@ -2074,7 +2074,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
     async def test_http_auth_ext_token_01(self):
         with self.http_con() as http_con:
             # Create a PKCE challenge and verifier
-            verifier = base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+            verifier = base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
             challenge = base64.urlsafe_b64encode(
                 hashlib.sha256(verifier).digest()
             ).rstrip(b'=')
@@ -2100,7 +2100,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 http_con,
                 {
                     "code": pkce.id,
-                    "verifier": base64.urlsafe_b64encode(os.urandom(40))
+                    "verifier": base64.urlsafe_b64encode(os.urandom(43))
                     .rstrip(b"=")
                     .decode(),
                 },
@@ -2138,3 +2138,33 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
 
             self.assertEqual(replay_attack_status, 403)
+
+    async def test_http_auth_ext_token_02(self):
+        with self.http_con() as http_con:
+            # Too short: 32-octet -> 43-octet base64url
+            verifier = base64.urlsafe_b64encode(os.urandom(31)).rstrip(b'=')
+            (_, _, status) = self.http_con_request(
+                http_con,
+                {
+                    "code": str(uuid.uuid4()),
+                    "verifier": verifier.decode(),
+                },
+                path="token",
+            )
+
+            self.assertEqual(status, 400)
+
+    async def test_http_auth_ext_token_03(self):
+        with self.http_con() as http_con:
+            # Too long: 96-octet -> 128-octet base64url
+            verifier = base64.urlsafe_b64encode(os.urandom(97)).rstrip(b'=')
+            (_, _, status) = self.http_con_request(
+                http_con,
+                {
+                    "code": str(uuid.uuid4()),
+                    "verifier": verifier.decode(),
+                },
+                path="token",
+            )
+
+            self.assertEqual(status, 400)

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -505,7 +505,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
             redirect_to = f"{self.http_addr}/some/path"
-            challenge = "a" * 32
+            challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(
+                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                    ).digest()
+                )
+                .rstrip(b'=')
+                .decode()
+            )
 
             _, headers, status = self.http_con_request(
                 http_con,
@@ -666,7 +674,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
-            challenge = "a" * 32
+            challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(
+                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                    ).digest()
+                )
+                .rstrip(b'=')
+                .decode()
+            )
             await self.con.query(
                 """
                 insert ext::auth::PKCE {
@@ -973,7 +989,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
-            challenge = "a" * 32
+            challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(
+                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                    ).digest()
+                )
+                .rstrip(b'=')
+                .decode()
+            )
             await self.con.query(
                 """
                 insert ext::auth::PKCE {
@@ -1056,7 +1080,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
-            challenge = "a" * 32
+            challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(
+                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                    ).digest()
+                )
+                .rstrip(b'=')
+                .decode()
+            )
 
             discovery_request = (
                 "GET",
@@ -1256,7 +1288,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
-            challenge = "a" * 32
+            challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(
+                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                    ).digest()
+                )
+                .rstrip(b'=')
+                .decode()
+            )
             await self.con.query(
                 """
                 insert ext::auth::PKCE {
@@ -1318,7 +1358,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
             provider_id = provider_config.provider_id
             client_id = provider_config.client_id
-            challenge = "a" * 32
+            challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(
+                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                    ).digest()
+                )
+                .rstrip(b'=')
+                .decode()
+            )
 
             discovery_request = (
                 "GET",
@@ -1450,7 +1498,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
-            challenge = "a" * 32
+            challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(
+                        base64.urlsafe_b64encode(os.urandom(40)).rstrip(b'=')
+                    ).digest()
+                )
+                .rstrip(b'=')
+                .decode()
+            )
             await self.con.query(
                 """
                 insert ext::auth::PKCE {


### PR DESCRIPTION
This is the most secure way to pass an `auth_token` back to a server given that the Cookie we create is actually between the browser _and the EdgeDB server_ not the application's server.

Here's a quick overview of how it works:

1. The application server generates a random string (called the "verifier") and then hashes the verifier and sends this value (called the "challenge") at the beginning of the OAuth flow with the EdgeDB server. Importantly **the application server stores the verifier in an `HttpOnlly` cookie with the browser**. This allows the application to extract the verifier later.
2. The EdgeDB server stores this "challenge" in the database and adds it as a value in the `state` JWT that is passed back and forth through the typical OAuth flow.
3. At the end of the OAuth flow with the third-party Identity Provider, the EdgeDB server returns the ID to the PKCE object as a "code" and passes this back through the browser redirect to the application server.
4. The browser redirects to the application server where it then extracts the verifier from the cookie it set in step 1, and sends the `code` and `verifier` to the EdgeDB server (at `/token`).
5. The EdgeDB server looks up the `PKCE` object via the `code` (which is the `PKCE.id`), and then does the same sha256 hash on the verifier. If that hashed value matches the `PKCE.challenge` we know it's a good request, and we return the auth token and identity ID back to the application server. This completes the PKCE flow.

(additionally, we remove the used `PKCE` object to avoid replay attacks, and expire these `PKCE` objects after 10 minutes)

---

I didn't take a lot of time on naming and modularizing the various parts, so I would ❤️ LOVE ❤️  to get some feedback on naming, code structure, etc.