### PR TITLE
Fix cardinality inference of polymorphic shape elements

### DIFF
--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1205,3 +1205,67 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         AT_MOST_ONE
         """
+
+    def test_edgeql_ir_card_inference_142(self):
+        """
+        select Named { [is Card].element }
+% OK %
+        element: AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_143(self):
+        """
+        select Named { element := [is Card].element }
+% OK %
+        element: AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_144(self):
+        """
+        select (
+          select assert_exists(Named) { [is Card].element } limit 1).element
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_145(self):
+        """
+        select Named { [is Named].name }
+% OK %
+        name: ONE
+        """
+
+    def test_edgeql_ir_card_inference_146(self):
+        """
+        select User { [is Named].name }
+% OK %
+        name: ONE
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "possibly an empty set returned")
+    def test_edgeql_ir_card_inference_147(self):
+        """
+        select Named { [is User].name }
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "possibly an empty set returned")
+    def test_edgeql_ir_card_inference_148(self):
+        """
+        select Named { name := [is User].name }
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "possibly an empty set returned")
+    def test_edgeql_ir_card_inference_149(self):
+        """
+        select Named { [is schema::Object].name }
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "possibly an empty set returned")
+    def test_edgeql_ir_card_inference_150(self):
+        """
+        select User { [is schema::Object].name }
+        """


### PR DESCRIPTION
We weren't properly accounting for the intersection when computing 
cardinality of shape elements like `[is User].element`. Note that fixing
this can break queries, since now if you write something like `Named { [is
User].name }`, we will correctly infer that the result card is optional and
we will error, since
`Named.name` is `required`.

The core issue here is that we grab the original pointer from the class
named in the polymorphic query, and then make a subtype of it that we
attach to our real view. This results in us inheriting its cardinality.

_normalize_view_ptr_expr is a pretty big tangle, and I have not improved it
today. I have an idea for a follow-up, though.

Fixes #6254.