### PR TITLE
Clean up some volatility_ref related code

### DIFF
--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -82,19 +82,16 @@ def get_volatility_ref(
 
 def setup_iterator_volatility(
         iterator: Optional[Union[irast.Set, pgast.IteratorCTE]], *,
-        is_cte: bool=False,
         ctx: context.CompilerContextLevel) -> None:
     if iterator is None:
         return
-
-    old = () if is_cte else ctx.volatility_ref
 
     path_id = iterator.path_id
 
     # We use a callback scheme here to avoid inserting volatility ref
     # columns unless there is actually a volatile operation that
     # requires it.
-    ctx.volatility_ref = old + (
+    ctx.volatility_ref += (
         lambda stmt, xctx: get_volatility_ref(path_id, stmt, ctx=xctx),)
 
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1417,7 +1417,6 @@ def range_for_material_objtype(
             with ctx.newrel() as sctx:
                 sctx.pending_type_ctes.add(rw_key)
                 sctx.pending_query = sctx.rel
-                sctx.volatility_ref = ()
                 # Normally we want to compile type rewrites without
                 # polluting them with any sort of overlays, but when
                 # compiling triggers, we recompile all of the type

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3855,7 +3855,6 @@ def process_encoded_param(
     if (param_cte := ctx.param_ctes.get(param.name)) is None:
         with ctx.newrel() as sctx:
             sctx.pending_query = sctx.rel
-            sctx.volatility_ref = ()
             sctx.rel_overlays = context.RelOverlays()
             arg_ref = dispatch.compile(decoder, ctx=sctx)
 


### PR DESCRIPTION
Now that #6313 made newrel always clear volatility_ref, we can get rid
of a bunch of code that was doing that explicitly.