### PR TITLE
Add a special param token for normalization

### DIFF
--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -236,11 +236,13 @@ fn hash(text: &str) -> [u8; 64] {
     return result;
 }
 
-/// Produces tokens corresponding to (<module::typ>$var)
+/// Produces tokens corresponding to (<lit typ>$var)
 fn arg_type_cast(typ: &'static str, var: String, span: Span) -> Token<'static> {
+    // the `lit` is required so these tokens have different text than an actual
+    // type cast and parameter, so their hashes don't clash.
     Token {
         kind: Kind::ParameterAndType,
-        text: format!("<{typ}>{var}").into(),
+        text: format!("<lit {typ}>{var}").into(),
         value: None,
         span,
     }

--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use edgeql_parser::keywords::Keyword;
@@ -77,45 +76,45 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
                     Some(Token { kind: Kind::Keyword(Keyword("limit")), .. })))
             && tok.text != "9223372036854775808"
             => {
-                rewritten_tokens.extend(arg_type_cast( "__std__", "int64",
-                    next_var(),
-                    tok.span));
+                rewritten_tokens.push(arg_type_cast(
+                    "int64", next_var(), tok.span
+                ));
                 variables.push(Variable {
                     value: tok.value.clone().unwrap(),
                 });
                 continue;
             }
             Kind::FloatConst => {
-                rewritten_tokens.extend(arg_type_cast( "__std__", "float64",
-                    next_var(),
-                    tok.span));
+                rewritten_tokens.push(arg_type_cast(
+                    "float64", next_var(), tok.span
+                ));
                 variables.push(Variable {
                     value: tok.value.clone().unwrap(),
                 });
                 continue;
             }
             Kind::BigIntConst => {
-                rewritten_tokens.extend(arg_type_cast( "__std__", "bigint",
-                    next_var(),
-                    tok.span));
+                rewritten_tokens.push(arg_type_cast(
+                    "bigint", next_var(), tok.span
+                ));
                 variables.push(Variable {
                     value: tok.value.clone().unwrap(),
                 });
                 continue;
             }
             Kind::DecimalConst => {
-                rewritten_tokens.extend(arg_type_cast( "__std__", "decimal",
-                    next_var(),
-                    tok.span));
+                rewritten_tokens.push(arg_type_cast(
+                    "decimal", next_var(), tok.span
+                ));
                 variables.push(Variable {
                     value: tok.value.clone().unwrap(),
                 });
                 continue;
             }
             Kind::Str => {
-                rewritten_tokens.extend(arg_type_cast( "__std__", "str",
-                    next_var(),
-                    tok.span));
+                rewritten_tokens.push(arg_type_cast(
+                    "str", next_var(), tok.span
+                ));
                 variables.push(Variable {
                     value: tok.value.clone().unwrap(),
                 });
@@ -178,14 +177,15 @@ fn is_operator(token: &Token) -> bool {
         | DistinctFrom | Comma | OpenParen | CloseParen | OpenBracket | CloseBracket
         | OpenBrace | CloseBrace | Dot | Semicolon | Colon | Add | Sub | Mul | Div | Modulo
         | Pow | Less | Greater | Eq | Ampersand | Pipe | At => true,
-        DecimalConst | FloatConst | IntConst | BigIntConst | BinStr | Argument | Str
-        | BacktickName | Keyword(_) | Ident | Substitution | EOF | EOI | Epsilon | StartBlock
-        | StartExtension | StartFragment | StartMigration | StartSDLDocument => false,
+        DecimalConst | FloatConst | IntConst | BigIntConst | BinStr | Parameter
+        | ParameterAndType | Str | BacktickName | Keyword(_) | Ident | Substitution | EOF | EOI
+        | Epsilon | StartBlock | StartExtension | StartFragment | StartMigration
+        | StartSDLDocument => false,
     }
 }
 
 fn serialize_tokens(tokens: &[Token]) -> String {
-    use edgeql_parser::tokenizer::Kind::Argument;
+    use edgeql_parser::tokenizer::Kind::Parameter;
 
     let mut buf = String::new();
     let mut needs_space = false;
@@ -194,7 +194,7 @@ fn serialize_tokens(tokens: &[Token]) -> String {
             break;
         }
 
-        if needs_space && !is_operator(token) && token.kind != Argument {
+        if needs_space && !is_operator(token) && token.kind != Parameter {
             buf.push(' ');
         }
         buf.push_str(&token.text);
@@ -210,7 +210,7 @@ where
     let mut max_visited = None::<usize>;
     let mut names = BTreeSet::new();
     for t in tokens {
-        if t.kind == Kind::Argument {
+        if t.kind == Kind::Parameter {
             if let Ok(v) = t.text[1..].parse() {
                 if max_visited.map(|old| v > old).unwrap_or(true) {
                     max_visited = Some(v);
@@ -237,36 +237,13 @@ fn hash(text: &str) -> [u8; 64] {
 }
 
 /// Produces tokens corresponding to (<module::typ>$var)
-fn arg_type_cast(
-    module: &'static str,
-    typ: &'static str,
-    var: String,
-    span: Span,
-) -> [Token<'static>; 8] {
-    fn tk(kind: Kind, text: Cow<'_, str>, span: Span) -> Token {
-        let value = if kind == Kind::Ident {
-            Some(Value::String(text.to_string()))
-        } else {
-            None
-        };
-        Token {
-            kind,
-            text,
-            value,
-            span,
-        }
+fn arg_type_cast(typ: &'static str, var: String, span: Span) -> Token<'static> {
+    Token {
+        kind: Kind::ParameterAndType,
+        text: format!("<{typ}>{var}").into(),
+        value: None,
+        span,
     }
-
-    [
-        tk(Kind::OpenParen, "(".into(), span),
-        tk(Kind::Less, "<".into(), span),
-        tk(Kind::Ident, module.into(), span),
-        tk(Kind::Namespace, "::".into(), span),
-        tk(Kind::Ident, typ.into(), span),
-        tk(Kind::Greater, ">".into(), span),
-        tk(Kind::Argument, var.into(), span),
-        tk(Kind::CloseParen, ")".into(), span),
-    ]
 }
 
 #[cfg(test)]

--- a/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
@@ -27,7 +27,7 @@ fn test_int() {
         SELECT 1 + 2
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT <int64>$0+<int64>$1");
+        "SELECT <lit int64>$0+<lit int64>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(1),
@@ -44,7 +44,7 @@ fn test_str() {
         SELECT "x" + "yy"
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT <str>$0+<str>$1");
+        "SELECT <lit str>$0+<lit str>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::String("x".into()),
@@ -61,7 +61,7 @@ fn test_float() {
         SELECT 1.5 + 23.25
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT <float64>$0+<float64>$1");
+        "SELECT <lit float64>$0+<lit float64>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Float(1.5),
@@ -78,7 +78,7 @@ fn test_bigint() {
         SELECT 1n + 23n
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT <bigint>$0+<bigint>$1");
+        "SELECT <lit bigint>$0+<lit bigint>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::BigInt("1".into()),
@@ -95,7 +95,7 @@ fn test_bigint_exponent() {
         SELECT 1e10n + 23e13n
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT <bigint>$0+<bigint>$1");
+        "SELECT <lit bigint>$0+<lit bigint>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::BigInt(BigInt::from(10000000000u64).to_str_radix(16)),
@@ -112,7 +112,7 @@ fn test_decimal() {
         SELECT 1.33n + 23.77n
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT <decimal>$0+<decimal>$1");
+        "SELECT <lit decimal>$0+<lit decimal>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Decimal("1.33".parse().unwrap()),
@@ -128,7 +128,7 @@ fn test_positional() {
     let entry = normalize(r###"
         SELECT <int64>$0 + 2
     "###).unwrap();
-    assert_eq!(entry.processed_source, "SELECT<int64>$0+<int64>$1");
+    assert_eq!(entry.processed_source, "SELECT<int64>$0+<lit int64>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(2),
@@ -142,7 +142,7 @@ fn test_named() {
         SELECT <int64>$test_var + 2
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT<int64>$test_var+<int64>$__edb_arg_1");
+        "SELECT<int64>$test_var+<lit int64>$__edb_arg_1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(2),
@@ -156,7 +156,7 @@ fn test_limit_1() {
         SELECT User { one := 1 } LIMIT 1
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT User{one:=<int64>$0}LIMIT 1");
+        "SELECT User{one:=<lit int64>$0}LIMIT 1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(1),
@@ -170,7 +170,7 @@ fn test_tuple_access() {
         SELECT User { one := 2, two := .field.2, three := .field  . 3 }
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT User{one:=<int64>$0,\
+        "SELECT User{one:=<lit int64>$0,\
                      two:=.field.2,three:=.field.3}");
     assert_eq!(entry.variables, vec![vec![
         Variable {
@@ -187,8 +187,8 @@ fn test_script() {
     "###).unwrap();
     assert_eq!(
         entry.processed_source,
-        "SELECT <int64>$0+<int64>$1;\
-        SELECT <int64>$2;",
+        "SELECT <lit int64>$0+<lit int64>$1;\
+        SELECT <lit int64>$2;",
     );
     assert_eq!(entry.variables, vec![
         vec![
@@ -216,7 +216,7 @@ fn test_script_with_args() {
     "###).unwrap();
     assert_eq!(
         entry.processed_source,
-        "SELECT <int64>$2+$1;SELECT$1+<int64>$3;",
+        "SELECT <lit int64>$2+$1;SELECT$1+<lit int64>$3;",
     );
     assert_eq!(entry.variables, vec![
         vec![

--- a/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
@@ -27,7 +27,7 @@ fn test_int() {
         SELECT 1 + 2
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT(<__std__::int64>$0)+(<__std__::int64>$1)");
+        "SELECT <int64>$0+<int64>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(1),
@@ -44,7 +44,7 @@ fn test_str() {
         SELECT "x" + "yy"
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT(<__std__::str>$0)+(<__std__::str>$1)");
+        "SELECT <str>$0+<str>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::String("x".into()),
@@ -61,7 +61,7 @@ fn test_float() {
         SELECT 1.5 + 23.25
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT(<__std__::float64>$0)+(<__std__::float64>$1)");
+        "SELECT <float64>$0+<float64>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Float(1.5),
@@ -78,7 +78,7 @@ fn test_bigint() {
         SELECT 1n + 23n
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT(<__std__::bigint>$0)+(<__std__::bigint>$1)");
+        "SELECT <bigint>$0+<bigint>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::BigInt("1".into()),
@@ -95,7 +95,7 @@ fn test_bigint_exponent() {
         SELECT 1e10n + 23e13n
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT(<__std__::bigint>$0)+(<__std__::bigint>$1)");
+        "SELECT <bigint>$0+<bigint>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::BigInt(BigInt::from(10000000000u64).to_str_radix(16)),
@@ -112,7 +112,7 @@ fn test_decimal() {
         SELECT 1.33n + 23.77n
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT(<__std__::decimal>$0)+(<__std__::decimal>$1)");
+        "SELECT <decimal>$0+<decimal>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Decimal("1.33".parse().unwrap()),
@@ -128,7 +128,7 @@ fn test_positional() {
     let entry = normalize(r###"
         SELECT <int64>$0 + 2
     "###).unwrap();
-    assert_eq!(entry.processed_source, "SELECT<int64>$0+(<__std__::int64>$1)");
+    assert_eq!(entry.processed_source, "SELECT<int64>$0+<int64>$1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(2),
@@ -142,7 +142,7 @@ fn test_named() {
         SELECT <int64>$test_var + 2
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT<int64>$test_var+(<__std__::int64>$__edb_arg_1)");
+        "SELECT<int64>$test_var+<int64>$__edb_arg_1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(2),
@@ -156,7 +156,7 @@ fn test_limit_1() {
         SELECT User { one := 1 } LIMIT 1
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT User{one:=(<__std__::int64>$0)}LIMIT 1");
+        "SELECT User{one:=<int64>$0}LIMIT 1");
     assert_eq!(entry.variables, vec![vec![
         Variable {
             value: Value::Int(1),
@@ -170,7 +170,7 @@ fn test_tuple_access() {
         SELECT User { one := 2, two := .field.2, three := .field  . 3 }
     "###).unwrap();
     assert_eq!(entry.processed_source,
-        "SELECT User{one:=(<__std__::int64>$0),\
+        "SELECT User{one:=<int64>$0,\
                      two:=.field.2,three:=.field.3}");
     assert_eq!(entry.variables, vec![vec![
         Variable {
@@ -187,8 +187,8 @@ fn test_script() {
     "###).unwrap();
     assert_eq!(
         entry.processed_source,
-        "SELECT(<__std__::int64>$0)+(<__std__::int64>$1);\
-        SELECT(<__std__::int64>$2);",
+        "SELECT <int64>$0+<int64>$1;\
+        SELECT <int64>$2;",
     );
     assert_eq!(entry.variables, vec![
         vec![
@@ -216,7 +216,7 @@ fn test_script_with_args() {
     "###).unwrap();
     assert_eq!(
         entry.processed_source,
-        "SELECT(<__std__::int64>$2)+$1;SELECT$1+(<__std__::int64>$3);",
+        "SELECT <int64>$2+$1;SELECT$1+<int64>$3;",
     );
     assert_eq!(entry.variables, vec![
         vec![

--- a/edb/edgeql-parser/src/parser.rs
+++ b/edb/edgeql-parser/src/parser.rs
@@ -688,7 +688,8 @@ fn get_token_kind(token_name: &str) -> Kind {
         ":=" => Assign,
         "-=" => SubAssign,
 
-        "ARGUMENT" => Argument,
+        "PARAMETER" => Parameter,
+        "PARAMETERANDTYPE" => ParameterAndType,
         "SUBSTITUTION" => Substitution,
 
         _ => {

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -111,7 +111,7 @@ pub enum Kind {
     Pipe,            // |
     At,              // @
     Parameter,       // $something, $`something`
-    ParameterAndType,// <int>$something
+    ParameterAndType,// <lit int>$something
     DecimalConst,
     FloatConst,
     IntConst,

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -110,7 +110,8 @@ pub enum Kind {
     Ampersand,       // &
     Pipe,            // |
     At,              // @
-    Argument,        // $something, $`something`
+    Parameter,       // $something, $`something`
+    ParameterAndType,// <int>$something
     DecimalConst,
     FloatConst,
     IntConst,
@@ -527,7 +528,7 @@ impl<'a> Tokenizer<'a> {
                                             "backtick-quoted argument cannot be empty",
                                         ));
                                     }
-                                    return Ok((Argument, idx + 1));
+                                    return Ok((Parameter, idx + 1));
                                 }
                                 check_prohibited(c, false)?;
                             }
@@ -588,7 +589,7 @@ impl<'a> Tokenizer<'a> {
                         )));
                     }
                 }
-                return Ok((Argument, end_idx));
+                return Ok((Parameter, end_idx));
             }
             '\\' => match iter.next() {
                 Some((_, '(')) => {

--- a/edb/edgeql-parser/src/validation.rs
+++ b/edb/edgeql-parser/src/validation.rs
@@ -142,7 +142,7 @@ pub fn parse_value(token: &Token) -> Result<Option<Value>, String> {
     use Kind::*;
     let text = &token.text;
     let string_value = match token.kind {
-        Argument => {
+        Parameter => {
             if text[1..].starts_with('`') {
                 text[2..text.len() - 1].replace("``", "`")
             } else {

--- a/edb/edgeql-parser/tests/tokenizer.rs
+++ b/edb/edgeql-parser/tests/tokenizer.rs
@@ -560,7 +560,7 @@ fn tuple_paths() {
     assert_eq!(tok_str("$0.1.2.3.4.5"),
         ["$0", ".", "1", ".", "2", ".", "3", ".", "4", ".", "5"]);
     assert_eq!(tok_typ("$0.1.2.3.4.5"),
-        [Argument, Dot, IntConst, Dot, IntConst,
+        [Parameter, Dot, IntConst, Dot, IntConst,
                 Dot, IntConst, Dot, IntConst, Dot, IntConst]);
     assert_eq!(tok_err("tup.1n"),
         "unexpected char \'n\', only integers \
@@ -797,20 +797,20 @@ fn test_dollar() {
         ["select", "$a", "+", "b", ";", "$b", "test",
          ";", "$a", "+", "b", ";", "$b", ";"]);
     assert_eq!(tok_typ("select $a+b; $b test; $a+b; $b ;"),
-        [keyword("select"), Argument, Add, Ident, Semicolon, Argument, Ident,
-         Semicolon, Argument, Add, Ident, Semicolon, Argument, Semicolon]);
+        [keyword("select"), Parameter, Add, Ident, Semicolon, Parameter, Ident,
+         Semicolon, Parameter, Add, Ident, Semicolon, Parameter, Semicolon]);
     assert_eq!(tok_str("select $def x$y test; $def x$y"),
         ["select", "$def", "x", "$y", "test",
          ";", "$def", "x", "$y"]);
     assert_eq!(tok_typ("select $def x$y test; $def x$y"),
-        [keyword("select"), Argument, Ident, Argument, Ident,
-         Semicolon, Argument, Ident, Argument]);
+        [keyword("select"), Parameter, Ident, Parameter, Ident,
+         Semicolon, Parameter, Ident, Parameter]);
     assert_eq!(tok_str("select $`x``y` + $0 + $`zz` + $1.2 + $фыва"),
         ["select", "$`x``y`", "+", "$0", "+", "$`zz`", "+", "$1", ".", "2",
          "+", "$фыва"]);
     assert_eq!(tok_typ("select $`x``y` + $0 + $`zz` + $1.2 + $фыва"),
-        [keyword("select"), Argument, Add, Argument, Add, Argument,
-         Add, Argument, Dot, IntConst, Add, Argument]);
+        [keyword("select"), Parameter, Add, Parameter, Add, Parameter,
+         Add, Parameter, Dot, IntConst, Add, Parameter]);
     assert_eq!(tok_err(r#"$-"#),
         "bare $ is not allowed");
     assert_eq!(tok_err(r#"$0abc"#),

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -241,7 +241,7 @@ class FuncDeclArgName(Nonterm):
         self.val = dp.val
         self.context = dp.context
 
-    def reduce_ARGUMENT(self, dp):
+    def reduce_PARAMETER(self, dp):
         if dp.val[1].isdigit():
             raise EdgeQLSyntaxError(
                 f'numeric parameters are not supported',

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1553,8 +1553,8 @@ class Constant(Nonterm):
         self.val = qlast.Parameter(name=param.val[1:])
 
     def reduce_PARAMETERANDTYPE(self, param):
-        text: str = param.val[1:]
-        type_name, param_name = text.removeprefix('<').split('>$')
+        assert param.val.startswith('<lit ')
+        type_name, param_name = param.val.removeprefix('<lit ').split('>$')
         self.val = qlast.TypeCast(
             type=qlast.TypeName(
                 maintype=qlast.ObjectRef(

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1535,14 +1535,27 @@ class ExprList(ListNonterm, element=Expr, separator=tokens.T_COMMA):
 
 
 class Constant(Nonterm):
-    # ARGUMENT
+    # PARAMETER
     # | BaseNumberConstant
     # | BaseStringConstant
     # | BaseBooleanConstant
     # | BaseBytesConstant
 
-    def reduce_ARGUMENT(self, *kids):
-        self.val = qlast.Parameter(name=kids[0].val[1:])
+    def reduce_PARAMETER(self, param):
+        self.val = qlast.Parameter(name=param.val[1:])
+
+    def reduce_PARAMETERANDTYPE(self, param):
+        text: str = param.val[1:]
+        type_name, param_name = text.removeprefix('<').split('>$')
+        self.val = qlast.TypeCast(
+            type=qlast.TypeName(
+                maintype=qlast.ObjectRef(
+                    name=type_name,
+                    module='__std__'
+                )
+            ),
+            expr=qlast.Parameter(name=param_name),
+        )
 
     @parsing.inline(0)
     def reduce_BaseNumberConstant(self, *kids):
@@ -1805,14 +1818,14 @@ class FuncCallArgExpr(Nonterm):
             kids[2].val,
         )
 
-    def reduce_ARGUMENT_ASSIGN_Expr(self, *kids):
+    def reduce_PARAMETER_ASSIGN_Expr(self, *kids):
         if kids[0].val[1].isdigit():
             raise errors.EdgeQLSyntaxError(
-                f"numeric named arguments are not supported",
+                f"numeric named parameters are not supported",
                 context=kids[0].context)
         else:
             raise errors.EdgeQLSyntaxError(
-                f"named arguments do not need a '$' prefix, "
+                f"named parameters do not need a '$' prefix, "
                 f"rewrite as '{kids[0].val[1:]} := ...'",
                 context=kids[0].context)
 

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -164,8 +164,13 @@ class T_AT(Token, lextoken='@'):
     pass
 
 
-class T_ARGUMENT(Token):
+class T_PARAMETER(Token):
     pass
+
+
+class T_PARAMETERANDTYPE(Token):
+    pass
+    "A special token produced by normalization"
 
 
 class T_ASSIGN(Token, lextoken=':='):

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -169,7 +169,6 @@ class T_PARAMETER(Token):
 
 
 class T_PARAMETERANDTYPE(Token):
-    pass
     "A special token produced by normalization"
 
 

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -169,7 +169,8 @@ class T_PARAMETER(Token):
 
 
 class T_PARAMETERANDTYPE(Token):
-    "A special token produced by normalization"
+    # A special token produced by normalization
+    pass
 
 
 class T_ASSIGN(Token, lextoken=':='):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -18,7 +18,6 @@
 
 
 import re
-from typing import Optional
 import unittest  # NOQA
 
 from edb import errors
@@ -3588,7 +3587,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"named arguments do not need a '\$' prefix, "
+                  r"named parameters do not need a '\$' prefix, "
                   r"rewrite as 'a := \.\.\.'",
                   line=2, col=25)
     def test_edgeql_syntax_function_08(self):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -18,12 +18,14 @@
 
 
 import re
+from typing import Optional
 import unittest  # NOQA
 
 from edb import errors
 
 from edb.testbase import lang as tb
 from edb.edgeql import generate_source as edgeql_to_source
+from edb.edgeql import tokenizer
 from edb.edgeql.parser import grammar as qlgrammar
 from edb.tools import test
 
@@ -6193,3 +6195,35 @@ aa';
 % OK %
         DESCRIBE INSTANCE CONFIG AS DDL;
         """
+
+
+class TestEdgeQLNormalization(EdgeQLSyntaxTest):
+
+    def _run_test(self, *, source, spec=None, expected=None):
+        super()._run_test(
+            source=tokenizer.NormalizedSource.from_string(source),
+            spec=spec,
+            expected=expected
+        )
+
+    def assert_equal(
+        self,
+        expected,
+        result,
+        *,
+        re_filter: str | None = None,
+        message: str | None = None
+    ) -> None:
+        pass
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=25)
+    def test_edgeql_normalization_01(self):
+        '''
+        select count(foo 1);
+        '''
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=22)
+    def test_edgeql_normalization_02(self):
+        '''
+        select count 1;
+        '''


### PR DESCRIPTION
When working on the parser, I had a test case:
```
select count(foo 1);
```
... which should report a missing comma.
But when issuing that to the server, I got an error saying `InvalidReferenceError: function 'default::foo' does not exist`. That's because we do query "normalization", where the literals are extracted and replaced with params:

```
select count(foo (<int>$1);
```

... which is syntactically valid EdgeQL

... which is not good.

So this PR creates a new special token without textual representation that's produced during normalization, so literals don't expand to something that messes up parsing.