### PR TITLE
Fix behavior when a property appears in multiple splats

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_10_10_00_00
+EDGEDB_CATALOG_VERSION = 2023_10_10_00_01
 EDGEDB_MAJOR_VERSION = 4
 
 

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -386,12 +386,12 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
     ) -> Tuple[dbops.Trigger, ...]:
         cname = constraint.raw_constraint_name()
 
-        ins_trigger_name = common.edgedb_name_to_pg_name(cname + '_instrigger')
+        ins_trigger_name = cname + '_instrigger'
         ins_trigger = dbops.Trigger(
             name=ins_trigger_name, table_name=table_name, events=('insert', ),
             procedure=proc_name, is_constraint=True, inherit=True)
 
-        upd_trigger_name = common.edgedb_name_to_pg_name(cname + '_updtrigger')
+        upd_trigger_name = cname + '_updtrigger'
         condition = constraint.get_trigger_condition()
 
         upd_trigger = dbops.Trigger(


### PR DESCRIPTION
Currently one applies and then the other is ignored. This was revealed
by #6255, since now some of those queries will error.

We take the pointer from the ancestor class. If the types don't have
an ancestor relationship, we error.