### PR TITLE
Fix DML with constraints on abstract types

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -800,6 +800,11 @@ def compile_inheritance_conflict_checks(
 
     conflicters = []
     for subject_stype, anc_type, ir in modified_ancestors:
+
+        # don't enforce any constraints for abstract object type
+        if subject_stype.get_abstract(schema=ctx.env.schema):
+            continue
+
         conflicters.extend(
             _compile_inheritance_conflict_selects(
                 stmt, ir, anc_type, subject_stype, ctx=ctx

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -431,6 +431,12 @@ def fini_dml_stmt(
             else:
                 stop_ref = base_typeref
 
+            # When the base type is abstract, there will be no CTE for it,
+            # so the overlays of children types have to apply to the whole
+            # ancestry tree.
+            if base_typeref.is_abstract:
+                stop_ref = None
+
             # The overlay for update is in two parts:
             # First, filter out objects that have been updated, then union them
             # back in. (If we just did union, we'd see the old values also.)


### PR DESCRIPTION
Some constraints are inforced by adding a CTE that does the check.
When an a constraint was defined on an abstract type, we were trying
and failing to generate this check for the abstract type as well.

This PR removes this check for all abstract object types.

Closes #6419
