### PR TITLE
Cache config JSON to speed up extension config access

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_10_02_00_02
+EDGEDB_CATALOG_VERSION = 2023_10_02_00_03
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/server/pgcon/__init__.py
+++ b/edb/server/pgcon/__init__.py
@@ -27,7 +27,8 @@ from .errors import (
 )
 
 from .pgcon import (
-    connect, PGConnection, SETUP_TEMP_TABLE_SCRIPT, set_init_con_script_data
+    connect, PGConnection, SETUP_TEMP_TABLE_SCRIPT, SETUP_CONFIG_CACHE_SCRIPT,
+    set_init_con_script_data,
 )
 
 __all__ = (
@@ -39,4 +40,5 @@ __all__ = (
     'BackendPrivilegeError',
     'BackendCatalogNameError',
     'SETUP_TEMP_TABLE_SCRIPT',
+    'SETUP_CONFIG_CACHE_SCRIPT',
 )

--- a/edb/server/pgcon/__init__.pyi
+++ b/edb/server/pgcon/__init__.pyi
@@ -146,3 +146,4 @@ class PGConnection:
 
 
 SETUP_TEMP_TABLE_SCRIPT: str
+SETUP_CONFIG_CACHE_SCRIPT: str

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -407,6 +407,8 @@ async def execute_system_config(
         config_ops = query_unit.config_ops
     await dbv.apply_config_ops(conn, config_ops)
 
+    await conn.sql_execute(b'delete from _config_cache')
+
     # If this is a backend configuration setting we also
     # need to make sure it has been loaded.
     if query_unit.backend_config:


### PR DESCRIPTION
Every config object and multi link view makes a call to
_read_sys_config, which adds up pretty badly when accessing extension
configs.

Add a temporary _config_cache table that is used to cache results, and
modify _read_sys_config_full to be able to compute the output for all
three relevant config levels at once.

`select cfg::Config.extensions[is ext::_conf::Config].config_name`
goes from taking about 50ms on average to taking ~23ms on a cache
miss and ~6.5ms on a cache hit.
(Before I removed instance level extension config objects in #6193,
it took ~300ms.)

Probably the last part of #5954 that will get done before 4.x.