### PR TITLE
Fix query_compilation metrics

### DIFF
--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -976,6 +976,7 @@ cdef class DatabaseConnectionView:
         self,
         query_req: QueryRequestInfo,
         cached_globally=False,
+        use_metrics=True,
     ) -> CompiledQuery:
         source = query_req.source
         if cached_globally:
@@ -1038,11 +1039,12 @@ cdef class DatabaseConnectionView:
             else:
                 self.cache_compiled_query(query_req, query_unit_group)
 
-        metrics.edgeql_query_compilations.inc(
-            1.0,
-            self.tenant.get_instance_name(),
-            'cache' if cached else 'compiler',
-        )
+        if use_metrics:
+            metrics.edgeql_query_compilations.inc(
+                1.0,
+                self.tenant.get_instance_name(),
+                'cache' if cached else 'compiler',
+            )
 
         return CompiledQuery(
             query_unit_group=query_unit_group,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1094,7 +1094,9 @@ cdef class DatabaseConnectionView:
                 )
         finally:
             metrics.edgeql_query_compilation_duration.observe(
-                time.monotonic() - started_at)
+                time.monotonic() - started_at,
+                self.tenant.get_instance_name(),
+            )
 
         unit_group, self._last_comp_state, self._last_comp_state_id = result
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1036,7 +1036,8 @@ cdef class DatabaseConnectionView:
 
         metrics.edgeql_query_compilations.inc(
             1.0,
-            'cache' if cached else 'compiler'
+            self.tenant.get_instance_name(),
+            'cache' if cached else 'compiler',
         )
 
         return CompiledQuery(

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -984,7 +984,11 @@ cdef class DatabaseConnectionView:
             # or anything from std schema, for example:
             #     YES:  select ext::auth::UIConfig { ... }
             #     NO:   select default::User { ... }
-            query_unit_group = self.server.system_compile_cache.get(query_req)
+            query_unit_group = (
+                self.server.system_compile_cache.get(query_req)
+                if self._query_cache_enabled
+                else None
+            )
         else:
             query_unit_group = self.lookup_compiled_query(query_req)
         cached = True

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -94,10 +94,11 @@ edgeql_query_compilations = registry.new_labeled_counter(
     labels=('tenant', 'path')
 )
 
-edgeql_query_compilation_duration = registry.new_histogram(
+edgeql_query_compilation_duration = registry.new_labeled_histogram(
     'edgeql_query_compilation_duration',
     'Time it takes to compile an EdgeQL query or script.',
     unit=prom.Unit.SECONDS,
+    labels=('tenant',),
 )
 
 background_errors = registry.new_labeled_counter(

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -91,7 +91,7 @@ idle_client_connections = registry.new_labeled_counter(
 edgeql_query_compilations = registry.new_labeled_counter(
     'edgeql_query_compilations_total',
     'Number of compiled/cached queries or scripts.',
-    labels=('path',)
+    labels=('tenant', 'path')
 )
 
 edgeql_query_compilation_duration = registry.new_histogram(

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -960,6 +960,9 @@ cdef class EdgeConnection(frontend.FrontendConnection):
                 if self._cancelled:
                     raise ConnectionAbortedError
             else:
+                metrics.edgeql_query_compilations.inc(
+                    1.0, self.get_tenant_label(), 'cache'
+                )
                 compiled = dbview.CompiledQuery(
                     query_unit_group=query_unit_group,
                     first_extra=query_req.source.first_extra(),
@@ -994,7 +997,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         if self.debug:
             self.debug_print('EXECUTE', query_req.source.text())
 
-        metrics.edgeql_query_compilations.inc(1.0, 'cache')
         force_script = any(x.needs_readback for x in query_unit_group)
         if (
             _dbview.in_tx_error()

--- a/edb/server/protocol/execute.pyi
+++ b/edb/server/protocol/execute.pyi
@@ -35,6 +35,7 @@ async def parse_execute_json(
     output_format: compiler.OutputFormat = compiler.OutputFormat.JSON,
     query_cache_enabled: Optional[bool] = None,
     cached_globally: bool = False,
+    use_metrics: bool = True,
 ) -> bytes:
     ...
 

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -478,6 +478,7 @@ async def parse_execute_json(
     output_format: compiler.OutputFormat = compiler.OutputFormat.JSON,
     query_cache_enabled: Optional[bool] = None,
     cached_globally: bool = False,
+    use_metrics: bool = True,
 ) -> bytes:
     # WARNING: only set cached_globally to True when the query is
     # strictly referring to only shared stable objects in user schema
@@ -504,7 +505,11 @@ async def parse_execute_json(
         allow_capabilities=compiler.Capability.MODIFICATIONS,
     )
 
-    compiled = await dbv.parse(query_req, cached_globally=cached_globally)
+    compiled = await dbv.parse(
+        query_req,
+        cached_globally=cached_globally,
+        use_metrics=use_metrics,
+    )
 
     pgcon = await tenant.acquire_pgcon(db.name)
     try:

--- a/edb/server/protocol/system_api.py
+++ b/edb/server/protocol/system_api.py
@@ -124,6 +124,7 @@ async def _ping(tenant):
         # pool is healthy.
         query_cache_enabled=False,
         cached_globally=True,
+        use_metrics=False,
     )
 
 


### PR DESCRIPTION
This is needed to fix the 60 queries/min idle cloud instance stats chart issue.

* Add tenant label to query_compilation metrics
* Fix a bug that the same query is counted twice when not cached
* Make globally cached queries honor the query_cache_enabled flag
* Add use_metrics option to avoid counting system API queries