### PR TITLE
+automatically generated DDL output

### DIFF
--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -9,8 +9,8 @@ CLI
 :edb-alt-title: The EdgeDB CLI
 
 The ``edgedb`` command-line interface (CLI) provides an idiomatic way to
-install EdgeDB, spin up local instances, open a REPL, execute queries, manage
-auth roles, introspect schema, create migrations, and more.
+install EdgeDB, spin up local instances, open a REPL, execute queries,
+manage auth roles, introspect schema, create migrations, and more.
 
 You can install it with one shell command.
 

--- a/docs/guides/migrations/names.rst
+++ b/docs/guides/migrations/names.rst
@@ -76,6 +76,20 @@ need to provide some kind of placeholder value for those cases. We
 type ``'change me'`` (although any other string would do, too). This is
 different from specifying a ``default`` value since it will be applied
 to *existing* objects, whereas the ``default`` applies to *new ones*.
+
+Unseen to us (unless we take a look at the automatically generated
+``.edgeql`` files inside our ``/dbschema`` folder), EdgeDB has created
+a migration script that includes the following command to make our
+schema change happen.
+
+.. code-block:: edgeql
+
+  ALTER TYPE default::User {
+      ALTER PROPERTY name {
+          SET REQUIRED USING (<std::str>'change me');
+      };
+  };
+
 We then run :ref:`ref_cli_edgedb_migrate` to apply the changes.
 
 Next we realize that we actually want to make names unique, perhaps to


### PR DESCRIPTION
Small change: adds the automatically generated DDL output during the first step so that the next DDL example is not so jarring.