### PR TITLE
Add OAuth providers to sign up hosted auth

### DIFF
--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -161,7 +161,7 @@ def render_login_page(
 def render_signup_page(
     *,
     base_path: str,
-    provider_name: str,
+    providers: frozenset,
     error_message: Optional[str] = None,
     email: Optional[str] = None,
     challenge: str,
@@ -172,6 +172,37 @@ def render_signup_page(
     dark_logo_url: Optional[str] = None,
     brand_color: Optional[str] = None
 ):
+    password_provider = None
+    for p in providers:
+        if p.name == 'builtin::local_emailpassword':
+            password_provider = p
+            break
+
+    oauth_providers = [
+        p for p in providers
+        if p.name.startswith('builtin::oauth_')
+    ]
+
+    oauth_params = {
+        'redirect_to': redirect_to,
+        'challenge': challenge,
+        'redirect_to_on_signup': redirect_to,
+    }
+
+    oauth_buttons = '\n'.join([
+        f'''
+        <a href="../authorize?{urllib.parse.urlencode({
+            'provider': p.name,
+            **oauth_params
+        })}">
+        {(
+            '<img src="_static/icon_' + p.name[15:] + '.svg" alt="' +
+            p.display_name+' Icon" />'
+        ) if p.name in known_oauth_provider_names else ''}
+        <span>Sign up with {p.display_name}</span>
+        </a>'''
+        for p in oauth_providers
+    ])
     return _render_base_page(
         title=f'Sign up{f" to {app_name}" if app_name else ""}',
         logo_url=logo_url,
@@ -184,8 +215,24 @@ def render_signup_page(
            if app_name else '<span>Sign up</span>'}</h1>
 
       {_render_error_message(error_message)}
-
-      <input type="hidden" name="provider" value="{provider_name}" />
+    {
+      f"""
+      <div class="oauth-buttons">
+        {oauth_buttons}
+      </div>""" if len(oauth_providers) > 0 else ''
+    }
+    {
+      """
+      <div class="divider">
+        <span>or</span>
+      </div>"""
+      if password_provider is not None
+        and len(oauth_providers) > 0
+      else ''
+    }
+    {
+      f"""
+      <input type="hidden" name="provider" value="{password_provider.name}" />
       <input type="hidden" name="redirect_on_failure" value="{
         base_path}/ui/signup" />
       <input type="hidden" name="redirect_to" value="{redirect_to}" />
@@ -203,6 +250,8 @@ def render_signup_page(
         Already have an account?
         <a href="signin">Sign in</a>
       </div>
+      </div>""" if password_provider is not None else ''
+    }
     </form>'''
     )
 


### PR DESCRIPTION
Add the OAuth provider buttons to the "Sign Up" hosted auth page.

Previously this page was disabled unless you had the password provider configured, but now we conditionally show you all of the providers, including the password provider.