### PR TITLE
Fix type name injection on computed backlinks without a shape

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -328,9 +328,6 @@ def derive_ptr(
     if derive_backlink:
         attrs = attrs.copy() if attrs else {}
         attrs['computed_backlink'] = ptr
-        ntarget = ptr.get_source(ctx.env.schema)
-        assert isinstance(ntarget, s_types.Type)
-        target = ntarget
         ptr = ctx.env.schema.get('std::link', type=s_pointers.Pointer)
 
     ctx.env.schema, derived = ptr.derive_ref(

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -8223,3 +8223,12 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ''',
             __typenames__=True
         )
+
+    async def test_edgeql_type_pointer_backlink_01(self):
+        # Type injection on bare backlinks was broken in 3.x (#5930)
+        await self.con._fetchall(
+            r'''
+            select schema::Type {name, refs := .<target[is schema::Pointer]};
+            ''',
+            __typenames__=True
+        )


### PR DESCRIPTION
The support for computed backlinks in #5227 introduced a bug where
a computed backlink would have the material type as its target, not
the view into which `__tname__` had been injected, and so we wouldn't
report `__tname__` in our descriptor.

The root cause of this was that we were ignoring the ptr_target and
rederiving it from the source of the base pointer, which was losing
the shape. Not sure why we were doing that at all.

Fixes #5930