### PR TITLE
Fix a protocol bug involving CONFIGURE INSTANCE

### DIFF
--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -92,7 +92,7 @@ async def execute(
         if query_unit.drop_db:
             await tenant.on_before_drop_db(query_unit.drop_db, dbv.dbname)
         if query_unit.system_config:
-            await execute_system_config(be_conn, dbv, query_unit)
+            await execute_system_config(be_conn, dbv, query_unit, state)
         else:
             config_ops = query_unit.config_ops
 
@@ -176,15 +176,16 @@ async def execute(
             dbv.set_state_serializer(state_serializer)
         if side_effects:
             signal_side_effects(dbv, side_effects)
-        if not dbv.in_tx() and not query_unit.tx_rollback:
+        if not dbv.in_tx() and not query_unit.tx_rollback and query_unit.sql:
             state = dbv.serialize_state()
             if state is not orig_state:
                 # In 3 cases the state is changed:
                 #   1. The non-tx query changed the state
                 #   2. The state is synced with dbview (orig_state is None)
                 #   3. We came out from a transaction (orig_state is None)
-                # Excluding one special case when the state is NOT changed:
+                # Excluding two special case when the state is NOT changed:
                 #   1. An orphan ROLLBACK command without a paring start tx
+                #   2. There was no SQL, so the state can't have been synced.
                 be_conn.last_state = state
     finally:
         if query_unit.drop_db:
@@ -381,9 +382,14 @@ async def execute_system_config(
     conn: pgcon.PGConnection,
     dbv: dbview.DatabaseConnectionView,
     query_unit: compiler.QueryUnit,
+    state: bytes,
 ):
     if query_unit.is_system_config:
         dbv.server.before_alter_system_config()
+
+    # Sync state
+    await conn.sql_fetch(b'select 1', state=state)
+
     if query_unit.sql:
         if len(query_unit.sql) > 1:
             raise errors.InternalServerError(

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -880,6 +880,7 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
     async def test_server_proto_configure_06(self):
+        con2 = None
         try:
             await self.con.execute('''
                 CONFIGURE SESSION SET singleprop := '42';
@@ -897,6 +898,11 @@ class TestServerConfig(tb.QueryTestCase):
                     '1', '2', '3'
                 ],
             )
+
+            con2 = await self.connect(database=self.con.dbname)
+            await con2.execute('''
+                start transaction
+            ''')
 
             await self.con.execute('''
                 CONFIGURE INSTANCE SET multiprop := {'4', '5'};
@@ -931,6 +937,8 @@ class TestServerConfig(tb.QueryTestCase):
             await self.con.execute('''
                 CONFIGURE INSTANCE RESET multiprop;
             ''')
+            if con2:
+                await con2.aclose()
 
     async def test_server_proto_configure_07(self):
         try:


### PR DESCRIPTION
CONFIGURE INSTANCE didn't sync the state to a connection but we still
indicated that it did on the pgcon. This could lead to state mismatch
issues.

Also fix another potential vector for such things that I don't think
is actually currently possible (op that changes state but runs no
sql).