### PR TITLE
Fixes for OAuth flow after testing Apple OIDC

### DIFF
--- a/edb/server/protocol/auth_ext/apple.py
+++ b/edb/server/protocol/auth_ext/apple.py
@@ -25,17 +25,24 @@ from . import base
 
 class AppleProvider(base.OpenIDProvider):
     def __init__(self, *args, **kwargs):
-        super().__init__("apple", "https://appleid.apple.com", *args, **kwargs)
+        super().__init__(
+            "apple",
+            "https://appleid.apple.com",
+            *args,
+            content_type=base.ContentType.FORM_ENCODED,
+            **kwargs,
+        )
 
     async def get_code_url(self, state: str, redirect_uri: str) -> str:
         oidc_config = await self._get_oidc_config()
         params = {
             "client_id": self.client_id,
-            "scope": "openid profile name",  # Non-standard "name" scope
+            "scope": "openid email name",  # Non-standard "name" scope
             "state": state,
             "redirect_uri": redirect_uri,
             "nonce": str(uuid.uuid4()),
-            "response_type": "code",
+            "response_type": "code id_token",
+            "response_mode": "form_post",
         }
         encoded = urllib.parse.urlencode(params)
         return f"{oidc_config.authorization_endpoint}?{encoded}"

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -33,6 +33,7 @@ cdef class HttpRequest:
         public bytes host
         public bytes authorization
         public object params
+        public object forwarded
 
 
 cdef class HttpResponse:

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -71,6 +71,7 @@ cdef class HttpRequest:
         self.body = b''
         self.authorization = b''
         self.content_type = b''
+        self.forwarded = {}
 
 
 cdef class HttpResponse:


### PR DESCRIPTION
Namely:

- Must specify a `response_mode` when requesting any scopes
- Must handle POST with form urlencoded data on the callback instead of in the querystring