### PR TITLE
Add PKCE to email+password flow

### DIFF
--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -128,6 +128,9 @@ class MultiTenantServer(server.BaseServer):
     def retrieve_tenant(self, sslobj) -> edbtenant.Tenant | None:
         return self._tenants_by_sslobj.pop(sslobj, None)
 
+    def iter_tenants(self) -> Iterator[edbtenant.Tenant]:
+        return iter(self._tenants.values())
+
     async def _before_start_servers(self) -> None:
         assert self._task_group is not None
         await self._task_group.__aenter__()

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -20,6 +20,7 @@
 import asyncio
 import datetime
 import http
+import http.cookies
 import json
 import logging
 import urllib.parse
@@ -73,7 +74,9 @@ class Router:
         try:
             match args:
                 case ("authorize",):
-                    query = request.url.query.decode("ascii")
+                    query = urllib.parse.parse_qs(
+                        request.url.query.decode("ascii")
+                    )
                     provider_name = _get_search_param(query, "provider")
                     redirect_to = _get_search_param(query, "redirect_to")
                     challenge = _get_search_param(query, "challenge")
@@ -106,7 +109,9 @@ class Router:
                             form_data, "error_description"
                         )
                     elif request.url.query is not None:
-                        query = request.url.query.decode("ascii")
+                        query = urllib.parse.parse_qs(
+                            request.url.query.decode("ascii")
+                        )
                         state = _maybe_get_search_param(query, "state")
                         code = _maybe_get_search_param(query, "code")
                         error = _maybe_get_search_param(query, "error")
@@ -186,13 +191,12 @@ class Router:
                     session_token = self._make_session_token(identity.id)
                     response.status = http.HTTPStatus.FOUND
                     response.custom_headers["Location"] = new_url
-                    response.custom_headers["Set-Cookie"] = (
-                        f"edgedb-session={session_token}; "
-                        f"HttpOnly; Secure; SameSite=Strict"
-                    )
+                    _set_cookie(response, "edgedb-session", session_token)
 
                 case ("token",):
-                    query = request.url.query.decode("ascii")
+                    query = urllib.parse.parse_qs(
+                        request.url.query.decode("ascii")
+                    )
                     code = _get_search_param(query, "code")
                     verifier = _get_search_param(query, "verifier")
 
@@ -333,10 +337,7 @@ class Router:
                             self.db, identity.id, maybe_challenge
                         )
                         session_token = self._make_session_token(identity.id)
-                        response.custom_headers["Set-Cookie"] = (
-                            f"edgedb-session={session_token}; "
-                            f"HttpOnly; Secure; SameSite=Strict"
-                        )
+                        _set_cookie(response, "edgedb-session", session_token)
                         if data.get("redirect_to") is not None:
                             response.status = http.HTTPStatus.FOUND
                             redirect_params = urllib.parse.urlencode(
@@ -491,7 +492,7 @@ class Router:
                         else:
                             raise ex
 
-                case ('reset_password', ):
+                case ('reset_password',):
                     data = self._get_data_from_request(request)
 
                     local_provider_name = data.get("provider")
@@ -520,10 +521,7 @@ class Router:
                         )
 
                         session_token = self._make_session_token(identity.id)
-                        response.custom_headers["Set-Cookie"] = (
-                            f"edgedb-session={session_token}; "
-                            f"HttpOnly; Secure; SameSite=Strict"
-                        )
+                        _set_cookie(response, "edgedb-session", session_token)
                         if data.get("redirect_to") is not None:
                             response.status = http.HTTPStatus.FOUND
                             redirect_params = urllib.parse.urlencode(
@@ -564,7 +562,7 @@ class Router:
                         else:
                             raise ex
 
-                case ('ui', 'signin',):
+                case ('ui', 'signin'):
                     ui_config = self._get_ui_config()
 
                     if ui_config is None:
@@ -576,17 +574,27 @@ class Router:
                             "ext::auth::AuthConfig::providers",
                             frozenset
                         )
-
                         if providers is None or len(providers) == 0:
                             raise errors.MissingConfiguration(
                                 'ext::auth::AuthConfig::providers',
                                 'No providers are configured'
                             )
 
-                        query = (
+                        query = urllib.parse.parse_qs(
                             request.url.query.decode("ascii")
-                            if request.url.query else ''
+                            if request.url.query
+                            else ''
                         )
+
+                        maybe_challenge = _get_pkce_challenge(
+                            response=response,
+                            cookies=request.cookies,
+                            query_dict=query,
+                        )
+                        if maybe_challenge is None:
+                            raise errors.InvalidData(
+                                'Missing "challenge" in register request'
+                            )
 
                         response.status = http.HTTPStatus.OK
                         response.content_type = b'text/html'
@@ -598,13 +606,14 @@ class Router:
                                 query, 'error'
                             ),
                             email=_maybe_get_search_param(query, 'email'),
+                            challenge=maybe_challenge,
                             app_name=ui_config.app_name,
                             logo_url=ui_config.logo_url,
                             dark_logo_url=ui_config.dark_logo_url,
                             brand_color=ui_config.brand_color,
                         )
 
-                case ('ui', 'signup',):
+                case ('ui', 'signup'):
                     ui_config = self._get_ui_config()
                     password_provider = (
                         self._get_password_provider()
@@ -619,10 +628,21 @@ class Router:
                             if ui_config else b'Auth UI not enabled'
                         )
                     else:
-                        query = (
+                        query = urllib.parse.parse_qs(
                             request.url.query.decode("ascii")
-                            if request.url.query else ''
+                            if request.url.query
+                            else ''
                         )
+
+                        maybe_challenge = _get_pkce_challenge(
+                            response=response,
+                            cookies=request.cookies,
+                            query_dict=query,
+                        )
+                        if maybe_challenge is None:
+                            raise errors.InvalidData(
+                                'Missing "challenge" in register request'
+                            )
 
                         response.status = http.HTTPStatus.OK
                         response.content_type = b'text/html'
@@ -634,13 +654,14 @@ class Router:
                                 query, 'error'
                             ),
                             email=_maybe_get_search_param(query, 'email'),
+                            challenge=maybe_challenge,
                             app_name=ui_config.app_name,
                             logo_url=ui_config.logo_url,
                             dark_logo_url=ui_config.dark_logo_url,
                             brand_color=ui_config.brand_color,
                         )
 
-                case ('ui', 'forgot-password',):
+                case ('ui', 'forgot-password'):
                     ui_config = self._get_ui_config()
                     password_provider = (
                         self._get_password_provider()
@@ -655,9 +676,10 @@ class Router:
                             if ui_config else b'Auth UI not enabled'
                         )
                     else:
-                        query = (
+                        query = urllib.parse.parse_qs(
                             request.url.query.decode("ascii")
-                            if request.url.query else ''
+                            if request.url.query
+                            else ''
                         )
 
                         response.status = http.HTTPStatus.OK
@@ -678,7 +700,7 @@ class Router:
                             brand_color=ui_config.brand_color,
                         )
 
-                case ('ui', 'reset-password',):
+                case ('ui', 'reset-password'):
                     ui_config = self._get_ui_config()
                     password_provider = (
                         self._get_password_provider()
@@ -693,9 +715,10 @@ class Router:
                             if ui_config else b'Auth UI not enabled'
                         )
                     else:
-                        query = (
+                        query = urllib.parse.parse_qs(
                             request.url.query.decode("ascii")
-                            if request.url.query else ''
+                            if request.url.query
+                            else ''
                         )
 
                         reset_token = _maybe_get_search_param(
@@ -808,7 +831,7 @@ class Router:
                 response=response,
                 status=http.HTTPStatus.INTERNAL_SERVER_ERROR,
                 message=str(ex),
-                ex_type=type(ex),
+                ex_type=edb_errors.InternalServerError,
             )
 
     def _get_callback_url(self) -> str:
@@ -978,13 +1001,15 @@ def _fail_with_error(
     response.status = status
 
 
-def _maybe_get_search_param(query: str, key: str) -> str | None:
-    params = urllib.parse.parse_qs(query).get(key)
+def _maybe_get_search_param(
+    query_dict: dict[str, list[str]], key: str
+) -> str | None:
+    params = query_dict.get(key)
     return params[0] if params else None
 
 
-def _get_search_param(query: str, key: str) -> str:
-    val = _maybe_get_search_param(query, key)
+def _get_search_param(query_dict: dict[str, list[str]], key: str) -> str:
+    val = _maybe_get_search_param(query_dict, key)
     if val is None:
         raise errors.InvalidData(f"Missing query parameter: {key}")
     return val
@@ -997,3 +1022,34 @@ def _maybe_get_form_field(
     if maybe_val is None:
         return None
     return maybe_val[0]
+
+
+def _get_pkce_challenge(
+    *,
+    response,
+    cookies: http.cookies.SimpleCookie,
+    query_dict: dict[str, list[str]]
+) -> str | None:
+    cookie_name = 'edgedb-pkce-challenge'
+    challenge: str | None = _maybe_get_search_param(query_dict, 'challenge')
+    if challenge is not None:
+        _set_cookie(response, cookie_name, challenge)
+    else:
+        if 'edgedb-pkce-challenge' in cookies:
+            challenge = cookies['edgedb-pkce-challenge'].value
+    return challenge
+
+
+def _set_cookie(
+    response: Any,
+    name: str,
+    value: str,
+    http_only: bool = True,
+    secure: bool = True,
+    same_site: str = "Strict",
+):
+    val: http.cookies.Morsel = http.cookies.SimpleCookie({name: value})[name]
+    val["httponly"] = http_only
+    val["secure"] = secure
+    val["samesite"] = same_site
+    response.custom_headers["Set-Cookie"] = val.OutputString()

--- a/edb/server/protocol/auth_ext/pkce.py
+++ b/edb/server/protocol/auth_ext/pkce.py
@@ -16,11 +16,25 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+import typing
 
+import asyncio
 import json
+import logging
 import dataclasses
 
+from edb.common import taskgroup
+from edb.ir import statypes
 from edb.server.protocol import execute
+
+if typing.TYPE_CHECKING:
+    from edb.server import server as edbserver
+    from edb.server import tenant as edbtenant
+
+
+logger = logging.getLogger("edb.server")
+VALIDITY = statypes.Duration.from_microseconds(10 * 60_000_000)  # 10 minutes
 
 
 @dataclasses.dataclass(repr=False)
@@ -108,9 +122,9 @@ async def get_by_id(db, id: str) -> PKCEChallenge:
             identity_id := .identity.id
         }
         filter .id = <uuid>$id
-        and (datetime_current() - .created_at) < <duration>'10 minutes';
+        and (datetime_current() - .created_at) < <duration>$validity;
         """,
-        variables={"id": id},
+        variables={"id": id, "validity": VALIDITY.to_backend_str()},
     )
 
     result_json = json.loads(r.decode())
@@ -130,3 +144,43 @@ async def delete(db, id: str) -> None:
 
     result_json = json.loads(r.decode())
     assert len(result_json) == 1
+
+
+async def _gc(tenant: edbtenant.Tenant):
+    try:
+        async with taskgroup.TaskGroup() as g:
+            for db in tenant.iter_dbs():
+                if "auth" in db.extensions:
+                    g.create_task(
+                        execute.parse_execute_json(
+                            db,
+                            """
+                            delete ext::auth::PKCEChallenge filter
+                                (datetime_of_statement() - .created_at) >
+                                <duration>$validity
+                            """,
+                            variables={"validity": VALIDITY.to_backend_str()},
+                        ),
+                    )
+    except Exception as ex:
+        logger.debug(
+            "GC of ext::auth::PKCEChallenge failed (instance: %s)",
+            tenant.get_instance_name(),
+            exc_info=ex,
+        )
+
+
+async def gc(server: edbserver.BaseServer):
+    while True:
+        try:
+            tasks = [
+                tenant.create_task(_gc(tenant), interruptable=False)
+                for tenant in server.iter_tenants()
+                if tenant.accept_new_tasks
+            ]
+            if tasks:
+                await asyncio.wait(tasks)
+        except Exception as ex:
+            logger.debug("GC of ext::auth::PKCEChallenge failed", exc_info=ex)
+        finally:
+            await asyncio.sleep(VALIDITY.to_microseconds() / 1_000_000.0)

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -37,6 +37,7 @@ def render_login_page(
     providers: frozenset,
     error_message: Optional[str] = None,
     email: Optional[str] = None,
+    challenge: str,
     # config
     redirect_to: str,
     app_name: Optional[str] = None,
@@ -57,7 +58,13 @@ def render_login_page(
 
     oauth_buttons = '\n'.join([
         f'''
-        <a href="authorize?provider={p.name}">
+        <a href="../authorize?provider={
+            p.name
+        }&redirect_to={
+            redirect_to
+        }&challenge={
+            challenge
+        }">
         {(
             '<img src="_static/icon_' + p.name[15:] + '.svg" alt="' +
             p.display_name+' Icon" />'
@@ -114,6 +121,7 @@ def render_login_page(
       <input type="hidden" name="redirect_on_failure" value="{
         base_path}/ui/signin" />
       <input type="hidden" name="redirect_to" value="{redirect_to}" />
+      <input type="hidden" name="challenge" value="{challenge}" />
 
       {_render_error_message(error_message)}
 
@@ -146,6 +154,7 @@ def render_signup_page(
     provider_name: str,
     error_message: Optional[str] = None,
     email: Optional[str] = None,
+    challenge: str,
     # config
     redirect_to: str,
     app_name: Optional[str] = None,
@@ -170,6 +179,7 @@ def render_signup_page(
       <input type="hidden" name="redirect_on_failure" value="{
         base_path}/ui/signup" />
       <input type="hidden" name="redirect_to" value="{redirect_to}" />
+      <input type="hidden" name="challenge" value="{challenge}" />
 
       <label for="email">Email</label>
       <input id="email" name="email" type="email" value="{email or ''}" />

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -34,6 +34,7 @@ cdef class HttpRequest:
         public bytes authorization
         public object params
         public object forwarded
+        public object cookies
 
 
 cdef class HttpResponse:

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -23,6 +23,7 @@ include "./consts.pxi"
 import asyncio
 import collections
 import http
+import http.cookies
 import re
 import ssl
 import urllib.parse
@@ -72,6 +73,7 @@ cdef class HttpRequest:
         self.authorization = b''
         self.content_type = b''
         self.forwarded = {}
+        self.cookies = http.cookies.SimpleCookie()
 
 
 cdef class HttpResponse:
@@ -231,6 +233,8 @@ cdef class HttpProtocol:
                 self.current_request.forwarded = {}
             forwarded_key = name[len(b'x-forwarded-'):]
             self.current_request.forwarded[forwarded_key] = value
+        elif name == b'cookie':
+            self.current_request.cookies.load(value.decode('ascii'))
 
     def on_body(self, body: bytes):
         self.current_request.body += body

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1356,3 +1356,7 @@ class Tenant(ha_base.ClusterProtocol):
     def get_compiler_args(self) -> dict[str, Any]:
         assert self._dbindex is not None
         return {"dbindex": self._dbindex}
+
+    def iter_dbs(self) -> Iterator[dbview.Database]:
+        if self._dbindex is not None:
+            yield from self._dbindex.iter_dbs()


### PR DESCRIPTION
In order to support the hosted UI, we also need the PKCE flow for email+password. This is just as well since it's slightly more secure anyway. That means that developers will need to implement PKCE even if they aren't using an OAuth provider.