### PR TITLE
Support some simple constraints on config object properties

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_10_02_00_01
+EDGEDB_CATALOG_VERSION = 2023_10_02_00_02
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -33,6 +33,7 @@ import immutables
 from edb import errors
 
 from edb.common import typeutils
+from edb.common import parsing
 from edb.common import uuidgen
 from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
@@ -151,6 +152,30 @@ def evaluate_Array(
     )
 
 
+def _process_op_result(
+    value: object,
+    typeref: irast.TypeRef,
+    schema: s_schema.Schema,
+    *,
+    srcctx: Optional[parsing.ParserContext]=None,
+) -> irast.ConstExpr:
+    qlconst: qlast.BaseConstant
+    if isinstance(value, str):
+        qlconst = qlast.StringConstant.from_python(value)
+    elif isinstance(value, bool):
+        qlconst = qlast.BooleanConstant.from_python(value)
+    else:
+        raise UnsupportedExpressionError(
+            f"unsupported result type: {type(value)}", context=srcctx
+        )
+
+    result = qlcompiler.compile_constant_tree_to_ir(
+        qlconst, styperef=typeref, schema=schema)
+
+    assert isinstance(result, irast.ConstExpr), 'expected ConstExpr'
+    return result
+
+
 op_table = {
     # Concatenation
     ('Infix', 'std::++'): lambda a, b: a + b,
@@ -158,6 +183,8 @@ op_table = {
     ('Infix', 'std::>'): lambda a, b: a > b,
     ('Infix', 'std::<='): lambda a, b: a <= b,
     ('Infix', 'std::<'): lambda a, b: a < b,
+    ('Infix', 'std::='): lambda a, b: a == b,
+    ('Infix', 'std::!='): lambda a, b: a != b,
 }
 
 
@@ -192,21 +219,38 @@ def evaluate_OperatorCall(
         args.append(arg_val)
 
     value = eval_func(*args)
-    qlconst: qlast.BaseConstant
-    if isinstance(value, str):
-        qlconst = qlast.StringConstant.from_python(value)
-    elif isinstance(value, bool):
-        qlconst = qlast.BooleanConstant.from_python(value)
-    else:
-        raise UnsupportedExpressionError(
-            f"unsupported result type: {type(value)}", context=opcall.context
-        )
+    return _process_op_result(
+        value, opcall.typeref, schema, srcctx=opcall.context)
 
-    result = qlcompiler.compile_constant_tree_to_ir(
-        qlconst, styperef=opcall.typeref, schema=schema)
 
-    assert isinstance(result, irast.ConstExpr), 'expected ConstExpr'
-    return result
+@evaluate.register(irast.SliceIndirection)
+def evaluate_SliceIndirection(
+        slice: irast.SliceIndirection,
+        schema: s_schema.Schema) -> irast.ConstExpr:
+
+    args = [slice.expr, slice.start, slice.stop]
+    vals = [
+        evaluate_to_python_val(arg, schema=schema) if arg else None
+        for arg in args
+    ]
+
+    for arg, arg_val in zip(args, vals):
+        if arg is None:
+            continue
+        if isinstance(arg_val, tuple):
+            raise UnsupportedExpressionError(
+                f'non-singleton operations are not supported',
+                context=slice.context)
+        if arg_val is None:
+            raise UnsupportedExpressionError(
+                f'empty operations are not supported',
+                context=slice.context)
+
+    base, start, stop = vals
+
+    value = base[start:stop]
+    return _process_op_result(
+        value, slice.expr.typeref, schema, srcctx=slice.context)
 
 
 def _evaluate_union(

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -143,6 +143,7 @@ create extension package _conf VERSION '1.0' {
         create required property value -> std::str {
             set readonly := true;
             create delegated constraint std::exclusive;
+            create constraint expression on (__subject__[:5] != 'asdf_');
         };
         create property opt_value -> std::str {
             set readonly := true;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16244,6 +16244,17 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             };
         ''')
 
+        async with self.assertRaisesRegexTx(
+            edgedb.ConfigurationError, "invalid setting value"
+        ):
+            await self.con.execute('''
+                configure current database insert ext::_conf::SubObj {
+                    name := '3!',
+                    value := 'asdf_wrong',
+                    extra := 42,
+                };
+            ''')
+
         # This is fine, constraint on value is delegated
         await self.con.execute('''
             configure current database insert ext::_conf::SecretObj {


### PR DESCRIPTION
We have to be able to evaluate them at compile time, which is a bit of a
downside, but probably doesn't matter in practice.