### PR TITLE
Doc empty set operations

### DIFF
--- a/docs/edgeql/select.rst
+++ b/docs/edgeql/select.rst
@@ -102,19 +102,19 @@ And the following inserts:
 
 .. code-block:: edgeql-repl
 
-  db> insert Hero { 
+  db> insert Hero {
   ...   name := "Spider-Man",
-  ...   secret_identity := "Peter Parker" 
+  ...   secret_identity := "Peter Parker"
   ... };
   {default::Hero {id: 6be1c9c6...}}
 
-  db> insert Hero { 
-  ...   name := "Iron Man", 
-  ...   secret_identity := "Tony Stark" 
+  db> insert Hero {
+  ...   name := "Iron Man",
+  ...   secret_identity := "Tony Stark"
   ... };
   {default::Hero {id: 6bf7115a... }}
 
-  db> for n in { "Sandman", "Electro", "Green Goblin", "Doc Ock" } 
+  db> for n in { "Sandman", "Electro", "Green Goblin", "Doc Ock" }
   ...   union (
   ...     insert Villain {
   ...     name := n,
@@ -136,7 +136,7 @@ And the following inserts:
   db> insert Movie {
   ...  title := "Spider-Man: No Way Home",
   ...  release_year := 2021,
-  ...  characters := (select Person filter .name in 
+  ...  characters := (select Person filter .name in
   ...    { "Spider-Man", "Sandman", "Electro", "Green Goblin", "Doc Ock" })
   ...  };
   {default::Movie {id: 6c60c28a...}}
@@ -144,7 +144,7 @@ And the following inserts:
   db> insert Movie {
   ...  title := "Iron Man",
   ...  release_year := 2008,
-  ...  characters := (select Person filter .name in 
+  ...  characters := (select Person filter .name in
   ...   { "Iron Man", "Obadiah Stane" })
   ...  };
   {default::Movie {id: 6d1f430e...}}
@@ -403,8 +403,8 @@ with their names but also get any properties defined on the ``Hero`` for those
         secret_identity: 'Tony Stark'
       },
       default::Villain {
-        name: 'Sandman', 
-        id: 6c22bdf0-5c03-11ee-99ff-dfaea4d947ce, 
+        name: 'Sandman',
+        id: 6c22bdf0-5c03-11ee-99ff-dfaea4d947ce,
         secret_identity: {}
       },
       default::Villain {
@@ -440,33 +440,33 @@ properties and links on the specified type.
     ... };
     {
       default::Villain {
-        name: 'Sandman', 
+        name: 'Sandman',
         id: 6c22bdf0-5c03-11ee-99ff-dfaea4d947ce,
-        secret_identity: {}, 
+        secret_identity: {},
         villains: {}
       },
       default::Villain {
-        name: 'Electro', 
-        id: 6c22c3d6-5c03-11ee-99ff-734255881e5d, 
-        secret_identity: {}, 
+        name: 'Electro',
+        id: 6c22c3d6-5c03-11ee-99ff-734255881e5d,
+        secret_identity: {},
         villains: {}
       },
       default::Villain {
-        name: 'Green Goblin', 
-        id: 6c22c46c-5c03-11ee-99ff-c79f24cf638b, 
-        secret_identity: {}, 
+        name: 'Green Goblin',
+        id: 6c22c46c-5c03-11ee-99ff-c79f24cf638b,
+        secret_identity: {},
         villains: {}
       },
       default::Villain {
-        name: 'Doc Ock', 
-        id: 6c22c502-5c03-11ee-99ff-cbacc3918129, 
-        secret_identity: {}, 
+        name: 'Doc Ock',
+        id: 6c22c502-5c03-11ee-99ff-cbacc3918129,
+        secret_identity: {},
         villains: {}
       },
       default::Villain {
-        name: 'Obadiah Stane', 
-        id: 6c42c4ec-5c03-11ee-99ff-872c9906a467, 
-        secret_identity: {}, 
+        name: 'Obadiah Stane',
+        id: 6c42c4ec-5c03-11ee-99ff-872c9906a467,
+        secret_identity: {},
         villains: {}
       },
       default::Hero {
@@ -475,19 +475,19 @@ properties and links on the specified type.
         secret_identity: 'Peter Parker',
         villains: {
           default::Villain {
-            name: 'Electro', 
+            name: 'Electro',
             id: 6c22c3d6-5c03-11ee-99ff-734255881e5d
           },
           default::Villain {
-            name: 'Sandman', 
+            name: 'Sandman',
             id: 6c22bdf0-5c03-11ee-99ff-dfaea4d947ce
           },
           default::Villain {
-            name: 'Doc Ock', 
+            name: 'Doc Ock',
             id: 6c22c502-5c03-11ee-99ff-cbacc3918129
           },
           default::Villain {
-            name: 'Green Goblin', 
+            name: 'Green Goblin',
             id: 6c22c46c-5c03-11ee-99ff-c79f24cf638b
           },
         },
@@ -583,7 +583,7 @@ filter to both the selected ``Hero`` objects and their linked ``villains``.
   ... } filter .name ilike "%man";
   {
     default::Hero {
-      name: 'Spider-Man', 
+      name: 'Spider-Man',
       villains: {
         default::Villain {
           name: 'Doc Ock'
@@ -591,7 +591,7 @@ filter to both the selected ``Hero`` objects and their linked ``villains``.
       }
     },
     default::Hero {
-      name: 'Iron Man', 
+      name: 'Iron Man',
       villains: {
         default::Villain {
           name: 'Obadiah Stane'
@@ -680,7 +680,7 @@ ordering across pagination queries.
   ... offset 2
   ... limit 2;
   {
-    default::Villain {name: 'Obadiah Stane'}, 
+    default::Villain {name: 'Obadiah Stane'},
     default::Villain {name: 'Sandman'},
   }
 
@@ -873,8 +873,8 @@ Below, we use a subquery to select all movies containing a villain's nemesis.
   ... };
   {
     default::Villain {
-      name: 'Sandman', 
-      nemesis_name: 'Spider-Man', 
+      name: 'Sandman',
+      nemesis_name: 'Spider-Man',
       movies_with_nemesis: {
         default::Movie {title: 'Spider-Man: No Way Home'}
       }
@@ -930,9 +930,9 @@ abstract type (such as ``Movie.characters``) or a :eql:op:`union type
   ... filter .title = "Iron Man 2";
   {
     default::Movie {
-      title: 'Iron Man', 
+      title: 'Iron Man',
       characters: {
-        default::Villain {name: 'Obadiah Stane'}, 
+        default::Villain {name: 'Obadiah Stane'},
         default::Hero {name: 'Iron Man'}
       }
     }
@@ -959,17 +959,17 @@ by prefixing property/link references with ``[is <type>]``. This is known as a
   {
     ...
     default::Villain {
-      name: 'Obadiah Stane', 
-      secret_identity: {}, 
-      number_of_villains: 0, 
+      name: 'Obadiah Stane',
+      secret_identity: {},
+      number_of_villains: 0,
       nemesis: default::Hero {
         name: 'Iron Man'
       }
     },
     default::Hero {
-      name: 'Spider-Man', 
-      secret_identity: 'Peter Parker', 
-      number_of_villains: 4, 
+      name: 'Spider-Man',
+      secret_identity: 'Peter Parker',
+      number_of_villains: 4,
       nemesis: {}
     },
     ...
@@ -996,13 +996,13 @@ these cases, EdgeQL supports a shorthand.
   {
     ...
     default::Villain {
-      name: 'Obadiah Stane', 
-      secret_identity: {}, 
+      name: 'Obadiah Stane',
+      secret_identity: {},
       nemesis: default::Hero {name: 'Iron Man'}
     },
     default::Hero {
-      name: 'Spider-Man', 
-      secret_identity: 'Peter Parker', 
+      name: 'Spider-Man',
+      secret_identity: 'Peter Parker',
       nemesis: {}
     },
     ...
@@ -1071,10 +1071,10 @@ carries various information about the object's type, including its ``name``.
 
 .. code-block:: edgeql-repl
 
-    db> select <json>Person { 
+    db> select <json>Person {
     ...  __type__: {
-    ...    name 
-    ...    } 
+    ...    name
+    ...    }
     ...  } limit 1;
     {Json("{\"__type__\": {\"name\": \"default::Villain\"}}")}
 

--- a/docs/edgeql/select.rst
+++ b/docs/edgeql/select.rst
@@ -539,6 +539,14 @@ of the ``Villain`` type. In other words, we are in the **scope** of the
   ... filter .name = "Doc Ock";
   {default::Villain {name: 'Doc Ock'}}
 
+.. warning::
+
+    When using comparison operators like ``=`` or ``!=``, or boolean operators
+    ``and``, ``or``, and ``not``, keep in mind that these operators will
+    produce an empty set if an operand is an empty set. Check out :ref:`our
+    boolean cheatsheet <ref_cheatsheet_boolean>` for more info and help on how
+    to mitigate this if you know your operands may be an empty set.
+
 Learn to filter your queries by trying it in `our interactive filters
 tutorial </tutorial/basic-queries/config>`_.
 

--- a/docs/stdlib/bool.rst
+++ b/docs/stdlib/bool.rst
@@ -54,7 +54,9 @@ Booleans
         db> select (False, false, FALSE);
         {(false, false, false)}
 
-    These basic operators will always result in a boolean value:
+    These basic operators will always result in a boolean type value (although,
+    for some of them, that value may be the empty set if an operand is the
+    empty set):
 
     - :eql:op:`= <eq>`
     - :eql:op:`\!= <neq>`
@@ -69,7 +71,37 @@ Booleans
     - :eql:op:`like`
     - :eql:op:`ilike`
 
-    Some examples:
+    These operators will result in a boolean type value even if the right
+    operand is the empty set:
+
+    - :eql:op:`in`
+    - :eql:op:`not in <in>`
+
+    These operators will always result in a boolean ``true`` or ``false``
+    value, even if either operand is the empty set:
+
+    - :eql:op:`?= <coaleq>`
+    - :eql:op:`?!= <coalneq>`
+
+    These operators will produce the empty set if either operand is the empty
+    set:
+
+    - :eql:op:`= <eq>`
+    - :eql:op:`\!= <neq>`
+    - :eql:op:`\< <lt>`
+    - :eql:op:`\> <gt>`
+    - :eql:op:`\<= <lteq>`
+    - :eql:op:`\>= <gteq>`
+    - :eql:op:`like`
+    - :eql:op:`ilike`
+
+    If you need to use these operators and it's possible one or both operands
+    will be the empty set, you can ensure a ``bool`` product by
+    :eql:op:`coalescing <coalesce>`. With ``=`` and ``!=``, you can use their
+    respective dedicated coalescing operators, ``?=`` and ``?!=``. See each
+    individual operator for an example.
+
+    Some boolean operator examples:
 
     .. code-block:: edgeql-repl
 
@@ -109,6 +141,25 @@ Booleans
         db> select false or true;
         {true}
 
+    .. warning::
+
+        When either operand in an ``or`` is an empty set, the result will not
+        be a ``bool`` but instead an empty set.
+
+        .. code-block:: edgeql-repl
+
+            db> select true or <bool>{};
+            {}
+
+        If one of the operands in an ``or`` operation could be an empty set,
+        you may want to use the :eql:op:`coalesce` operator (``??``) on that
+        side to ensure you will still get a ``bool`` result.
+
+        .. code-block:: edgeql-repl
+
+            db> select true or (<bool>{} ?? false);
+            {true}
+
 
 ----------
 
@@ -122,6 +173,25 @@ Booleans
         db> select false and true;
         {false}
 
+    .. warning::
+
+        When either operand in an ``and`` is an empty set, the result will not
+        be a ``bool`` but instead an empty set.
+
+        .. code-block:: edgeql-repl
+
+            db> select true and <bool>{};
+            {}
+
+        If one of the operands in an ``and`` operation could be an empty set,
+        you may want to use the :eql:op:`coalesce` operator (``??``) on that
+        side to ensure you will still get a ``bool`` result.
+
+        .. code-block:: edgeql-repl
+
+            db> select true and (<bool>{} ?? false);
+            {false}
+
 
 ----------
 
@@ -134,6 +204,25 @@ Booleans
 
         db> select not false;
         {true}
+
+    .. warning::
+
+        When the operand in a ``not`` is an empty set, the result will not be a
+        ``bool`` but instead an empty set.
+
+        .. code-block:: edgeql-repl
+
+            db> select not <bool>{};
+            {}
+
+        If the operand in a ``not`` operation could be an empty set, you may
+        want to use the :eql:op:`coalesce` operator (``??``) on that side to
+        ensure you will still get a ``bool`` result.
+
+        .. code-block:: edgeql-repl
+
+            db> select not (<bool>{} ?? false);
+            {true}
 
 
 ----------

--- a/docs/stdlib/generic.rst
+++ b/docs/stdlib/generic.rst
@@ -70,6 +70,19 @@ Generic
         db> select 'hello' = 'world';
         {false}
 
+    .. warning::
+
+        When either operand in an equality comparison is an empty set, the
+        result will not be a ``bool`` but instead an empty set.
+
+        .. code-block:: edgeql-repl
+
+            db> select true = <bool>{};
+            {}
+
+        If one of the operands in an equality comparison could be an empty set,
+        you may want to use the :eql:op:`coalescing equality <coaleq>` operator
+        (``?=``) instead.
 
 ----------
 
@@ -93,6 +106,20 @@ Generic
         {false}
         db> select 'hello' != 'world';
         {true}
+
+    .. warning::
+
+        When either operand in an inequality comparison is an empty set, the
+        result will not be a ``bool`` but instead an empty set.
+
+        .. code-block:: edgeql-repl
+
+            db> select true != <bool>{};
+            {}
+
+        If one of the operands in an inequality comparison could be an empty
+        set, you may want to use the :eql:op:`coalescing inequality <coaleq>`
+        operator (``?!=``) instead.
 
 
 ----------


### PR DESCRIPTION
The goal here was to make some sort of note about this in any place the user might like to trip over it. Let me know if there are any good candidates I've missed. I stopped short of noting it on every page that discusses filtering — particularly ``update``, and ``delete`` — because we don't really discuss filtering at all on those pages, the assumption being, I think, that you learn about filtering from the ``select`` documentation. I think this is OK, but I could be convinced otherwise.

Even though the greater than/less than operators are also subject to this, I have decided not to add notes for them because I can't really think of a practical scenario where a user will trip over this with those particular operators. That could be more of a failure of my own imagination than a reflection of reality, so I'm open to dissenting opinions.

Closes #6115