### PR TITLE
Fix parser for old versions of Rust

### DIFF
--- a/edb/edgeql-parser/Cargo.toml
+++ b/edb/edgeql-parser/Cargo.toml
@@ -3,7 +3,7 @@ name = "edgeql-parser"
 version = "0.1.0"
 license = "MIT/Apache-2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
-rust-version = "1.59"
+rust-version = "1.65.0"
 edition = "2021"
 
 [dependencies]

--- a/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
+++ b/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
@@ -3,7 +3,7 @@ name = "edgeql-parser-python"
 license = "MIT/Apache-2.0"
 version = "0.1.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
-rust-version = "1.59"
+rust-version = "1.65.0"
 edition = "2021"
 
 [dependencies]

--- a/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use once_cell::sync::OnceCell;
 
 use cpython::{
     ObjectProtocol, PyClone, PyInt, PyList, PyNone, PyObject, PyResult, PyString, PyTuple, Python,
@@ -78,7 +78,7 @@ py_class!(pub class Terminal |py| {
     }
 });
 
-static PARSER_SPECS: OnceLock<(parser::Spec, PyObject)> = OnceLock::new();
+static PARSER_SPECS: OnceCell<(parser::Spec, PyObject)> = OnceCell::new();
 
 fn downcast_tokens<'a>(
     py: Python,

--- a/edb/graphql-rewrite/Cargo.toml
+++ b/edb/graphql-rewrite/Cargo.toml
@@ -3,7 +3,7 @@ name = "graphql-rewrite"
 version = "0.1.0"
 license = "MIT/Apache-2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
-rust-version = "1.59"
+rust-version = "1.65.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Edit: I've replaced usage of `std::sync::OnceLock` with `once_cell::OnceCell`, since `std::sync::OnceLock` is unstable on whatever version we are using in `macos-x86_64` build.

I've also updated our declared MRSV to 1.65.0, since that's what our code supports. It is gated by `let...else` syntax:

```
│ 502 | /     let CSTNode::Terminal(terminal) = value else {                                           
│ 503 | |         return;                                                                              
│ 504 | |     };  
```

I don't think we should be concerned with raising MSRV, since these packages are probably compiled by us only. But maybe we should change our tests to build with MSRV instead of latest or stable, so bumps to the MSRV don't go unnoticed as they did here.