### PR TITLE
Medium-sized rework of normalization

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -354,6 +354,10 @@ class Ptr(Base):
     direction: typing.Optional[str] = None
     type: typing.Optional[str] = None
 
+    @property
+    def name(self) -> str:
+        return self.ptr.name
+
 
 class Splat(Base):
     """Represents a splat operation (expansion to all props/links) in shapes"""
@@ -394,7 +398,9 @@ class IfElse(Expr):
 
 
 class TupleElement(Base):
-    name: ObjectRef
+    # This stores the name in another node instead of as a str just so
+    # that the name can have a separate source context.
+    name: Ptr
     val: Expr
 
 

--- a/edb/edgeql/compiler/eta_expand.py
+++ b/edb/edgeql/compiler/eta_expand.py
@@ -323,7 +323,7 @@ def eta_expand_tuple(
 
     els = [
         qlast.TupleElement(
-            name=qlast.ObjectRef(name=name),
+            name=qlast.Ptr(ptr=qlast.ObjectRef(name=name)),
             val=eta_expand(astutils.extend_path(path, name), subtype, ctx=ctx),
         )
         for name, subtype in stype.iter_subtypes(ctx.env.schema)

--- a/edb/edgeql/compiler/normalization.py
+++ b/edb/edgeql/compiler/normalization.py
@@ -96,7 +96,6 @@ def renormalize_compat(
 
 def _normalize_recursively(
     node: qlast.Base,
-    field: str,
     value: Any,
     *,
     schema: s_schema.Schema,
@@ -125,22 +124,65 @@ def _normalize_recursively(
 
 
 @normalize.register
-def normalize_Base(
+def normalize_generic(
     node: qlast.Base,
     *,
     schema: s_schema.Schema,
     modaliases: Mapping[Optional[str], str],
     localnames: AbstractSet[str] = frozenset(),
+    skip: Collection[str] = frozenset(),
 ) -> None:
     for field, value in base.iter_fields(node):
-        _normalize_recursively(
-            node,
-            field,
-            value,
-            schema=schema,
-            modaliases=modaliases,
-            localnames=localnames,
+        if field not in skip:
+            _normalize_recursively(
+                node,
+                value,
+                schema=schema,
+                modaliases=modaliases,
+                localnames=localnames,
+            )
+
+
+# This is the heart of the whole thing.
+@normalize.register
+def normalize_ObjectRef(
+    ref: qlast.ObjectRef,
+    *,
+    schema: s_schema.Schema,
+    modaliases: Mapping[Optional[str], str],
+    localnames: AbstractSet[str] = frozenset(),
+) -> None:
+    if ref.name not in localnames:
+        obj = schema.get(
+            s_utils.ast_ref_to_name(ref),
+            default=None,
+            module_aliases=modaliases,
         )
+        if obj is not None:
+            name = obj.get_name(schema)
+            assert isinstance(name, sn.QualName)
+            ref.module = name.module
+        elif ref.module in modaliases:
+            # Even if the name was not resolved in the
+            # schema it may be the name of the object
+            # being defined, as such the default module
+            # should be used. Names that must be ignored
+            # (like aliases and parameters) have already
+            # been filtered by the localnames.
+            ref.module = modaliases[ref.module]
+
+
+@normalize.register
+def normalize_Ptr(
+    ref: qlast.Ptr,
+    *,
+    schema: s_schema.Schema,
+    modaliases: Mapping[Optional[str], str],
+    localnames: AbstractSet[str] = frozenset(),
+) -> None:
+    # Make sure we don't normalize the ptr ObjectRef.
+    # (Why is it even an ObjectRef?)
+    pass
 
 
 @normalize.register
@@ -241,21 +283,20 @@ def normalize_SelectQuery(
         localnames=localnames,
     )
 
-    for field in ('where', 'orderby', 'offset', 'limit'):
-        value = getattr(node, field, None)
-        _normalize_recursively(
-            node,
-            field,
-            value,
-            schema=schema,
-            modaliases=modaliases,
-            localnames=localnames,
-        )
+    normalize_generic(
+        node,
+        schema=schema,
+        modaliases=modaliases,
+        localnames=localnames,
+        skip=('aliases', 'result'),
+    )
 
 
-@normalize.register
-def normalize_InsertQuery(
-    node: qlast.InsertQuery,
+@normalize.register(qlast.InsertQuery)
+@normalize.register(qlast.UpdateQuery)
+@normalize.register(qlast.DeleteQuery)
+def normalize_DML(
+    node: qlast.InsertQuery | qlast.UpdateQuery | qlast.DeleteQuery,
     *,
     schema: s_schema.Schema,
     modaliases: Mapping[Optional[str], str],
@@ -270,100 +311,13 @@ def normalize_InsertQuery(
         localnames=localnames,
     )
 
-    # Process the subject expression
-    _normalize_objref(
-        node.subject,
-        schema=schema,
-        modaliases=modaliases,
-        localnames=localnames,
-    )
-
-    for field in ('shape', 'unless_conflict',):
-        value = getattr(node, field, None)
-        _normalize_recursively(
-            node,
-            field,
-            value,
-            schema=schema,
-            modaliases=modaliases,
-            localnames=localnames,
-        )
-
-
-@normalize.register
-def normalize_UpdateQuery(
-    node: qlast.UpdateQuery,
-    *,
-    schema: s_schema.Schema,
-    modaliases: Mapping[Optional[str], str],
-    localnames: AbstractSet[str] = frozenset(),
-) -> None:
-
-    # Process WITH block
-    modaliases, localnames = _normalize_with_block(
+    normalize_generic(
         node,
         schema=schema,
         modaliases=modaliases,
         localnames=localnames,
+        skip=('aliases',),
     )
-
-    # Process the subject expression
-    localnames = _normalize_aliased_field(
-        node,
-        'subject',
-        schema=schema,
-        modaliases=modaliases,
-        localnames=localnames,
-    )
-
-    for field in ('where', 'shape',):
-        value = getattr(node, field, None)
-        _normalize_recursively(
-            node,
-            field,
-            value,
-            schema=schema,
-            modaliases=modaliases,
-            localnames=localnames,
-        )
-
-
-@normalize.register
-def normalize_DeleteQuery(
-    node: qlast.DeleteQuery,
-    *,
-    schema: s_schema.Schema,
-    modaliases: Mapping[Optional[str], str],
-    localnames: AbstractSet[str] = frozenset(),
-) -> None:
-
-    # Process WITH block
-    modaliases, localnames = _normalize_with_block(
-        node,
-        schema=schema,
-        modaliases=modaliases,
-        localnames=localnames,
-    )
-
-    # Process the subject expression
-    localnames = _normalize_aliased_field(
-        node,
-        'subject',
-        schema=schema,
-        modaliases=modaliases,
-        localnames=localnames,
-    )
-
-    for field in ('where', 'orderby', 'offset', 'limit'):
-        value = getattr(node, field, None)
-        _normalize_recursively(
-            node,
-            field,
-            value,
-            schema=schema,
-            modaliases=modaliases,
-            localnames=localnames,
-        )
 
 
 @normalize.register
@@ -392,13 +346,13 @@ def normalize_ForQuery(
         localnames=localnames,
     )
 
-    # Process the result expression
-    localnames = _normalize_aliased_field(
+    # Process the rest
+    normalize_generic(
         node,
-        'result',
         schema=schema,
         modaliases=modaliases,
         localnames=localnames,
+        skip=('aliases', 'iterator'),
     )
 
 
@@ -435,72 +389,17 @@ def normalize_GroupQuery(
         localnames=localnames,
     )
 
-    _normalize_recursively(
+    normalize_generic(
         node,
-        'by',
-        node.by,
         schema=schema,
         modaliases=modaliases,
         localnames=localnames,
+        skip=('aliases', 'subject', 'using'),
     )
 
 
-def _normalize_objref(
-    ref: qlast.ObjectRef,
-    *,
-    schema: s_schema.Schema,
-    modaliases: Mapping[Optional[str], str],
-    localnames: AbstractSet[str] = frozenset(),
-) -> None:
-    if ref.name not in localnames:
-        obj = schema.get(
-            s_utils.ast_ref_to_name(ref),
-            default=None,
-            module_aliases=modaliases,
-        )
-        if obj is not None:
-            name = obj.get_name(schema)
-            assert isinstance(name, sn.QualName)
-            ref.module = name.module
-        elif ref.module in modaliases:
-            # Even if the name was not resolved in the
-            # schema it may be the name of the object
-            # being defined, as such the default module
-            # should be used. Names that must be ignored
-            # (like aliases and parameters) have already
-            # been filtered by the localnames.
-            ref.module = modaliases[ref.module]
-
-
 @normalize.register
-def normalize_Path(
-    node: qlast.Path,
-    *,
-    schema: s_schema.Schema,
-    modaliases: Mapping[Optional[str], str],
-    localnames: AbstractSet[str] = frozenset(),
-) -> None:
-
-    for step in node.steps:
-        if isinstance(step, (qlast.Expr, qlast.TypeIntersection)):
-            normalize(
-                step,
-                schema=schema,
-                modaliases=modaliases,
-                localnames=localnames,
-            )
-        elif isinstance(step, qlast.ObjectRef):
-            # This is a specific path root, resolve it.
-            _normalize_objref(
-                step,
-                schema=schema,
-                modaliases=modaliases,
-                localnames=localnames,
-            )
-
-
-@normalize.register
-def compile_FunctionCall(
+def normalize_FunctionCall(
     node: qlast.FunctionCall,
     *,
     schema: s_schema.Schema,
@@ -555,51 +454,23 @@ def compile_TypeName(
     if isinstance(node.maintype, qlast.ObjectRef):
         # This is a specific path root, resolve it.
         if (
-                # maintype names 'array', 'tuple', 'range', and 'multirange'
-                # specifically should also be ignored
-                node.maintype.name not in {
-                    'array', 'tuple', 'range', 'multirange', *localnames
-                }
+            # maintype names 'array', 'tuple', 'range', and 'multirange'
+            # specifically should also be ignored
+            node.maintype.name not in {
+                'array', 'tuple', 'range', 'multirange',
+            }
         ):
-            maintype = schema.get(
-                s_utils.ast_ref_to_name(node.maintype),
-                default=None,
-                module_aliases=modaliases,
-            )
-
-            if maintype is not None:
-                name = maintype.get_name(schema)
-                assert isinstance(name, sn.QualName)
-                node.maintype.module = name.module
-            elif node.maintype.module in modaliases:
-                # Even if the name was not resolved in the schema it
-                # may be the name of the object being defined, as such
-                # the default module should be used. Names that must
-                # be ignored (like aliases and parameters) have
-                # already been filtered by the localnames.
-                node.maintype.module = modaliases[node.maintype.module]
-
-    if node.subtypes is not None:
-        for st in node.subtypes:
             normalize(
-                st,
+                node.maintype,
                 schema=schema,
                 modaliases=modaliases,
                 localnames=localnames,
             )
 
-
-@normalize.register
-def normalize_GlobalExpr(
-    node: qlast.GlobalExpr,
-    *,
-    schema: s_schema.Schema,
-    modaliases: Mapping[Optional[str], str],
-    localnames: AbstractSet[str] = frozenset(),
-) -> None:
-    _normalize_objref(
-        node.name,
+    normalize_generic(
+        node,
         schema=schema,
         modaliases=modaliases,
         localnames=localnames,
+        skip=('maintype',),
     )

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -2049,7 +2049,7 @@ def get_globals_as_json(
 
             main_param = subctx.create_anchor(param, 'a')
             tuple_el = qlast.TupleElement(
-                name=qlast.ObjectRef(name=name),
+                name=qlast.Ptr(ptr=qlast.ObjectRef(name=name)),
                 val=qlast.BinOp(
                     op='??',
                     left=qlast.TypeCast(expr=main_param, type=json_type),

--- a/edb/edgeql/compiler/tuple_args.py
+++ b/edb/edgeql/compiler/tuple_args.py
@@ -230,7 +230,8 @@ def _make_tuple(
     is_named = fields and fields[0][0]
     if is_named:
         return qlast.NamedTuple(elements=[
-            qlast.TupleElement(name=qlast.ObjectRef(name=not_none(f)), val=e)
+            qlast.TupleElement(name=qlast.Ptr(
+                ptr=qlast.ObjectRef(name=not_none(f))), val=e)
             for f, e in fields
         ])
     else:

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1490,7 +1490,7 @@ class NamedTuple(Nonterm):
 class NamedTupleElement(Nonterm):
     def reduce_ShortNodeName_ASSIGN_Expr(self, *kids):
         self.val = qlast.TupleElement(
-            name=kids[0].val,
+            name=qlast.Ptr(ptr=kids[0].val, context=kids[0].val.context),
             val=kids[2].val
         )
 


### PR DESCRIPTION
Rework the normalization pass to make it less likely to have bugs like https://github.com/edgedb/edgedb/issues/5798,
where I forgot to add `unless_conflict` to normalization *three years ago* and
it didn't get noticed until triggers allowed putting DML in the schema
again.

It's already the case that *most* nodes have a totally generic
normalize implementation, but nodes that have any special handling
currently need fully special handling.

Instead, make the generic normalize function take a list of fields to
*skip*, which lets nodes have custom handling for the fields that need
it and then generically process the rest. This lets us merge all the
DML statements, also.

Then, registering the normalizer for ObjectRef allows us to drop the
handlers for Global and Path (which incidentally fixes normalization
of splats with type names in them).

The one snag is that Ptr and TupleElement use ObjectRef to refer to a
name that isn't allowed to be qualified. For now I have fixed this by
having a no-op normalizer for Ptr and then making TupleElement use Ptr
instead of ObjectRef, but I think I am going to follow up by making
Ptr just have a str instead of an ObjectRef, which is something that's
annoyed me for a while.