### PR TITLE
Fix an error message of affected refs

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2231,7 +2231,8 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                         cmd.set_attribute_value(key, value)
                     self.add(delta)
             except errors.QueryError as e:
-                desc = self.get_friendly_description(schema=schema)
+                orig_schema = context.current().original_schema
+                desc = self.get_friendly_description(schema=orig_schema)
                 raise errors.SchemaDefinitionError(
                     f'cannot {desc} because this affects'
                     f' {" and ".join(refdesc)}',


### PR DESCRIPTION
An error message was using schema after applied changes
instead of the original schema. Found during https://github.com/edgedb/edgedb/pull/6420

This was the error before the fix:
```
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/delta.py", line 2234, in _finalize_affected_refs
    desc = self.get_friendly_description(schema=schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/delta.py", line 1845, in get_friendly_description
    object_desc = self.get_friendly_object_name_for_description(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/delta.py", line 2521, in get_friendly_object_name_for_description
    object_desc = object.get_verbosename(schema, with_parent=True)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/pointers.py", line 587, in get_verbosename
    vn = super().get_verbosename(schema)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/referencing.py", line 90, in get_verbosename
    vn = super().get_verbosename(schema)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/objects.py", line 1071, in get_verbosename
    dname = self.get_displayname(schema)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/objects.py", line 1065, in get_displayname
    return type(self).get_displayname_static(self.get_name(schema))
                                             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/objects.py", line 739, in regular_getter
    data = schema.get_obj_data_raw(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/schema.py", line 1778, in get_obj_data_raw
    return self._base_schema.get_obj_data_raw(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aljaz/EdgeDB/edgedb/edb/schema/schema.py", line 735, in get_obj_data_raw
    raise errors.SchemaError(err) from None
edb.errors.SchemaError: cannot get item data: item '0de91645-7a46-11ee-9f0b-59ec2524d619' is not present in the schema <FlatSchema gen:8214 at 0x7fb98612fb90>
```