### PR TITLE
Pass PKCE `challenge` through to authorize redirect

### DIFF
--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -128,6 +128,9 @@ class MultiTenantServer(server.BaseServer):
     def retrieve_tenant(self, sslobj) -> edbtenant.Tenant | None:
         return self._tenants_by_sslobj.pop(sslobj, None)
 
+    def iter_tenants(self) -> Iterator[edbtenant.Tenant]:
+        return iter(self._tenants.values())
+
     async def _before_start_servers(self) -> None:
         assert self._task_group is not None
         await self._task_group.__aenter__()

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -82,7 +82,7 @@ class Router:
                     oauth_client = oauth.Client(
                         db=self.db,
                         provider_name=provider_name,
-                        base_url=test_url,
+                        base_url=test_url
                     )
                     await pkce.create(self.db, challenge)
                     authorize_url = await oauth_client.get_authorize_url(
@@ -304,7 +304,7 @@ class Router:
                             redirect_params = urllib.parse.urlencode(
                                 {
                                     "error": str(ex),
-                                    "email": data.get('email', ''),
+                                    "email": data.get('email', '')
                                 }
                             )
                             redirect_url = (
@@ -381,7 +381,7 @@ class Router:
                         else:
                             raise ex
 
-                case ('send_reset_email',):
+                case ('send_reset_email', ):
                     data = self._get_data_from_request(request)
 
                     local_provider_name = data.get("provider")
@@ -400,18 +400,16 @@ class Router:
                                 "Missing 'reset_url' in data"
                             )
 
-                        (
-                            identity,
-                            secret,
-                        ) = await local_client.get_identity_and_secret(data)
+                        identity, secret = (
+                            await local_client.get_identity_and_secret(data))
 
                         new_reset_token = self._make_reset_token(
                             identity.id, secret
                         )
 
-                        reset_token_params = urllib.parse.urlencode(
-                            {"reset_token": new_reset_token}
-                        )
+                        reset_token_params = urllib.parse.urlencode({
+                            "reset_token": new_reset_token
+                        })
                         reset_url = f"{data['reset_url']}?{reset_token_params}"
 
                         from_addr = util.get_config(
@@ -450,9 +448,11 @@ class Router:
                         if task.done():
                             await task
 
-                        return_data = {
-                            "email_sent": data.get('email'),
-                        }
+                        return_data = (
+                            {
+                                "email_sent": data.get('email'),
+                            }
+                        )
 
                         if data.get("redirect_to") is not None:
                             response.status = http.HTTPStatus.FOUND
@@ -466,7 +466,9 @@ class Router:
                         else:
                             response.status = http.HTTPStatus.OK
                             response.content_type = b"application/json"
-                            response.body = json.dumps(return_data).encode()
+                            response.body = json.dumps(
+                                return_data
+                            ).encode()
                     except aiosmtplib.SMTPException as ex:
                         if not debug.flags.server:
                             logger.warning(
@@ -515,8 +517,8 @@ class Router:
                             )
                         reset_token = data['reset_token']
 
-                        identity_id, secret = self._get_data_from_reset_token(
-                            reset_token
+                        identity_id, secret = (
+                            self._get_data_from_reset_token(reset_token)
                         )
 
                         identity = await local_client.update_password(
@@ -568,10 +570,7 @@ class Router:
                         else:
                             raise ex
 
-                case (
-                    'ui',
-                    'signin',
-                ):
+                case ('ui', 'signin'):
                     ui_config = self._get_ui_config()
 
                     if ui_config is None:
@@ -581,13 +580,13 @@ class Router:
                         providers = util.maybe_get_config(
                             self.db,
                             "ext::auth::AuthConfig::providers",
-                            frozenset,
+                            frozenset
                         )
 
                         if providers is None or len(providers) == 0:
                             raise errors.MissingConfiguration(
                                 'ext::auth::AuthConfig::providers',
-                                'No providers are configured',
+                                'No providers are configured'
                             )
 
                         query = urllib.parse.parse_qs(
@@ -615,10 +614,7 @@ class Router:
                             brand_color=ui_config.brand_color,
                         )
 
-                case (
-                    'ui',
-                    'signup',
-                ):
+                case ('ui', 'signup'):
                     ui_config = self._get_ui_config()
                     password_provider = (
                         self._get_password_provider()
@@ -630,8 +626,7 @@ class Router:
                         response.status = http.HTTPStatus.NOT_FOUND
                         response.body = (
                             b'Password provider not configured'
-                            if ui_config
-                            else b'Auth UI not enabled'
+                            if ui_config else b'Auth UI not enabled'
                         )
                     else:
                         query = urllib.parse.parse_qs(
@@ -656,10 +651,7 @@ class Router:
                             brand_color=ui_config.brand_color,
                         )
 
-                case (
-                    'ui',
-                    'forgot-password',
-                ):
+                case ('ui', 'forgot-password'):
                     ui_config = self._get_ui_config()
                     password_provider = (
                         self._get_password_provider()
@@ -671,8 +663,7 @@ class Router:
                         response.status = http.HTTPStatus.NOT_FOUND
                         response.body = (
                             b'Password provider not configured'
-                            if ui_config
-                            else b'Auth UI not enabled'
+                            if ui_config else b'Auth UI not enabled'
                         )
                     else:
                         query = urllib.parse.parse_qs(
@@ -699,10 +690,7 @@ class Router:
                             brand_color=ui_config.brand_color,
                         )
 
-                case (
-                    'ui',
-                    'reset-password',
-                ):
+                case ('ui', 'reset-password'):
                     ui_config = self._get_ui_config()
                     password_provider = (
                         self._get_password_provider()
@@ -714,8 +702,7 @@ class Router:
                         response.status = http.HTTPStatus.NOT_FOUND
                         response.body = (
                             b'Password provider not configured'
-                            if ui_config
-                            else b'Auth UI not enabled'
+                            if ui_config else b'Auth UI not enabled'
                         )
                     else:
                         query = urllib.parse.parse_qs(
@@ -725,26 +712,24 @@ class Router:
                         )
 
                         reset_token = _maybe_get_search_param(
-                            query, 'reset_token'
-                        )
+                            query, 'reset_token')
 
                         if reset_token is not None:
                             try:
-                                (
-                                    identity_id,
-                                    secret,
-                                ) = self._get_data_from_reset_token(reset_token)
+                                identity_id, secret = (
+                                    self._get_data_from_reset_token(
+                                        reset_token
+                                    )
+                                )
 
                                 local_client = local.Client(
                                     db=self.db,
-                                    provider_name=password_provider.name,
+                                    provider_name=password_provider.name
                                 )
 
-                                is_valid = (
-                                    await (
-                                        local_client.validate_reset_secret(
-                                            identity_id, secret
-                                        )
+                                is_valid = await (
+                                    local_client.validate_reset_secret(
+                                        identity_id, secret
                                     )
                                 )
                             except Exception:
@@ -771,7 +756,8 @@ class Router:
 
                 case ('ui', '_static', filename):
                     filepath = os.path.join(
-                        os.path.dirname(__file__), '_static', filename
+                        os.path.dirname(__file__),
+                        '_static', filename
                     )
                     try:
                         with open(filepath, 'rb') as f:
@@ -853,9 +839,9 @@ class Router:
         self, provider: str, redirect_to: str, challenge: str
     ) -> str:
         signing_key = self._get_auth_signing_key()
-        expires_at = datetime.datetime.now(
-            datetime.timezone.utc
-        ) + datetime.timedelta(minutes=5)
+        expires_at = (
+            datetime.datetime.now(datetime.timezone.utc) +
+            datetime.timedelta(minutes=5))
 
         state_claims = {
             "iss": self.base_path,
@@ -970,15 +956,19 @@ class Router:
 
     def _get_ui_config(self):
         return util.maybe_get_config(
-            self.db, "ext::auth::AuthConfig::ui", CompositeConfigType
+            self.db, "ext::auth::AuthConfig::ui",
+            CompositeConfigType
         )
 
     def _get_password_provider(self):
         providers = util.get_config(
-            self.db, "ext::auth::AuthConfig::providers", frozenset
+            self.db,
+            "ext::auth::AuthConfig::providers",
+            frozenset
         )
         password_providers = [
-            p for p in providers if (p.name == 'builtin::local_emailpassword')
+            p for p in providers
+            if (p.name == 'builtin::local_emailpassword')
         ]
 
         return password_providers[0] if len(password_providers) == 1 else None

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -831,7 +831,7 @@ class Router:
                 response=response,
                 status=http.HTTPStatus.INTERNAL_SERVER_ERROR,
                 message=str(ex),
-                ex_type=type(ex),
+                ex_type=edb_errors.InternalServerError,
             )
 
     def _get_callback_url(self) -> str:

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -606,6 +606,9 @@ class Router:
                                 query, 'error'
                             ),
                             email=_maybe_get_search_param(query, 'email'),
+                            challenge=_get_search_param(
+                                query, 'challenge'
+                            ),
                             app_name=ui_config.app_name,
                             logo_url=ui_config.logo_url,
                             dark_logo_url=ui_config.dark_logo_url,

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -574,7 +574,6 @@ class Router:
                             "ext::auth::AuthConfig::providers",
                             frozenset
                         )
-
                         if providers is None or len(providers) == 0:
                             raise errors.MissingConfiguration(
                                 'ext::auth::AuthConfig::providers',
@@ -592,6 +591,10 @@ class Router:
                             cookies=request.cookies,
                             query_dict=query,
                         )
+                        if maybe_challenge is None:
+                            raise errors.InvalidData(
+                                'Missing "challenge" in register request'
+                            )
 
                         response.status = http.HTTPStatus.OK
                         response.content_type = b'text/html'
@@ -636,6 +639,10 @@ class Router:
                             cookies=request.cookies,
                             query_dict=query,
                         )
+                        if maybe_challenge is None:
+                            raise errors.InvalidData(
+                                'Missing "challenge" in register request'
+                            )
 
                         response.status = http.HTTPStatus.OK
                         response.content_type = b'text/html'
@@ -647,6 +654,7 @@ class Router:
                                 query, 'error'
                             ),
                             email=_maybe_get_search_param(query, 'email'),
+                            challenge=maybe_challenge,
                             app_name=ui_config.app_name,
                             logo_url=ui_config.logo_url,
                             dark_logo_url=ui_config.dark_logo_url,

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -20,6 +20,7 @@
 import asyncio
 import datetime
 import http
+import http.cookies
 import json
 import logging
 import urllib.parse
@@ -190,10 +191,7 @@ class Router:
                     session_token = self._make_session_token(identity.id)
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = new_url
-                    response.custom_headers["Set-Cookie"] = (
-                        f"edgedb-session={session_token}; "
-                        f"HttpOnly; Secure; SameSite=Strict"
-                    )
+                    _set_cookie(response, "edgedb-session", session_token)
 
                 case ("token",):
                     query = urllib.parse.parse_qs(
@@ -339,10 +337,7 @@ class Router:
                             self.db, identity.id, maybe_challenge
                         )
                         session_token = self._make_session_token(identity.id)
-                        response.custom_headers["Set-Cookie"] = (
-                            f"edgedb-session={session_token}; "
-                            f"HttpOnly; Secure; SameSite=Strict"
-                        )
+                        _set_cookie(response, "edgedb-session", session_token)
                         if data.get("redirect_to") is not None:
                             response.status = http.HTTPStatus.FOUND
                             redirect_params = urllib.parse.urlencode(
@@ -526,10 +521,7 @@ class Router:
                         )
 
                         session_token = self._make_session_token(identity.id)
-                        response.custom_headers["Set-Cookie"] = (
-                            f"edgedb-session={session_token}; "
-                            f"HttpOnly; Secure; SameSite=Strict"
-                        )
+                        _set_cookie(response, "edgedb-session", session_token)
                         if data.get("redirect_to") is not None:
                             response.status = http.HTTPStatus.FOUND
                             redirect_params = urllib.parse.urlencode(
@@ -1027,17 +1019,29 @@ def _maybe_get_form_field(
 def _get_pkce_challenge(
     *,
     response,
-    cookies: dict[bytes, bytes],
+    cookies: http.cookies.SimpleCookie,
     query_dict: dict[str, list[str]]
 ) -> str | None:
+    cookie_name = 'edgedb-pkce-challenge'
     challenge: str | None = _maybe_get_search_param(query_dict, 'challenge')
     if challenge is not None:
-        response.custom_headers["Set-Cookie"] = (
-            f"edgedb-pkce-challenge={challenge}; "
-            f"HttpOnly; Secure; SameSite=Strict"
-        )
+        _set_cookie(response, cookie_name, challenge)
     else:
-        if b'edgedb-pkce-challenge' in cookies:
-            cookie_value: bytes = cookies[b'edgedb-pkce-challenge']
-            challenge = cookie_value.decode()
+        if 'edgedb-pkce-challenge' in cookies:
+            challenge = cookies['edgedb-pkce-challenge'].value
     return challenge
+
+
+def _set_cookie(
+    response: Any,
+    name: str,
+    value: str,
+    http_only: bool = True,
+    secure: bool = True,
+    same_site: str = "Strict",
+):
+    val: http.cookies.Morsel = http.cookies.SimpleCookie({name: value})[name]
+    val["httponly"] = http_only
+    val["secure"] = secure
+    val["samesite"] = same_site
+    response.custom_headers["Set-Cookie"] = val.OutputString()

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -595,7 +595,7 @@ class Router:
                             else ''
                         )
 
-                        challenge = _get_pkce_challenge(
+                        maybe_challenge = _get_pkce_challenge(
                             response=response,
                             cookies=request.cookies,
                             query_dict=query,
@@ -611,7 +611,7 @@ class Router:
                                 query, 'error'
                             ),
                             email=_maybe_get_search_param(query, 'email'),
-                            challenge=challenge,
+                            challenge=maybe_challenge,
                             app_name=ui_config.app_name,
                             logo_url=ui_config.logo_url,
                             dark_logo_url=ui_config.dark_logo_url,
@@ -639,7 +639,7 @@ class Router:
                             else ''
                         )
 
-                        challenge = _get_pkce_challenge(
+                        maybe_challenge = _get_pkce_challenge(
                             response=response,
                             cookies=request.cookies,
                             query_dict=query,
@@ -1022,6 +1022,7 @@ def _maybe_get_form_field(
     if maybe_val is None:
         return None
     return maybe_val[0]
+
 
 def _get_pkce_challenge(
     *,

--- a/edb/server/protocol/auth_ext/pkce.py
+++ b/edb/server/protocol/auth_ext/pkce.py
@@ -16,11 +16,25 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+import typing
 
+import asyncio
 import json
+import logging
 import dataclasses
 
+from edb.common import taskgroup
+from edb.ir import statypes
 from edb.server.protocol import execute
+
+if typing.TYPE_CHECKING:
+    from edb.server import server as edbserver
+    from edb.server import tenant as edbtenant
+
+
+logger = logging.getLogger("edb.server")
+VALIDITY = statypes.Duration.from_microseconds(10 * 60_000_000)  # 10 minutes
 
 
 @dataclasses.dataclass(repr=False)
@@ -108,9 +122,9 @@ async def get_by_id(db, id: str) -> PKCEChallenge:
             identity_id := .identity.id
         }
         filter .id = <uuid>$id
-        and (datetime_current() - .created_at) < <duration>'10 minutes';
+        and (datetime_current() - .created_at) < <duration>$validity;
         """,
-        variables={"id": id},
+        variables={"id": id, "validity": VALIDITY.to_backend_str()},
     )
 
     result_json = json.loads(r.decode())
@@ -130,3 +144,43 @@ async def delete(db, id: str) -> None:
 
     result_json = json.loads(r.decode())
     assert len(result_json) == 1
+
+
+async def _gc(tenant: edbtenant.Tenant):
+    try:
+        async with taskgroup.TaskGroup() as g:
+            for db in tenant.iter_dbs():
+                if "auth" in db.extensions:
+                    g.create_task(
+                        execute.parse_execute_json(
+                            db,
+                            """
+                            delete ext::auth::PKCEChallenge filter
+                                (datetime_of_statement() - .created_at) >
+                                <duration>$validity
+                            """,
+                            variables={"validity": VALIDITY.to_backend_str()},
+                        ),
+                    )
+    except Exception as ex:
+        logger.debug(
+            "GC of ext::auth::PKCEChallenge failed (instance: %s)",
+            tenant.get_instance_name(),
+            exc_info=ex,
+        )
+
+
+async def gc(server: edbserver.BaseServer):
+    while True:
+        try:
+            tasks = [
+                tenant.create_task(_gc(tenant), interruptable=False)
+                for tenant in server.iter_tenants()
+                if tenant.accept_new_tasks
+            ]
+            if tasks:
+                await asyncio.wait(tasks)
+        except Exception as ex:
+            logger.debug("GC of ext::auth::PKCEChallenge failed", exc_info=ex)
+        finally:
+            await asyncio.sleep(VALIDITY.to_microseconds() / 1_000_000.0)

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -58,7 +58,7 @@ def render_login_page(
 
     oauth_buttons = '\n'.join([
         f'''
-        <a href="authorize?provider={p.name}{
+        <a href="../authorize?provider={p.name}&redirect_to={redirect_to}{
             f"&challenge={challenge}" if challenge else ""
         }">
         {(

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -37,6 +37,7 @@ def render_login_page(
     providers: frozenset,
     error_message: Optional[str] = None,
     email: Optional[str] = None,
+    challenge: Optional[str] = None,
     # config
     redirect_to: str,
     app_name: Optional[str] = None,
@@ -57,7 +58,9 @@ def render_login_page(
 
     oauth_buttons = '\n'.join([
         f'''
-        <a href="authorize?provider={p.name}">
+        <a href="authorize?provider={p.name}{
+            f"&challenge={challenge}" if challenge else ""
+        }">
         {(
             '<img src="_static/icon_' + p.name[15:] + '.svg" alt="' +
             p.display_name+' Icon" />'

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -37,7 +37,7 @@ def render_login_page(
     providers: frozenset,
     error_message: Optional[str] = None,
     email: Optional[str] = None,
-    challenge: Optional[str] = None,
+    challenge: str,
     # config
     redirect_to: str,
     app_name: Optional[str] = None,
@@ -58,8 +58,12 @@ def render_login_page(
 
     oauth_buttons = '\n'.join([
         f'''
-        <a href="../authorize?provider={p.name}&redirect_to={redirect_to}{
-            f"&challenge={challenge}" if challenge else ""
+        <a href="../authorize?provider={
+            p.name
+        }&redirect_to={
+            redirect_to
+        }&challenge={
+            challenge
         }">
         {(
             '<img src="_static/icon_' + p.name[15:] + '.svg" alt="' +
@@ -117,6 +121,7 @@ def render_login_page(
       <input type="hidden" name="redirect_on_failure" value="{
         base_path}/ui/signin" />
       <input type="hidden" name="redirect_to" value="{redirect_to}" />
+      <input type="hidden" name="challenge" value="{challenge}" />
 
       {_render_error_message(error_message)}
 
@@ -149,6 +154,7 @@ def render_signup_page(
     provider_name: str,
     error_message: Optional[str] = None,
     email: Optional[str] = None,
+    challenge: str,
     # config
     redirect_to: str,
     app_name: Optional[str] = None,
@@ -173,6 +179,7 @@ def render_signup_page(
       <input type="hidden" name="redirect_on_failure" value="{
         base_path}/ui/signup" />
       <input type="hidden" name="redirect_to" value="{redirect_to}" />
+      <input type="hidden" name="challenge" value="{challenge}" />
 
       <label for="email">Email</label>
       <input id="email" name="email" type="email" value="{email or ''}" />

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -34,6 +34,7 @@ cdef class HttpRequest:
         public bytes authorization
         public object params
         public object forwarded
+        public object cookies
 
 
 cdef class HttpResponse:

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -23,6 +23,7 @@ include "./consts.pxi"
 import asyncio
 import collections
 import http
+import http.cookies
 import re
 import ssl
 import urllib.parse
@@ -72,7 +73,7 @@ cdef class HttpRequest:
         self.authorization = b''
         self.content_type = b''
         self.forwarded = {}
-        self.cookies = {}
+        self.cookies = http.cookies.SimpleCookie()
 
 
 cdef class HttpResponse:
@@ -233,13 +234,7 @@ cdef class HttpProtocol:
             forwarded_key = name[len(b'x-forwarded-'):]
             self.current_request.forwarded[forwarded_key] = value
         elif name == b'cookie':
-            if self.current_request.cookies is None:
-                self.current_request.cookies = {}
-            cookies = value.split(b'; ')
-            for cookie in cookies:
-                key, value = cookie.split(b'=', 1)
-                value = value.split(b'; ', 1)[0]
-                self.current_request.cookies[key] = value
+            self.current_request.cookies.load(value.decode('ascii'))
 
     def on_body(self, body: bytes):
         self.current_request.body += body

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -72,6 +72,7 @@ cdef class HttpRequest:
         self.authorization = b''
         self.content_type = b''
         self.forwarded = {}
+        self.cookies = {}
 
 
 cdef class HttpResponse:
@@ -231,6 +232,14 @@ cdef class HttpProtocol:
                 self.current_request.forwarded = {}
             forwarded_key = name[len(b'x-forwarded-'):]
             self.current_request.forwarded[forwarded_key] = value
+        elif name == b'cookie':
+            if self.current_request.cookies is None:
+                self.current_request.cookies = {}
+            cookies = value.split(b'; ')
+            for cookie in cookies:
+                key, value = cookie.split(b'=', 1)
+                value = value.split(b'; ', 1)[0]
+                self.current_request.cookies[key] = value
 
     def on_body(self, body: bytes):
         self.current_request.body += body

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1356,3 +1356,7 @@ class Tenant(ha_base.ClusterProtocol):
     def get_compiler_args(self) -> dict[str, Any]:
         assert self._dbindex is not None
         return {"dbindex": self._dbindex}
+
+    def iter_dbs(self) -> Iterator[dbview.Database]:
+        if self._dbindex is not None:
+            yield from self._dbindex.iter_dbs()


### PR DESCRIPTION
We require that `authorize` calls contain a `challenge` string to use PKCE to protect the auth token from being exposed in untrusted contexts. This passes the provided `challenge` string from the application through.

We would like to allow this behavior to be configurable, where developers could opt into the implicit flow instead if they are ok with that security trade-off.