### PR TITLE
Elevate link prop insert, update, query docs to "Links" page

### DIFF
--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -586,13 +586,13 @@ a shape on the link.
 
 .. code-block:: edgeql-repl
 
-    edgedb> select Person {
-    .......   name,
-    .......   family_members: {
-    .......     name,
-    .......     @relationship
-    .......   }
-    ....... };
+    db> select Person {
+    ...   name,
+    ...   family_members: {
+    ...     name,
+    ...     @relationship
+    ...   }
+    ... };
     {
       default::Person {name: 'Alice', family_members: {}},
       default::Person {

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -538,7 +538,7 @@ property allows us to modify the link property of the existing link.
         # 🚫
         insert Movie {
           title := 'The Incredible Hulk',
-          actors := {(
+          characters := {(
               select Person {
                 @character_name := 'The Hulk'
               } filter .name = 'Mark Ruffalo'
@@ -560,12 +560,12 @@ property allows us to modify the link property of the existing link.
         # ✅
         insert Movie {
           title := 'The Incredible Hulk',
-          actors := assert_distinct((
-            with characters := {
+          characters := assert_distinct((
+            with actors := {
               ('The Hulk', 'Mark Ruffalo'),
               ('Abomination', 'Tim Roth')
             },
-            for character in characters union (
+            for actor in actors union (
               select Person {
                 @character_name := character.0
               } filter .name = character.1

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -497,7 +497,7 @@ linked object being added. Be sure to prepend the link property's name with
         }
         filter .name = "Alice"
       )
-    }
+    };
 
 The shape could alternatively be included on an insert if the object being
 linked (the ``Person`` named "Alice" in this example) is being inserted as part
@@ -522,7 +522,7 @@ already-established link between the two:
         }
         filter .name = "Alice"
       )
-    }
+    };
 
 Using ``select .family_members`` here with the shape including the link
 property allows us to modify the existing link's link property.

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -509,7 +509,7 @@ already-established link between the two:
 
 .. code-block:: edgeql
 
-    update Person {
+    update Person set {
       name := "Bob",
       family_members := (
         select .family_members {

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -453,6 +453,10 @@ the *nature/strength* of the relationship.
           }
         }
 
+.. note::
+
+    Link properties cannot be made required. They are always optional.
+
 Above, we model a family tree with a single ``Person`` type. The ``Person.
 family_members`` link is a many-to-many relation; each ``family_members`` link
 can contain a string ``relationship`` describing the relationship of the two
@@ -603,7 +607,9 @@ a shape on the link.
     In the query results above, Alice appears to have no family members even
     though we know that, if she is Bob's step-sister, he must be her
     step-brother. We would need to update Alice manually before this is
-    reflected in the database.
+    reflected in the database. Since link properties cannot be required, not
+    setting one is always allowed and results in the value being the empty set
+    (``{}``).
 
 .. note::
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -485,15 +485,15 @@ linked object being added. Be sure to prepend the link property's name with
 
 .. code-block:: edgeql
 
-  insert Person {
-    name := "Bob",
-    family_members := (
-      select detached Person {
-        @relationship := "sister"
-      }
-      filter .name = "Alice"
-    )
-  }
+    insert Person {
+      name := "Bob",
+      family_members := (
+        select detached Person {
+          @relationship := "sister"
+        }
+        filter .name = "Alice"
+      )
+    }
 
 The shape could alternatively be included on an insert if the object being
 linked (the ``Person`` named "Alice" in this example) is being inserted as part
@@ -509,15 +509,15 @@ already-established link between the two:
 
 .. code-block:: edgeql
 
-  update Person {
-    name := "Bob",
-    family_members := (
-      select .family_members {
-        @relationship := "step-sister"
-      }
-      filter .name = "Alice"
-    )
-  }
+    update Person {
+      name := "Bob",
+      family_members := (
+        select .family_members {
+          @relationship := "step-sister"
+        }
+        filter .name = "Alice"
+      )
+    }
 
 .. warning::
 
@@ -577,22 +577,22 @@ a shape on the link.
 
 .. code-block:: edgeql-repl
 
-  edgedb> select Person {
-  .......   name,
-  .......   family_members: {
-  .......     name,
-  .......     @relationship
-  .......   }
-  ....... };
-  {
-    default::Person {name: 'Alice', family_members: {}},
-    default::Person {
-      name: 'Bob',
-      family_members: {
-        default::Person {name: 'Alice', @relationship: 'step-sister'}
-      }
-    },
-  }
+    edgedb> select Person {
+    .......   name,
+    .......   family_members: {
+    .......     name,
+    .......     @relationship
+    .......   }
+    ....... };
+    {
+      default::Person {name: 'Alice', family_members: {}},
+      default::Person {
+        name: 'Bob',
+        family_members: {
+          default::Person {name: 'Alice', @relationship: 'step-sister'}
+        }
+      },
+    }
 
 .. note::
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -505,11 +505,12 @@ of the query. If the outer person ("Bob" in the example) already exists and
 only the links need to be added, this can be done in an ``update`` query
 instead of an ``insert`` as shown in the example above.
 
-Updating a link's link property is similar to adding a new one except you can
-select the link on the object instead of selecting from the object type since
-the link has already been established. Here, we've discovered that Alice is
-actually Bob's *step*-sister, so we want to change the link property on the
-already-established link between the two:
+Updating a link's property is similar to adding a new one except that you no
+longer need to select from the object type being linked: you can instead select
+the existing link on the object being updated because the link has already been
+established. Here, we've discovered that Alice is actually Bob's *step*-sister,
+so we want to change the link property on the already-established link between
+the two:
 
 .. code-block:: edgeql
 
@@ -525,7 +526,7 @@ already-established link between the two:
     };
 
 Using ``select .family_members`` here with the shape including the link
-property allows us to modify the existing link's link property.
+property allows us to modify the link property of the existing link.
 
 .. warning::
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -509,8 +509,9 @@ already-established link between the two:
 
 .. code-block:: edgeql
 
-    update Person set {
-      name := "Bob",
+    update Person
+    filter .name = "Bob"
+    set {
       family_members := (
         select .family_members {
           @relationship := "step-sister"

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -519,6 +519,9 @@ already-established link between the two:
       )
     }
 
+Using ``select .family_members`` here with the shape including the link
+property allows us to modify the existing link's link property.
+
 .. warning::
 
     A link property cannot be referenced in a set union *except* in the case of

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -254,9 +254,9 @@ same "shirt owner" relationship is represented with a ``multi`` link.
 
 .. note::
 
-  Don't forget the exclusive constraint! This is required to ensure that each
-  ``Shirt`` corresponds to a single ``Person``. Without it, the relationship
-  will be many-to-many.
+    Don't forget the exclusive constraint! This is required to ensure that each
+    ``Shirt`` corresponds to a single ``Person``. Without it, the relationship
+    will be many-to-many.
 
 Under the hood, a ``multi`` link is stored in an intermediate `association
 table <https://en.wikipedia.org/wiki/Associative_entity>`_, whereas a
@@ -600,9 +600,9 @@ a shape on the link.
 
 .. note::
 
-  For a full guide on modeling, inserting, updating, and querying link
-  properties, see the :ref:`Using Link Properties <ref_guide_linkprops>`
-  guide.
+    For a full guide on modeling, inserting, updating, and querying link
+    properties, see the :ref:`Using Link Properties <ref_guide_linkprops>`
+    guide.
 
 .. _ref_datamodel_link_deletion:
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -479,8 +479,9 @@ than spreading it across link and object properties.
 Inserting and updating link properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To insert a link property, add the link property to a shape on the linked
-object being added. Be sure to prepend the link property's name with ``@``.
+To add a link with a link property, add the link property to a shape on the
+linked object being added. Be sure to prepend the link property's name with
+``@``.
 
 .. code-block:: edgeql
 
@@ -494,15 +495,17 @@ object being added. Be sure to prepend the link property's name with ``@``.
     )
   }
 
-The shape could also be included on an insert if the object being linked (the
-``Person`` named "Alice" in this example) is being inserted as part of the
-query. If the outer person ("Bob" in the example) already exists and only the
-links need to be added, this can be done in an ``update`` query.
+The shape could alternatively be included on an insert if the object being
+linked (the ``Person`` named "Alice" in this example) is being inserted as part
+of the query. If the outer person ("Bob" in the example) already exists and
+only the links need to be added, this can be done in an ``update`` query
+instead of an ``insert`` as shown in the example above.
 
-Updating a link property is similar except you can select the link instead of
-selecting from the object type since the link has already been established.
-Here, we've discovered that Alice is actually Bob's step-sister, so we want to
-change the link property on the already-established link between the two:
+Updating a link's link property is similar to adding a new one except you can
+select the link on the object instead of selecting from the object type since
+the link has already been established. Here, we've discovered that Alice is
+actually Bob's *step*-sister, so we want to change the link property on the
+already-established link between the two:
 
 .. code-block:: edgeql
 

--- a/docs/guides/cheatsheet/link_properties.rst
+++ b/docs/guides/cheatsheet/link_properties.rst
@@ -187,6 +187,7 @@ Querying
 .. code-block:: edgeql-repl
 
   edgedb> select Person {
+  .......   name,
   .......   friends: {
   .......     name,
   .......     @strength


### PR DESCRIPTION
The information we have on link properties on the "Links" page doesn't currently give you enough to start using them. It has always seemed weird to me that information that is fundamental to using the feature is hidden away in a cheatsheet. I feel like a cheatsheet should be a place to catch interesting use cases but not for the foundational info the user needs to use the feature. Elevating that info as a result.

Closes #6124