### PR TITLE
Fix some regressions involving property defaults

### DIFF
--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from typing import *
 
+from edb import errors
+
 from edb.ir import ast as irast
 from edb.ir import utils as irutils
 
@@ -41,6 +43,10 @@ def compile_SelectStmt(
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
     if ctx.singleton_mode:
+        if not irutils.is_trivial_select(stmt):
+            raise errors.UnsupportedFeatureError(
+                'Clause on SELECT statement in simple expression')
+
         return dispatch.compile(stmt.result, ctx=ctx)
 
     parent_ctx = ctx

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5911,7 +5911,10 @@ class AlterProperty(PropertyMetaCommand, adapts=s_props.AlterProperty):
         if self.metadata_only:
             return schema
 
-        if not is_comp:
+        if (
+            not is_comp
+            and (src and has_table(src.scls, schema))
+        ):
             orig_def_val = self.get_pointer_default(prop, orig_schema, context)
             def_val = self.get_pointer_default(prop, schema, context)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2001,6 +2001,24 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 """
             )
 
+    async def test_edgeql_ddl_default_14(self):
+        await self.con.execute(r"""
+            create type X;
+            insert X;
+        """)
+
+        with self.assertRaisesRegex(
+            edgedb.MissingRequiredError,
+            'missing value for required property',
+        ):
+            await self.con.execute(r"""
+                alter type X {
+                    create required property foo -> str {
+                        set default := (select "!" filter false);
+                    }
+                };
+            """)
+
     async def test_edgeql_ddl_default_circular(self):
         await self.con.execute(r"""
             CREATE TYPE TestDefaultCircular {
@@ -2771,6 +2789,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     set default := '';
                 };
             };
+            # And that aliases don't either
+            create alias Alias := Foo;
         """)
 
         await self.con.execute(r"""


### PR DESCRIPTION
* Fix ISE on adding a default to a property when the type has an alias
   of it. Fixes #6261.
 * Fix miscompiling of defaults in database when a select with
   a clause is used. This was because the singleton-mode version
   of select compilation just ignored clauses silently.