### PR TITLE
Recompile functions when globals/aliases/computeds change

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2002,7 +2002,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         include_ancestors: bool=False,
         extra_refs: Optional[Dict[so.Object, List[str]]]=None,
         filter: Type[so.Object] | Tuple[Type[so.Object], ...] | None = None,
-        metadata_only: bool=True,
+        metadata_only: bool=False,
     ) -> s_schema.Schema:
         scls = self.scls
         expr_refs = s_expr.get_expr_referrers(schema, scls)
@@ -3340,6 +3340,7 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
             context,
             action=f'rename {vn}',
             fixer=self._fix_referencing_expr,
+            metadata_only=True,
         )
 
         if not context.canonical:

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1729,6 +1729,10 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         default=None,
     )
 
+    #: Is this from an expression change being propagated.
+    #: FIXME: Every place this is used is a hack and some are bugs.
+    from_expr_propagation = struct.Field(bool, default=False)
+
     scls: so.Object_T
     _delta_action: ClassVar[str]
     _schema_metaclass: ClassVar[  # type: ignore
@@ -3502,9 +3506,6 @@ class AlterObject(AlterObjectOrFragment[so.Object_T], Generic[so.Object_T]):
 
     #: If True, only apply changes to properties, not "real" schema changes
     metadata_only = struct.Field(bool, default=False)
-
-    #: Is this from an expression change being propagated.
-    from_expr_propagation = struct.Field(bool, default=False)
 
     def get_verb(self) -> str:
         return 'alter'

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2064,6 +2064,9 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                 delta_create, cmd_create, ctx_stack = ref.init_delta_branch(
                     schema, context, cmdtype=AlterObject)
 
+                cmd_drop.from_expr_propagation = True
+                cmd_create.from_expr_propagation = True
+
                 # Mark it metadata_only so that if it actually gets
                 # applied, only the metadata is changed but not
                 # the real underlying schema.
@@ -2071,11 +2074,11 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                     cmd_drop.metadata_only = True
                     cmd_create.metadata_only = True
 
-                    # Treat the drop as canonical, since we only need
-                    # to eliminate the reference, not get to a fully
-                    # consistent state, and the canonicalization can
-                    # mess up "associated" attributes.
-                    cmd_drop.canonical = True
+                # Treat the drop as canonical, since we only need
+                # to eliminate the reference, not get to a fully
+                # consistent state, and the canonicalization can
+                # mess up "associated" attributes.
+                cmd_drop.canonical = True
 
                 try:
                     # Compute a dummy value
@@ -3485,6 +3488,9 @@ class AlterObject(AlterObjectOrFragment[so.Object_T], Generic[so.Object_T]):
 
     #: If True, only apply changes to properties, not "real" schema changes
     metadata_only = struct.Field(bool, default=False)
+
+    #: Is this from an expression change being propagated.
+    from_expr_propagation = struct.Field(bool, default=False)
 
     def get_verb(self) -> str:
         return 'alter'

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1988,22 +1988,79 @@ class ObjectCommand(Command, Generic[so.Object_T]):
 
             return op
 
+    def _fix_referencing_expr_after_rename(
+        self,
+        schema: s_schema.Schema,
+        cmd: ObjectCommand[so.Object],
+        fn: str,
+        context: CommandContext,
+        expr: s_expr.Expression,
+    ) -> s_expr.Expression:
+        if isinstance(self, RenameObject):
+            new_name = self.new_name
+        elif (fops := self.get_subcommands(type=RenameObject)):
+            new_name = fops[0].new_name
+        else:
+            raise AssertionError("not a rename!")
+
+        # Recompile the expression with reference tracking on so that we
+        # can clean up the ast.
+        field = cmd.get_schema_metaclass().get_field(fn)
+        compiled = cmd.compile_expr_field(
+            schema, context, field, expr,
+            track_schema_ref_exprs=True)
+        assert compiled.irast.schema_ref_exprs is not None
+
+        # Now that the compilation is done, try to do the fixup.
+        new_shortname = sn.shortname_from_fullname(new_name)
+        old_shortname = sn.shortname_from_fullname(self.classname).name
+        for ref in compiled.irast.schema_ref_exprs.get(self.scls, []):
+            assert isinstance(
+                ref,
+                (qlast.ObjectRef, qlast.FunctionCall, qlast.Ptr)
+            ), f"only support object refs and func calls but got {ref}"
+            if isinstance(ref, qlast.FunctionCall):
+                ref.func = ((new_shortname.module, new_shortname.name)
+                            if isinstance(new_shortname, sn.QualName)
+                            else new_shortname.name)
+            elif (
+                isinstance(ref, (qlast.Ptr, qlast.ObjectRef))
+                and ref.name == old_shortname
+            ):
+                ref.name = new_shortname.name
+                if (
+                    isinstance(new_shortname, sn.QualName)
+                    and isinstance(ref, qlast.ObjectRef)
+                    and new_shortname.module != "__"
+                ):
+                    ref.module = new_shortname.module
+
+        # say as_fragment=True as a hack to avoid renormalizing it
+        out = s_expr.Expression.from_ast(
+            compiled.qlast, schema, modaliases={}, as_fragment=True)
+        return out
+
     def _propagate_if_expr_refs(
         self,
         schema: s_schema.Schema,
         context: CommandContext,
         *,
         action: str,
-        fixer: Optional[
-            Callable[[s_schema.Schema, ObjectCommand[so.Object], str,
-                      CommandContext, s_expr.Expression],
-                     s_expr.Expression]
-        ]=None,
         include_ancestors: bool=False,
         extra_refs: Optional[Dict[so.Object, List[str]]]=None,
         filter: Type[so.Object] | Tuple[Type[so.Object], ...] | None = None,
         metadata_only: bool=False,
     ) -> s_schema.Schema:
+
+        # If we are a rename or contain a rename, we need to fix up expressions
+        if (
+            isinstance(self, RenameObject)
+            or self.get_subcommands(type=RenameObject)
+        ):
+            fixer = self._fix_referencing_expr_after_rename
+        else:
+            fixer = None
+
         scls = self.scls
         expr_refs = s_expr.get_expr_referrers(schema, scls)
         if include_ancestors and isinstance(scls, so.InheritingObject):
@@ -3283,51 +3340,6 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         new_name = mcls.get_displayname_static(self.new_name)
         return f"rename {object_desc} to '{new_name}'"
 
-    def _fix_referencing_expr(
-        self,
-        schema: s_schema.Schema,
-        cmd: ObjectCommand[so.Object],
-        fn: str,
-        context: CommandContext,
-        expr: s_expr.Expression,
-    ) -> s_expr.Expression:
-        # Recompile the expression with reference tracking on so that we
-        # can clean up the ast.
-        field = cmd.get_schema_metaclass().get_field(fn)
-        compiled = cmd.compile_expr_field(
-            schema, context, field, expr,
-            track_schema_ref_exprs=True)
-        assert compiled.irast.schema_ref_exprs is not None
-
-        # Now that the compilation is done, try to do the fixup.
-        new_shortname = sn.shortname_from_fullname(self.new_name)
-        old_shortname = sn.shortname_from_fullname(self.classname).name
-        for ref in compiled.irast.schema_ref_exprs.get(self.scls, []):
-            assert isinstance(
-                ref,
-                (qlast.ObjectRef, qlast.FunctionCall, qlast.Ptr)
-            ), f"only support object refs and func calls but got {ref}"
-            if isinstance(ref, qlast.FunctionCall):
-                ref.func = ((new_shortname.module, new_shortname.name)
-                            if isinstance(new_shortname, sn.QualName)
-                            else new_shortname.name)
-            elif (
-                isinstance(ref, (qlast.Ptr, qlast.ObjectRef))
-                and ref.name == old_shortname
-            ):
-                ref.name = new_shortname.name
-                if (
-                    isinstance(new_shortname, sn.QualName)
-                    and isinstance(ref, qlast.ObjectRef)
-                    and new_shortname.module != "__"
-                ):
-                    ref.module = new_shortname.module
-
-        # say as_fragment=True as a hack to avoid renormalizing it
-        out = s_expr.Expression.from_ast(
-            compiled.qlast, schema, modaliases={}, as_fragment=True)
-        return out
-
     def _alter_begin(
         self,
         schema: s_schema.Schema,
@@ -3337,14 +3349,16 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         context.renames[self.classname] = self.new_name
         context.renamed_objs.add(scls)
 
-        vn = scls.get_verbosename(schema)
-        schema = self._propagate_if_expr_refs(
-            schema,
-            context,
-            action=f'rename {vn}',
-            fixer=self._fix_referencing_expr,
-            metadata_only=True,
-        )
+        # Propagate the change, but only if it wasn't handled by the
+        # enclosing Alter.
+        if context.current().op not in context.affected_finalization:
+            vn = scls.get_verbosename(schema)
+            schema = self._propagate_if_expr_refs(
+                schema,
+                context,
+                action=f'rename {vn}',
+                metadata_only=True,
+            )
 
         if not context.canonical:
             self.set_attribute_value(

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -417,6 +417,12 @@ class AlterAliasLike(
             elif not expr and is_alias and self.has_attribute_value('expr'):
                 self.add(self._delete_alias_type(self.scls, schema, context))
 
+            schema = self._propagate_if_expr_refs(
+                schema,
+                context,
+                action=self.get_friendly_description(schema=schema),
+            )
+
         return super()._alter_begin(schema, context)
 
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -386,7 +386,12 @@ class AlterAliasLike(
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        if not context.canonical and not self.metadata_only:
+        if (
+            not context.canonical
+            # FIXME: This is not really correct, but alias altering is
+            # currently too broken to accept expr propagations.
+            and not self.from_expr_propagation
+        ):
             expr = self.get_attribute_value('expr')
             is_alias = self._is_alias(self.scls, schema)
             if expr:

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -2173,7 +2173,7 @@ class AlterFunction(AlterCallableObject[Function], FunctionCommand):
 
         vn = scls.get_verbosename(schema, with_parent=True)
         schema = self._propagate_if_expr_refs(
-            schema, context, metadata_only=False, extra_refs=extra_refs,
+            schema, context, extra_refs=extra_refs,
             action=f'alter the definition of {vn}')
 
         return schema

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1314,18 +1314,9 @@ class Function(
         """Return a minimal function body that satisfies its return type."""
         rt = self.get_return_type(schema)
 
-        if rt.is_scalar():
-            # scalars and enums can be cast from a string
-            text = f'SELECT <{rt.get_displayname(schema)}>""'
-        elif rt.is_object_type():
-            # just grab an object of the appropriate type
-            text = f'SELECT {rt.get_displayname(schema)} LIMIT 1'
-        else:
-            # Can't easily create a valid cast, so just cast empty set
-            # into the given type. Technically this potentially breaks
-            # cardinality requirement, but since this is a dummy
-            # expression it doesn't matter at the moment.
-            text = f'SELECT <{rt.get_displayname(schema)}>{{}}'
+        text = f'''
+            SELECT assert_exists(<{rt.get_displayname(schema)}>{{}}) LIMIT 1
+        '''
 
         return s_expr.Expression(text=text)
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -80,6 +80,15 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
     ) -> s_schema.Schema:
         from . import referencing as s_referencing
 
+        # HACK: Don't inherit fields if the command comes from
+        # expression change propagation. It shouldn't be necessary,
+        # and can cause a knock-on bug: when aliases directly refer to
+        # another alias, they *incorrectly* have 'expr' marked as an
+        # inherited_field, which causes trouble here.
+        # Fixing this in 3.x/4.x would require a schema repair, though.
+        if self.from_expr_propagation:
+            return schema
+
         mcls = self.get_schema_metaclass()
         scls = self.scls
 

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -602,7 +602,6 @@ class AlterObjectType(ObjectTypeCommand,
                 action=self.get_friendly_description(schema=schema),
                 include_ancestors=True,
                 filter=functions.Function,
-                metadata_only=False,
             )
 
         return schema

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2101,7 +2101,7 @@ class AlterPointer(
     ) -> s_schema.Schema:
         schema = super()._alter_begin(schema, context)
 
-        if (
+        if not context.canonical and (
             self.get_attribute_value('expr') is not None
             or bool(self.get_subcommands(type=constraints.ConstraintCommand))
             or (

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5435,6 +5435,47 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     );
                 """)
 
+    async def test_edgeql_ddl_function_recompile_01(self):
+        # Test that we recompile functions as things change
+        await self.con.execute('''
+            create alias X := '1';
+            create global Y -> str { set default := '2' };
+            create type Z { create property p := '3' };
+            insert Z;
+            create function test() -> set of str using (
+                X ++ (global Y) ++ Z.p
+            );
+        ''')
+
+        await self.assert_query_result(
+            'select test()',
+            ['123']
+        )
+
+        await self.con.execute('''
+            alter alias X using ('A');
+        ''')
+        await self.assert_query_result(
+            'select test()',
+            ['A23']
+        )
+
+        await self.con.execute('''
+            alter global Y { set default := 'B' };
+        ''')
+        await self.assert_query_result(
+            'select test()',
+            ['AB3']
+        )
+
+        await self.con.execute('''
+            alter type Z alter property p using ('C');
+        ''')
+        await self.assert_query_result(
+            'select test()',
+            ['ABC']
+        )
+
     async def test_edgeql_ddl_module_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5438,7 +5438,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_recompile_01(self):
         # Test that we recompile functions as things change
         await self.con.execute('''
-            create alias X := '1';
+            create alias X0 := '1';
+            create alias X := X0;
             create global Y -> str { set default := '2' };
             create type Z { create property p := '3' };
             insert Z;
@@ -5453,7 +5454,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute('''
-            alter alias X using ('A');
+            alter alias X0 using ('A');
         ''')
         await self.assert_query_result(
             'select test()',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8425,6 +8425,20 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             """,
         ])
 
+    def test_schema_migrations_alias_alter_01(self):
+        self._assert_migration_equivalence([
+            r"""
+            alias X := '0';
+            alias Y := X;
+            alias Z := Y;
+            """,
+            r"""
+            alias X := '1';
+            alias Y := X;
+            alias Z := Y;
+            """,
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
All of the machinery to do this right was already in place,
but wasn't used for aliases and many places were not included
because metadata_only was the default for _propagate_if_expr_refs,
even though that mostly only made sense for renames.

Fixes #6380.