### PR TITLE
Switch actions workflows to use releases/ instead of stable/

### DIFF
--- a/.github/workflows.src/tests-patches.tpl.yml
+++ b/.github/workflows.src/tests-patches.tpl.yml
@@ -7,11 +7,11 @@ on:
     inputs: {}
   pull_request:
     branches:
-      - stable/*
+      - releases/*
   push:
     branches:
       - patch-test*
-      - stable/*
+      - releases/*
 
 jobs:
   build:

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -7,7 +7,6 @@ on:
       - master
       - ci
       - "releases/*"
-      - "stable/*"
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -5,11 +5,11 @@ on:
     inputs: {}
   pull_request:
     branches:
-      - stable/*
+      - releases/*
   push:
     branches:
       - patch-test*
-      - stable/*
+      - releases/*
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,6 @@ on:
       - master
       - ci
       - "releases/*"
-      - "stable/*"
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
This is a forward port. I already directly pushed the change to
releases/4.x.