### PR TITLE
Add a '_protected' flag to pointers

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_09_28_00_01
+EDGEDB_CATALOG_VERSION = 2023_10_02_00_00
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/edgeql/compiler/config_desc.py
+++ b/edb/edgeql/compiler/config_desc.py
@@ -386,7 +386,8 @@ def _describe_config_object(
         ):
             pn = str(ptr_name)
             if (
-                pn in ('id', '__type__')
+                pn == 'id'
+                or p.get_protected(schema)
                 or p.get_annotation(
                     schema,
                     s_name.QualName('cfg', 'internal'),

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -132,7 +132,7 @@ create extension package _conf VERSION '1.0' {
         create required property fixed -> std::str {
             set default := "fixed!";
             set readonly := true;
-            set _protected := true;
+            set protected := true;
         };
     };
     create type ext::_conf::Obj extending cfg::ConfigObject {

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -129,6 +129,11 @@ create extension package _conf VERSION '1.0' {
         create required property value -> std::str {
             set readonly := true;
         };
+        create required property fixed -> std::str {
+            set default := "fixed!";
+            set readonly := true;
+            set _protected := true;
+        };
     };
     create type ext::_conf::Obj extending cfg::ConfigObject {
         create required property name -> std::str {

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -423,7 +423,7 @@ ALTER TYPE std::BaseObject {
     # when operating on tables directly.
     CREATE REQUIRED LINK __type__ -> schema::ObjectType {
         SET readonly := True;
-        SET _protected := True;
+        SET protected := True;
     };
 };
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -423,6 +423,7 @@ ALTER TYPE std::BaseObject {
     # when operating on tables directly.
     CREATE REQUIRED LINK __type__ -> schema::ObjectType {
         SET readonly := True;
+        SET _protected := True;
     };
 };
 

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -291,7 +291,8 @@ def resolve_relation(
         pointers = obj.get_pointers(ctx.schema).objects(ctx.schema)
 
         for p in pointers:
-            if p.is_protected_pointer(ctx.schema):
+            # TODO: We ought to support type
+            if p.get_shortname(ctx.schema).name == '__type__':
                 continue
             card = p.get_cardinality(ctx.schema)
             if card.is_multi():

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -454,6 +454,12 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         compcoef=0.909,
     )
 
+    _protected = so.SchemaField(
+        bool,
+        default=False,
+        compcoef=0.909,
+    )
+
     # For non-derived pointers this is strongly correlated with
     # "expr" below.  Derived pointers might have "computable" set,
     # but expr=None.
@@ -750,9 +756,8 @@ class Pointer(referencing.NamedReferencedInheritingObject,
     def is_link_property(self, schema: s_schema.Schema) -> bool:
         raise NotImplementedError
 
-    def is_protected_pointer(self, schema: s_schema.Schema) -> bool:
-        sn = self.get_shortname(schema).name
-        return sn == '__type__'
+    def get_protected(self, schema: s_schema.Schema) -> bool:
+        return self.get__protected(schema)
 
     def is_dumpable(self, schema: s_schema.Schema) -> bool:
         return (

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -454,7 +454,7 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         compcoef=0.909,
     )
 
-    _protected = so.SchemaField(
+    protected = so.SchemaField(
         bool,
         default=False,
         compcoef=0.909,
@@ -755,9 +755,6 @@ class Pointer(referencing.NamedReferencedInheritingObject,
 
     def is_link_property(self, schema: s_schema.Schema) -> bool:
         raise NotImplementedError
-
-    def get_protected(self, schema: s_schema.Schema) -> bool:
-        return self.get__protected(schema)
 
     def is_dumpable(self, schema: s_schema.Schema) -> bool:
         return (

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -7944,7 +7944,8 @@ aa \
 
     async def test_edgeql_expr_cannot_assign_id_01(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError, r'cannot assign to id'):
+                edgedb.QueryError, r"cannot assign to property 'id'",
+                _hint=None):
             await self.con.execute(r"""
                 SELECT Text {
                     id := <uuid>'77841036-8e35-49ce-b509-2cafa0c25c4f'

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5486,10 +5486,21 @@ class TestInsert(tb.QueryTestCase):
 
         )
 
+    async def test_edgeql_insert_specified_type(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                "cannot assign to link '__type__'"):
+            await self.con.execute('''
+                INSERT Person {
+                    __type__ := (introspect Object),
+                    name := "test",
+                 }
+            ''')
+
     async def test_edgeql_insert_explicit_id_00(self):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
-                "cannot assign to id"):
+                "cannot assign to property 'id'"):
             await self.con.execute('''
                 INSERT Person {
                     id := <uuid>'ffffffff-ffff-ffff-ffff-ffffffffffff',

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1417,7 +1417,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # equivalent to re-writing it.
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'cannot access id on a polymorphic shape element'):
+                r"cannot access property 'id' on a polymorphic shape element"):
             await self.con.query(r'''
                 SELECT User {
                     [IS Named].id,


### PR DESCRIPTION
This is useful for config purposes.

Turns out that we *didn't* do a safety check for `__type__` on insert,
but would generate bogus SQL and ISE, so this fixes that.

Clean up some error messages in similar id related code, also.

I think we could just call it 'protected', though.