### PR TITLE
Increase --wait-until-available time in edb cli dev command

### DIFF
--- a/edb/tools/cli.py
+++ b/edb/tools/cli.py
@@ -39,7 +39,7 @@ def cli(args: tuple[str, ...]):
         '--wait-until-available' not in args_list and
         not any('--wait-until-available=' in a for a in args_list)
     ):
-        args_list += ['--wait-until-available', '5s']
+        args_list += ['--wait-until-available', '60s']
 
     sys.exit(rustcli.rustcli(args=[sys.argv[0], *args_list]))
 


### PR DESCRIPTION
I realized that for literally years I have always passed
`--wait-until-available 100s` when I run `edb cli` and I just
remembered that I can just change things to make my dev workflow
better.