### PR TITLE
Fix renames of types with rewrites on them

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13418,6 +13418,33 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
             """DROP ALIAS Alias;""",
         )
 
+    async def test_edgeql_ddl_rename_ref_rewrites_01(self):
+        await self._simple_rename_ref_tests(
+            """
+                alter type Note create property rtest -> str {
+                    create rewrite update using (.note);
+                };
+            """,
+            """
+                alter type default::Note drop property rtest;
+            """,
+            type_refs=0,
+        )
+
+    async def test_edgeql_ddl_rename_ref_triggers_01(self):
+        await self._simple_rename_ref_tests(
+            """
+                alter type Note {
+                    create trigger log_new after insert, update for each
+                    do (__new__.note);
+                };
+            """,
+            """
+                alter type default::Note drop trigger log_new;
+            """,
+            type_refs=0,
+        )
+
     async def test_edgeql_ddl_describe_nested_module_01(self):
         await self.con.execute(r"""
             create module foo;


### PR DESCRIPTION
The mechanism for processing changes that affect expressions in the
schema (like renames to things used in expressions) was not correctly
initializing a context stack for the expression-containing objects it
modified. It had some custom code that created a context for the
outermost object it was processing, but this didn't work right for
more nested objects (an object type containing a pointer containing a
rewrite).

Fortunately init_delta_branch returns exactly the right context stack
to use, so just use it. (I think that this rename handling code
predates init_delta_branch doing this helpful thing.)