### PR TITLE
Fix test broken by merging old PR

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -211,7 +211,7 @@ def get_verbosename_from_fqname(
     assert traceobj is not None
 
     name = str(fq_name)
-    clsname = traceobj.__class__.__name__.lower()
+    clsname = traceobj.get_schema_class_displayname()
     ofobj = ''
 
     if isinstance(traceobj, qltracer.Alias):
@@ -654,6 +654,8 @@ def _trace_item_layout(
                 qltracer.Property
                 if isinstance(decl, qlast.CreateConcreteProperty) else
                 qltracer.Link
+                if isinstance(decl, qlast.CreateConcreteProperty) else
+                qltracer.UnknownPointer
             )
             ptr = PointerType(
                 s_name.QualName('__', pn.name),

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -51,6 +51,10 @@ class NamedObject:
     def get_name(self, schema: s_schema.Schema) -> sn.QualName:
         return self.name
 
+    @classmethod
+    def get_schema_class_displayname(cls) -> str:
+        return cls.__name__.lower()
+
 
 SentinelObject = NamedObject(
     name=sn.QualName(module='__unknown__', name='__unknown__'),
@@ -255,6 +259,18 @@ class Link(Pointer):
         schema: s_schema.Schema,
     ) -> bool:
         return False
+
+
+class UnknownPointer(Pointer):
+    def is_property(
+        self,
+        schema: s_schema.Schema,
+    ) -> bool:
+        return False
+
+    @classmethod
+    def get_schema_class_displayname(cls) -> str:
+        return 'link or property'
 
 
 class AccessPolicy(NamedObject):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -931,7 +931,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.InvalidDefinitionError,
-        "field 'foo' .*was already declared"
+        "link or property 'foo' .*was already declared"
     )
     def test_schema_field_dupe_03(self):
         """


### PR DESCRIPTION
I just merged #5785, and one of the tests in it is broken because
since I wrote the first PR, we started allowing computed
links/properties without specifiers.