### PR TITLE
Fix configuring effective_io_concurrency

### DIFF
--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -625,11 +625,7 @@ def _compile_config_value(
 ) -> pgast.BaseExpr:
     val: pgast.BaseExpr
 
-    if op.backend_setting:
-        assert op.backend_expr is not None
-        expr = op.backend_expr
-    else:
-        expr = op.expr
+    expr = op.backend_expr or op.expr
 
     with ctx.new() as subctx:
         if op.backend_setting or op.scope == qltypes.ConfigScope.GLOBAL:

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1726,6 +1726,14 @@ class TestSeparateCluster(tb.TestCase):
                     cur_shared[0]
                 )
 
+                cur_eff = await c1.query_single('''
+                    select assert_single(cfg::Config.effective_io_concurrency)
+                ''')
+                await c1.query(f'''
+                    configure instance set
+                        effective_io_concurrency := {cur_eff}
+                ''')
+
                 await c1.aclose()
                 await c2.aclose()
                 await t1.aclose()


### PR DESCRIPTION
Configuring actual postgres backend settings only works for nontrivial
types like duration and memory, not simple ones like int.

I think the problem was introduced by cc5958c48.

Fixes #6109.