### PR TITLE
Fix get_debug_info and tests re: multi-tenant / remote-compiler CI

### DIFF
--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -651,6 +651,9 @@ class AbstractPool:
         finally:
             self._release_worker(worker)
 
+    def get_debug_info(self):
+        return {}
+
 
 class BaseLocalPool(
     AbstractPool, amsg.ServerProtocol, asyncio.SubprocessProtocol
@@ -843,6 +846,12 @@ class BaseLocalPool(
         # Skip disconnected workers
         if worker.get_pid() in self._workers:
             self._workers_queue.release(worker, put_in_front=put_in_front)
+
+    def get_debug_info(self):
+        return dict(
+            worker_pids=list(self._workers.keys()),
+            template_pid=self.get_template_pid(),
+        )
 
 
 @srvargs.CompilerPoolMode.Fixed.assign_implementation
@@ -1221,6 +1230,13 @@ class RemotePool(AbstractPool):
             if not callback:
                 self._sync_lock.release()
         return preargs, callback
+
+    def get_debug_info(self):
+        return dict(
+            address="{}:{}".format(*self._pool_addr),
+            size=self._semaphore._bound_value,  # type: ignore
+            free=self._semaphore._value,  # type: ignore
+        )
 
 
 @dataclasses.dataclass

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -963,12 +963,11 @@ class BaseServer:
             ),
             instance_config=config.debug_serialize_config(
                 self._get_sys_config()),
-            compiler_pool=dict(
-                worker_pids=list(
-                    self._compiler_pool._workers.keys()  # type: ignore
-                ),
-                template_pid=self._compiler_pool.get_template_pid(),
-            ) if self._compiler_pool else None,
+            compiler_pool=(
+                self._compiler_pool.get_debug_info()
+                if self._compiler_pool
+                else None
+            ),
         )
 
     def get_report_config_typedesc(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16387,6 +16387,9 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                             path="server-info",
                         )
                         data = json.loads(rdata)
+                        if 'databases' not in data:
+                            # multi-tenant instance - use the first tenant
+                            data = next(iter(data['tenants'].values()))
                         db_data = data['databases'][self.get_database_name()]
                         config = db_data['config']
                         assert (

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -372,6 +372,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                         path="server-info",
                     )
                     data = json.loads(rdata)
+                    if 'databases' not in data:
+                        # multi-tenant instance - use the first tenant
+                        data = next(iter(data['tenants'].values()))
                     config = data['databases'][dbname]['config']
                     if 'ext::auth::AuthConfig::providers' not in config:
                         raise AssertionError('database config not ready')


### PR DESCRIPTION
- [x] Tests learn to parse multi-tenant debug info
- [x] Extract compiler debug info properly