### PR TITLE
Be able to depend on multiple dml sources when producing overlays

### DIFF
--- a/edb/common/typeutils.py
+++ b/edb/common/typeutils.py
@@ -61,3 +61,11 @@ def is_container(obj):
 
 def is_container_type(type_):
     return isinstance(type_, type) and _is_container_type(type_)
+
+
+def dedup(old: Collection[T]) -> List[T]:
+    new: List[T] = []
+    for x in old:
+        if x not in new:
+            new.append(x)
+    return new

--- a/edb/common/typeutils.py
+++ b/edb/common/typeutils.py
@@ -61,11 +61,3 @@ def is_container(obj):
 
 def is_container_type(type_):
     return isinstance(type_, type) and _is_container_type(type_)
-
-
-def dedup(old: Collection[T]) -> List[T]:
-    new: List[T] = []
-    for x in old:
-        if x not in new:
-            new.append(x)
-    return new

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -1042,6 +1042,20 @@ def replace_pathid_prefix(
         dir = part.rptr_dir()
         assert dir
 
+        if (
+            isinstance(ptrref, irast.TupleIndirectionPointerRef)
+            and result.target.collection == 'tuple'
+        ):
+            # For tuple indirections, we want to update the target
+            # type when we get mapped to a subtype.
+            idx = get_tuple_element_index(ptrref)
+            target = result.target
+            if target.id != target.subtypes[idx].id:
+                ptrref = ptrref.replace(
+                    out_source=target,
+                    out_target=target.subtypes[idx],
+                )
+
         if ptrref.source_ptr:
             result = result.ptr_path()
         result = result.extend(

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -29,7 +29,7 @@ import json
 from edb import errors
 
 from edb.common import ast
-from edb.common.typeutils import dedup
+from edb.common import ordered
 
 from edb.edgeql import qltypes as ft
 
@@ -273,7 +273,7 @@ def get_dml_sources(
     # TODO: Make this caching.
     visitor = CollectDMLSourceVisitor()
     visitor.visit(ir_set)
-    return dedup(visitor.dml)
+    return tuple(ordered.OrderedSet(visitor.dml))
 
 
 class ContainsDMLVisitor(ast.NodeVisitor):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -29,6 +29,7 @@ import json
 from edb import errors
 
 from edb.common import ast
+from edb.common.typeutils import dedup
 
 from edb.edgeql import qltypes as ft
 
@@ -242,41 +243,37 @@ def collapse_type_intersection(
     return source, result
 
 
-def get_nearest_dml_stmt(
-    ir_set: irast.Set
-) -> Optional[irast.MutatingLikeStmt]:
-    """For a given *ir_set* representing a Path, return the nearest path
-       step that is a DML expression.
-    """
-    cur_set: Optional[irast.Set] = ir_set
-    while cur_set is not None:
-        if isinstance(cur_set.expr, irast.MutatingLikeStmt):
-            return cur_set.expr
-        elif isinstance(cur_set.expr, irast.SelectStmt):
-            cur_set = cur_set.expr.result
-        # FIXME: This is a narrow hack around issue #3030 designed to
-        # make simple cases work. This probably covers most cases but
-        # does not cover everything in general.
-        # The critical one is assert_exists inserted by access policies.
-        elif (
-            isinstance(cur_set.expr, irast.Call)
-            and str(cur_set.expr.func_shortname) in {
-                'std::assert_exists',
-                'std::assert_single',
-                'std::assert_distinct',
-                'std::enumerate',
-                'std::min',
-                'std::max',
-                'std::DISTINCT',
-            }
+class CollectDMLSourceVisitor(ast.NodeVisitor):
+    skip_hidden = True
 
-        ):
-            cur_set = cur_set.expr.args[-1].expr
-        elif cur_set.rptr is not None:
-            cur_set = cur_set.rptr.source
-        else:
-            cur_set = None
-    return None
+    def __init__(self) -> None:
+        super().__init__()
+        self.dml: list[irast.MutatingLikeStmt] = []
+
+    def visit_MutatingLikeStmt(self, stmt: irast.MutatingLikeStmt) -> None:
+        # Only INSERTs and UPDATEs produce meaningful overlays.
+        if not isinstance(stmt, irast.DeleteStmt):
+            self.dml.append(stmt)
+
+    def visit_Set(self, node: irast.Set) -> None:
+        # Visit sub-trees
+        if node.expr:
+            self.visit(node.expr)
+        elif node.rptr:
+            self.visit(node.rptr.source)
+
+
+def get_dml_sources(
+    ir_set: irast.Set
+) -> Sequence[irast.MutatingLikeStmt]:
+    """Find the DML expressions that can contribute to the value of a set
+
+    This is used to compute which overlays to use during SQL compilation.
+    """
+    # TODO: Make this caching.
+    visitor = CollectDMLSourceVisitor()
+    visitor.visit(ir_set)
+    return dedup(visitor.dml)
 
 
 class ContainsDMLVisitor(ast.NodeVisitor):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -273,6 +273,9 @@ def get_dml_sources(
     # TODO: Make this caching.
     visitor = CollectDMLSourceVisitor()
     visitor.visit(ir_set)
+    # Deduplicate, but preserve order. It shouldn't matter for
+    # *correctness* but it helps keep the nondeterminism in the output
+    # SQL down.
     return tuple(ordered.OrderedSet(visitor.dml))
 
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -467,7 +467,8 @@ class CompilerContext(compiler.CompilerContext[CompilerContextLevel]):
 
 
 RewriteKey = Tuple[uuid.UUID, bool]
-FullRewriteKey = Tuple[uuid.UUID, bool, Optional['irast.MutatingLikeStmt']]
+FullRewriteKey = Tuple[
+    uuid.UUID, bool, Optional[frozenset['irast.MutatingLikeStmt']]]
 
 
 class Environment:

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -970,7 +970,7 @@ def process_set_as_path_type_intersection(
         poly_rvar = relctx.range_for_typeref(
             target_typeref,
             path_id=ir_set.path_id,
-            dml_source=irutils.get_nearest_dml_stmt(ir_set),
+            dml_source=irutils.get_dml_sources(ir_set),
             lateral=True,
             ctx=ctx,
         )

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -505,6 +505,18 @@ class TestDelete(tb.QueryTestCase):
             }],
         )
 
+    async def test_edgeql_delete_assert_exists(self):
+        await self.con.execute(r"""
+            INSERT DeleteTest2 { name := 'x' };
+        """)
+
+        await self.assert_query_result(
+            r"""
+            select assert_exists((delete DeleteTest2 filter .name = 'x'));
+            """,
+            [{}],
+        )
+
     async def test_edgeql_delete_then_union(self):
         await self.con.execute(r"""
             INSERT DeleteTest2 { name := 'x' };

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2410,6 +2410,127 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_insert_tuples_01(self):
+        await self.assert_query_result(
+            r"""
+                with noobs := {
+                  ((insert InsertTest { l2 := 1 }), "bar"),
+                  ((insert InsertTest { l2 := 2 }), "eggs"),
+                },
+                select noobs;
+            """,
+            [
+                ({}, "bar"),
+                ({}, "eggs"),
+            ]
+        )
+
+        await self.assert_query_result(
+            r"""
+                select {
+                  ((insert InsertTest { l2 := 1 }), "bar"),
+                  ((insert InsertTest { l2 := 2 }), "eggs"),
+                }
+            """,
+            [
+                ({}, "bar"),
+                ({}, "eggs"),
+            ]
+        )
+
+    async def test_edgeql_insert_tuples_02(self):
+        await self.assert_query_result(
+            r"""
+                with noobs := {
+                  ((insert InsertTest { l2 := 1 }), "bar"),
+                  ((insert DerivedTest { l2 := 2 }), "eggs"),
+                },
+                select noobs;
+            """,
+            [
+                ({}, "bar"),
+                ({}, "eggs"),
+            ]
+        )
+
+        await self.assert_query_result(
+            r"""
+                select {
+                  ((insert InsertTest { l2 := 1 }), "bar"),
+                  ((insert DerivedTest { l2 := 2 }), "eggs"),
+                }
+            """,
+            [
+                ({}, "bar"),
+                ({}, "eggs"),
+            ]
+        )
+
+    async def test_edgeql_insert_tuples_03(self):
+        await self.assert_query_result(
+            r"""
+                with noobs := {
+                  ((insert InsertTest { l2 := 1 }), "bar"),
+                  ((insert Person { name := "x" }), "eggs"),
+                },
+                select noobs;
+            """,
+            [
+                ({}, "bar"),
+                ({}, "eggs"),
+            ]
+        )
+
+        await self.assert_query_result(
+            r"""
+                select {
+                  ((insert InsertTest { l2 := 1 }), "bar"),
+                  ((insert Person { name := "y" }), "eggs"),
+                }
+            """,
+            [
+                ({}, "bar"),
+                ({}, "eggs"),
+            ]
+        )
+
+    async def test_edgeql_insert_tuples_04(self):
+        await self.assert_query_result(
+            r"""
+            with noobs := {
+              ((insert Subordinate { name := "foo" }), "bar"),
+              ((insert Subordinate { name := "spam" }), "eggs"),
+            },
+            select (insert InsertTest {
+                l2 := 1,
+                subordinates := assert_distinct(
+                    noobs.0 { @comment := noobs.1 }),
+            }) { subordinates: {name, @comment} order by .name };
+            """,
+            [
+                {
+                    "subordinates": [
+                        {"name": "foo", "@comment": "bar"},
+                        {"name": "spam", "@comment": "eggs"}
+                    ]
+                }
+            ],
+        )
+
+        await self.assert_query_result(
+            r"""
+            select InsertTest { subordinates: {name, @comment} };
+            """,
+            [
+                {
+                    "subordinates": [
+                        {"name": "foo", "@comment": "bar"},
+                        {"name": "spam", "@comment": "eggs"}
+                    ]
+                }
+            ],
+        )
+
     async def test_edgeql_insert_collection_01(self):
         await self.con.execute(r"""
             INSERT CollectionTest {
@@ -6158,9 +6279,6 @@ class TestInsert(tb.QueryTestCase):
             [1],
         )
 
-    @test.xfail('''
-        This is broken because of #6057
-    ''')
     async def test_edgeql_insert_coalesce_02(self):
         await self.assert_query_result(
             '''


### PR DESCRIPTION
Queries like:
```
with noobs := {
  ((insert Person { name := "foo" }), "bar"),
  ((insert Person { name := "spam" }), "eggs"),
},
select noobs;
```
would return an empty set, since (for annoying reasons that could
possibly be avoided in this simple case but not in the general case),
we need to do an `ensure_source_rvar` on `noobs`, but
`get_nearest_dml_stmt` is highly limited and can only find one DML
statement. This means we can't produce the proper overlay that
includes both Persons.

Upgrade `get_nearest_dml_stmt` to be able to collect all of the
relevant DML sources.

Fixes #6057. That bug was just a special case of #3030; this fix thus
represents a combination of forward progress on #3030 as well as some
lateral movement: as discussed in that issue, some queries are now
*differently* wrong (see test_edgeql_update_union_overlay_02, which
previously would have returned the old value twice instead of the
new value twice). I am going to close #3030 in favor of an
updated #6222 once this is merged.