### PR TITLE
Create an allow-list of redirect URLs

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -252,7 +252,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             create annotation std::description :=
                 "When redirecting the user in various flows, the URL will be \
                 checked against this list to ensure they are going \
-                to a trusted domain controlled by thee application. URLs are \
+                to a trusted domain controlled by the application. URLs are \
                 matched based on checking if the candidate redirect URL is \
                 a match or a subdirectory of any of these allowed URLs";
         };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -247,6 +247,15 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
                 indicates that the token should never expire.";
             set default := <std::duration>'336 hours';
         };
+
+        create multi property allowed_redirect_urls -> std::str {
+            create annotation std::description :=
+                "When redirecting the user in various flows, the URL will be \
+                checked against this list to ensure they are going \
+                to a trusted domain controlled by thee application. URLs are \
+                matched based on checking if the candidate redirect URL is \
+                a match or a subdirectory of any of these allowed URLs";
+        };
     };
 
     create scalar type ext::auth::SMTPSecurity extending enum<PlainText, TLS, STARTTLS, STARTTLSOrPlainText>;

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1394,8 +1394,9 @@ class Router:
         allowed_urls = util.get_config(
             self.db,
             "ext::auth::AuthConfig::allowed_redirect_urls",
-            Set[str],
+            frozenset,
         )
+        allowed_urls = cast(Set[str], allowed_urls)
         parsed_url = urllib.parse.urlparse(url)
 
         for allowed_url in allowed_urls:

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -206,15 +206,13 @@ class Router:
             query, "redirect_to_on_signup"
         )
         if not self._is_url_allowed(redirect_to):
-            raise errors.MissingConfiguration(
-                "allowed_redirect_urls",
+            raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
         if redirect_to_on_signup and not self._is_url_allowed(
             redirect_to_on_signup
         ):
-            raise errors.MissingConfiguration(
-                "allowed_redirect_urls",
+            raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
         challenge = _get_search_param(query, "challenge")
@@ -271,8 +269,7 @@ class Router:
                 raise errors.InvalidData("Invalid state token")
 
             if not self._is_url_allowed(redirect_to):
-                raise errors.MissingConfiguration(
-                    "allowed_redirect_urls",
+                raise errors.InvalidData(
                     "Redirect URL does not match any allowed URLs.",
                 )
 
@@ -300,15 +297,13 @@ class Router:
                 Optional[str], claims.get("redirect_to_on_signup")
             )
             if not self._is_url_allowed(redirect_to):
-                raise errors.MissingConfiguration(
-                    "allowed_redirect_urls",
+                raise errors.InvalidData(
                     "Redirect URL does not match any allowed URLs.",
                 )
             if redirect_to_on_signup and not self._is_url_allowed(
                 redirect_to_on_signup
             ):
-                raise errors.MissingConfiguration(
-                    "allowed_redirect_urls",
+                raise errors.InvalidData(
                     "Redirect URL does not match any allowed URLs.",
                 )
             challenge = cast(str, claims["challenge"])
@@ -401,8 +396,7 @@ class Router:
 
         maybe_redirect_to = cast(Optional[str], data.get("redirect_to"))
         if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.MissingConfiguration(
-                "allowed_redirect_urls",
+            raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
         maybe_challenge = cast(Optional[str], data.get("challenge"))
@@ -489,8 +483,7 @@ class Router:
 
         maybe_redirect_to = data.get("redirect_to")
         if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.MissingConfiguration(
-                "allowed_redirect_urls",
+            raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
 
@@ -536,8 +529,7 @@ class Router:
             )
             if redirect_on_failure is not None:
                 if not self._is_url_allowed(redirect_on_failure):
-                    raise errors.MissingConfiguration(
-                        "allowed_redirect_urls",
+                    raise errors.InvalidData(
                         "Redirect URL does not match any allowed URLs.",
                     )
                 response.status = http.HTTPStatus.FOUND
@@ -642,14 +634,12 @@ class Router:
         _check_keyset(data, {"provider", "reset_url", "challenge"})
         local_client = local.Client(db=self.db, provider_name=data["provider"])
         if not self._is_url_allowed(data["reset_url"]):
-            raise errors.MissingConfiguration(
-                "allowed_redirect_urls",
+            raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
         maybe_redirect_to = data.get("redirect_to")
         if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.MissingConfiguration(
-                "allowed_redirect_urls",
+            raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
 
@@ -705,8 +695,7 @@ class Router:
             )
             if redirect_on_failure is not None:
                 if not self._is_url_allowed(redirect_on_failure):
-                    raise errors.MissingConfiguration(
-                        "allowed_redirect_urls",
+                    raise errors.InvalidData(
                         "Redirect URL does not match any allowed URLs.",
                     )
                 response.status = http.HTTPStatus.FOUND
@@ -729,8 +718,7 @@ class Router:
 
         maybe_redirect_to = data.get("redirect_to")
         if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.MissingConfiguration(
-                "allowed_redirect_urls",
+            raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
 
@@ -762,8 +750,7 @@ class Router:
             )
             if redirect_on_failure is not None:
                 if not self._is_url_allowed(redirect_on_failure):
-                    raise errors.MissingConfiguration(
-                        "allowed_redirect_urls",
+                    raise errors.InvalidData(
                         "Redirect URL does not match any allowed URLs.",
                     )
                 response.status = http.HTTPStatus.FOUND

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1396,27 +1396,13 @@ class Router:
             "ext::auth::AuthConfig::allowed_redirect_urls",
             frozenset,
         )
-        allowed_urls = cast(Set[str], allowed_urls)
-        parsed_url = urllib.parse.urlparse(url)
+        allowed_urls = cast(FrozenSet[str], allowed_urls).union(
+            {str(self.base_path)}
+        )
+        lower_url = url.lower()
 
         for allowed_url in allowed_urls:
-            if url == allowed_url:
-                return True
-
-            parsed_allowed_url = urllib.parse.urlparse(allowed_url)
-            url_hostname = parsed_url.hostname
-            allowed_hostname = parsed_allowed_url.hostname
-            if url_hostname is None or allowed_hostname is None:
-                continue
-            url_hostname_domain = '.'.join(url_hostname.split('.')[-2:])
-            allowed_hostname_domain = '.'.join(allowed_hostname.split('.')[-2:])
-
-            if (
-                parsed_url.scheme == parsed_allowed_url.scheme
-                and url_hostname_domain == allowed_hostname_domain
-                and parsed_url.port == parsed_allowed_url.port
-                and parsed_url.path.startswith(parsed_allowed_url.path)
-            ):
+            if lower_url.startswith(allowed_url.lower()):
                 return True
 
         return False

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1397,7 +1397,7 @@ class Router:
             frozenset,
         )
         allowed_urls = cast(FrozenSet[str], allowed_urls).union(
-            {str(self.base_path)}
+            {self.base_path}
         )
         lower_url = url.lower()
 

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -205,6 +205,18 @@ class Router:
         redirect_to_on_signup = _maybe_get_search_param(
             query, "redirect_to_on_signup"
         )
+        if not self._is_url_allowed(redirect_to):
+            raise errors.MissingConfiguration(
+                "allowed_redirect_urls",
+                "Redirect URL does not match any allowed URLs.",
+            )
+        if redirect_to_on_signup and not self._is_url_allowed(
+            redirect_to_on_signup
+        ):
+            raise errors.MissingConfiguration(
+                "allowed_redirect_urls",
+                "Redirect URL does not match any allowed URLs.",
+            )
         challenge = _get_search_param(query, "challenge")
         oauth_client = oauth.Client(
             db=self.db, provider_name=provider_name, base_url=self.test_url
@@ -258,6 +270,12 @@ class Router:
             except Exception:
                 raise errors.InvalidData("Invalid state token")
 
+            if not self._is_url_allowed(redirect_to):
+                raise errors.MissingConfiguration(
+                    "allowed_redirect_urls",
+                    "Redirect URL does not match any allowed URLs.",
+                )
+
             params = {
                 "error": error,
             }
@@ -281,6 +299,18 @@ class Router:
             redirect_to_on_signup = cast(
                 Optional[str], claims.get("redirect_to_on_signup")
             )
+            if not self._is_url_allowed(redirect_to):
+                raise errors.MissingConfiguration(
+                    "allowed_redirect_urls",
+                    "Redirect URL does not match any allowed URLs.",
+                )
+            if redirect_to_on_signup and not self._is_url_allowed(
+                redirect_to_on_signup
+            ):
+                raise errors.MissingConfiguration(
+                    "allowed_redirect_urls",
+                    "Redirect URL does not match any allowed URLs.",
+                )
             challenge = cast(str, claims["challenge"])
         except Exception:
             raise errors.InvalidData("Invalid state token")
@@ -369,9 +399,14 @@ class Router:
     async def handle_register(self, request: Any, response: Any):
         data = self._get_data_from_request(request)
 
-        maybe_redirect_to = data.get("redirect_to")
-        maybe_challenge = data.get("challenge")
-        register_provider_name = data.get("provider")
+        maybe_redirect_to = cast(Optional[str], data.get("redirect_to"))
+        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
+            raise errors.MissingConfiguration(
+                "allowed_redirect_urls",
+                "Redirect URL does not match any allowed URLs.",
+            )
+        maybe_challenge = cast(Optional[str], data.get("challenge"))
+        register_provider_name = cast(Optional[str], data.get("provider"))
         if register_provider_name is None:
             raise errors.InvalidData('Missing "provider" in register request')
 
@@ -452,6 +487,13 @@ class Router:
             raise errors.InvalidData('Missing "challenge" in register request')
         await pkce.create(self.db, maybe_challenge)
 
+        maybe_redirect_to = data.get("redirect_to")
+        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
+            raise errors.MissingConfiguration(
+                "allowed_redirect_urls",
+                "Redirect URL does not match any allowed URLs.",
+            )
+
         local_client = local.Client(
             db=self.db, provider_name=authenticate_provider_name
         )
@@ -471,14 +513,14 @@ class Router:
             )
             session_token = self._make_session_token(local_identity.id)
             _set_cookie(response, "edgedb-session", session_token)
-            if data.get("redirect_to") is not None:
+            if maybe_redirect_to:
                 response.status = http.HTTPStatus.FOUND
                 redirect_params = urllib.parse.urlencode(
                     {
                         "code": pkce_code,
                     }
                 )
-                redirect_url = f"{data['redirect_to']}?{redirect_params}"
+                redirect_url = f"{maybe_redirect_to}?{redirect_params}"
                 response.custom_headers["Location"] = redirect_url
             else:
                 response.status = http.HTTPStatus.OK
@@ -490,9 +532,14 @@ class Router:
                 ).encode()
         except Exception as ex:
             redirect_on_failure = data.get(
-                "redirect_on_failure", data.get("redirect_to")
+                "redirect_on_failure", maybe_redirect_to
             )
             if redirect_on_failure is not None:
+                if not self._is_url_allowed(redirect_on_failure):
+                    raise errors.MissingConfiguration(
+                        "allowed_redirect_urls",
+                        "Redirect URL does not match any allowed URLs.",
+                    )
                 response.status = http.HTTPStatus.FOUND
                 redirect_params = urllib.parse.urlencode(
                     {
@@ -594,6 +641,17 @@ class Router:
 
         _check_keyset(data, {"provider", "reset_url", "challenge"})
         local_client = local.Client(db=self.db, provider_name=data["provider"])
+        if not self._is_url_allowed(data["reset_url"]):
+            raise errors.MissingConfiguration(
+                "allowed_redirect_urls",
+                "Redirect URL does not match any allowed URLs.",
+            )
+        maybe_redirect_to = data.get("redirect_to")
+        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
+            raise errors.MissingConfiguration(
+                "allowed_redirect_urls",
+                "Redirect URL does not match any allowed URLs.",
+            )
 
         try:
             try:
@@ -625,10 +683,10 @@ class Router:
                 "email_sent": data.get('email'),
             }
 
-            if data.get("redirect_to") is not None:
+            if maybe_redirect_to:
                 response.status = http.HTTPStatus.FOUND
                 redirect_params = urllib.parse.urlencode(return_data)
-                redirect_url = f"{data['redirect_to']}?{redirect_params}"
+                redirect_url = f"{maybe_redirect_to}?{redirect_params}"
                 response.custom_headers["Location"] = redirect_url
             else:
                 response.status = http.HTTPStatus.OK
@@ -643,9 +701,14 @@ class Router:
 
         except Exception as ex:
             redirect_on_failure = data.get(
-                "redirect_on_failure", data.get("redirect_to")
+                "redirect_on_failure", maybe_redirect_to
             )
             if redirect_on_failure is not None:
+                if not self._is_url_allowed(redirect_on_failure):
+                    raise errors.MissingConfiguration(
+                        "allowed_redirect_urls",
+                        "Redirect URL does not match any allowed URLs.",
+                    )
                 response.status = http.HTTPStatus.FOUND
                 redirect_params = urllib.parse.urlencode(
                     {
@@ -664,6 +727,13 @@ class Router:
         _check_keyset(data, {"provider", "reset_token"})
         local_client = local.Client(db=self.db, provider_name=data["provider"])
 
+        maybe_redirect_to = data.get("redirect_to")
+        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
+            raise errors.MissingConfiguration(
+                "allowed_redirect_urls",
+                "Redirect URL does not match any allowed URLs.",
+            )
+
         try:
             reset_token = data['reset_token']
 
@@ -671,18 +741,16 @@ class Router:
                 reset_token
             )
 
-            await local_client.update_password(
-                identity_id, secret, data
-            )
+            await local_client.update_password(identity_id, secret, data)
             await pkce.create(self.db, challenge)
             code = await pkce.link_identity_challenge(
                 self.db, identity_id, challenge
             )
 
-            if data.get("redirect_to") is not None:
+            if maybe_redirect_to:
                 response.status = http.HTTPStatus.FOUND
                 redirect_params = urllib.parse.urlencode({"code": code})
-                redirect_url = f"{data['redirect_to']}?{redirect_params}"
+                redirect_url = f"{maybe_redirect_to}?{redirect_params}"
                 response.custom_headers["Location"] = redirect_url
             else:
                 response.status = http.HTTPStatus.OK
@@ -690,9 +758,14 @@ class Router:
                 response.body = json.dumps({"code": code}).encode()
         except Exception as ex:
             redirect_on_failure = data.get(
-                "redirect_on_failure", data.get("redirect_to")
+                "redirect_on_failure", maybe_redirect_to
             )
             if redirect_on_failure is not None:
+                if not self._is_url_allowed(redirect_on_failure):
+                    raise errors.MissingConfiguration(
+                        "allowed_redirect_urls",
+                        "Redirect URL does not match any allowed URLs.",
+                    )
                 response.status = http.HTTPStatus.FOUND
                 redirect_params = urllib.parse.urlencode(
                     {
@@ -1316,6 +1389,36 @@ class Router:
                 f" {identity_id}. This email address may not exist"
                 " in our system, or it might already be verified."
             )
+
+    def _is_url_allowed(self, url: str) -> bool:
+        allowed_urls = util.get_config(
+            self.db,
+            "ext::auth::AuthConfig::allowed_redirect_urls",
+            Set[str],
+        )
+        parsed_url = urllib.parse.urlparse(url)
+
+        for allowed_url in allowed_urls:
+            if url == allowed_url:
+                return True
+
+            parsed_allowed_url = urllib.parse.urlparse(allowed_url)
+            url_hostname = parsed_url.hostname
+            allowed_hostname = parsed_allowed_url.hostname
+            if url_hostname is None or allowed_hostname is None:
+                continue
+            url_hostname_domain = '.'.join(url_hostname.split('.')[-2:])
+            allowed_hostname_domain = '.'.join(allowed_hostname.split('.')[-2:])
+
+            if (
+                parsed_url.scheme == parsed_allowed_url.scheme
+                and url_hostname_domain == allowed_hostname_domain
+                and parsed_url.port == parsed_allowed_url.port
+                and parsed_url.path.startswith(parsed_allowed_url.path)
+            ):
+                return True
+
+        return False
 
 
 def _fail_with_error(

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -349,6 +349,11 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         CONFIGURE CURRENT DATABASE SET
         ext::auth::SMTPConfig::sender := 'noreply@example.com';
 
+        CONFIGURE CURRENT DATABASE SET
+        ext::auth::AuthConfig::allowed_redirect_urls := {{
+            'http://example.com'
+        }};
+
         CONFIGURE CURRENT DATABASE
         INSERT ext::auth::GitHubOAuthProvider {{
             secret := '{GITHUB_SECRET}',

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -1969,7 +1969,6 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             self.assertEquals(status, 400)
 
-
     async def test_http_auth_ext_local_password_register_json_02(self):
         with self.http_con() as http_con:
             provider_name = "builtin::local_emailpassword"
@@ -2429,28 +2428,6 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
 
             self.assertEqual(status, 400)
-
-    async def test_http_auth_ext_local_password_forgot_form_02(self):
-        with self.http_con() as http_con:
-            provider_name = "builtin::local_emailpassword"
-
-            form_data = {
-                "provider": provider_name,
-                "reset_url": "https://not-on-the-allow-list.com/reset-password",
-                "email": f"{uuid.uuid4()}@example.com",
-                "challenge": uuid.uuid4(),
-            }
-            form_data_encoded = urllib.parse.urlencode(form_data).encode()
-
-            _, _, status = self.http_con_request(
-                http_con,
-                None,
-                path="send-reset-email",
-                method="POST",
-                body=form_data_encoded,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-            self.assertEquals(status, 400)
 
     async def test_http_auth_ext_local_password_forgot_form_01(self):
         with self.http_con() as http_con:

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -409,6 +409,16 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.loop.run_until_complete(
+            cls.con.execute(
+                f"""
+                CONFIGURE CURRENT DATABASE SET
+                ext::auth::AuthConfig::allowed_redirect_urls := {{
+                    '{cls.http_addr}'
+                }};
+                """
+            )
+        )
         cls.loop.run_until_complete(cls._wait_for_db_config())
 
     @classmethod

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -351,7 +351,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
         CONFIGURE CURRENT DATABASE SET
         ext::auth::AuthConfig::allowed_redirect_urls := {{
-            'http://example.com'
+            'https://example.com'
         }};
 
         CONFIGURE CURRENT DATABASE
@@ -414,16 +414,6 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.loop.run_until_complete(
-            cls.con.execute(
-                f"""
-                CONFIGURE CURRENT DATABASE SET
-                ext::auth::AuthConfig::allowed_redirect_urls := {{
-                    '{cls.http_addr}'
-                }};
-                """
-            )
-        )
         cls.loop.run_until_complete(cls._wait_for_db_config())
 
     @classmethod
@@ -714,7 +704,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                             "login": "octocat",
                             "name": "monalisa octocat",
                             "email": "octocat@example.com",
-                            "avatar_url": "http://example.com/example.jpg",
+                            "avatar_url": "https://example.com/example.jpg",
                             "updated_at": now.isoformat(),
                         }
                     ),
@@ -826,7 +816,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                             "login": "octocat",
                             "name": "monalisa octocat",
                             "email": "octocat+2@example.com",
-                            "avatar_url": "http://example.com/example.jpg",
+                            "avatar_url": "https://example.com/example.jpg",
                             "updated_at": now.isoformat(),
                         }
                     ),
@@ -1790,7 +1780,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 "provider": provider_name,
                 "email": "test@example.com",
                 "password": "test_password",
-                "redirect_to": "http://example.com/some/path",
+                "redirect_to": "https://example.com/some/path",
                 "challenge": str(uuid.uuid4()),
             }
             form_data_encoded = urllib.parse.urlencode(form_data).encode()
@@ -1829,7 +1819,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             assert location is not None
             parsed_location = urllib.parse.urlparse(location)
             parsed_query = urllib.parse.parse_qs(parsed_location.query)
-            self.assertEqual(parsed_location.scheme, "http")
+            self.assertEqual(parsed_location.scheme, "https")
             self.assertEqual(parsed_location.netloc, "example.com")
             self.assertEqual(parsed_location.path, "/some/path")
             self.assertEqual(
@@ -1909,7 +1899,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
 
             # Try to register the same user again (with redirect_on_failure)
-            redirect_on_failure_url = "http://example.com/different/path"
+            redirect_on_failure_url = "https://example.com/different/path"
             (
                 _,
                 redirect_on_failure_headers,
@@ -2212,7 +2202,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 "provider": form_data["provider"],
                 "email": random_email,
                 "password": form_data["password"],
-                "redirect_to": "http://example.com/some/path",
+                "redirect_to": "https://example.com/some/path",
                 "challenge": str(uuid.uuid4()),
             }
             auth_data_encoded_redirect_to = urllib.parse.urlencode(
@@ -2263,8 +2253,8 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 "provider": form_data["provider"],
                 "email": random_email,
                 "password": form_data["password"],
-                "redirect_to": "http://example.com/some/path",
-                "redirect_on_failure": "http://example.com/failure/path",
+                "redirect_to": "https://example.com/some/path",
+                "redirect_on_failure": "https://example.com/failure/path",
                 "challenge": str(uuid.uuid4()),
             }
             auth_data_encoded_redirect_on_failure = urllib.parse.urlencode(
@@ -2318,7 +2308,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                         refresh_token := <str>$refresh_token,
                         identity := (
                             insert ext::auth::Identity {
-                                issuer := "http://example.com",
+                                issuer := "https://example.com",
                                 subject := "abcdefg",
                             }
                         ),


### PR DESCRIPTION
In various flows, we use application-provided URLs to redirect the user back into the application. These URLs should be allow-listed and checked before redirecting the user to mitigate against spoofing.