### PR TITLE
Experiment with UNION-less FOR

### DIFF
--- a/edb/edgeql-parser/src/parser/custom_errors.rs
+++ b/edb/edgeql-parser/src/parser/custom_errors.rs
@@ -219,7 +219,20 @@ impl<'s> Parser<'s> {
                 && self.compare_stack(
                     &[
                         Cond::keyword("for"),
-                        Cond::Production("OptionalOptional"),
+                        Cond::Production("Identifier"),
+                        Cond::keyword("in"),
+                    ],
+                    i,
+                    ctx,
+                )
+            {
+                return Some((i + 3, ParserRule::ForIterator));
+            }
+            if !found_union
+                && self.compare_stack(
+                    &[
+                        Cond::keyword("for"),
+                        Cond::keyword("optional"),
                         Cond::Production("Identifier"),
                         Cond::keyword("in"),
                     ],

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -159,23 +159,45 @@ class GroupingElementList(
     pass
 
 
-class OptionalOptional(Nonterm):
-    def reduce_OPTIONAL(self, *kids):
-        self.val = True
-
-    def reduce_empty(self, *kids):
-        self.val = False
-
-
 class SimpleFor(Nonterm):
     def reduce_For(self, *kids):
-        r"%reduce FOR OptionalOptional Identifier IN AtomicExpr \
+        r"%reduce FOR Identifier IN AtomicExpr \
                   UNION Expr"
+        _, alias, _, iterator, _, result = kids
         self.val = qlast.ForQuery(
-            optional=kids[1].val,
-            iterator_alias=kids[2].val,
-            iterator=kids[4].val,
-            result=kids[6].val,
+            iterator_alias=alias.val,
+            iterator=iterator.val,
+            result=result.val,
+        )
+
+    def reduce_ForOpt(self, *kids):
+        r"%reduce FOR OPTIONAL Identifier IN AtomicExpr \
+                  UNION Expr"
+        _, _, alias, _, iterator, _, result = kids
+        self.val = qlast.ForQuery(
+            optional=True,
+            iterator_alias=alias.val,
+            iterator=iterator.val,
+            result=result.val,
+        )
+
+    def reduce_For2(self, *kids):
+        r"%reduce FOR Identifier IN AtomicExpr Set"
+        _, alias, _, iterator, result = kids
+        self.val = qlast.ForQuery(
+            iterator_alias=alias.val,
+            iterator=iterator.val,
+            result=result.val,
+        )
+
+    def reduce_ForOpt2(self, *kids):
+        r"%reduce FOR OPTIONAL Identifier IN AtomicExpr Set"
+        _, _, alias, _, iterator, result = kids
+        self.val = qlast.ForQuery(
+            optional=True,
+            iterator_alias=alias.val,
+            iterator=iterator.val,
+            result=result.val,
         )
 
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3431,6 +3431,49 @@ aa';
         FOR x in <datetime>'1999-03-31T15:17:00Z' UNION x;
         """
 
+    def test_edgeql_syntax_barefor_01(self):
+        """
+        FOR x in ({1,2} + {3,4}) { x };
+
+% OK %
+
+        FOR x in ({1,2} + {3,4}) UNION { x };
+        """
+
+    def test_edgeql_syntax_barefor_02(self):
+        """
+        FOR x IN {(('Alice', 'White') UNION ('Bob', 'Green'))}
+        {(
+            SELECT User{first_tname, last_name, age}
+            FILTER (
+                (.first_name = x.0)
+                AND
+                (.last_name = x.1)
+            )
+        )};
+
+% OK %
+
+        FOR x IN {(('Alice', 'White') UNION ('Bob', 'Green'))} UNION
+        {(
+            SELECT User{first_tname, last_name, age}
+            FILTER (
+                (.first_name = x.0)
+                AND
+                (.last_name = x.1)
+            )
+        )};
+        """
+
+    def test_edgeql_syntax_barefor_03(self):
+        """
+        FOR x in ({1,2} + {3,4}) { x, 2 };
+
+% OK %
+
+        FOR x in ({1,2} + {3,4}) UNION { x, 2 };
+        """
+
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   'Missing parentheses around complex expression in a '
                   'FOR iterator clause',


### PR DESCRIPTION
Elvis suggested we try dropping the UNION from FOR. When I tried
dropping it and requiring just a ParenExpr, I was sucked into a rabbit
hole of apparent bugs in our parser that I haven't followed up on yet.

But it *does* work with braces... Thoughts?