### PR TITLE
Try retrying client connection errors on drop_db

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -642,7 +642,7 @@ async def drop_db(conn, dbname):
     # with a retry loop. Without this, tests would flake
     # a lot.
     async for tr in TestCase.try_until_succeeds(
-        ignore=edgedb.ExecutionError,
+        ignore=(edgedb.ExecutionError, edgedb.ClientConnectionError),
         timeout=30
     ):
         async with tr:


### PR DESCRIPTION
Hopefully fixes #6411.
Our bindings won't retry `DROP DATABASE` automatically.