### PR TITLE
Move script entrypoints from `setup.py` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "edgedb-server"
 description = "EdgeDB Server"
 requires-python = '>=3.10.0'
-dynamic = ["entry-points", "version"]
+dynamic = ["version"]
 dependencies = [
     'edgedb==1.6.0',
 
@@ -23,6 +23,11 @@ dependencies = [
     'argon2-cffi~=23.1.0',
     'aiosmtplib~=2.0',
 ]
+
+[project.scripts]
+edgedb-server = "edb.server.main:main"
+edb = "edb.tools.edb:edbcommands"
+edgedb = "edb.cli:rustcli"
 
 [project.optional-dependencies]
 test = [

--- a/setup.py
+++ b/setup.py
@@ -918,18 +918,8 @@ def _version():
     return buildmeta.get_version_from_scm(ROOT_PATH)
 
 
-_entry_points = {
-    'edgedb-server = edb.server.main:main',
-    'edgedb = edb.cli:rustcli',
-    'edb = edb.tools.edb:edbcommands',
-}
-
-
 setuptools.setup(
     version=_version(),
-    entry_points={
-        "console_scripts": _entry_points,
-    },
     cmdclass={
         'build': build,
         'build_metadata': build_metadata,


### PR DESCRIPTION
The latest victim of the ongoing march of Python packaging deprecations
is the `entry_points` argument.  We stopped doing dynamic things to
entrypoints in `setup.py` some time ago anyway, so it's an easy fix.
