### PR TITLE
Fix some migration crashes due to missing source contexts

### DIFF
--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -143,7 +143,10 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def has_source_context(self):
         return FIELD_DETAILS in self._attrs
 
-    def set_source_context(self, context):
+    def set_source_context(self, context: Optional[pctx.ParserContext]):
+        if not context:
+            return
+
         start = context.start_point
         end = context.end_point
         ex.replace_context(self, context)


### PR DESCRIPTION
A None check was added by #5693, so just extract that.

Fixes #6187.