### PR TITLE
Reuse the same PKCE object when reusing challenge

### DIFF
--- a/edb/server/protocol/auth_ext/pkce.py
+++ b/edb/server/protocol/auth_ext/pkce.py
@@ -56,7 +56,8 @@ async def create(db, challenge: str):
         """
         insert ext::auth::PKCEChallenge {
             challenge := <str>$challenge,
-        }
+        } unless conflict on .challenge
+        else (select ext::auth::PKCEChallenge)
         """,
         variables={
             "challenge": challenge,


### PR DESCRIPTION
The most legitimate use case for this is in the hosted UI, you might go back and forth with a few providers before completing with one. In each case, it'll reuse the same `challenge` string since that is set up only once when doing the initial request to the hosted auth UI.

This doesn't seem to have any ill-effects from a security standpoint since the challenge itself is meant to be intercepted and in cleartext. And in order to use it, you need the verifier, which you will get at the end, but the `PKCEChallenge` wiill have already been deleted by then, so it will not expose the `Identity` that was made with it.