### PR TITLE
Fix uuid->object casts in access policies in nested INSERTs

### DIFF
--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -420,6 +420,7 @@ class CompilerContextLevel(compiler.ContextLevel):
                 self.path_scope = collections.ChainMap()
                 self.rel_hierarchy = {}
                 self.scope_tree = prevlevel.scope_tree.root
+                self.volatility_ref = ()
 
                 self.disable_semi_join = frozenset()
                 self.force_optional = frozenset()


### PR DESCRIPTION
The problem was a stray volatility_ref from an enclosing context that
was showing up in an access policy enforcement CTE.  The
volatility_refs from enclosing contexts are never going to be valid in
a new CTE.

Fix this by making newrel() clear volatility_ref.

I have a pending follow-up patch that will clean up volatility_ref
management at existing newrel call sites.

Fixes #6305.