### PR TITLE
Fix unused WITH DML when body is an INSERT

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1152,6 +1152,9 @@ def _infer_stmt_cardinality(
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
+    for part in (ir.bindings or []):
+        infer_cardinality(part, scope_tree=scope_tree, ctx=ctx)
+
     result = ir.subject if isinstance(ir, irast.MutatingStmt) else ir.result
     result_card = infer_cardinality(
         result,
@@ -1278,6 +1281,8 @@ def __infer_insert_stmt(
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
+    for part in (ir.bindings or []):
+        infer_cardinality(part, scope_tree=scope_tree, ctx=ctx)
 
     infer_cardinality(
         ir.subject, is_mutation=True, scope_tree=scope_tree, ctx=ctx

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -553,7 +553,7 @@ def _infer_stmt_multiplicity(
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
 ) -> inf_ctx.MultiplicityInfo:
-    # WITH block bindings need to be validated, they don't have to
+    # WITH block bindings need to be validated; they don't have to
     # have multiplicity UNIQUE, but their sub-expressions must be valid.
     for part in (ir.bindings or []):
         infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
@@ -649,6 +649,11 @@ def __infer_insert_stmt(
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
 ) -> inf_ctx.MultiplicityInfo:
+    # WITH block bindings need to be validated, they don't have to
+    # have multiplicity UNIQUE, but their sub-expressions must be valid.
+    for part in (ir.bindings or []):
+        infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
+
     # INSERT will always return a proper set, but we still want to
     # process the sub-expressions.
     infer_multiplicity(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -249,6 +249,35 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
+        await self.con.execute(r"""
+            with _ := (
+                INSERT InsertTest {
+                    name := 'insert simple 01',
+                    l2 := (select 1 filter true),
+                }
+            ),
+            INSERT InsertTest {
+                name := 'insert simple 01',
+                l2 := 2,
+            }
+        """)
+        await self.assert_query_result(
+            r"""
+                SELECT
+                    InsertTest {
+                        l2
+                    }
+                FILTER
+                    InsertTest.name = 'insert simple 01'
+                ORDER BY .l2
+            """,
+            [
+                {'l2': 0},
+                {'l2': 1},
+                {'l2': 2},
+            ]
+        )
+
     async def test_edgeql_insert_nested_01(self):
         await self.con.execute('''
             INSERT Subordinate {


### PR DESCRIPTION
The problem was cardinality inference wasn't getting run on it.  If
the body of the WITH was something other than an INSERT, cardinality
inference happened somewhat by accident, since multiplicity inference
was done properly.

Fixes #6279.