### PR TITLE
Use consistent kebab-case for auth URLs

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -92,7 +92,7 @@ class Router:
                     return await self.handle_resend_verification_email(
                         *handler_args
                     )
-                case ('send_reset_email',):
+                case ('send-reset-email',):
                     return await self.handle_send_reset_email(*handler_args)
                 case ('reset_password',):
                     return await self.handle_reset_password(*handler_args)

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -306,7 +306,7 @@ def render_forgot_password_page(
         brand_color=brand_color,
         cleanup_search_params=['error', 'email', 'email_sent'],
         content=f'''
-    <form class="container" method="POST" action="../send_reset_email">
+    <form class="container" method="POST" action="../send-reset-email">
       <h1>{f'<span>Reset password for</span> {html.escape(app_name)}'
            if app_name else '<span>Reset password</span>'}</h1>
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -2431,7 +2431,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             body, _, status = self.http_con_request(
                 http_con,
                 None,
-                path="send_reset_email",
+                path="send-reset-email",
                 method="POST",
                 body=form_data_encoded,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -2504,7 +2504,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             _, redirect_headers, redirect_status = self.http_con_request(
                 http_con,
                 None,
-                path="send_reset_email",
+                path="send-reset-email",
                 method="POST",
                 body=urllib.parse.urlencode(
                     {
@@ -2546,7 +2546,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             _, _, error_status = self.http_con_request(
                 http_con,
                 None,
-                path="send_reset_email",
+                path="send-reset-email",
                 method="POST",
                 body=urllib.parse.urlencode(
                     {
@@ -2592,7 +2592,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             _, _, status = self.http_con_request(
                 http_con,
                 None,
-                path="send_reset_email",
+                path="send-reset-email",
                 method="POST",
                 body=form_data_encoded,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},


### PR DESCRIPTION
I meant to do this in #6344. Luckily this is just an internal endpoint that only the UI knows about so no worries about backwards incompatibility or documentation changes. 