### PR TITLE
Don't cache UI assets in memory when the Admin UI is disabled

### DIFF
--- a/edb/server/protocol/ui_ext.pyx
+++ b/edb/server/protocol/ui_ext.pyx
@@ -36,19 +36,20 @@ STATIC_FILES_DIR = str(buildmeta.get_shared_data_dir_path() / 'ui')
 
 static_files = dict()
 
-for dirpath, _, filenames in os.walk(STATIC_FILES_DIR):
-    for filename in filenames:
-        fullpath = os.path.join(dirpath, filename)
+def cache_assets():
+    for dirpath, _, filenames in os.walk(STATIC_FILES_DIR):
+        for filename in filenames:
+            fullpath = os.path.join(dirpath, filename)
 
-        mimetype = mimetypes.guess_type(filename)[0]
-        if mimetype is None:
-            mimetype = 'application/octet-stream'
+            mimetype = mimetypes.guess_type(filename)[0]
+            if mimetype is None:
+                mimetype = 'application/octet-stream'
 
-        with open(fullpath, 'rb') as f:
-            static_files[os.path.relpath(fullpath, STATIC_FILES_DIR)] = (
-                f.read(),
-                mimetype.encode()
-            )
+            with open(fullpath, 'rb') as f:
+                static_files[os.path.relpath(fullpath, STATIC_FILES_DIR)] = (
+                    f.read(),
+                    mimetype.encode()
+                )
 
 async def handle_request(
     request,

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -60,6 +60,7 @@ from edb.server import protocol
 from edb.server import tenant as edbtenant
 from edb.server.protocol import binary  # type: ignore
 from edb.server.protocol import pg_ext  # type: ignore
+from edb.server.protocol import ui_ext  # type: ignore
 from edb.server.protocol.auth_ext import pkce
 from edb.server import metrics
 from edb.server import pgcon
@@ -357,6 +358,9 @@ class BaseServer:
         return self._config_settings
 
     async def init(self):
+        if self.is_admin_ui_enabled():
+            ui_ext.cache_assets()
+
         sys_config = self._get_sys_config()
         if not self._listen_hosts:
             self._listen_hosts = (


### PR DESCRIPTION
Saves ~10MiB or about 10% of all Python allocations in the baseline.
