### PR TITLE
Make 'reference to a non-existent schema item <id>' an ISE

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1313,7 +1313,7 @@ class FlatSchema(Schema):
             sclass_name = self._id_to_type[obj_id]
         except KeyError:
             if default is so.NoDefault:
-                raise errors.InvalidReferenceError(
+                raise LookupError(
                     f'reference to a non-existent schema item {obj_id}'
                     f' in schema {self!r}'
                 ) from None
@@ -1322,7 +1322,7 @@ class FlatSchema(Schema):
         else:
             obj = so.Object.schema_restore((sclass_name, obj_id))
             if type is not None and not isinstance(obj, type):
-                raise errors.InvalidReferenceError(
+                raise TypeError(
                     f'schema object {obj_id!r} exists, but is a '
                     f'{obj.__class__.get_schema_class_displayname()!r}, '
                     f'not a {type.get_schema_class_displayname()!r}'


### PR DESCRIPTION
It is always a bug.