### PR TITLE
Fix compilation of explicit ids in inserts that can be empty

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -589,6 +589,8 @@ def _mk_dynamic_get_path(
         # This is used in rewrites to go back to the original
         if fallback_rvar:
             return fallback_rvar
+        if not rptr:
+            raise LookupError('only pointers appear in insert fallback')
         # Properties that aren't specified are {}
         return pgast.NullConstant()
     return dynamic_get_path

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -585,10 +585,6 @@ def can_omit_optional_wrapper(
     # cases. This is mainly an optimization for passing globals to
     # functions, where we need to convert a bunch of optional params
     # to json, and for casting out of json there and in schema updates.
-    #
-    # (FIXME: This also works around an obscure INSERT bug in which
-    # inserting values into `id` that need optional wrappers break.
-    # Since user code can't specify `id` at all, this is low prio.)
     if (
         isinstance(ir_set.expr, irast.TypeCast)
         and ((

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5708,7 +5708,7 @@ class TestInsert(tb.QueryTestCase):
 
         await self.con.execute('''
             INSERT Person {
-                id := <uuid>'ffffffff-ffff-ffff-ffff-ffffffffffff',
+                id := <uuid>to_json('"ffffffff-ffff-ffff-ffff-ffffffffffff"'),
                 name := "test",
              }
         ''')


### PR DESCRIPTION
Explicit ids in inserts that have nontrivial possibly empty
expressions would fail, because an interaction with optional wrapping
caused the id path to fall back to the identity of the source, which
the fallback rvar happily provided as NULL.

I ran across this bug in #3834, but hacked around it instead of fixing
it (the fix would have been totally different then, also), since
explicitly-specified `id`s were purely internal, so it wasn't
high-priority. Of course, two months later we added explicitly
specified ids.