### PR TITLE
Enable CI testing of patches to the auth extension

### DIFF
--- a/.github/scripts/patches/create-databases.py
+++ b/.github/scripts/patches/create-databases.py
@@ -15,10 +15,13 @@ try:
     db = edgedb.create_client(
         host='localhost', port=10000, tls_security='insecure'
     )
-    for name in ['json', 'functions', 'expressions', 'casts', 'policies', 'vector', 'scope']:
+    for name in [
+        'json', 'functions', 'expressions', 'casts', 'policies', 'vector',
+        'scope', 'httpextauth',
+    ]:
         db.execute(f'create database {name};')
 
-    # For the scope database, let's actually migration to it.  This
+    # For the scope database, let's actually migrate to it.  This
     # will test that the migrations can still work after the upgrade.
     db2 = edgedb.create_client(
         host='localhost', port=10000, tls_security='insecure', database='scope'
@@ -34,6 +37,19 @@ try:
         POPULATE MIGRATION;
         COMMIT MIGRATION;
     ''')
+    db2.close()
+
+    # For the httpextauth database, create the proper extensions, so
+    # that patching of the auth extension in place can get tested.
+    db2 = edgedb.create_client(
+        host='localhost', port=10000, tls_security='insecure',
+        database='httpextauth'
+    )
+    db2.execute(f'''
+        create extension pgcrypto;
+        create extension auth;
+    ''')
+    db2.close()
 
 finally:
     proc.terminate()

--- a/.github/workflows.src/tests-patches.tpl.yml
+++ b/.github/workflows.src/tests-patches.tpl.yml
@@ -67,7 +67,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -468,7 +468,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -338,7 +338,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
     TRANSACTION_ISOLATION = False
     PARALLELISM_GRANULARITY = 'suite'
 
-    EXTENSION_SETUP = [
+    SETUP = [
         f"""
         CONFIGURE CURRENT DATABASE SET
         ext::auth::AuthConfig::auth_signing_key := '{SIGNING_KEY}';

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -30,8 +30,10 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest):
     # EdgeQL/HTTP queries cannot run in a transaction
     TRANSACTION_ISOLATION = False
 
+    EXTENSIONS = ['notebook']
+
     @classmethod
-    def get_extension_name(cls):
+    def get_extension_path(cls):
         return 'notebook'
 
     def run_queries(self, queries: List[str]):


### PR DESCRIPTION
Have the patches testing script populate httpextauth with the
appropriate extensions, so that patching installed extensions will be
tested.

This required some adjusting of the test suite to make happen, since
BaseHttpExtensionTest would unconditionally create the extensions, but
we need to skip that if they already exist. It turns out that the base
DatabaseTestCase *also* has an EXTENSIONS property, and it populates
the extensions using a migration, which fits what we want perfectly.
Just ditch the whole `get_extension_name` bit.