### PR TITLE
Support globals-using functions in defaults

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -2018,6 +2018,11 @@ def get_globals_as_json(
     """
     # TODO: arrange to compute this once per query, in a CTE or some such?
 
+    # If globals are empty, arrange to still pass in the argument but
+    # don't put anything in it.
+    if ctx.env.options.make_globals_empty:
+        globs = ()
+
     objctx = ctx.env.options.schema_object_context
     if globs and objctx in (s_constr.Constraint, s_indexes.Index):
         typname = objctx.get_schema_class_displayname()

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6853,25 +6853,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 }
             """)
 
-        await self.con.execute("""
-            create type X;
-        """)
-
-        # We can't set a default that uses a global when creating a new
-        # pointer, since it would need to run *now* and populate the data
-        async with self.assertRaisesRegexTx(
-            edgedb.UnsupportedFeatureError,
-            r"functions that reference globals may not be used when "
-            r"converting/populating data in migrations"
-        ):
-            await self.con.execute("""
-                alter type X {
-                    create property foo -> str {
-                        set default := (gfoo());
-                    }
-                };
-            """)
-
     async def test_edgeql_ddl_global_05(self):
         await self.con.execute("""
             create global foo -> str;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7129,20 +7129,24 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.con.execute('''
             alter global foo set default := "!";
+            create function get_foo() -> optional str using (global foo);
         ''')
 
         # Try it again now that there is a default
         await self.con.execute('''
             alter type Foo { create required property name2 -> str {
                 set default := (global foo);
-            } }
+            } };
+            alter type Foo { create required property name3 -> str {
+                set default := (get_foo());
+            } };
         ''')
 
         await self.assert_query_result(
             '''
-                select Foo { name, name2 }
+                select Foo { name, name2, name3 }
             ''',
-            [{'name': "test", 'name2': "!"}],
+            [{'name': "test", 'name2': "!", 'name3': "!"}],
         )
 
     async def test_edgeql_ddl_property_computable_01(self):


### PR DESCRIPTION
We already support actually using globals (#5268), and not supporting
global-using function was an oversight.

Fixes #6374.