### PR TITLE
Include auth_ext static assets in the package build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include LICENSE README.md logo.svg
 
 recursive-include edb/edgeql-parser *
 recursive-include edb/edgeql-parser/edgeql-parser-python *
+recursive-include edb/server/protocol/auth_ext/_static *

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -2729,3 +2729,12 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         await self.con.query_single('''
             select global ext::auth::ClientTokenIdentity
         ''')
+
+    async def test_http_auth_ext_static_files(self):
+        with MockAuthProvider(), self.http_con() as http_con:
+            _, _, status = self.http_con_request(
+                http_con,
+                path="ui/_static/icon_github.svg",
+            )
+
+            self.assertEqual(status, 200)


### PR DESCRIPTION
I verified that the assets are in the sdist.

Also add a test that fetches one of the assets. I'll kick off a
release dry-run to verify that it works.