### PR TITLE
Allow `if .. then .. else` at the top level

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -459,7 +459,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.write(')')
 
     def visit_IfElse(self, node: qlast.IfElse) -> None:
-        self.write('(')
+        parent = node._parent  # type: ignore
+        parenthesize = not (
+            isinstance(parent, qlast.SelectQuery)
+            and parent.implicit
+            and parent._parent is None  # type: ignore
+        )
+        if parenthesize:
+            self.write('(')
         if node.python_style:
             self.visit(node.if_expr)
             self._write_keywords(' IF ')
@@ -467,13 +474,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self._write_keywords(' ELSE ')
             self.visit(node.else_expr)
         else:
-            self._write_keywords(' IF ')
+            self._write_keywords('IF ')
             self.visit(node.condition)
             self._write_keywords(' THEN ')
             self.visit(node.if_expr)
             self._write_keywords(' ELSE ')
             self.visit(node.else_expr)
-        self.write(')')
+        if parenthesize:
+            self.write(')')
 
     def visit_Tuple(self, node: qlast.Tuple) -> None:
         self.write('(')

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1422,13 +1422,9 @@ class Expr(Nonterm):
             python_style=True,
         )
 
-    def reduce_IF_Expr_THEN_Expr_ELSE_Expr(self, *kids):
-        _, condition, _, if_expr, _, else_expr = kids
-        self.val = qlast.IfElse(
-            condition=condition.val,
-            if_expr=if_expr.val,
-            else_expr=else_expr.val,
-        )
+    @parsing.inline(0)
+    def reduce_IfThenElseExpr(self, _):
+        pass
 
     def reduce_Expr_UNION_Expr(self, *kids):
         self.val = qlast.BinOp(left=kids[0].val, op='UNION',
@@ -1441,6 +1437,16 @@ class Expr(Nonterm):
     def reduce_Expr_INTERSECT_Expr(self, *kids):
         self.val = qlast.BinOp(left=kids[0].val, op='INTERSECT',
                                right=kids[2].val)
+
+
+class IfThenElseExpr(Nonterm):
+    def reduce_IF_Expr_THEN_Expr_ELSE_Expr(self, *kids):
+        _, condition, _, if_expr, _, else_expr = kids
+        self.val = qlast.IfElse(
+            condition=condition.val,
+            if_expr=if_expr.val,
+            else_expr=else_expr.val,
+        )
 
 
 class CompareOp(Nonterm):

--- a/edb/edgeql/parser/grammar/start.py
+++ b/edb/edgeql/parser/grammar/start.py
@@ -84,6 +84,9 @@ class SingleStatement(Nonterm):
         # Expressions
         pass
 
+    def reduce_IfThenElseExpr(self, *kids):
+        self.val = qlast.SelectQuery(result=kids[0].val, implicit=True)
+
     @parsing.inline(0)
     def reduce_DDLStmt(self, _):
         # Data definition commands

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -8293,6 +8293,14 @@ aa \
             [[]],
         )
 
+    async def test_edgeql_expr_if_else_toplevel(self):
+        await self.assert_query_result(
+            r"""
+                if true then 10 else 11
+            """,
+            [10],
+        )
+
     async def test_edgeql_expr_setop_01(self):
         await self.assert_query_result(
             r"""SELECT EXISTS <str>{};""",

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -874,6 +874,11 @@ aa';
         SELECT a = b = c;
         """
 
+    def test_edgeql_toplevel_if(self):
+        """
+        IF true THEN (SELECT Foo) ELSE (INSERT Foo);
+        """
+
     def test_edgeql_syntax_required_01(self):
         """
         SELECT REQUIRED (User.groups.description);


### PR DESCRIPTION
Since `if` is similar to `for` in its control-like nature and we allow
the latter, allow writing `if` at the top level without an extra
`select`, which is especially useful with the recent ability to do
conditional DML.

    edgedb> if user_id
    ....... then (select User filter .id = user_id)
    ....... else (insert User)
