### PR TITLE
Fix scope bugs in SET ... USING statements

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4864,7 +4864,7 @@ class PointerMetaCommand(
         root_uid = -1
         iter_uid = -2
         body_uid = -3
-        # scope tree wrapping is roughy equivalent to:
+        # scope tree wrapping is roughly equivalent to:
         # "(std::obj) uid:-1": {
         #   "BRANCH uid:-2",
         #   "FENCE uid:-3": { ... compiled scope children ... }
@@ -4876,7 +4876,9 @@ class PointerMetaCommand(
             unique_id=body_uid,
             fenced=True
         )
-        for child in ir.scope_tree.children:
+        # Need to make a copy of the children list because
+        # attach_child removes the node from the parent list.
+        for child in list(ir.scope_tree.children):
             scope_body.attach_child(child)
 
         scope_root = irast.ScopeTreeNode(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3243,6 +3243,23 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 ],
             )
 
+        # Something simple but forcing it to use assert_exists
+        async with self._run_and_rollback():
+            await self.con.execute("""
+                ALTER TYPE Foo ALTER PROPERTY p {
+                    SET REQUIRED USING (
+                        assert_exists((select '3' filter true)))
+                }
+            """)
+
+            await self.assert_query_result(
+                'SELECT Foo { p } ORDER BY .p',
+                [
+                    {'p': '1'},
+                    {'p': '3'},
+                ],
+            )
+
         # A reference to another property of the same host type.
         async with self._run_and_rollback():
             await self.con.execute("""


### PR DESCRIPTION
Because of an iteration/mutation issue, only some of the scope tree
nodes were being copied over to the new tree.

Fixes #6266.