### PR TITLE
Improvements to string function page

### DIFF
--- a/docs/stdlib/string.rst
+++ b/docs/stdlib/string.rst
@@ -36,13 +36,13 @@ Strings
       - :eql:func-desc:`to_str`
 
     * - :eql:func:`len`
-      - Return string's length.
+      - Returns a string's length.
 
     * - :eql:func:`contains`
-      - Test if a string contains a substring.
+      - Tests if a string contains a substring.
 
     * - :eql:func:`find`
-      - Find index of a substring.
+      - Finds the index of a substring.
 
     * - :eql:func:`str_lower`
       - :eql:func-desc:`str_lower`
@@ -78,7 +78,7 @@ Strings
       - :eql:func-desc:`str_reverse`
 
     * - :eql:func:`str_split`
-      - Split a string into an array using a delimiter.
+      - Splits a string into an array using a delimiter.
 
     * - :eql:func:`re_match`
       - :eql:func-desc:`re_match`
@@ -115,7 +115,7 @@ Strings
         {'I ❤️ EdgeDB'}
 
     Note that when a :eql:type:`str` is cast into a :eql:type:`json`,
-    the result is a JSON string value. Same applies for casting back
+    the result is a JSON string value. The same applies for casting back
     from :eql:type:`json` - only a JSON string value can be cast into
     a :eql:type:`str`:
 
@@ -133,8 +133,13 @@ Strings
 
     .. code-block:: edgeql-repl
 
-        db> select r'a raw \\\ string';
-        {'a raw \\\ string'}
+        db> select r'A raw \n string';
+        {'A raw \\n string'}
+        db> select 'Not a raw \n string';
+        {
+          'Not a raw
+         string',
+        }
         db> select $$something$$;
         {'something'}
         db> select $marker$something $$
@@ -185,8 +190,20 @@ Strings
 
     .. code-block:: edgeql-repl
 
-        db> select 'some text'[10];
-        InvalidValueError: string index 10 is out of bounds
+        db> select 'some text'[8];
+        {'x'}
+        db> select 'some text'[9];
+        InvalidValueError: string index 9 is out of bounds
+
+    A slice up to the next index can be used if an empty string is
+    preferred to an error when outside the bounds of the string:
+
+    .. code-block:: edgeql-repl
+
+        db> select 'some text'[8:9];
+        {'t'}
+        db> select 'some text'[9:10];
+        {''}
 
 
 ----------
@@ -307,7 +324,7 @@ Strings
 
 .. eql:function:: std::str_lower(string: str) -> str
 
-    Return a lowercase copy of the input *string*.
+    Returns a lowercase copy of the input string.
 
     .. code-block:: edgeql-repl
 
@@ -320,7 +337,7 @@ Strings
 
 .. eql:function:: std::str_upper(string: str) -> str
 
-    Return an uppercase copy of the input *string*.
+    Returns an uppercase copy of the input string.
 
     .. code-block:: edgeql-repl
 
@@ -333,9 +350,9 @@ Strings
 
 .. eql:function:: std::str_title(string: str) -> str
 
-    Return a titlecase copy of the input *string*.
+    Returns a titlecase copy of the input string.
 
-    Every word in the *string* will have the first letter capitalized
+    Every word in the string will have the first letter capitalized
     and the rest converted to lowercase.
 
     .. code-block:: edgeql-repl
@@ -350,10 +367,10 @@ Strings
 .. eql:function:: std::str_pad_start(string: str, n: int64, fill: str = ' ') \
                     -> str
 
-    Return the input *string* padded at the start to the length *n*.
+    Returns the input string padded at the start to the length *n*.
 
-    If the *string* is longer than *n*, then it is truncated to the
-    first *n* characters. Otherwise, the *string* is padded on the
+    If the string is longer than *n*, then it is truncated to the
+    first *n* characters. Otherwise, the string is padded on the
     left up to the total length *n* using *fill* characters (space by
     default).
 
@@ -373,10 +390,10 @@ Strings
 .. eql:function:: std::str_pad_end(string: str, n: int64, fill: str = ' ') \
                     -> str
 
-    Return the input *string* padded at the end to the length *n*.
+    Returns the input string padded at the end to the length *n*.
 
-    If the *string* is longer than *n*, then it is truncated to the
-    first *n* characters. Otherwise, the *string* is padded on the
+    If the string is longer than *n*, then it is truncated to the
+    first *n* characters. Otherwise, the string is padded on the
     right up to the total length *n* using *fill* characters (space by
     default).
 
@@ -395,11 +412,11 @@ Strings
 
 .. eql:function:: std::str_trim_start(string: str, trim: str = ' ') -> str
 
-    Return the input string with all *trim* characters removed from its start.
+    Returns the input string with all *trim* characters removed
+    from the start.
 
-    If the *trim* specifies more than one character they will be
-    removed from the beginning of the *string* regardless of the order
-    in which they appear.
+    If *trim* specifies more than one character they will be removed from
+    the beginning of the string regardless of the order in which they appear.
 
     .. code-block:: edgeql-repl
 
@@ -420,11 +437,10 @@ Strings
 
 .. eql:function:: std::str_trim_end(string: str, trim: str = ' ') -> str
 
-    Return the input string with all *trim* characters removed from its end.
+    Returns the input string with all *trim* characters removed from the end.
 
-    If the *trim* specifies more than one character they will be
-    removed from the end of the *string* regardless of the order
-    in which they appear.
+    If *trim* specifies more than one character they will be removed from
+    the end of the string regardless of the order in which they appear.
 
     .. code-block:: edgeql-repl
 
@@ -445,12 +461,12 @@ Strings
 
 .. eql:function:: std::str_trim(string: str, trim: str = ' ') -> str
 
-    Return the input string with *trim* characters removed from both ends.
+    Returns the input string with *trim* characters removed from both ends.
 
-    If the *trim* specifies more than one character they will be
-    removed from both ends of the *string* regardless of the order
-    in which they appear. This is the same as applying
-    :eql:func:`str_ltrim` and :eql:func:`str_rtrim`.
+    If *trim* specifies more than one character they will be removed from
+    both ends of the string regardless of the order in which they appear.
+    This is the same as applying 
+    :eql:func:`str_trim_start` and :eql:func:`str_trim_end`.
 
     .. code-block:: edgeql-repl
 
@@ -471,9 +487,9 @@ Strings
 
 .. eql:function:: std::str_repeat(string: str, n: int64) -> str
 
-    Repeat the input *string* *n* times.
+    Repeats the input string *n* times.
 
-    If *n* is zero or negative an empty string is returned.
+    An empty string is returned if *n* is zero or negative.
 
     .. code-block:: edgeql-repl
 
@@ -488,10 +504,10 @@ Strings
 
 .. eql:function:: std::str_replace(s: str, old: str, new: str) -> str
 
-    Replace all occurrences of *old* substring with the *new* one.
+    Replaces all occurrences of a substring with a new one.
 
-    Given a string *s* find all non-overlapping occurrences of the substring
-    *old* and replace them with the substring *new*.
+    Given a string *s*, finds all non-overlapping occurrences of the
+    substring *old* and replaces them with the substring *new*.
 
     .. code-block:: edgeql-repl
 
@@ -508,7 +524,7 @@ Strings
 
 .. eql:function:: std::str_reverse(string: str) -> str
 
-    Reverse the order of the characters in the string.
+    Reverses the order of the characters in the string.
 
     .. code-block:: edgeql-repl
 
@@ -525,7 +541,7 @@ Strings
 
     :index: split str_split explode
 
-    Split string into array elements using the supplied delimiter.
+    Splits a string into array elements using the supplied delimiter.
 
     .. code-block:: edgeql-repl
 
@@ -546,12 +562,12 @@ Strings
 
     :index: regex regexp regular
 
-    Find the first regular expression match in a string.
+    Finds the first regular expression match in a string.
 
-    Given an input *string* and a regular expression :ref:`pattern
-    <string_regexp>` find the first match for the regular expression
-    within the *string*. Return the match, each match represented by
-    an :eql:type:`array\<str\>` of matched groups.
+    Given an input string and a regular expression :ref:`pattern
+    <string_regexp>`, finds the first match for the regular expression
+    within the string. Each match returned is represented by an
+    :eql:type:`array\<str\>` of matched groups.
 
     .. code-block:: edgeql-repl
 
@@ -567,11 +583,11 @@ Strings
 
     :index: regex regexp regular
 
-    Find all regular expression matches in a string.
+    Finds all regular expression matches in a string.
 
-    Given an input *string* and a regular expression :ref:`pattern
-    <string_regexp>` repeatedly match the regular expression within
-    the *string*. Return the set of all matches, each match
+    Given an input string and a regular expression :ref:`pattern
+    <string_regexp>`, repeatedly matches the regular expression within
+    the string. Returns the set of all matches, with each match
     represented by an :eql:type:`array\<str\>` of matched groups.
 
     .. code-block:: edgeql-repl
@@ -590,19 +606,21 @@ Strings
 
     :index: regex regexp regular replace
 
-    Replace matching substrings in a given string.
+    Replaces matching substrings in a given string.
 
-    Given an input *string* and a regular expression :ref:`pattern
-    <string_regexp>` replace matching substrings with the replacement
-    string *sub*. Optional :ref:`flag <string_regexp_flags>` arguments
-    can be used to specify additional regular expression flags. Return
-    the string resulting from substring replacement.
+    Takes an input string and a regular expression :ref:`pattern
+    <string_regexp>`, replacing matching substrings with the replacement
+    string *sub*. Optional :ref:`flag arguments<string_regexp_flags>`
+    can be used to specify additional regular expression flags.
 
     .. code-block:: edgeql-repl
 
-        db> select re_replace(r'l', r'L', 'Hello World',
-        ...                   flags := 'g');
-        {'HeLLo WorLd'}
+        db> select re_replace('a', 'A', 'Alabama');
+        {'AlAbama'}
+        db> select re_replace('a', 'A', 'Alabama', flags := 'g');
+        {'AlAbAmA'}
+        db> select re_replace('A', 'A', 'Alabama', flags := 'ig');
+        {'AlAbAmA'}
 
 
 ----------
@@ -612,11 +630,11 @@ Strings
 
     :index: regex regexp regular match
 
-    Test if a regular expression has a match in a string.
+    Tests if a regular expression has a match in a string.
 
-    Given an input *string* and a regular expression :ref:`pattern
-    <string_regexp>` test whether there is a match for the regular
-    expression within the *string*. Return ``true`` if there is a
+    Given an input string and a regular expression :ref:`pattern
+    <string_regexp>`, tests whether there is a match for the regular
+    expression within the string. Returns ``true`` if there is a
     match, ``false`` otherwise.
 
     .. code-block:: edgeql-repl
@@ -645,12 +663,11 @@ Strings
 
     :index: stringify dumps join array_to_string decode TextDecoder
 
-    Return string representation of the input value.
+    Returns the string representation of the input value.
 
-    This is a very versatile polymorphic function that is defined for
-    many different input types. In general, there are corresponding
-    converter functions from :eql:type:`str` back to the specific
-    types, which share the meaning of the format argument *fmt*.
+    A versatile polymorphic function defined for different input types,
+    ``to_str`` uses corresponding converter functions from :eql:type:`str`
+    to specific types via the format argument *fmt*.
 
     When converting :eql:type:`bytes`, :eql:type:`datetime`,
     :eql:type:`cal::local_datetime`, :eql:type:`cal::local_date`,
@@ -694,7 +711,7 @@ Strings
         {'-123.45'}
 
     When converting :eql:type:`json`, this function can take
-    ``'pretty'`` as the optional *fmt* argument to produce a
+    ``'pretty'`` as an optional *fmt* argument to produce a
     pretty-formatted JSON string.
 
     See also :eql:func:`to_json`.
@@ -723,8 +740,8 @@ Strings
 
     .. warning::
 
-        There's a deprecated version of ``std::to_str`` which operates
-        on arrays, however :eql:func:`array_join` should be used instead.
+        A version of ``std::to_str`` exists which operates on arrays but has
+        been deprecated; :eql:func:`array_join` should be used instead.
 
 
 ----------
@@ -746,10 +763,9 @@ BRE, ERE, and ARE support can be found in `PostgreSQL documentation`_.
                 https://www.postgresql.org/docs/10/static/
                 functions-matching.html#POSIX-SYNTAX-DETAILS
 
-For convenience, here's a table outlining the different options
-accepted as the ``flags`` argument to various regular expression
-functions, or as `embedded options`_ in the pattern itself, e.g.
-``'(?i)fooBAR'``:
+The table below outlines the different options accepted as the ``flags``
+argument to various regular expression functions, or as
+`embedded options`_ in the pattern itself, e.g. ``'(?i)fooBAR'``:
 
 .. _`embedded options`:
   https://www.postgresql.org/docs/10/functions-matching.html#POSIX-METASYNTAX
@@ -773,7 +789,7 @@ Option  Description
 ``s``   non-newline-sensitive matching (default)
 ``t``   tight syntax (default)
 ``w``   inverse partial newline-sensitive ("weird") matching
-``x``   expanded syntax ignoring white-space characters
+``x``   expanded syntax ignoring whitespace characters
 ======  ==================================================================
 
 
@@ -808,8 +824,8 @@ Formatting
 
 
 Some of the type converter functions take an extra argument specifying
-the formatting (either for converting to a :eql:type:`str` or parsing
-from one). The different formatting options are collected in this section.
+formatting (either for converting to a :eql:type:`str` or parsing from one).
+The different formatting options are collected in this section.
 
 
 .. _ref_std_converters_datetime_fmt:
@@ -983,7 +999,7 @@ Some additional formatting modifiers:
 |               | usage notes)                      | Day           |
 +---------------+-----------------------------------+---------------+
 
-Normally when parsing a string input whitespace is ignored, unless
+Whitespace is normally ignored when parsing string input, unless
 the *FX* prefix modifier is used. For example:
 
 .. code-block:: edgeql-repl
@@ -1006,7 +1022,7 @@ Number formatting options
 +============+=====================================================+
 | 9          | digit position (can be dropped if insignificant)    |
 +------------+-----------------------------------------------------+
-| 0          | digit position (will not be dropped, even if        |
+| 0          | digit position (will not be dropped even if         |
 |            | insignificant)                                      |
 +------------+-----------------------------------------------------+
 | .          | (period)  decimal point                             |


### PR DESCRIPTION
Noticed today that this page could use some care.

Notable changes:

* Change to third person singular tense for the function intros ("Test if a string..." -> "Tests if a string...")
* Some extra examples, especially in re_replace - the `flags` parameter was new to me and inclarity on how to use it was what led me to notice this page
* General rewriting. One notable change is that I've removed all the instances of italics for *string*. Here the word *string* is italicized to indicate that it's a parameter name, but it feels awkward when reading as gives the impression of a type name when the type is actually *str*, plus the context I think is clear enough that any reader will know that string means the input string.
* The deprecated functions str_ltrim and str_rtrim are still referenced here so changed them. Don't see them anywhere else in the documentation now except to mention that they are deprecated.

The page looks good to me now but feel free to hop in and propose any other changes while the PR is open.