### PR TITLE
Fix coalesce with DML in non-dev builds

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -386,6 +386,7 @@ def _compile_dml_coalesce(
                 rhs_b
             ]),
             optional=True,
+            from_desugaring=True,
         )
 
         subctx.iterator_path_ids |= {lhs_ir.path_id}

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -88,9 +88,6 @@ class GlobalCompilerOptions:
     #: Whether to just treat all globals as empty instead of compiling them
     make_globals_empty: bool = False
 
-    #: Is this a dev instance of the compiler
-    devmode: bool = False
-
     #: Is the compiler running in testmode
     testmode: bool = False
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -195,7 +195,7 @@ def compile_ForQuery(
         if (
             qlstmt.optional
             and not qlstmt.from_desugaring
-            and not ctx.env.options.devmode
+            and not ctx.env.options.testmode
         ):
             raise errors.UnsupportedFeatureError(
                 "'FOR OPTIONAL' is an internal testing feature",
@@ -299,8 +299,8 @@ def _make_group_binding(
 def compile_InternalGroupQuery(
     expr: qlast.InternalGroupQuery, *, ctx: context.ContextLevel
 ) -> irast.Set:
-    # We disallow use of FOR GROUP except for when running on a dev build.
-    if not expr.from_desugaring and not ctx.env.options.devmode:
+    # We disallow use of FOR GROUP except for when running in test mode.
+    if not expr.from_desugaring and not ctx.env.options.testmode:
         raise errors.UnsupportedFeatureError(
             "'FOR GROUP' is an internal testing feature",
             context=expr.context,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1538,7 +1538,6 @@ def _get_compile_options(
             and not ctx.schema_reflection_mode
         ) or is_explain,
         testmode=_get_config_val(ctx, '__internal_testmode'),
-        devmode=_is_dev_instance(ctx),
         schema_reflection_mode=ctx.schema_reflection_mode
     )
 
@@ -1648,7 +1647,7 @@ def _compile_ql_administer(
     script_info: Optional[irast.ScriptInfo] = None,
 ) -> dbstate.BaseQuery:
     if ql.expr.func == 'statistics_update':
-        if not _is_dev_instance(ctx):
+        if not _get_config_val(ctx, '__internal_testmode'):
             raise errors.QueryError(
                 'statistics_update() can only be executed in test mode',
                 context=ql.context)
@@ -2942,13 +2941,6 @@ def _check_force_database_error(
             "invalid 'force_database_error' value'")
 
     raise errval
-
-
-def _is_dev_instance(ctx: CompileContext) -> bool:
-    # Determine whether we are on a dev instance by the presence
-    # of a test schema element.
-    std_schema = ctx.compiler_state.std_schema
-    return bool(std_schema.get('cfg::TestSessionConfig', None))
 
 
 def _get_config_val(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -28,6 +28,7 @@ from edb.tools import test
 
 class TestInsert(tb.QueryTestCase):
     '''The scope of the tests is testing various modes of Object creation.'''
+    INTERNAL_TESTMODE = False
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'insert.esdl')


### PR DESCRIPTION
Additionally, stop conditioning these testing features on whether it
is dev build but instead based on whether the testmode flag is
set. Moreover, get rid of the code path for testing whether an
instance is a dev instance, since anything conditioned on that *can't*
be tested by our test suite as it currently stands.