### PR TITLE
Fix a dependence on order in a trigger test

### DIFF
--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -1266,7 +1266,7 @@ class TestTriggers(tb.QueryTestCase):
             {"name": "old", "notes": {"f", "d!"}},
             {"name": "old", "notes": {"b", "a!"}},
             {"name": "old", "notes": {"c", "e"}},
-            {"name": "old", "notes": ["c!", "e!", "f!"]},
+            {"name": "old", "notes": {"c!", "e!", "f!"}},
         ])
 
         await self.assert_query_result(


### PR DESCRIPTION
One of the parts of the assert_query_result shape used a list
incorrect instead of a set.

This has failed in testing *once* that we've noticed, while running
tests for the v4.0a3 release. I just reran the tests there without
fixing it in a3, but we'll cherry-pick this fix for b1.