### PR TITLE
Add styled container to verification pages

### DIFF
--- a/edb/server/protocol/auth_ext/_static/styles.css
+++ b/edb/server/protocol/auth_ext/_static/styles.css
@@ -34,7 +34,7 @@ body:after {
   max-height: 100px;
 }
 
-form {
+.container {
   grid-row: 2;
   background: #fff;
   padding: 24px;
@@ -48,7 +48,7 @@ form {
   flex-direction: column;
 }
 
-form h1 {
+.container h1 {
   margin: 0;
   color: #495057;
   font-size: 22px;
@@ -56,11 +56,11 @@ form h1 {
   font-weight: 550;
   margin-bottom: 20px;
 }
-form h1 span {
+.container h1 span {
   opacity: 0.7;
 }
 
-form input {
+.container input {
   border-radius: 8px;
   border: 1px solid #DEE2E6;
   background: #F8F9FA;
@@ -74,11 +74,11 @@ form input {
   margin-bottom: 16px;
 }
 
-form input:focus-visible {
+.container input:focus-visible {
   outline: 3px solid var(--accent-focus-color);
 }
 
-form label {
+.container label {
   color: #495057;
   font-size: 16px;
   font-weight: 450;
@@ -86,7 +86,7 @@ form label {
   margin-bottom: 8px;
 }
 
-form button {
+.container button {
   display: grid;
   align-items: center;
   grid-template-columns: 1fr auto 1fr;
@@ -102,17 +102,17 @@ form button {
   cursor: pointer;
   margin: 8px 0;
 }
-form button span {
+.container button span {
   grid-column: 2;
 }
-form button svg {
+.container button svg {
   margin-left: 8px;
   justify-self: end;
 }
-form button:hover {
+.container button:hover {
   background: var(--accent-bg-hover-color);
 }
-form button:focus-visible {
+.container button:focus-visible {
   outline: 3px solid var(--accent-focus-color);
   outline-offset: 2px;
 }
@@ -232,25 +232,26 @@ a.field-note:hover {
 @media (prefers-color-scheme: dark) {
   body {
     background: #191C1F;
-  }
-
-  form {
-    background: #2A2F34;
-  }
-  form h1 {
     color: #DEE2E6;
   }
 
-  form input {
+  .container {
+    background: #2A2F34;
+  }
+  .container h1 {
+    color: #DEE2E6;
+  }
+
+  .container input {
     border-color: #495057;
     background: #31373D;
     color: #DEE2E6;
   }
-  form input:focus-visible {
+  .container input:focus-visible {
     outline-color: var(--accent-focus-dark-color);
   }
 
-  form label {
+  .container label {
     color: #dee2e6;
   }
 

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -104,7 +104,7 @@ def render_login_page(
         brand_color=brand_color,
         cleanup_search_params=['error', 'email'],
         content=f'''
-    <form method="POST" action="../authenticate" novalidate>
+    <form class="container" method="POST" action="../authenticate" novalidate>
       <h1>{f'<span>Sign in to</span> {html.escape(app_name)}'
            if app_name else '<span>Sign in</span>'}</h1>
 
@@ -212,7 +212,7 @@ def render_signup_page(
         brand_color=brand_color,
         cleanup_search_params=['error', 'email'],
         content=f'''
-    <form method="POST" action="../register" novalidate>
+    <form class="container" method="POST" action="../register" novalidate>
       <h1>{f'<span>Sign up to</span> {html.escape(app_name)}'
            if app_name else '<span>Sign up</span>'}</h1>
 
@@ -300,7 +300,7 @@ def render_forgot_password_page(
         brand_color=brand_color,
         cleanup_search_params=['error', 'email', 'email_sent'],
         content=f'''
-    <form method="POST" action="../send_reset_email">
+    <form class="container" method="POST" action="../send_reset_email">
       <h1>{f'<span>Reset password for</span> {html.escape(app_name)}'
            if app_name else '<span>Reset password</span>'}</h1>
 
@@ -356,7 +356,7 @@ def render_reset_password_page(
         brand_color=brand_color,
         cleanup_search_params=['error'],
         content=f'''
-    <form method="POST" action="../reset_password">
+    <form class="container" method="POST" action="../reset_password">
       <h1>{f'<span>Reset password for</span> {html.escape(app_name)}'
            if app_name else '<span>Reset password</span>'}</h1>
 
@@ -406,10 +406,12 @@ def render_email_verification_page(
         brand_color=brand_color,
         cleanup_search_params=['error'],
         content=f'''
+    <div class="container">
       <h1>{f'<span>Verify email for</span> {html.escape(app_name)}'
            if app_name else '<span>Verify email</span>'}</h1>
 
-      {content}'''
+      {content}
+    </form>''',
     )
 
 
@@ -419,15 +421,18 @@ def render_email_verification_expired_page(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None
+    brand_color: Optional[str] = None,
 ):
     verification_token = html.escape(verification_token)
-    content = f'''
-    Your verification token has expired.
-    <a href="resend-verification?verification_token={verification_token}">
-        Click here to resend the verification email
-    </a>
-    '''
+    content = _render_error_message(
+        f'''
+        Your verification token has expired.
+        <a href="resend-verification?verification_token={verification_token}">
+            Click here to resend the verification email
+        </a>
+        ''',
+        False,
+    )
 
     return _render_base_page(
         title=f'Verification expired{f" for {app_name}" if app_name else ""}',
@@ -436,10 +441,12 @@ def render_email_verification_expired_page(
         brand_color=brand_color,
         cleanup_search_params=['error'],
         content=f'''
+    <div class="container">
       <h1>{f'<span>Verification expired for</span> {html.escape(app_name)}'
            if app_name else '<span>Verification expired</span>'}</h1>
 
-      {content}'''
+      {content}
+    </div>''',
     )
 
 
@@ -451,13 +458,16 @@ def render_resend_verification_done_page(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None
+    brand_color: Optional[str] = None,
 ):
     if verification_token is None:
-        content = f"""
-        Missing verification token, please follow the link provided in the
-        original email, or on the signin page.
-        """
+        content = _render_error_message(
+            f"""
+            Missing verification token, please follow the link provided in the
+            original email, or on the signin page.
+            """,
+            False,
+        )
     else:
         verification_token = html.escape(verification_token)
         if is_valid:
@@ -478,10 +488,12 @@ def render_resend_verification_done_page(
         brand_color=brand_color,
         cleanup_search_params=['error'],
         content=f'''
+    <div class="container">
       <h1>{f'<span>Email verification resent for</span> {html.escape(app_name)}'
            if app_name else '<span>Email verification resent</span>'}</h1>
 
-      {content}'''
+      {content}
+    </div>''',
     )
 
 

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -46,7 +46,7 @@ def render_login_page(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None
+    brand_color: Optional[str] = None,
 ):
     password_provider = None
     for p in providers:
@@ -55,8 +55,7 @@ def render_login_page(
             break
 
     oauth_providers = [
-        p for p in providers
-        if p.name.startswith('builtin::oauth_')
+        p for p in providers if p.name.startswith('builtin::oauth_')
     ]
 
     oauth_params = {
@@ -68,8 +67,9 @@ def render_login_page(
         oauth_params['redirect_to_on_signup'] = redirect_to_on_signup
 
     oauth_label = "Sign in with" if password_provider else "Continue with"
-    oauth_buttons = '\n'.join([
-        f'''
+    oauth_buttons = '\n'.join(
+        [
+            f'''
         <a href="../authorize?{urllib.parse.urlencode({
             'provider': p.name,
             **oauth_params
@@ -80,10 +80,12 @@ def render_login_page(
         ) if p.name in known_oauth_provider_names else ''}
         <span>{oauth_label} {p.display_name}</span>
         </a>'''
-        for p in oauth_providers
-    ])
+            for p in oauth_providers
+        ]
+    )
 
-    forgot_link_script = f'''<script>
+    forgot_link_script = (
+        f'''<script>
         const forgotLink = document.getElementById("forgot-password-link");
         const emailInput = document.getElementById("email");
 
@@ -95,7 +97,10 @@ def render_login_page(
         forgotLink.href = `forgot-password?email=${{
         encodeURIComponent(emailInput.value)
         }}`
-        </script>''' if password_provider is not None else ''
+        </script>'''
+        if password_provider is not None
+        else ''
+    )
 
     return _render_base_page(
         title=f'Sign in{f" to {app_name}" if app_name else ""}',
@@ -155,7 +160,7 @@ def render_login_page(
       </div>""" if password_provider is not None else ''
     }
     </form>
-    {forgot_link_script}'''
+    {forgot_link_script}''',
     )
 
 
@@ -171,7 +176,7 @@ def render_signup_page(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None
+    brand_color: Optional[str] = None,
 ):
     password_provider = None
     for p in providers:
@@ -180,8 +185,7 @@ def render_signup_page(
             break
 
     oauth_providers = [
-        p for p in providers
-        if p.name.startswith('builtin::oauth_')
+        p for p in providers if p.name.startswith('builtin::oauth_')
     ]
 
     oauth_params = {
@@ -191,8 +195,9 @@ def render_signup_page(
     }
 
     oauth_label = "Sign up with" if password_provider else "Continue with"
-    oauth_buttons = '\n'.join([
-        f'''
+    oauth_buttons = '\n'.join(
+        [
+            f'''
         <a href="../authorize?{urllib.parse.urlencode({
             'provider': p.name,
             **oauth_params
@@ -203,8 +208,9 @@ def render_signup_page(
         ) if p.name in known_oauth_provider_names else ''}
         <span>{oauth_label} {p.display_name}</span>
         </a>'''
-        for p in oauth_providers
-    ])
+            for p in oauth_providers
+        ]
+    )
     return _render_base_page(
         title=f'Sign up{f" to {app_name}" if app_name else ""}',
         logo_url=logo_url,
@@ -255,7 +261,7 @@ def render_signup_page(
       </div>
       </div>""" if password_provider is not None else ''
     }
-    </form>'''
+    </form>''',
     )
 
 
@@ -270,7 +276,7 @@ def render_forgot_password_page(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None
+    brand_color: Optional[str] = None,
 ):
     if email_sent is not None:
         content = _render_success_message(
@@ -310,7 +316,7 @@ def render_forgot_password_page(
         Back to
         <a href="signin">Sign In</a>
       </div>
-    </form>'''
+    </form>''',
     )
 
 
@@ -326,13 +332,13 @@ def render_reset_password_page(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None
+    brand_color: Optional[str] = None,
 ):
     if not is_valid:
         content = _render_error_message(
             f'''Reset token is invalid, it may have expired.
             <a href="forgot-password">Try sending another reset email</a>''',
-            False
+            False,
         )
     else:
         content = f'''
@@ -361,7 +367,7 @@ def render_reset_password_page(
            if app_name else '<span>Reset password</span>'}</h1>
 
       {content}
-    </form>'''
+    </form>''',
     )
 
 
@@ -374,7 +380,7 @@ def render_email_verification_page(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None
+    brand_color: Optional[str] = None,
 ):
     resend_url = None
     if verification_token:
@@ -386,13 +392,11 @@ def render_email_verification_page(
         messages = ''.join(
             [_render_error_message(error) for error in error_messages]
         )
-        content = (
-            f'''
+        content = f'''
             {messages}
             {f'<a href="{resend_url}">Try sending another reset email</a>'
              if resend_url else ''}
             '''
-        )
     else:
         content = '''
         Email has been successfully verified. You may now
@@ -509,15 +513,20 @@ def _render_base_page(
     dark_logo_url: Optional[str] = None,
     brand_color: Optional[str] = None,
 ):
-    logo = f'''
+    logo = (
+        f'''
       <picture class="brand-logo">
         {'<source srcset="'+html.escape(dark_logo_url)+
           '" media="(prefers-color-scheme: dark)" />'
           if dark_logo_url else ''}
         <img src="{html.escape(logo_url)}" />
-      </picture>''' if logo_url else ''
+      </picture>'''
+        if logo_url
+        else ''
+    )
 
-    cleanup_script = f'''<script>
+    cleanup_script = (
+        f'''<script>
       const params = ["{'", "'.join(cleanup_search_params)}"];
       const url = new URL(location);
       if (params.some((p) => url.searchParams.has(p))) {{
@@ -526,7 +535,10 @@ def _render_base_page(
         }}
         history.replaceState(null, '', url);
       }}
-    </script>''' if len(cleanup_search_params) > 0 else ''
+    </script>'''
+        if len(cleanup_search_params) > 0
+        else ''
+    )
 
     if brand_color is None or hex_color_regexp.fullmatch(brand_color) is None:
         brand_color = '1f8aed'
@@ -550,7 +562,8 @@ def _render_base_page(
 
 
 def _render_error_message(error_message: Optional[str], escape: bool = True):
-    return (f'''
+    return (
+        f'''
         <div class="error-message">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="20"
           viewBox="0 0 24 20" fill="none">
@@ -570,7 +583,9 @@ def _render_error_message(error_message: Optional[str], escape: bool = True):
         </svg>
         <span>{html.escape(error_message) if escape else error_message}</span>
         </div>'''
-            if error_message else '')
+        if error_message
+        else ''
+    )
 
 
 def _render_success_message(success_message: str):
@@ -754,15 +769,23 @@ def rgb_to_hsl(r: float, g: float, b: float) -> tuple[float, float, float]:
     l = max(r, g, b)
     s = l - min(r, g, b)
     h = (
-        ((g - b) / s) if l == r else
-        (2 + (b - r) / s) if l == g else
-        (4 + (r - g) / s)
-    ) if s != 0 else 0
+        (
+            ((g - b) / s)
+            if l == r
+            else (2 + (b - r) / s)
+            if l == g
+            else (4 + (r - g) / s)
+        )
+        if s != 0
+        else 0
+    )
     return (
         60 * h + 360 if 60 * h < 0 else 60 * h,
-        100 * (
+        100
+        * (
             (s / (2 * l - s) if l <= 0.5 else s / (2 - (2 * l - s)))
-            if s != 0 else 0
+            if s != 0
+            else 0
         ),
         (100 * (2 * l - s)) / 2,
     )


### PR DESCRIPTION
Verification pages lacked a container element since they are not forms. Moves the container element styles to a `container` class, and then updates our existing `form` styling and the new non-form "pages" to have this class.

---

Ran Black on the UI module on accident, but decided to just roll with it here as a separate commit.