### PR TITLE
Make ext::auth::ClientTokenIdentity single

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -523,6 +523,17 @@ def compile_GlobalExpr(
         # Wrap the reference in a subquery so that it does not get
         # factored out or go directly into the scope tree.
         qry = qlast.SelectQuery(result=qlast.Path(steps=[obj_ref]))
+
+        # HACK: 4.0-rc1 shipped with an ext::auth::ClientTokenIdentity
+        # that was multi instead of single.
+        # We don't have a good way to repair that yet... so we resort
+        # to our old trick of fixing it in the compiler.
+        if (
+            str(glob.get_name(ctx.env.schema))
+            == 'ext::auth::ClientTokenIdentity'
+        ):
+            qry.limit = qlast.IntegerConstant(value='1')
+
         return dispatch.compile(qry, ctx=ctx)
 
     default = glob.get_default(ctx.env.schema)

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -2724,3 +2724,8 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 parsed_query.get("error"),
                 ["Invalid 'reset_token'"],
             )
+
+    async def test_client_token_identity_card(self):
+        await self.con.query_single('''
+            select global ext::auth::ClientTokenIdentity
+        ''')


### PR DESCRIPTION
We don't have a great story currently for how to fix this kind of
extension issue, so for now let's resort to the tried-and-true method
and fixing it in the compiler :(.