### PR TITLE
Make parser spec generation deterministic

### DIFF
--- a/edb/edgeql-parser/src/parser.rs
+++ b/edb/edgeql-parser/src/parser.rs
@@ -523,13 +523,13 @@ fn injection_cost(kind: &Kind) -> u16 {
     use Kind::*;
 
     match kind {
-        Ident => 9,
+        Ident => 10,
         Substitution => 8,
 
         // Manual keyword tweaks to encourage some error messages and discourage others.
         Keyword(keywords::Keyword("delete" | "update" | "migration" | "role" | "global")) => 100,
         Keyword(keywords::Keyword("insert")) => 20,
-        Keyword(keywords::Keyword("select" | "property" | "type" | "filter")) => 10,
+        Keyword(keywords::Keyword("select" | "property" | "type")) => 10,
         Keyword(_) => 15,
 
         Dot => 5,

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -134,12 +134,20 @@ def parse(
         # TODO: emit multiple errors
 
         # Heuristic to pick the error:
+        # - the only Unexpected, if it is a keyword
         # - first encountered,
         # - Unexpected before Missing,
         # - original order.
         errs: List[ParserError] = result.errors()
-        errs.sort(key=lambda e: (e[1][0], -ord(e[0][1])))
-        error = errs[0]
+        unexpected = [e for e in errs if e[0].startswith('Unexpected')]
+        if (
+            len(unexpected) == 1
+            and unexpected[0][0].startswith('Unexpected keyword')
+        ):
+            error = unexpected[0]
+        else:
+            errs.sort(key=lambda e: (e[1][0], -ord(e[0][1])))
+            error = errs[0]
 
         message, span, hint, details = error
         position = qltokenizer.inflate_position(source.text(), span)

--- a/edb/tools/parser_demo.py
+++ b/edb/tools/parser_demo.py
@@ -327,4 +327,7 @@ QUERIES = [
     WITH MODULE welp
     CREATE DATABASE sample;
     ''',
+    '''
+    INSERT Foo FILTER Foo.bar = 42;
+    ''',
 ]

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2575,7 +2575,9 @@ aa';
         COMMIT;
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=16)
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  "Unexpected keyword 'DATABASE'",
+                  line=3, col=16)
     def test_edgeql_syntax_with_03(self):
         """
         WITH MODULE welp


### PR DESCRIPTION
I've tracked down the source of non-determinism in the parser recovery: spec generation.

Because we use a bunch of sets in parser generation, the order of productions could be different each time the spec was serialized. This does not produce a different grammar, but it does affect the priority of error recovery paths, that all have the same cost.

These were the two costs causing the problems:

```
Error [1/2]:
    INSERT Foo FILTER Foo.bar = 42;
               ^^^^^^ Unexpected keyword 'FILTER'

Error [2/2]:
    INSERT Foo FILTER Foo.bar = 42;
                     ^ Missing '.'
```


```
Error [1/2]:
    INSERT Foo FILTER Foo.bar = 42;
              ^ Missing '.'

Error [2/2]:
    INSERT Foo FILTER Foo.bar = 42;
               ^^^^^^ Unexpected keyword 'FILTER'
```

Since they have the same recovery actions, their costs are equivalent. But when we pick which error to report, we pick the first one encountered, which depends on how the spec was serialized.

With this PR, the serialized spec is deterministic down to each byte in the serialized form. I've also tweaked the heuristics for picking the error, so we get the nicer one.