### PR TITLE
+'please specify another' for nonexistent database

### DIFF
--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1185,7 +1185,7 @@ cdef class DatabaseIndex:
             return self._dbs[dbname]
         except KeyError:
             raise errors.UnknownDatabaseError(
-                f'database {dbname!r} does not exist')
+                f'database {dbname!r} does not exist; please specify another')
 
     def maybe_get_db(self, dbname):
         return self._dbs.get(dbname)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -98,7 +98,7 @@ class TestDatabase(tb.ConnectedTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.UnknownDatabaseError,
-                r'database "databasename" does not exist'):
+                r'database "databasename" does not exist; please specify another'):
             await self.con.execute('DROP DATABASE databasename;')
 
     async def test_database_drop_recreate(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -98,7 +98,8 @@ class TestDatabase(tb.ConnectedTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.UnknownDatabaseError,
-                r'database "databasename" does not exist; please specify another'):
+                r'database "databasename" does not exist; \
+                    please specify another'):
             await self.con.execute('DROP DATABASE databasename;')
 
     async def test_database_drop_recreate(self):


### PR DESCRIPTION
A bit of Python code needs to be changed to add the final 'please specify another one' output mentioned here so gave it a go: https://github.com/edgedb/edgedb-cli/issues/1125

I've changed test_database_drop_01 to match as well but the workflow tests are still showing the old output. Revert the change to test_database_drop_01 or do something else? @msullivan 