### PR TITLE
Allow empty arrays without cast in INSERT.

### DIFF
--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -78,6 +78,10 @@ def is_ql_empty_set(expr: qlast.Expr) -> bool:
     return isinstance(expr, qlast.Set) and len(expr.elements) == 0
 
 
+def is_ql_empty_array(expr: qlast.Expr) -> bool:
+    return isinstance(expr, qlast.Array) and len(expr.elements) == 0
+
+
 def is_ql_path(qlexpr: qlast.Expr) -> bool:
     if isinstance(qlexpr, qlast.Shape):
         if qlexpr.expr:

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -230,6 +230,7 @@ def new_tuple_set(
 
 def new_array_set(
         elements: Sequence[irast.Set], *,
+        stype: Optional[s_types.Type]=None,
         ctx: context.ContextLevel,
         srcctx: Optional[parsing.ParserContext]=None) -> irast.Set:
 
@@ -237,6 +238,11 @@ def new_array_set(
     arr = irast.Array(elements=elements, typeref=dummy_typeref)
     if elements:
         stype = inference.infer_type(arr, env=ctx.env)
+    elif stype is not None and stype.is_array():
+        # When constructing an empty array, we should skip explicit cast any
+        # time that we would skip it for an empty set because we can infer it
+        # from the context.
+        pass
     else:
         anytype = s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
         ctx.env.schema, stype = s_types.Array.from_subtypes(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1365,6 +1365,13 @@ def compile_result_clause(
                 ctx=sctx,
                 srcctx=result_expr.context,
             )
+        elif astutils.is_ql_empty_array(result_expr):
+            expr = setgen.new_array_set(
+                [],
+                stype=sctx.empty_result_type_hint,
+                ctx=sctx,
+                srcctx=result_expr.context,
+            )
         else:
             with sctx.new() as ectx:
                 if shape is not None:

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2520,6 +2520,34 @@ class TestInsert(tb.QueryTestCase):
             [2],
         )
 
+    async def test_edgeql_insert_collection_05(self):
+        # Make sure that empty arrays are accepted for inserts even when types
+        # are not explicitly specified.
+        await self.con.execute(r"""
+            INSERT CollectionTest {
+                str_array := [],
+                float_array := [],
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT
+                    CollectionTest {
+                        str_array,
+                        float_array
+                    }
+                FILTER
+                    len(.float_array) = 0;
+            """,
+            [
+                {
+                    'str_array': [],
+                    'float_array': [],
+                },
+            ]
+        )
+
     async def test_edgeql_insert_correlated_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,


### PR DESCRIPTION
In case we're inserting an empty array literal, we can infer the type to be matching the property type as long as the property is some kind of array as well.