### PR TITLE
Fix UPDATE with rewrites on tuples

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1984,6 +1984,7 @@ def process_update_shape(
             and updvalue is not None
         ):
             with ctx.newscope() as scopectx:
+                scopectx.expr_exposed = False
                 val: pgast.BaseExpr
 
                 if irtyputils.is_tuple(element.typeref):

--- a/tests/test_edgeql_rewrites.py
+++ b/tests/test_edgeql_rewrites.py
@@ -953,3 +953,28 @@ class TestRewrites(tb.QueryTestCase):
             'select Person { first_name }',
             [{'first_name': 'updated'}],
         )
+
+    async def test_edgeql_rewrites_24(self):
+        await self.con.execute(
+            '''
+            create type X {
+                create property tup -> tuple<int64, str> {
+                    create rewrite insert, update using ((1, '2'));
+                };
+            };
+            insert X;
+            '''
+        )
+        await self.assert_query_result(
+            'select X { tup }',
+            [{'tup': (1, '2')}],
+        )
+        await self.con.execute(
+            '''
+            update X set {};
+            '''
+        )
+        await self.assert_query_result(
+            'select X { tup }',
+            [{'tup': (1, '2')}],
+        )


### PR DESCRIPTION
Closes #6291

We had `expr_exposed` set on ctx that was used to provide
the value for UPDATE expression.
This caused the value to be serialized.
