### PR TITLE
Fix access policy type rewrites of std::Object

### DIFF
--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -362,17 +362,20 @@ def try_type_rewrite(
         ]
 
     # If we have multiple sets, union them together
+    rewritten_set: Optional[irast.Set]
     if len(sets) > 1:
         with ctx.new() as subctx:
             subctx.expr_exposed = context.Exposure.UNEXPOSED
             subctx.anchors = subctx.anchors.copy()
             parts: List[qlast.Expr] = [subctx.create_anchor(x) for x in sets]
-            filtered_set = dispatch.compile(
+            rewritten_set = dispatch.compile(
                 qlast.Set(elements=parts), ctx=subctx)
+    elif len(sets) > 0:
+        rewritten_set = sets[0]
     else:
-        filtered_set = sets[0]
+        rewritten_set = None
 
-    type_rewrites[rw_key] = filtered_set
+    type_rewrites[rw_key] = rewritten_set
 
 
 def compile_dml_write_policies(

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -1296,3 +1296,41 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             __typenames__=True,
         )
         self.assertEqual(obj, [])
+
+    async def test_edgeql_policies_global_01(self):
+        # GH issue #6404
+
+        clan_and_global = '''
+            type Clan {
+                access policy allow_select_players
+                    allow select
+                    using (
+                        global current_player.clan.id ?= .id
+                    );
+            }
+            create abstract type Principal;
+            create type Player extending Principal {
+                create required link clan: Clan;
+            };
+            global current_player_id: uuid;
+            global current_player := (
+                select Player filter .id = global current_player_id
+            );
+        '''
+
+        await self.migrate(
+            '''
+            type Principal;
+            type Player extending Principal {
+                required link clan: Clan;
+            }
+            ''' + clan_and_global
+        )
+
+        await self.migrate(
+            '''
+            type Player {
+                required link clan: Clan;
+            }
+            ''' + clan_and_global
+        )

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -1307,10 +1307,6 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
                     using (
                         global current_player.clan.id ?= .id
                     );
-            }
-            create abstract type Principal;
-            create type Player extending Principal {
-                create required link clan: Clan;
             };
             global current_player_id: uuid;
             global current_player := (


### PR DESCRIPTION
Closes #6404

Access policy code that composes type rewrites assumed that
if an object type has children with access policies
then there will be at least one child that is a material type.

This is not the case for std::Object when its child types are
objects derived from aliases.
