### PR TITLE
Support DML on right hand side of coalesce expressions

### DIFF
--- a/edb/edgeql-parser/src/parser/custom_errors.rs
+++ b/edb/edgeql-parser/src/parser/custom_errors.rs
@@ -91,8 +91,8 @@ impl<'s> Parser<'s> {
             },
 
             ParserRule::ForIterator => {
-                let span = if i >= 3 {
-                    let span_start = self.get_from_top(i - 3).unwrap();
+                let span = if i >= 4 {
+                    let span_start = self.get_from_top(i - 4).unwrap();
                     let span = super::get_span_of_nodes(&[span_start.value]).unwrap_or_default();
                     span.combine(token.span)
                 } else {
@@ -219,6 +219,7 @@ impl<'s> Parser<'s> {
                 && self.compare_stack(
                     &[
                         Cond::keyword("for"),
+                        Cond::Production("OptionalOptional"),
                         Cond::Production("Identifier"),
                         Cond::keyword("in"),
                     ],
@@ -226,7 +227,7 @@ impl<'s> Parser<'s> {
                     ctx,
                 )
             {
-                return Some((i + 2, ParserRule::ForIterator));
+                return Some((i + 3, ParserRule::ForIterator));
             }
 
             // Also keep track of the element right after current.

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -602,6 +602,8 @@ class DeleteQuery(PipelinedQuery):
 
 
 class ForQuery(Query):
+    from_desugaring: bool = False
+    optional: bool = False
     iterator: Expr
     iterator_alias: str
 

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -127,6 +127,9 @@ def compile_BinOp(
             )
             return dispatch.compile(balanced, ctx=ctx)
 
+    if expr.op == '??' and utils.contains_dml(expr.right):
+        return _compile_dml_coalesce(expr, ctx=ctx)
+
     op_node = func.compile_operator(
         expr, op_name=expr.op, qlargs=[expr.left, expr.right], ctx=ctx)
 
@@ -305,6 +308,93 @@ def compile_Array(
                 context=expr_el.context)
 
     return setgen.new_array_set(elements, ctx=ctx, srcctx=expr.context)
+
+
+def _compile_dml_coalesce(
+        expr: qlast.BinOp, *, ctx: context.ContextLevel) -> irast.Set:
+    """Transform a coalesce that contains DML into FOR loops
+
+    The basic approach is to extract the pieces from the ?? and
+    rewrite them into:
+        for optional x in (LHS,) union (
+          {
+            x.0,
+            (for _ in (select () filter not exists x) union (RHS)),
+          }
+        )
+
+    Optional for is needed because the LHS needs to be bound in a for
+    in order to get put in a CTE and only executed once, but the RHS
+    needs to be dependent on the LHS being empty.
+
+    We hackily wrap the LHS in a 1-ary tuple and then project it back
+    out because the OPTIONAL FOR implementation doesn't properly
+    handle object-type iterators. OPTIONAL FOR relies on having a
+    non-NULL identity ref but objects use their actual id, which
+    will be NULL.
+    """
+    with ctx.newscope(fenced=False) as subctx:
+        # We have to compile it under a factoring fence to prevent
+        # correlation with outside things. We can't just rely on the
+        # factoring fences inserted when compiling the FORs, since we
+        # are going to need to explicitly exempt the iterator
+        # expression from that.
+        subctx.path_scope.factoring_fence = True
+        subctx.path_scope.factoring_allowlist.update(ctx.iterator_path_ids)
+
+        ir = func.compile_operator(
+            expr, op_name=expr.op, qlargs=[expr.left, expr.right], ctx=subctx)
+
+        # Extract the IR parts from the ??
+        # Note that lhs_ir will be unfenced while rhs_ir
+        # will have been compiled under fences.
+        match ir.expr:
+            case irast.OperatorCall(args=[
+                irast.CallArg(expr=lhs_ir),
+                irast.CallArg(expr=rhs_ir),
+            ]):
+                pass
+            case _:
+                raise AssertionError('malformed DML ??')
+
+        subctx.anchors = subctx.anchors.copy()
+
+        alias = ctx.aliases.get('b')
+        cond_path = qlast.Path(
+            steps=[qlast.ObjectRef(name=alias)],
+        )
+
+        rhs_b = qlast.ForQuery(
+            iterator_alias='__',
+            iterator=qlast.SelectQuery(
+                result=qlast.Tuple(elements=[]),
+                where=qlast.UnaryOp(
+                    op='NOT',
+                    operand=qlast.UnaryOp(op='EXISTS', operand=cond_path),
+                ),
+            ),
+            result=subctx.create_anchor(rhs_ir, check_dml=True),
+        )
+
+        full = qlast.ForQuery(
+            iterator_alias=alias,
+            iterator=qlast.Tuple(elements=[subctx.create_anchor(lhs_ir, 'b')]),
+            result=qlast.Set(elements=[
+                qlast.Path(steps=[
+                    cond_path, qlast.Ptr(ptr=qlast.ObjectRef(name='0'))
+                ]),
+                rhs_b
+            ]),
+            optional=True,
+        )
+
+        subctx.iterator_path_ids |= {lhs_ir.path_id}
+        res = dispatch.compile(full, ctx=subctx)
+        # Indicate that the original ?? code should determine the
+        # cardinality/multiplicity.
+        res.card_inference_override = ir
+
+        return res
 
 
 def _compile_dml_ifelse(

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -328,6 +328,7 @@ def _compile_dml_ifelse(
         # are going to need to explicitly exempt the iterator
         # expression from that.
         subctx.path_scope.factoring_fence = True
+        subctx.path_scope.factoring_allowlist.update(ctx.iterator_path_ids)
 
         ir = func.compile_operator(
             expr, op_name='std::IF',

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -338,13 +338,6 @@ def _special_case(name: str) -> Callable[[_SpecialCaseFunc], _SpecialCaseFunc]:
     return func
 
 
-#: A dictionary of conditional callables and the indices
-#: of the arguments that are evaluated conditionally.
-CONDITIONAL_OPS = {
-    sn.QualName('std', '??'): {1},
-}
-
-
 def compile_operator(
         qlexpr: qlast.Base, op_name: str, qlargs: List[qlast.Expr], *,
         ctx: context.ContextLevel) -> irast.Set:
@@ -357,9 +350,6 @@ def compile_operator(
         raise errors.QueryError(
             f'no operator matches the given name and argument types',
             context=qlexpr.context)
-
-    fq_op_name = next(iter(opers)).get_shortname(ctx.env.schema)
-    conditional_args = CONDITIONAL_OPS.get(fq_op_name)
 
     typemods = polyres.find_callable_typemods(
         opers, num_args=len(qlargs), kwargs_names=set(), ctx=ctx)
@@ -374,7 +364,6 @@ def compile_operator(
         arg_ir = polyres.compile_arg(
             qlarg,
             typemods[ai],
-            in_conditional=bool(conditional_args and ai in conditional_args),
             prefer_subquery_args=prefer_subquery_args,
             ctx=ctx,
         )

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -578,7 +578,6 @@ def compile_arg(
     arg_ql: qlast.Expr,
     typemod: ft.TypeModifier,
     *,
-    in_conditional: bool=False,
     prefer_subquery_args: bool=False,
     ctx: context.ContextLevel,
 ) -> irast.Set:
@@ -595,9 +594,6 @@ def compile_arg(
 
     new = ctx.newscope(fenced=False) if branched else ctx.new()
     with new as argctx:
-        if in_conditional:
-            argctx.disallow_dml = "inside conditional expressions"
-
         if optional:
             argctx.path_scope.mark_as_optional()
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -159,14 +159,23 @@ class GroupingElementList(
     pass
 
 
+class OptionalOptional(Nonterm):
+    def reduce_OPTIONAL(self, *kids):
+        self.val = True
+
+    def reduce_empty(self, *kids):
+        self.val = False
+
+
 class SimpleFor(Nonterm):
     def reduce_For(self, *kids):
-        r"%reduce FOR Identifier IN AtomicExpr \
+        r"%reduce FOR OptionalOptional Identifier IN AtomicExpr \
                   UNION Expr"
         self.val = qlast.ForQuery(
-            iterator_alias=kids[1].val,
-            iterator=kids[3].val,
-            result=kids[5].val,
+            optional=kids[1].val,
+            iterator_alias=kids[2].val,
+            iterator=kids[4].val,
+            result=kids[6].val,
         )
 
 

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -191,19 +191,21 @@ def compile_iterator_expr(
 
         # If the iterator value is nullable, add a null test. This
         # makes sure that we don't spuriously produce output when
-        # iterating over options pointers.
-        if isinstance(iterator_query, pgast.SelectStmt):
-            iterator_var = pathctx.get_path_value_var(
-                iterator_query, path_id=iterator_expr.path_id, env=ctx.env)
-            if iterator_var.nullable:
-                iterator_query.where_clause = astutils.extend_binop(
-                    iterator_query.where_clause,
-                    pgast.NullTest(arg=iterator_var, negated=True))
-        elif isinstance(iterator_query, pgast.Relation):
-            # will never be null
-            pass
-        else:
-            raise NotImplementedError()
+        # iterating over optional pointers.
+        is_optional = ctx.scope_tree.is_optional(iterator_expr.path_id)
+        if not is_optional:
+            if isinstance(iterator_query, pgast.SelectStmt):
+                iterator_var = pathctx.get_path_value_var(
+                    iterator_query, path_id=iterator_expr.path_id, env=ctx.env)
+                if iterator_var.nullable:
+                    iterator_query.where_clause = astutils.extend_binop(
+                        iterator_query.where_clause,
+                        pgast.NullTest(arg=iterator_var, negated=True))
+            elif isinstance(iterator_query, pgast.Relation):
+                # will never be null
+                pass
+            else:
+                raise NotImplementedError()
 
         # Regardless of result type, we use transient identity,
         # for path identity of the iterator expression.  This is
@@ -214,6 +216,9 @@ def compile_iterator_expr(
         if not already_existed:
             relctx.ensure_bond_for_expr(
                 iterator_expr.expr.result, iterator_query, ctx=subctx)
+            if is_optional:
+                relctx.ensure_bond_for_expr(
+                    iterator_expr, iterator_query, ctx=subctx)
 
     return iterator_rvar
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -535,6 +535,7 @@ def compile_iterator_cte(
             parent=last_iterator)
 
     with ctx.newrel() as ictx:
+        ictx.scope_tree = ctx.scope_tree
         ictx.path_scope[iterator_set.path_id] = ictx.rel
 
         # Correlate with enclosing iterators

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -898,6 +898,8 @@ def eval_Shape(node: qlast.Shape, ctx: EvalContext) -> Result:
 def eval_For(node: qlast.ForQuery, ctx: EvalContext) -> Result:
     ctx = eval_aliases(node, ctx)
     iter_vals = strip_shapes(subquery(node.iterator, ctx=ctx))
+    if node.optional and not iter_vals:
+        iter_vals = [None]
     qil = ctx.query_input_list + [(IORef(node.iterator_alias),)]
     out = []
     for val in iter_vals:

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -480,17 +480,6 @@ class TestDelete(tb.QueryTestCase):
             }],
         )
 
-    async def test_edgeql_delete_in_conditional_bad_01(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                'DELETE statements cannot be used'):
-            await self.con.execute(r'''
-                SELECT
-                    (SELECT DeleteTest2)
-                    ??
-                    (DELETE DeleteTest2);
-            ''')
-
     async def test_edgeql_delete_abstract_01(self):
         await self.con.execute(r"""
 

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -1106,3 +1106,90 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [{"key": "Earth"}, {"key": "Water"}]
         )
+
+    async def test_edgeql_for_optional_01(self):
+        # Lol FOR OPTIONAL doesn't work for object-type iterators
+        # but it does work for 1-ary tuples
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    ((select User filter .name = 'George'),)
+                union x.0.deck_cost ?? 0;
+            ''',
+            [0],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    ((select User filter .name = 'George'),)
+                union x.0
+            ''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    ((select User filter .name = 'George'),)
+                union x
+            ''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    ((select User filter .name = 'Alice'),)
+                union x.0.deck_cost ?? 0;
+            ''',
+            [11],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    ((select User filter .name = 'George'),)
+                union (insert Award { name := "Participation" })
+            ''',
+            [{}],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for optional x in (<bool>{})
+                union (insert Award { name := "Participation!" })
+            ''',
+            [{}],
+        )
+
+    @test.xerror('''
+        FOR OPTIONAL is disabled for object-type iterators
+    ''')
+    async def test_edgeql_for_optional_02(self):
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    (select User filter .name = 'George')
+                union x.deck_cost ?? 0;
+            ''',
+            [0],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    (select User filter .name = 'Alice')
+                union x.deck_cost ?? 0;
+            ''',
+            [11],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for optional x in
+                    (select User filter .name = 'George')
+                union (insert Award { name := "Participation" })
+            ''',
+            [{}],
+        )

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2520,18 +2520,6 @@ class TestInsert(tb.QueryTestCase):
             [2],
         )
 
-    async def test_edgeql_insert_in_conditional_bad_01(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                'INSERT statements cannot be used inside '
-                'conditional expressions'):
-            await self.con.execute(r'''
-                SELECT
-                    (SELECT Subordinate FILTER .name = 'foo')
-                    ??
-                    (INSERT Subordinate { name := 'no way' });
-            ''')
-
     async def test_edgeql_insert_correlated_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
@@ -6105,4 +6093,111 @@ class TestInsert(tb.QueryTestCase):
             select InsertTest { l2 } order by .l2;
             ''',
             [{'l2': 2}, {'l2': 4}],
+        )
+
+    async def test_edgeql_insert_coalesce_01(self):
+        await self.assert_query_result(
+            '''
+            select (select InsertTest filter .l2 = 2) ??
+              (insert InsertTest { l2 := 2 });
+            ''',
+            [{}],
+        )
+
+        await self.assert_query_result(
+            '''
+            select (select InsertTest filter .l2 = 2) ??
+              (insert InsertTest { l2 := 2 });
+            ''',
+            [{}],
+        )
+
+        await self.assert_query_result(
+            '''
+            select count((delete InsertTest))
+            ''',
+            [1],
+        )
+
+    @test.xfail('''
+        This is broken because of #6057
+    ''')
+    async def test_edgeql_insert_coalesce_02(self):
+        await self.assert_query_result(
+            '''
+            select ((select InsertTest filter .l2 = 2), true) ??
+              ((insert InsertTest { l2 := 2 }), false);
+            ''',
+            [({}, False)],
+        )
+
+        await self.assert_query_result(
+            '''
+            select ((select InsertTest filter .l2 = 2), true) ??
+              ((insert InsertTest { l2 := 2 }), false);
+            ''',
+            [({}, True)],
+        )
+
+    async def test_edgeql_insert_coalesce_03(self):
+        await self.assert_query_result(
+            '''
+            select (
+                (update InsertTest filter .l2 = 2 set { name := "!" }) ??
+                  (insert InsertTest { l2 := 2, name := "?" })
+            ) { l2, name }
+            ''',
+            [{'l2': 2, 'name': "?"}],
+        )
+
+        await self.assert_query_result(
+            '''
+            select (
+                (update InsertTest filter .l2 = 2 set { name := "!" }) ??
+                  (insert InsertTest { l2 := 2, name := "?" })
+            ) { l2, name }
+            ''',
+            [{'l2': 2, 'name': "!"}],
+        )
+
+        await self.assert_query_result(
+            '''
+            select InsertTest { l2, name }
+            ''',
+            [{'l2': 2, 'name': "!"}],
+        )
+
+        await self.assert_query_result(
+            '''
+            select count((delete InsertTest))
+            ''',
+            [1],
+        )
+
+    async def test_edgeql_insert_coalesce_04(self):
+        Q = '''
+        select (for n in array_unpack(<array<int64>>$0) union (
+            (update InsertTest filter .l2 = n set { name := "!" }) ??
+              (insert InsertTest { l2 := n, name := "?" })
+        )) { l2, name, new := .id not in InsertTest.id } order by .l2
+        '''
+
+        await self.assert_query_result(
+            Q,
+            [
+                {'l2': 1, 'name': "?", 'new': True},
+                {'l2': 2, 'name': "?", 'new': True},
+            ],
+            variables=([1, 2],)
+        )
+
+        await self.assert_query_result(
+            Q,
+            [
+                {'l2': 0, 'name': "?", 'new': True},
+                {'l2': 1, 'name': "!", 'new': False},
+                {'l2': 2, 'name': "!", 'new': False},
+                {'l2': 3, 'name': "?", 'new': True},
+            ],
+            variables=([0, 1, 2, 3],)
         )

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -6087,3 +6087,22 @@ class TestInsert(tb.QueryTestCase):
                     insert DerivedTest { l2 := 200 }
                 )), (select ExceptTest.deleted limit 1));
             ''')
+
+    async def test_edgeql_insert_conditional_03(self):
+        await self.assert_query_result(
+            '''
+            select (for n in array_unpack(<array<int64>>$0) union (
+                if n % 2 = 0 then
+                  (insert InsertTest { l2 := n }) else {}
+            )) { l2 } order by .l2;
+            ''',
+            [{'l2': 2}, {'l2': 4}],
+            variables=([1, 2, 3, 4, 5],),
+        )
+
+        await self.assert_query_result(
+            '''
+            select InsertTest { l2 } order by .l2;
+            ''',
+            [{'l2': 2}, {'l2': 4}],
+        )

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2160,17 +2160,6 @@ class TestUpdate(tb.QueryTestCase):
             ]
         )
 
-    async def test_edgeql_update_in_conditional_bad_01(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                'UPDATE statements cannot be used'):
-            await self.con.execute(r'''
-                SELECT
-                    (SELECT UpdateTest)
-                    ??
-                    (UPDATE UpdateTest SET { name := 'no way' });
-            ''')
-
     async def test_edgeql_update_correlated_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -608,3 +608,13 @@ class TestModelSmokeTests(unittest.TestCase):
                 [{"n": [3], "m": [2]}, 2],
             ]),
         )
+
+    def test_model_for_optional_01(self):
+        self.assert_test_query(
+            r'''
+                for optional x in
+                    (select User filter .name = 'George')
+                union x.deck_cost ?? 0;
+            ''',
+            [0],
+        )


### PR DESCRIPTION
The basic approach is to extract the pieces from the ?? and rewrite them
into:
```
   for optional x in (LHS,) union (
     {
x.0,
(for _ in (select () filter not exists x) union (RHS)),
     }
   )
```

Optional for is needed because the LHS needs to be bound in a for in order
to get put in a CTE and only executed once, but the RHS needs to be
dependent on the LHS being empty.

We hackily wrap the LHS in a 1-ary tuple and then project it back out
because the OPTIONAL FOR implementation doesn't properly handle object-type
iterators. OPTIONAL FOR relies on having a non-NULL identity ref but
objects use their actual id, which will be NULL.

Follow-up to #6181. Like #6181, needs more testing.

One of the tests I wrote failed because of #6057, which I'm working on 
fixing also.