### PR TITLE
Do not log exception on invalid data

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -139,7 +139,6 @@ class Router:
             )
 
         except errors.InvalidData as ex:
-            markup.dump(ex)
             _fail_with_error(
                 response=response,
                 status=http.HTTPStatus.BAD_REQUEST,


### PR DESCRIPTION
The response should include enough information to be useful for debugging, no need to also log to stdout.