### PR TITLE
[4.x backport] Store std schema and reflection schema in the same pickle (#6317)

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -865,12 +865,11 @@ def prepare_patch(
 
     if not global_schema_update:
         updates.update(dict(
-            stdschema=schema,
-            reflschema=reflschema,
+            std_and_reflection_schema=(schema, reflschema),
         ))
 
     bins = (
-        'stdschema', 'reflschema', 'global_schema', 'classlayout',
+        'std_and_reflection_schema', 'global_schema', 'classlayout',
         'report_configs_typedesc_1_0', 'report_configs_typedesc_2_0',
     )
     rawbin = (
@@ -1401,16 +1400,14 @@ async def _init_stdlib(
     stdlib = stdlib._replace(stdschema=schema)
     version_key = patches.get_version_key(len(patches.PATCHES))
 
+    # stdschema and reflschema are combined in one pickle to preserve sharing
     await _store_static_bin_cache(
         ctx,
-        f'stdschema{version_key}',
-        pickle.dumps(schema, protocol=pickle.HIGHEST_PROTOCOL),
-    )
-
-    await _store_static_bin_cache(
-        ctx,
-        f'reflschema{version_key}',
-        pickle.dumps(stdlib.reflschema, protocol=pickle.HIGHEST_PROTOCOL),
+        f'std_and_reflection_schema{version_key}',
+        pickle.dumps(
+            (schema, stdlib.reflschema),
+            protocol=pickle.HIGHEST_PROTOCOL,
+        ),
     )
 
     await _store_static_bin_cache(

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 from .compiler import Compiler, CompilerState
 from .compiler import CompileContext, CompilerDatabaseState
 from .compiler import compile_edgeql_script
-from .compiler import load_std_schema
 from .compiler import new_compiler, new_compiler_from_pg, new_compiler_context
 from .compiler import compile, compile_schema_storage_in_delta
 from .dbstate import QueryUnit, QueryUnitGroup
@@ -44,7 +43,6 @@ __all__ = (
     'OutputFormat',
     'analyze_explain_output',
     'compile_edgeql_script',
-    'load_std_schema',
     'new_compiler',
     'new_compiler_from_pg',
     'new_compiler_context',

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -233,11 +233,12 @@ def new_compiler(
 async def new_compiler_from_pg(con: metaschema.PGConnection) -> Compiler:
     num_patches = await get_patch_count(con)
 
+    std_schema, reflection_schema = await load_std_and_reflection_schema(
+        con, num_patches)
+
     return new_compiler(
-        std_schema=await load_cached_schema(con, num_patches, 'stdschema'),
-        reflection_schema=await load_cached_schema(
-            con, num_patches, 'reflschema'
-        ),
+        std_schema=std_schema,
+        reflection_schema=reflection_schema,
         schema_class_layout=await load_schema_class_layout(
             con, num_patches
         ),
@@ -307,35 +308,49 @@ async def get_patch_count(backend_conn: metaschema.PGConnection) -> int:
     return res
 
 
-async def load_cached_schema(
+async def load_std_and_reflection_schema(
     backend_conn: metaschema.PGConnection,
     patches: int,
-    key: str,
-) -> s_schema.Schema:
+) -> tuple[s_schema.Schema, s_schema.Schema]:
     vkey = pg_patches.get_version_key(patches)
-    key += vkey
-    data = await backend_conn.sql_fetch_val(
-        b"""
-        SELECT bin FROM edgedbinstdata.instdata
-        WHERE key = $1
-        """,
-        args=[key.encode("utf-8")],
-    )
+
+    async def _fetch_schema(key: str) -> Optional[bytes]:
+        key = f"{key}{vkey}"
+        return await backend_conn.sql_fetch_val(
+            b"""
+            SELECT bin FROM edgedbinstdata.instdata
+            WHERE key = $1
+            """,
+            args=[key.encode("utf-8")],
+        )
+
+    # stdschema and reflschema are combined in one pickle to preserve sharing.
+    data = await _fetch_schema("std_and_reflection_schema")
+    # 4.0-beta.1 shipped before we merged stdschema and reflschema, so
+    # if std_and_reflection_schema is missing, fall back to loading
+    # stdschema and reflschema. (Which exists in instances created
+    # with 4.0-beta.1 but not in later versions.)
+    if not data:
+        std_data = await _fetch_schema("stdschema")
+        refl_data = await _fetch_schema("reflschema")
+
     try:
-        res: s_schema.FlatSchema = pickle.loads(data)
+        std_schema: s_schema.FlatSchema
+        refl_schema: s_schema.FlatSchema
+        if data:
+            std_schema, refl_schema = pickle.loads(data)
+        else:
+            assert std_data and refl_data
+            std_schema = pickle.loads(std_data)
+            refl_schema = pickle.loads(refl_data)
+
         if vkey != pg_patches.get_version_key(len(pg_patches.PATCHES)):
-            res = s_schema.upgrade_schema(res)
-        return res
+            std_schema = s_schema.upgrade_schema(std_schema)
+            refl_schema = s_schema.upgrade_schema(refl_schema)
+        return (std_schema, refl_schema)
     except Exception as e:
         raise RuntimeError(
             'could not load std schema pickle') from e
-
-
-async def load_std_schema(
-    backend_conn: metaschema.PGConnection,
-    patches: int,
-) -> s_schema.Schema:
-    return await load_cached_schema(backend_conn, patches, 'stdschema')
 
 
 async def load_schema_intro_query(


### PR DESCRIPTION
The reflection schema is a thin modification of the std schema so them sharing the same serialization container basically halves the memory consumption of cached schema (saving about 20MiB).

This backport needs to do a bit more work than the original: if std_and_reflection_schema is missing, we fall back to loading them separately.