### PR TITLE
Store std schema and reflection schema in the same pickle

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_10_11_00_00
+EDGEDB_CATALOG_VERSION = 2023_10_19_00_00
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1404,13 +1404,10 @@ async def _init_stdlib(
     await _store_static_bin_cache(
         ctx,
         f'stdschema{version_key}',
-        pickle.dumps(schema, protocol=pickle.HIGHEST_PROTOCOL),
-    )
-
-    await _store_static_bin_cache(
-        ctx,
-        f'reflschema{version_key}',
-        pickle.dumps(stdlib.reflschema, protocol=pickle.HIGHEST_PROTOCOL),
+        pickle.dumps(
+            (schema, stdlib.reflschema),
+            protocol=pickle.HIGHEST_PROTOCOL,
+        ),
     )
 
     await _store_static_bin_cache(

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -865,12 +865,11 @@ def prepare_patch(
 
     if not global_schema_update:
         updates.update(dict(
-            stdschema=schema,
-            reflschema=reflschema,
+            std_and_reflection_schema=(schema, reflschema),
         ))
 
     bins = (
-        'stdschema', 'reflschema', 'global_schema', 'classlayout',
+        'std_and_reflection_schema', 'global_schema', 'classlayout',
         'report_configs_typedesc_1_0', 'report_configs_typedesc_2_0',
     )
     rawbin = (
@@ -1403,7 +1402,7 @@ async def _init_stdlib(
 
     await _store_static_bin_cache(
         ctx,
-        f'stdschema{version_key}',
+        f'std_and_reflection_schema{version_key}',
         pickle.dumps(
             (schema, stdlib.reflschema),
             protocol=pickle.HIGHEST_PROTOCOL,

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 from .compiler import Compiler, CompilerState
 from .compiler import CompileContext, CompilerDatabaseState
 from .compiler import compile_edgeql_script
-from .compiler import load_std_schema
 from .compiler import new_compiler, new_compiler_from_pg, new_compiler_context
 from .compiler import compile, compile_schema_storage_in_delta
 from .dbstate import QueryUnit, QueryUnitGroup
@@ -44,7 +43,6 @@ __all__ = (
     'OutputFormat',
     'analyze_explain_output',
     'compile_edgeql_script',
-    'load_std_schema',
     'new_compiler',
     'new_compiler_from_pg',
     'new_compiler_context',


### PR DESCRIPTION
The reflection schema is a thin modification of the std schema so them
sharing the same serialization container basically halves the memory
consumption of cached schema (saving about 20MiB).
