### PR TITLE
Update OIDC provider based on Azure flow testing

### DIFF
--- a/edb/server/protocol/auth_ext/azure.py
+++ b/edb/server/protocol/auth_ext/azure.py
@@ -26,5 +26,6 @@ class AzureProvider(base.OpenIDProvider):
             "azure",
             "https://login.microsoftonline.com/common/v2.0",
             *args,
+            content_type=base.ContentType.FORM_ENCODED,
             **kwargs,
         )

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -127,7 +127,10 @@ class OpenIDProvider(BaseProvider):
             if content_type.startswith(str(ContentType.JSON)):
                 response_body = resp.json()
             else:
-                response_body = urllib.parse.parse_qs(resp.text)
+                response_body = {
+                    k: v[0] if len(v) == 1 else v
+                    for k, v in urllib.parse.parse_qs(resp.text).items()
+                }
 
             return data.OpenIDConnectAccessTokenResponse(**response_body)
 
@@ -162,7 +165,8 @@ class OpenIDProvider(BaseProvider):
             ) from e
         if payload.get("aud") != self.client_id:
             raise errors.InvalidData(
-                f"Invalid value for aud in id_token: {payload.get('aud')} != {self.client_id}"
+                "Invalid value for aud in id_token: "
+                f"{payload.get('aud')} != {self.client_id}"
             )
 
         return data.UserInfo(

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -19,6 +19,7 @@
 import uuid
 import urllib.parse
 import json
+import enum
 
 from typing import Callable
 from jwcrypto import jwt, jwk
@@ -60,9 +61,22 @@ class BaseProvider:
         return datetime.fromisoformat(value).timestamp() if value else None
 
 
+class ContentType(enum.StrEnum):
+    JSON = "application/json"
+    FORM_ENCODED = "application/x-www-form-urlencoded"
+
+
 class OpenIDProvider(BaseProvider):
-    def __init__(self, name: str, issuer_url: str, *args, **kwargs):
+    def __init__(
+        self,
+        name: str,
+        issuer_url: str,
+        *args,
+        content_type: ContentType = ContentType.JSON,
+        **kwargs,
+    ):
         super().__init__(name, issuer_url, *args, **kwargs)
+        self.content_type = content_type
 
     async def get_code_url(self, state: str, redirect_uri: str) -> str:
         oidc_config = await self._get_oidc_config()
@@ -86,23 +100,36 @@ class OpenIDProvider(BaseProvider):
         async with self.http_factory(
             base_url=f"{token_endpoint.scheme}://{token_endpoint.netloc}"
         ) as client:
-            resp = await client.post(
-                token_endpoint.path,
-                json={
-                    "grant_type": "authorization_code",
-                    "code": code,
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                    "redirect_uri": redirect_uri,
-                },
-            )
+            request_body = {
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "redirect_uri": redirect_uri,
+            }
+            if self.content_type == ContentType.JSON:
+                resp = await client.post(
+                    token_endpoint.path,
+                    json=request_body,
+                    headers={"Accept": "application/json"},
+                )
+            else:
+                resp = await client.post(
+                    token_endpoint.path,
+                    data=request_body,
+                    headers={"Accept": "application/x-www-form-urlencoded"},
+                )
             if resp.status_code >= 400:
                 raise errors.OAuthProviderFailure(
                     f"Failed to exchange code: {resp.text}"
                 )
-            json = resp.json()
+            content_type = resp.headers.get('Content-Type', self.content_type)
+            if content_type.startswith(str(ContentType.JSON)):
+                response_body = resp.json()
+            else:
+                response_body = urllib.parse.parse_qs(resp.text)
 
-            return data.OpenIDConnectAccessTokenResponse(**json)
+            return data.OpenIDConnectAccessTokenResponse(**response_body)
 
     async def fetch_user_info(
         self, token_response: data.OAuthAccessTokenResponse
@@ -133,10 +160,10 @@ class OpenIDProvider(BaseProvider):
             raise errors.MisconfiguredProvider(
                 "Failed to parse ID token with provider keyset"
             ) from e
-        if payload.get("iss") != self.issuer_url:
-            raise errors.InvalidData("Invalid value for iss in id_token")
         if payload.get("aud") != self.client_id:
-            raise errors.InvalidData("Invalid value for aud in id_token")
+            raise errors.InvalidData(
+                f"Invalid value for aud in id_token: {payload.get('aud')} != {self.client_id}"
+            )
 
         return data.UserInfo(
             sub=str(payload["sub"]),

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -107,17 +107,18 @@ class OpenIDProvider(BaseProvider):
                 "client_secret": self.client_secret,
                 "redirect_uri": redirect_uri,
             }
+            headers = {"Accept": ContentType.JSON.value}
             if self.content_type == ContentType.JSON:
                 resp = await client.post(
                     token_endpoint.path,
                     json=request_body,
-                    headers={"Accept": "application/json"},
+                    headers=headers,
                 )
             else:
                 resp = await client.post(
                     token_endpoint.path,
                     data=request_body,
-                    headers={"Accept": "application/x-www-form-urlencoded"},
+                    headers=headers,
                 )
             if resp.status_code >= 400:
                 raise errors.OAuthProviderFailure(


### PR DESCRIPTION
A few changes based on testing the OAuth flow for Azure:

1. Azure requires that requests are form encoded, but hilariously respond with JSON even if you ask for a form encoded response. 🤡 
2. The issuer for the Azure JWT will be the specific tenant that the user belongs to rather than the `common` tenant you requested with. Seems _fine_ to drop the requirement for matching issuer since there is no reasonable way to generically support arbitrary checks.

For point 2, maybe we can make this configurable in the sub-class for the `AzureProvider`? I'm open to suggestions here!