### PR TITLE
[4.x] Support auth for HTTP endpoints (#6352)

### DIFF
--- a/.github/workflows.src/tests-patches.tpl.yml
+++ b/.github/workflows.src/tests-patches.tpl.yml
@@ -67,7 +67,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_edgeql.py tests/test_server_auth.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -468,7 +468,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_edgeql.py tests/test_server_auth.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -38,7 +38,8 @@ CREATE ABSTRACT INHERITABLE ANNOTATION cfg::affects_compilation;
 
 CREATE SCALAR TYPE cfg::memory EXTENDING std::anyscalar;
 CREATE SCALAR TYPE cfg::AllowBareDDL EXTENDING enum<AlwaysAllow, NeverAllow>;
-CREATE SCALAR TYPE cfg::ConnectionTransport EXTENDING enum<TCP, TCP_PG, HTTP>;
+CREATE SCALAR TYPE cfg::ConnectionTransport EXTENDING enum<
+    TCP, TCP_PG, HTTP, SIMPLE_HTTP>;
 
 CREATE ABSTRACT TYPE cfg::ConfigObject EXTENDING std::BaseObject;
 
@@ -59,6 +60,11 @@ CREATE TYPE cfg::SCRAM EXTENDING cfg::AuthMethod {
 CREATE TYPE cfg::JWT EXTENDING cfg::AuthMethod {
     ALTER PROPERTY transports {
         SET default := { cfg::ConnectionTransport.HTTP };
+    };
+};
+CREATE TYPE cfg::Password EXTENDING cfg::AuthMethod {
+    ALTER PROPERTY transports {
+        SET default := { cfg::ConnectionTransport.SIMPLE_HTTP };
     };
 };
 

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -74,4 +74,13 @@ The current kinds are:
  * repair - fix up inconsistencies in *user* schemas
 """
 PATCHES: list[tuple[str, str]] = _setup_patches([
+    ('edgeql+schema+config', '''
+ALTER SCALAR TYPE cfg::ConnectionTransport EXTENDING
+    enum<TCP, TCP_PG, HTTP, SIMPLE_HTTP>;
+CREATE TYPE cfg::Password EXTENDING cfg::AuthMethod {
+    ALTER PROPERTY transports {
+        SET default := { cfg::ConnectionTransport.SIMPLE_HTTP };
+    };
+};
+'''),
 ])

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -117,6 +117,7 @@ class ServerAuthMethod(enum.StrEnum):
     Trust = "Trust"
     Scram = "SCRAM"
     JWT = "JWT"
+    Password = "Password"
 
 
 class ServerConnTransport(enum.StrEnum):
@@ -124,6 +125,7 @@ class ServerConnTransport(enum.StrEnum):
     HTTP = "HTTP"
     TCP = "TCP"
     TCP_PG = "TCP_PG"
+    SIMPLE_HTTP = "SIMPLE_HTTP"
 
 
 class ServerAuthMethods:
@@ -150,6 +152,7 @@ DEFAULT_AUTH_METHODS = ServerAuthMethods({
     ServerConnTransport.TCP: ServerAuthMethod.Scram,
     ServerConnTransport.TCP_PG: ServerAuthMethod.Scram,
     ServerConnTransport.HTTP: ServerAuthMethod.JWT,
+    ServerConnTransport.SIMPLE_HTTP: ServerAuthMethod.Password,
 })
 
 

--- a/edb/server/protocol/auth_helpers.pxd
+++ b/edb/server/protocol/auth_helpers.pxd
@@ -1,0 +1,27 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2021-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+cdef extract_token_from_auth_data(bytes auth_data)
+cdef auth_jwt(tenant, str prefixed_token, str user, str dbname)
+cdef _check_jwt_authz(tenant, claims, token_version, str user, str dbname)
+cdef _get_jwt_edb_scope(claims, claim)
+cdef scram_get_verifier(tenant, str user)
+cdef parse_basic_auth(str auth_payload)
+cdef extract_http_user(scheme, auth_payload, params)
+cdef auth_basic(tenant, str username, str password)

--- a/edb/server/protocol/auth_helpers.pyx
+++ b/edb/server/protocol/auth_helpers.pyx
@@ -1,0 +1,237 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Authentication code that is shared between HTTP and binary protocols"""
+
+from edgedb import scram
+
+import base64
+import hashlib
+import json
+import logging
+
+from jwcrypto import jwt
+
+from edb import errors
+from edb.common import debug
+
+from edb.server.protocol cimport args_ser
+
+
+cdef object logger = logging.getLogger('edb.server')
+
+
+cdef extract_token_from_auth_data(auth_data: bytes):
+    header_value = auth_data.decode("ascii")
+    scheme, _, payload = header_value.partition(" ")
+    return scheme.lower(), payload.strip()
+
+
+cdef auth_jwt(tenant, prefixed_token: str, user: str, dbname: str):
+    if not prefixed_token:
+        raise errors.AuthenticationError(
+            'authentication failed: no authorization data provided')
+
+    token_version = 0
+    for prefix in ["nbwt1_", "nbwt_", "edbt1_", "edbt_"]:
+        encoded_token = prefixed_token.removeprefix(prefix)
+        if encoded_token != prefixed_token:
+            if prefix == "nbwt1_" or prefix == "edbt1_":
+                token_version = 1
+            break
+    else:
+        raise errors.AuthenticationError(
+            'authentication failed: malformed JWT')
+
+    role = tenant.get_roles().get(user)
+    if role is None:
+        raise errors.AuthenticationError('authentication failed')
+
+    skey = tenant.server.get_jws_key()
+
+    try:
+        token = jwt.JWT(
+            key=skey,
+            algs=["RS256", "ES256"],
+            jwt=encoded_token,
+        )
+    except jwt.JWException as e:
+        logger.debug('authentication failure', exc_info=True)
+        raise errors.AuthenticationError(
+            f'authentication failed: {e.args[0]}'
+        ) from None
+    except Exception as e:
+        logger.debug('authentication failure', exc_info=True)
+        raise errors.AuthenticationError(
+            f'authentication failed: cannot decode JWT'
+        ) from None
+
+    try:
+        claims = json.loads(token.claims)
+    except Exception as e:
+        raise errors.AuthenticationError(
+            f'authentication failed: malformed claims section in JWT'
+        ) from None
+
+    _check_jwt_authz(
+        tenant, claims, token_version, user, dbname)
+
+
+cdef _check_jwt_authz(tenant, claims, token_version, user: str, dbname: str):
+    # Check general key validity (e.g. whether it's a revoked key)
+    tenant.check_jwt(claims)
+
+    token_instances = None
+    token_roles = None
+    token_databases = None
+
+    if token_version == 1:
+        token_roles = _get_jwt_edb_scope(claims, "edb.r")
+        token_instances = _get_jwt_edb_scope(claims, "edb.i")
+        token_databases = _get_jwt_edb_scope(claims, "edb.d")
+    else:
+        namespace = "edgedb.server"
+        if not claims.get(f"{namespace}.any_role"):
+            token_roles = claims.get(f"{namespace}.roles")
+            if not isinstance(token_roles, list):
+                raise errors.AuthenticationError(
+                    f'authentication failed: malformed claims section in'
+                    f' JWT: expected a list in "{namespace}.roles"'
+                )
+
+    if (
+        token_instances is not None
+        and tenant.get_instance_name() not in token_instances
+    ):
+        raise errors.AuthenticationError(
+            'authentication failed: secret key does not authorize '
+            f'access to this instance')
+
+    if (
+        token_databases is not None
+        and dbname not in token_databases
+    ):
+        raise errors.AuthenticationError(
+            'authentication failed: secret key does not authorize '
+            f'access to database "{dbname}"')
+
+    if token_roles is not None and user not in token_roles:
+        raise errors.AuthenticationError(
+            'authentication failed: secret key does not authorize '
+            f'access in role "{user}"')
+
+
+cdef _get_jwt_edb_scope(claims, claim):
+    if not claims.get(f"{claim}.all"):
+        scope = claims.get(claim, [])
+        if not isinstance(scope, list):
+            raise errors.AuthenticationError(
+                f'authentication failed: malformed claims section in'
+                f' JWT: expected a list in "{claim}"'
+            )
+        return frozenset(scope)
+    else:
+        return None
+
+
+cdef scram_get_verifier(tenant, user: str):
+    roles = tenant.get_roles()
+
+    rolerec = roles.get(user)
+    if rolerec is not None:
+        verifier_string = rolerec['password']
+        if verifier_string is not None:
+            try:
+                verifier = scram.parse_verifier(verifier_string)
+            except ValueError:
+                raise errors.AuthenticationError(
+                    f'invalid SCRAM verifier for user {user!r}') from None
+            is_mock = False
+            return verifier, is_mock
+
+    # To avoid revealing the validity of the submitted user name,
+    # generate a mock verifier using a salt derived from the
+    # received user name and the cluster mock auth nonce.
+    # The same approach is taken by Postgres.
+    nonce = tenant.get_instance_data('mock_auth_nonce')
+    salt = hashlib.sha256(nonce.encode() + user.encode()).digest()
+
+    verifier = scram.SCRAMVerifier(
+        mechanism='SCRAM-SHA-256',
+        iterations=scram.DEFAULT_ITERATIONS,
+        salt=salt[:scram.DEFAULT_SALT_LENGTH],
+        stored_key=b'',
+        server_key=b'',
+    )
+    is_mock = True
+    return verifier, is_mock
+
+
+def scram_verify_password(password: str, verifier: object) -> bool:
+    """Check the given password against a verifier.
+
+    Returns True if the password is OK, False otherwise.
+    """
+
+    # adapted from edgedb-python's scram.verify_password but made to
+    # take a verifier object instead of a string
+
+    bpassword = scram.saslprep(password).encode('utf-8')
+    salted_password = scram.get_salted_password(
+        bpassword, verifier.salt, verifier.iterations)
+    computed_key = scram.get_server_key(salted_password)
+    return verifier.server_key == computed_key
+
+
+cdef parse_basic_auth(auth_payload: str):
+    try:
+        decoded = base64.b64decode(auth_payload).decode('utf-8')
+    except ValueError:
+        raise errors.AuthenticationError(
+            'authentication failed: malformed authentication') from None
+    username, colon, password = decoded.partition(':')
+    if colon != ':':
+        raise errors.AuthenticationError(
+            'authentication failed: malformed authentication')
+    return username, password
+
+
+cdef extract_http_user(scheme, auth_payload, params):
+    """Extract the username from an HTTP request.
+
+    Raises an AuthenticationError if something is too malformed.
+
+    Returns the username, along with the password, if appropriate.
+    (To avoid needing to parse the packet twice.)
+    """
+
+    if scheme == 'basic':
+        return parse_basic_auth(auth_payload)
+    else:
+        # Respect X-EdgeDB-User if present, but otherwise default to 'edgedb'
+        if params and b'user' in params:
+            username = params[b'user'].decode('ascii')
+        else:
+            username = 'edgedb'
+        return username, None
+
+
+cdef auth_basic(tenant, username: str, password: str):
+    verifier, mock_auth = scram_get_verifier(tenant, username)
+    if not scram_verify_password(password, verifier) or mock_auth:
+        raise errors.AuthenticationError('authentication failed')

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -22,9 +22,14 @@ from typing import (
     Optional,
 )
 
+from edgedb import scram
+
 import asyncio
+import base64
 import decimal
+import hashlib
 import json
+import logging
 
 import immutables
 
@@ -45,6 +50,8 @@ from edb.server.pgproto.pgproto cimport WriteBuffer
 from edb.server.pgcon cimport pgcon
 from edb.server.pgcon import errors as pgerror
 
+
+cdef object logger = logging.getLogger('edb.server')
 
 cdef object FMT_NONE = compiler.OutputFormat.NONE
 

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -37,15 +37,18 @@ from edb.common import markup
 from edb.graphql import extension as graphql_ext
 
 from edb.server import args as srvargs
+from edb.server import config
 from edb.server.protocol cimport binary
 from edb.server.protocol import binary
 from edb.server.protocol import pg_ext
 from edb.server import defines as edbdef
+from edb.server.dbview cimport dbview
 # Without an explicit cimport of `pgproto.debug`, we
 # can't cimport `protocol.binary` for some reason.
 from edb.server.pgproto.debug cimport PG_DEBUG
 
 from . import auth
+from . cimport auth_helpers
 from . import edgeql_ext
 from . import metrics
 from . import server_info
@@ -588,6 +591,12 @@ cdef class HttpProtocol:
                 else:
                     args = path_parts[3:]
 
+                if extname != 'auth':
+                    if not await self._check_http_auth(
+                        request, response, dbname
+                    ):
+                        return
+
                 db = self.tenant.maybe_get_db(dbname=dbname)
                 if db is None:
                     return self._not_found(request, response)
@@ -705,6 +714,71 @@ cdef class HttpProtocol:
         response.body = message.encode("utf-8")
         response.status = http.HTTPStatus.BAD_REQUEST
         response.close_connection = True
+
+    async def _check_http_auth(
+        self,
+        HttpRequest request,
+        HttpResponse response,
+        str dbname,
+    ):
+        dbindex: dbview.DatabaseIndex = self.tenant._dbindex
+
+        scheme = None
+        try:
+            # Extract the username from the relevant request headers
+            scheme, auth_payload = auth_helpers.extract_token_from_auth_data(
+                request.authorization)
+            username, opt_password = auth_helpers.extract_http_user(
+                scheme, auth_payload, request.params)
+
+            # Fetch the configured auth method
+            authmethod = await self.tenant.get_auth_method(
+                username, srvargs.ServerConnTransport.SIMPLE_HTTP)
+            authmethod_name = authmethod._tspec.name.split('::')[1]
+
+            # If the auth method and the provided auth information match,
+            # try to resolve the authentication.
+            if authmethod_name == 'JWT' and scheme == 'bearer':
+                if not self.is_tls:
+                    raise errors.AuthenticationError(
+                        'JWT HTTP auth must use HTTPS')
+
+                auth_helpers.auth_jwt(
+                    self.tenant, auth_payload, username, dbname)
+            elif authmethod_name == 'Password' and scheme == 'basic':
+                if not self.is_tls:
+                    raise errors.AuthenticationError(
+                        'Basic HTTP auth must use HTTPS')
+
+                auth_helpers.auth_basic(self.tenant, username, opt_password)
+            elif authmethod_name == 'Trust':
+                pass
+            elif authmethod_name == 'SCRAM':
+                raise errors.AuthenticationError(
+                    'authentication failed: '
+                    'SCRAM authentication required but not supported for HTTP'
+                )
+            else:
+                raise errors.AuthenticationError(
+                    'authentication failed: wrong method used')
+
+        except Exception as ex:
+            if debug.flags.server:
+                markup.dump(ex)
+
+            response.body = str(ex).encode()
+            response.status = http.HTTPStatus.UNAUTHORIZED
+            response.close_connection = True
+
+            # If no scheme was specified, add a WWW-Authenticate header
+            if scheme == '':
+                response.custom_headers['WWW-Authenticate'] = (
+                    'Basic realm="edgedb", Bearer'
+                )
+
+            return False
+
+        return True
 
 
 def get_request_url(request, is_tls):

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1151,16 +1151,15 @@ class Server(BaseServer):
 
             patches[num] = entry
             _, _, updates, _ = entry
-            if 'stdschema' in updates:
-                self._std_schema = updates['stdschema']
+            if 'std_and_reflection_schema' in updates:
+                self._std_schema, self._refl_schema = updates[
+                    'std_and_reflection_schema']
                 # +config patches might modify config_spec, which requires
                 # a reload of it from the schema.
                 if '+config' in kind:
                     config_spec = config.load_spec_from_schema(self._std_schema)
                     self._config_settings = config_spec
 
-            if 'reflschema' in updates:
-                self._refl_schema = updates['reflschema']
             if 'local_intro_query' in updates:
                 self._local_intro_query = updates['local_intro_query']
             if 'global_intro_query' in updates:

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -106,6 +106,7 @@ class EdgeQLTestCase(BaseHttpExtensionTest):
                 req_data['globals'] = globals
             req = urllib.request.Request(self.http_addr, method='POST')
             req.add_header('Content-Type', 'application/json')
+            req.add_header('Authorization', self.make_auth_header())
             response = urllib.request.urlopen(
                 req, json.dumps(req_data).encode(), context=self.tls_context
             )
@@ -115,8 +116,12 @@ class EdgeQLTestCase(BaseHttpExtensionTest):
                 req_data['variables'] = json.dumps(variables)
             if globals is not None:
                 req_data['globals'] = json.dumps(globals)
-            response = urllib.request.urlopen(
+            req = urllib.request.Request(
                 f'{self.http_addr}/?{urllib.parse.urlencode(req_data)}',
+            )
+            req.add_header('Authorization', self.make_auth_header())
+            response = urllib.request.urlopen(
+                req,
                 context=self.tls_context,
             )
             resp_data = json.loads(response.read())
@@ -184,6 +189,7 @@ class GraphQLTestCase(BaseHttpExtensionTest):
 
             req = urllib.request.Request(self.http_addr, method='POST')
             req.add_header('Content-Type', 'application/json')
+            req.add_header('Authorization', self.make_auth_header())
             response = urllib.request.urlopen(
                 req, json.dumps(req_data).encode(), context=self.tls_context
             )
@@ -198,8 +204,12 @@ class GraphQLTestCase(BaseHttpExtensionTest):
                 req_data['globals'] = json.dumps(deprecated_globals)
             if variables is not None:
                 req_data['variables'] = json.dumps(variables)
-            response = urllib.request.urlopen(
+            req = urllib.request.Request(
                 f'{self.http_addr}/?{urllib.parse.urlencode(req_data)}',
+            )
+            req.add_header('Authorization', self.make_auth_header())
+            response = urllib.request.urlopen(
+                req,
                 context=self.tls_context,
             )
             resp_data = json.loads(response.read())

--- a/setup.py
+++ b/setup.py
@@ -1016,6 +1016,14 @@ setuptools.setup(
         ),
 
         setuptools_extension.Extension(
+            "edb.server.protocol.auth_helpers",
+            ["edb/server/protocol/auth_helpers.pyx"],
+            extra_compile_args=EXT_CFLAGS,
+            extra_link_args=EXT_LDFLAGS,
+            include_dirs=EXT_INC_DIRS,
+        ),
+
+        setuptools_extension.Extension(
             "edb.server.protocol.notebook_ext",
             ["edb/server/protocol/notebook_ext.pyx"],
             extra_compile_args=EXT_CFLAGS,

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -47,7 +47,11 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
     def test_http_edgeql_proto_errors_01(self):
         with self.http_con() as con:
             data, headers, status = self.http_con_request(
-                con, {}, path='non-existant')
+                con, {}, path='non-existant',
+                headers={
+                    'Authorization': self.make_auth_header(),
+                },
+            )
 
             self.assertEqual(status, 404)
             self.assertEqual(headers['connection'], 'close')
@@ -58,7 +62,13 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
 
     def test_http_edgeql_proto_errors_02(self):
         with self.http_con() as con:
-            data, headers, status = self.http_con_request(con, {})
+            data, headers, status = self.http_con_request(
+                con,
+                {},
+                headers={
+                    'Authorization': self.make_auth_header(),
+                },
+            )
 
             self.assertEqual(status, 400)
             self.assertEqual(headers['connection'], 'close')
@@ -71,7 +81,12 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
         with self.http_con() as con:
             con.send(b'blah\r\n\r\n\r\n\r\n')
             data, headers, status = self.http_con_request(
-                con, {'query': 'blah', 'variables': 'bazz'})
+                con,
+                {'query': 'blah', 'variables': 'bazz'},
+                headers={
+                    'Authorization': self.make_auth_header(),
+                },
+            )
 
             self.assertEqual(status, 400)
             self.assertEqual(headers['connection'], 'close')
@@ -382,6 +397,7 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
 
         req = urllib.request.Request(self.http_addr, method='POST')
         req.add_header('Content-Type', 'application/json')
+        req.add_header('Authorization', self.make_auth_header())
         response = urllib.request.urlopen(
             req, req_data, context=self.tls_context
         )

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -56,7 +56,12 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                         }
                     '''
                 }
-                data, headers, status = self.http_con_request(con, req1_data)
+                data, headers, status = self.http_con_request(
+                    con, req1_data,
+                    headers={
+                        'Authorization': self.make_auth_header(),
+                    },
+                )
                 self.assertEqual(status, 200)
                 self.assertNotIn('connection', headers)
                 self.assertEqual(
@@ -76,7 +81,12 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                         }
                     '''
                 }
-                data, headers, status = self.http_con_request(con, req2_data)
+                data, headers, status = self.http_con_request(
+                    con, req2_data,
+                    headers={
+                        'Authorization': self.make_auth_header(),
+                    },
+                )
                 self.assertEqual(status, 200)
                 self.assertNotIn('connection', headers)
                 self.assertEqual(
@@ -89,7 +99,11 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_http_errors_01(self):
         with self.http_con() as con:
             data, headers, status = self.http_con_request(
-                con, {}, path='non-existant')
+                con, {}, path='non-existant',
+                headers={
+                    'Authorization': self.make_auth_header(),
+                },
+            )
 
             self.assertEqual(status, 404)
             self.assertEqual(headers['connection'], 'close')
@@ -100,7 +114,12 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
 
     def test_graphql_http_errors_02(self):
         with self.http_con() as con:
-            data, headers, status = self.http_con_request(con, {})
+            data, headers, status = self.http_con_request(
+                con, {},
+                headers={
+                    'Authorization': self.make_auth_header(),
+                },
+            )
 
             self.assertEqual(status, 400)
             self.assertEqual(headers['connection'], 'close')
@@ -112,7 +131,11 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_http_errors_03(self):
         with self.http_con() as con:
             data, headers, status = self.http_con_request(
-                con, {'query': 'blah', 'variables': 'bazz'})
+                con, {'query': 'blah', 'variables': 'bazz'},
+                headers={
+                    'Authorization': self.make_auth_header(),
+                },
+            )
 
             self.assertEqual(status, 400)
             self.assertEqual(headers['connection'], 'close')
@@ -125,7 +148,11 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         with self.http_con() as con:
             con.send(b'blah\r\n\r\n\r\n\r\n')
             data, headers, status = self.http_con_request(
-                con, {'query': 'blah', 'variables': 'bazz'})
+                con, {'query': 'blah', 'variables': 'bazz'},
+                headers={
+                    'Authorization': self.make_auth_header(),
+                },
+            )
 
             self.assertEqual(status, 400)
             self.assertEqual(headers['connection'], 'close')

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -42,6 +42,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
         req = urllib.request.Request(
             self.http_addr, method='POST')  # type: ignore
         req.add_header('Content-Type', 'application/json')
+        req.add_header('Authorization', self.make_auth_header())
         response = urllib.request.urlopen(
             req, json.dumps(req_data).encode(), context=self.tls_context
         )
@@ -161,7 +162,11 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
     def test_http_notebook_04(self):
         req = urllib.request.Request(self.http_addr + '/status',
                                      method='GET')
-        response = urllib.request.urlopen(req, context=self.tls_context)
+        req.add_header('Authorization', self.make_auth_header())
+        response = urllib.request.urlopen(
+            req,
+            context=self.tls_context,
+        )
         resp_data = json.loads(response.read())
         self.assertEqual(resp_data, {'kind': 'status', 'status': 'OK'})
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2276,8 +2276,13 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
         else:
             server_args['adjacent_to'] = self.con
 
+        headers = {
+            'Authorization': self.make_auth_header(),
+        }
+
         async with tb.start_edgedb_server(**server_args) as sd:
 
+            print("SERVER", sd)
             await self.con.execute("CREATE EXTENSION notebook;")
 
             # First, ensure that the local server is aware of the new ext.
@@ -2290,9 +2295,11 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                             http_con,
                             path="notebook",
                             body={"queries": ["SELECT 1"]},
+                            headers=headers,
                         )
 
-                        self.assertEqual(status, http.HTTPStatus.OK)
+                        self.assertEqual(
+                            status, http.HTTPStatus.OK, f"fuck: {response} {_}")
                         self.assert_data_shape(
                             response,
                             {
@@ -2315,6 +2322,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                             http_con,
                             path="notebook",
                             body={"queries": ["SELECT 1"]},
+                            headers=headers,
                         )
 
                         self.assertEqual(status, http.HTTPStatus.OK)
@@ -2343,6 +2351,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                             http_con,
                             path="notebook",
                             body={"queries": ["SELECT 1"]},
+                            headers=headers,
                         )
 
                         self.assertEqual(status, http.HTTPStatus.NOT_FOUND)
@@ -2357,6 +2366,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                             http_con,
                             path="notebook",
                             body={"queries": ["SELECT 1"]},
+                            headers=headers,
                         )
 
                         self.assertEqual(status, http.HTTPStatus.NOT_FOUND)


### PR DESCRIPTION
4.x backport notes: This required a patch, and to help test that I added more tests to the patch tests.

This makes all extension endpoints except for 'auth' will go through authentication, since it seems like the safe default.

We add a new SIMPLE_HTTP transport method for HTTP endpoints. (Unfortunately, edgedb+http already uses HTTP, even though HTTP would be a better name for *this* one.)

We also add a new Password auth method that only works for SIMPLE_HTTP, and which is the default method for SIMPLE_HTTP. JWT authentication is also supported, but SCRAM is not.

This is a backwards incompatible change! Unless "Trust" is configured as a method for HTTP transports (which it will be in dev instances), HTTP endpoints will stop working when not authenticated to.

Fixes #6345.

Password authentication uses HTTP basic auth.

JWT authentication is done by adding a header of the form:
```
Authorization: bearer <JWT>
```

The username for JWT and Trust auth can be specified with the X-EdgeDB-User header.