### PR TITLE
Fix exclusive constraints in configuration objects

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_10_02_00_00
+EDGEDB_CATALOG_VERSION = 2023_10_02_00_01
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -447,7 +447,10 @@ def object_type_to_spec(
         exclusive = schema.get('std::exclusive', type=s_constr.Constraint)
         unique = (
             not ptype.is_object_type()
-            and any(c.issubclass(schema, exclusive) for c in constraints)
+            and any(
+                c.issubclass(schema, exclusive) and not c.get_delegated(schema)
+                for c in constraints
+            )
         )
         fields[str_pn] = statypes.CompositeTypeSpecField(
             name=str_pn,

--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -38,7 +38,7 @@ class CompositeTypeSpecField:
     name: str
     type: type | CompositeTypeSpec
     _: dataclasses.KW_ONLY
-    unique: bool = True
+    unique: bool = False
     default: Any = MISSING
     secret: bool = False
 
@@ -74,6 +74,15 @@ class CompositeTypeSpec:
     @property
     def __name__(self) -> str:
         return self.name
+
+    def get_field_unique_site(self, name: str) -> Optional[CompositeTypeSpec]:
+        typ: Optional[CompositeTypeSpec] = self
+        site: Optional[CompositeTypeSpec] = None
+        while typ:
+            if name in typ.fields and typ.fields[name].unique:
+                site = typ
+            typ = typ.parent
+        return site
 
 
 class CompositeType:

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -142,6 +142,7 @@ create extension package _conf VERSION '1.0' {
         };
         create required property value -> std::str {
             set readonly := true;
+            create delegated constraint std::exclusive;
         };
         create property opt_value -> std::str {
             set readonly := true;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16243,6 +16243,8 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                 extra := 42,
             };
         ''')
+
+        # This is fine, constraint on value is delegated
         await self.con.execute('''
             configure current database insert ext::_conf::SecretObj {
                 name := '4',
@@ -16250,10 +16252,22 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                 secret := '123456',
             };
         ''')
+
+        # But this collides
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, "value violate"
+        ):
+            await self.con.execute('''
+                configure current database insert ext::_conf::SecretObj {
+                    name := '5',
+                    value := 'foo',
+                };
+            ''')
+
         await self.con.execute('''
             configure current database insert ext::_conf::SecretObj {
                 name := '5',
-                value := 'foo',
+                value := 'quux',
             };
         ''')
         async with self.assertRaisesRegexTx(
@@ -16300,7 +16314,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                      tname='ext::_conf::SubObj', opt_value=None),
                 dict(name='4', value='foo',
                      tname='ext::_conf::SecretObj', opt_value=None),
-                dict(name='5', value='foo',
+                dict(name='5', value='quux',
                      tname='ext::_conf::SecretObj', opt_value=None),
             ],
             obj=dict(name='single', value='val', fixed='fixed!'),
@@ -16421,7 +16435,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                      'name': '4', 'value': 'foo',
                      'opt_value': None, 'secret': {'redacted': True}},
                     {'_tname': 'ext::_conf::SecretObj',
-                     'name': '5', 'value': 'foo',
+                     'name': '5', 'value': 'quux',
                      'opt_value': None, 'secret': None},
                 ],
             )
@@ -16458,7 +16472,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         CONFIGURE CURRENT DATABASE INSERT ext::_conf::SecretObj {
             name := '5',
             secret := {},  # REDACTED
-            value := 'foo',
+            value := 'quux',
         };
         CONFIGURE CURRENT DATABASE INSERT ext::_conf::SubObj {
             extra := 42,


### PR DESCRIPTION
Right now we use the full *tuple* of exclusive constraints as the
exclusive key. It needs to be each exclusive pointer individually.