### PR TITLE
Fix `ext::auth::ClientTokenIdentity` cardinality

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -523,17 +523,6 @@ def compile_GlobalExpr(
         # Wrap the reference in a subquery so that it does not get
         # factored out or go directly into the scope tree.
         qry = qlast.SelectQuery(result=qlast.Path(steps=[obj_ref]))
-
-        # HACK: 4.0-rc1 shipped with an ext::auth::ClientTokenIdentity
-        # that was multi instead of single.
-        # We don't have a good way to repair that yet... so we resort
-        # to our old trick of fixing it in the compiler.
-        if (
-            str(glob.get_name(ctx.env.schema))
-            == 'ext::auth::ClientTokenIdentity'
-        ):
-            qry.limit = qlast.IntegerConstant(value='1')
-
         return dispatch.compile(qry, ctx=ctx)
 
     default = glob.get_default(ctx.env.schema)

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -411,13 +411,13 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     };
 
     create global ext::auth::client_token -> std::str;
-    create global ext::auth::ClientTokenIdentity := (
+    create single global ext::auth::ClientTokenIdentity := (
         with
             conf := {
                 key := (
-                    cfg::Config.extensions[is ext::auth::AuthConfig]
-                    .auth_signing_key
-                ),
+                    select cfg::Config.extensions[is ext::auth::AuthConfig]
+                    limit 1
+                ).auth_signing_key,
             },
             jwt := {
                 claims := ext::auth::_jwt_verify(


### PR DESCRIPTION
Since `conf.key` is a set, we end up with a multi cardinality