### PR TITLE
Lock concurrent compiles of the same query

### DIFF
--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -63,6 +63,7 @@ cdef class Database:
 
     cdef:
         stmt_cache.StatementsCache _eql_to_compiled
+        object _cache_locks
         object _sql_to_compiled
         DatabaseIndex _index
         object _views

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -187,6 +187,7 @@ class BaseServer:
         self._system_compile_cache = lru.LRUMapping(
             maxsize=defines._MAX_QUERIES_CACHE
         )
+        self._system_compile_cache_locks: dict[Any, Any] = {}
 
         self._listen_sockets = listen_sockets
         if listen_sockets:
@@ -443,6 +444,10 @@ class BaseServer:
         ):
             if conn.dbname == dbname:
                 conn.request_stop()
+
+    @property
+    def system_compile_cache_locks(self):
+        return self._system_compile_cache_locks
 
     def _idle_gc_collector(self):
         try:


### PR DESCRIPTION
Concurrent compile requests of the same query (against the same dbver) should only be processed once.

Details are explained in each commit message.
