### PR TITLE
Return OAuth provider tokens

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -69,6 +69,14 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property challenge: std::str {
             create constraint exclusive;
         };
+        create property auth_token: std::str {
+            create annotation std::description :=
+                "Identity provider's auth token";
+        };
+        create property refresh_token: std::str {
+            create annotation std::description :=
+                "Identity provider's refresh token";
+        };
         create link identity: ext::auth::Identity;
     };
 

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -133,7 +133,4 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
     id_token: str
 
     def __init__(self, **kwargs):
-        for field in dataclasses.fields(self):
-            if field.name in kwargs:
-                setattr(self, field.name, kwargs.pop(field.name))
-        self._extra_fields = kwargs
+        super().__init__(**kwargs)

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -112,12 +112,14 @@ class OAuthAccessTokenResponse:
     access_token: str
     token_type: str
     expires_in: int
-    refresh_token: str
+    refresh_token: str | None
 
     def __init__(self, **kwargs):
         for field in dataclasses.fields(self):
             if field.name in kwargs:
                 setattr(self, field.name, kwargs.pop(field.name))
+            else:
+                setattr(self, field.name, None)
         self._extra_fields = kwargs
 
 

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -83,11 +83,17 @@ class Client:
 
     async def handle_callback(
         self, code: str, redirect_uri: str
-    ) -> data.Identity:
+    ) -> tuple[data.Identity, str | None, str | None]:
         response = await self.provider.exchange_code(code, redirect_uri)
         user_info = await self.provider.fetch_user_info(response)
+        auth_token = response.access_token
+        refresh_token = response.refresh_token
 
-        return await self._handle_identity(user_info)
+        return (
+            await self._handle_identity(user_info),
+            auth_token,
+            refresh_token,
+        )
 
     async def _handle_identity(self, user_info: data.UserInfo) -> data.Identity:
         """Update or create an identity"""

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -799,12 +799,12 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 { id, auth_token, refresh_token }
                 filter .identity.id = <uuid>$identity_id
                 """,
-                identity_id=identity[0].id
+                identity_id=identity[0].id,
             )
 
             self.assertEqual(len(pkce_object), 1)
-            self.assertEqual(pkce_object[0].auth_token, "github_access_token");
-            self.assertIsNone(pkce_object[0].refresh_token);
+            self.assertEqual(pkce_object[0].auth_token, "github_access_token")
+            self.assertIsNone(pkce_object[0].refresh_token)
 
             mock_provider.register_route_handler(*user_request)(
                 (


### PR DESCRIPTION
This saves the provider token(s) that we used during the OAuth flow into the PKCE flow so that when you complete the OAuth flow, you'll receive the provider token (and refresh token) in the response body.

Notes:
- We are storing the identity provider's token, which we should do carefully and as temporarily as possible. We're going to work on a periodic cleanup job separately that will GC any expired `PKCEChallenge` objects.
- The provider may or may not return a refresh token.
- We don't currently pass any additional scopes to the provider, but that's a pretty common use-case. We'll support that in a separate PR.