### PR TITLE
Fix use of UNLESS CONFLICT in triggers

### DIFF
--- a/edb/edgeql/compiler/normalization.py
+++ b/edb/edgeql/compiler/normalization.py
@@ -278,7 +278,7 @@ def normalize_InsertQuery(
         localnames=localnames,
     )
 
-    for field in ('shape',):
+    for field in ('shape', 'unless_conflict',):
         value = getattr(node, field, None)
         _normalize_recursively(
             node,

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -1142,6 +1142,10 @@ def trace_SortExpr(node: qlast.SortExpr, *, ctx: TracerContext) -> None:
 @trace.register
 def trace_InsertQuery(node: qlast.InsertQuery, *, ctx: TracerContext) -> None:
     with alias_context(ctx, node.aliases) as ctx:
+        if node.unless_conflict:
+            trace(node.unless_conflict[0], ctx=ctx)
+            trace(node.unless_conflict[1], ctx=ctx)
+
         tip = trace(qlast.Path(steps=[node.subject]), ctx=ctx)
         _update_path_prefix(tip, ctx=ctx)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3912,6 +3912,31 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_trigger_04(self):
+        schema = '''
+            type User {
+              trigger logInsert after insert for each do (
+                insert Log {
+                  user := __new__,
+                  action := 'Insert',
+                } unless conflict on .action else (
+                  insert BackupLog { user := __new__, action := '???' }
+                )
+              );
+            }
+
+            type Log {
+              required link user -> User;
+              required property action -> str { constraint exclusive; }
+            }
+            type BackupLog {
+              required link user -> User;
+              required property action -> str;
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_globals_funcs_01(self):
         schema = '''
             required global x1 -> int64 { default := 0 };

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3891,6 +3891,27 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_trigger_03(self):
+        schema = '''
+            type User {
+              trigger logInsert after insert for each do (
+                insert Log {
+                  user := __new__,
+                  action := 'Insert',
+                } unless conflict on .action else (
+                  update Log set { user := __new__ }
+                )
+              );
+            }
+
+            type Log {
+              required link user -> User;
+              required property action -> str { constraint exclusive; }
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_globals_funcs_01(self):
         schema = '''
             required global x1 -> int64 { default := 0 };


### PR DESCRIPTION
The bug was that normalization didn't process unless_conflict, so we
weren't getting module names in the DDL.

Fixes #6798.