### PR TITLE
Update SDL syntax for 4.0

### DIFF
--- a/docs/changelog/4_x.rst
+++ b/docs/changelog/4_x.rst
@@ -487,6 +487,9 @@ Bug fixes
 * Make ``id`` of schema objects stable.
   (:eql:gh:`#6058`)
 
+* Allow computed pointers on types to omit link/property kind specification.
+  (:eql:gh:`#6073`)
+
 * Support ``listen_ports`` greater than 32767.
   (:eql:gh:`#6194`)
 

--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -706,10 +706,30 @@ Here's a policy that limits the number of blog posts a ``User`` can post.
       }
 
 .. code-block:: sdl-diff
+    :version-lt: 4.0
 
       type User {
         required email: str { constraint exclusive; };
     +   multi link posts := .<author[is BlogPost]
+      }
+
+      type BlogPost {
+        required title: str;
+        required author: User;
+
+        access policy author_has_full_access
+          allow all
+          using (global current_user ?= .author.id);
+    +   access policy max_posts_limit
+    +     deny insert
+    +     using (count(.author.posts) > 500);
+      }
+
+.. code-block:: sdl-diff
+
+      type User {
+        required email: str { constraint exclusive; };
+    +   multi posts := .<author[is BlogPost]
       }
 
       type BlogPost {

--- a/docs/datamodel/computeds.rst
+++ b/docs/datamodel/computeds.rst
@@ -15,8 +15,7 @@ Object types can contain *computed* properties and links. Computed properties
 and links are not persisted in the database. Instead, they are evaluated *on
 the fly* whenever that field is queried. Computed properties must be declared
 with the ``property`` keyword and computed links must be declared with the
-``link`` keyword. While these keywords are optional for non-computed fields
-in EdgeDB 3.0+, they are still required for computed fields.
+``link`` keyword in EdgeDB versions prior to 4.0.
 
 .. code-block:: sdl
     :version-lt: 3.0
@@ -27,10 +26,18 @@ in EdgeDB 3.0+, they are still required for computed fields.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Person {
       name: str;
       property all_caps_name := str_upper(__source__.name);
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      name: str;
+      all_caps_name := str_upper(__source__.name);
     }
 
 Computed fields are associated with an EdgeQL expression. This expression
@@ -75,11 +82,20 @@ shorthand.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Person {
       first_name: str;
       last_name: str;
       property full_name := .first_name ++ ' ' ++ .last_name;
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      first_name: str;
+      last_name: str;
+      full_name := .first_name ++ ' ' ++ .last_name;
     }
 
 Type and cardinality inference
@@ -103,12 +119,22 @@ next time you try to :ref:`create a migration <ref_intro_migrations>`.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Person {
       first_name: str;
 
       # this is invalid, because first_name is not a required property
       required property first_name_upper := str_upper(.first_name);
+    }
+
+.. code-block:: sdl
+
+    type Person {
+      first_name: str;
+
+      # this is invalid, because first_name is not a required property
+      required first_name_upper := str_upper(.first_name);
     }
 
 Common use cases
@@ -136,10 +162,25 @@ queries, consider defining a computed field that encapsulates the filter.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Club {
       multi members: Person;
       multi link active_members := (
+        select .members filter .is_active = true
+      )
+    }
+
+    type Person {
+      name: str;
+      is_active: bool;
+    }
+
+.. code-block:: sdl
+
+    type Club {
+      multi members: Person;
+      multi active_members := (
         select .members filter .is_active = true
       )
     }
@@ -172,6 +213,7 @@ to traverse a link in the *reverse* direction.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type BlogPost {
       title: str;
@@ -181,6 +223,18 @@ to traverse a link in the *reverse* direction.
     type User {
       name: str;
       multi link blog_posts := .<author[is BlogPost]
+    }
+
+.. code-block:: sdl
+
+    type BlogPost {
+      title: str;
+      author: User;
+    }
+
+    type User {
+      name: str;
+      multi blog_posts := .<author[is BlogPost]
     }
 
 The ``User.blog_posts`` expression above uses the *backlink operator* ``.<`` in
@@ -201,6 +255,18 @@ database.
       property title -> str;
       link author -> User;
       required property created_at -> datetime {
+        readonly := true;
+        default := datetime_of_statement();
+      }
+    }
+
+.. code-block:: sdl
+    :version-lt: 4.0
+
+    type BlogPost {
+      title: str;
+      author: User;
+      required created_at: datetime {
         readonly := true;
         default := datetime_of_statement();
       }

--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -180,10 +180,20 @@ Constraints can be defined on computed properties.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type User {
       required username: str;
       required property clean_username := str_trim(str_lower(.username));
+
+      constraint exclusive on (.clean_username);
+    }
+
+.. code-block:: sdl
+
+    type User {
+      required username: str;
+      required clean_username := str_trim(str_lower(.username));
 
       constraint exclusive on (.clean_username);
     }

--- a/docs/datamodel/globals.rst
+++ b/docs/datamodel/globals.rst
@@ -230,10 +230,18 @@ Unlike query parameters, globals can be referenced
 
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type User {
       name: str;
       property is_self := (.id = global current_user_id)
+    };
+
+.. code-block:: sdl
+
+    type User {
+      name: str;
+      is_self := (.id = global current_user_id)
     };
 
 This is particularly useful when declaring :ref:`access policies

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -53,6 +53,7 @@ object, and thus assume ``multi`` as a default. Use the ``single`` keyword to
 declare a "to-one" backlink.
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Author {
       link posts := .<authors[is Article];
@@ -60,6 +61,16 @@ declare a "to-one" backlink.
 
     type CompanyEmployee {
       single link company := .<employees[is Company];
+    }
+
+.. code-block:: sdl
+
+    type Author {
+      posts := .<authors[is Article];
+    }
+
+    type CompanyEmployee {
+      single company := .<employees[is Company];
     }
 
 Required links

--- a/docs/edgeql/insert.rst
+++ b/docs/edgeql/insert.rst
@@ -31,6 +31,7 @@ samples on this page assume the following schema:
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     module default {
       abstract type Person {
@@ -40,6 +41,29 @@ samples on this page assume the following schema:
       type Hero extending Person {
         secret_identity: str;
         multi link villains := .<nemesis[is Villain];
+      }
+
+      type Villain extending Person {
+        nemesis: Hero;
+      }
+
+      type Movie {
+        required title: str { constraint exclusive };
+        required release_year: int64;
+        multi characters: Person;
+      }
+    }
+
+.. code-block:: sdl
+
+    module default {
+      abstract type Person {
+        required name: str { constraint exclusive };
+      }
+
+      type Hero extending Person {
+        secret_identity: str;
+        multi villains := .<nemesis[is Villain];
       }
 
       type Villain extending Person {

--- a/docs/edgeql/paths.rst
+++ b/docs/edgeql/paths.rst
@@ -42,8 +42,8 @@ Consider the following schema:
     }
 
     type Comment {
-      required property text: str;
-      required link author: User;
+      required text: str;
+      required author: User;
     }
 
 A few simple inserts will allow some experimentation with paths.
@@ -221,6 +221,7 @@ that the type name (in this case ``User``) doesn't need to be specified.
       }
 
 .. code-block:: sdl-diff
+    :version-lt: 4.0
 
       type User {
         required email: str;
@@ -228,6 +229,25 @@ that the type name (in this case ``User``) doesn't need to be specified.
     +   link all_links := .<author;
     +   link blog_links := .<author[is BlogPost];
     +   link comment_links := .<author[is Comment];
+      }
+
+      type BlogPost {
+        required title: str;
+        required author: User;
+      }
+      type Comment {
+        required text: str;
+        required author: User;
+      }
+
+.. code-block:: sdl-diff
+
+      type User {
+        required email: str;
+        multi friends: User;
+    +   all_links := .<author;
+    +   blog_links := .<author[is BlogPost];
+    +   comment_links := .<author[is Comment];
       }
 
       type BlogPost {

--- a/docs/edgeql/select.rst
+++ b/docs/edgeql/select.rst
@@ -76,6 +76,7 @@ demonstration purposes, the queries below assume the following schema:
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     module default {
       abstract type Person {
@@ -85,6 +86,29 @@ demonstration purposes, the queries below assume the following schema:
       type Hero extending Person {
         secret_identity: str;
         multi link villains := .<nemesis[is Villain];
+      }
+
+      type Villain extending Person {
+        nemesis: Hero;
+      }
+
+      type Movie {
+        required title: str { constraint exclusive };
+        required release_year: int64;
+        multi characters: Person;
+      }
+    }
+
+.. code-block:: sdl
+
+    module default {
+      abstract type Person {
+        required name: str { constraint exclusive };
+      }
+
+      type Hero extending Person {
+        secret_identity: str;
+        multi villains := .<nemesis[is Villain];
       }
 
       type Villain extending Person {
@@ -824,12 +848,22 @@ common to add them directly into your schema as computed links.
       }
 
 .. code-block:: sdl-diff
+    :version-lt: 4.0
 
       abstract type Person {
         required name: str {
           constraint exclusive;
         };
     +   multi link movies := .<characters[is Movie]
+      }
+
+.. code-block:: sdl-diff
+
+      abstract type Person {
+        required name: str {
+          constraint exclusive;
+        };
+    +   multi movies := .<characters[is Movie]
       }
 
 .. note::

--- a/docs/guides/cheatsheet/objects.rst
+++ b/docs/guides/cheatsheet/objects.rst
@@ -131,6 +131,7 @@ the other properties:
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Person extending HasImage {
         required first_name: str {
@@ -141,6 +142,33 @@ the other properties:
         }
         required last_name: str;
         property full_name :=
+            (
+                (
+                    (.first_name ++ ' ')
+                    if .first_name != '' else
+                    ''
+                ) ++
+                (
+                    (.middle_name ++ ' ')
+                    if .middle_name != '' else
+                    ''
+                ) ++
+                .last_name
+            );
+        bio: str;
+    }
+
+.. code-block:: sdl
+
+    type Person extending HasImage {
+        required first_name: str {
+            default := '';
+        }
+        required middle_name: str {
+            default := '';
+        }
+        required last_name: str;
+        full_name :=
             (
                 (
                     (.first_name ++ ' ')
@@ -224,6 +252,7 @@ aggregates values from another linked type:
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Movie extending HasImage {
         required title: str;
@@ -245,6 +274,30 @@ aggregates values from another linked type:
         };
 
         property avg_rating := math::mean(.<movie[is Review].rating);
+    }
+
+.. code-block:: sdl
+
+    type Movie extending HasImage {
+        required title: str;
+        required year: int64;
+
+        # Add an index for accessing movies by title and year,
+        # separately and in combination.
+        index on (.title);
+        index on (.year);
+        index on ((.title, .year));
+
+        description: str;
+
+        multi directors: Person {
+            extending crew;
+        };
+        multi actors: Person {
+            extending crew
+        };
+
+        avg_rating := math::mean(.<movie[is Review].rating);
     }
 
 

--- a/docs/guides/migrations/backlink.rst
+++ b/docs/guides/migrations/backlink.rst
@@ -76,12 +76,22 @@ define it as a computed link by using :ref:`backlink
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Event {
       required name: str;
 
       prev: Event;
       link next := .<prev[is Event];
+    }
+
+.. code-block:: sdl
+
+    type Event {
+      required name: str;
+
+      prev: Event;
+      next := .<prev[is Event];
     }
 
 The migration is straightforward enough:
@@ -144,6 +154,7 @@ we're interested in building event chains, not trees.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Event {
       required name: str;
@@ -152,6 +163,17 @@ we're interested in building event chains, not trees.
         constraint exclusive;
       };
       link next := .<prev[is Event];
+    }
+
+.. code-block:: sdl
+
+    type Event {
+      required name: str;
+
+      prev: Event {
+        constraint exclusive;
+      };
+      next := .<prev[is Event];
     }
 
 Since the ``next`` link is computed, the migration should not need any

--- a/docs/intro/schema.rst
+++ b/docs/intro/schema.rst
@@ -65,7 +65,7 @@ correspond to other object types.
 Properties
 ----------
 
-The ``property`` keyword is used to declare a property.
+Declare a property by naming it and setting its type.
 
 .. code-block:: sdl
     :version-lt: 3.0
@@ -151,10 +151,18 @@ queried.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Movie {
       required title: str;
       property uppercase_title := str_upper(.title);
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      uppercase_title := str_upper(.title);
     }
 
 See :ref:`Schema > Computeds <ref_datamodel_computed>`.
@@ -276,6 +284,7 @@ queries. The example below defines a backlink.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Movie {
       required title: str;
@@ -283,6 +292,19 @@ queries. The example below defines a backlink.
 
       # returns all movies with same title
       multi link same_title := (
+        with t := .title
+        select detached Movie filter .title = t
+      )
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      multi actors: Person;
+
+      # returns all movies with same title
+      multi same_title := (
         with t := .title
         select detached Movie filter .title = t
       )
@@ -307,6 +329,7 @@ A common use case for computed links is *backlinks*.
     }
 
 .. code-block:: sdl
+    :version-lt: 4.0
 
     type Movie {
       required title: str;
@@ -316,6 +339,18 @@ A common use case for computed links is *backlinks*.
     type Person {
       required name: str;
       multi link acted_in := .<actors[is Movie];
+    }
+
+.. code-block:: sdl
+
+    type Movie {
+      required title: str;
+      multi actors: Person;
+    }
+
+    type Person {
+      required name: str;
+      multi acted_in := .<actors[is Movie];
     }
 
 The computed link ``acted_in`` returns all ``Movie`` objects with a link

--- a/docs/reference/sdl/links.rst
+++ b/docs/reference/sdl/links.rst
@@ -40,7 +40,7 @@ Declare a *concrete* link "friends" within a "User" type:
         required name: str;
         address: str;
         # define a concrete link "friends"
-        multi link friends: User {
+        multi friends: User {
             extending friends_base;
         };
 
@@ -137,6 +137,50 @@ commands <ref_eql_ddl_links>`.
       "}" ]
 
 .. sdl:synopsis::
+    :version-lt: 4.0
+
+    # Concrete link form used inside type declaration:
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      link <name>
+      [ extending <base> [, ...] ] -> <type>
+      [ "{"
+          [ default := <expression> ; ]
+          [ readonly := {true | false} ; ]
+          [ on target delete <action> ; ]
+          [ <annotation-declarations> ]
+          [ <property-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+
+    # Computed link form used inside type declaration:
+    [{required | optional}] [{single | multi}]
+      link <name> := <expression>;
+
+    # Computed link form used inside type declaration (extended):
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      link <name>
+      [ extending <base> [, ...] ] [-> <type>]
+      [ "{"
+          using (<expression>) ;
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+    # Abstract link form:
+    abstract link <name> [extending <base> [, ...]]
+    [ "{"
+        [ readonly := {true | false} ; ]
+        [ <annotation-declarations> ]
+        [ <property-declarations> ]
+        [ <constraint-declarations> ]
+        [ <index-declarations> ]
+        ...
+      "}" ]
+
+.. sdl:synopsis::
 
     # Concrete link form used inside type declaration:
     [ overloaded ] [{required | optional}] [{single | multi}]
@@ -155,7 +199,7 @@ commands <ref_eql_ddl_links>`.
 
     # Computed link form used inside type declaration:
     [{required | optional}] [{single | multi}]
-      link <name> := <expression>;
+      [ link ] <name> := <expression>;
 
     # Computed link form used inside type declaration (extended):
     [ overloaded ] [{required | optional}] [{single | multi}]

--- a/docs/reference/sdl/properties.rst
+++ b/docs/reference/sdl/properties.rst
@@ -40,7 +40,7 @@ Declare *concrete* properties "name" and "address" within a "User" type:
     type User {
         # define concrete properties
         required name: str;
-        property address: str {
+        address: str {
             extending address_base;
         };
 
@@ -126,6 +126,44 @@ commands <ref_eql_ddl_props>`.
       "}" ]
 
 .. sdl:synopsis::
+    :version-lt: 4.0
+
+    # Concrete property form used inside type declaration:
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      property <name>
+      [ extending <base> [, ...] ] -> <type>
+      [ "{"
+          [ default := <expression> ; ]
+          [ readonly := {true | false} ; ]
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+    # Computed property form used inside type declaration:
+    [{required | optional}] [{single | multi}]
+      property <name> := <expression>;
+
+    # Computed property form used inside type declaration (extended):
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      property <name>
+      [ extending <base> [, ...] ] [-> <type>]
+      [ "{"
+          using (<expression>) ;
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+    # Abstract property form:
+    abstract property [<module>::]<name> [extending <base> [, ...]]
+    [ "{"
+        [ readonly := {true | false} ; ]
+        [ <annotation-declarations> ]
+        ...
+      "}" ]
+
+.. sdl:synopsis::
 
     # Concrete property form used inside type declaration:
     [ overloaded ] [{required | optional}] [{single | multi}]
@@ -141,7 +179,7 @@ commands <ref_eql_ddl_props>`.
 
     # Computed property form used inside type declaration:
     [{required | optional}] [{single | multi}]
-      property <name> := <expression>;
+      [ property ] <name> := <expression>;
 
     # Computed property form used inside type declaration (extended):
     [ overloaded ] [{required | optional}] [{single | multi}]

--- a/docs/stdlib/objects.rst
+++ b/docs/stdlib/objects.rst
@@ -30,6 +30,7 @@ type, which is a subtype of ``std::BaseObject``.
     Definition:
 
     .. code-block:: sdl
+        :version-lt: 3.0
 
         abstract type std::BaseObject {
             # Universally unique object identifier
@@ -41,6 +42,20 @@ type, which is a subtype of ``std::BaseObject``.
 
             # Object type in the information schema.
             required readonly link __type__ -> schema::ObjectType;
+        }
+
+    .. code-block:: sdl
+
+        abstract type std::BaseObject {
+            # Universally unique object identifier
+            required id: uuid {
+                default := (select std::uuid_generate_v1mc());
+                readonly := true;
+                constraint exclusive;
+            }
+
+            # Object type in the information schema.
+            required readonly __type__: schema::ObjectType;
         }
 
     Subtypes may override the ``id`` property, but only with a valid UUID


### PR DESCRIPTION
I had to go through nearly every SDL block for this, so I picked up a couple of other issues while I was doing that. Most of this PR is the syntax change though which no longer requires `property` or `link` for computeds. See https://github.com/edgedb/edgedb/pull/6073