### PR TITLE
Clear _config_cache in sys_pgcon before reloading reported config

### DIFF
--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -921,6 +921,7 @@ class Tenant(ha_base.ClusterProtocol):
                 data = await syscon.sql_fetch_val(
                     self._server.get_sys_query("report_configs"),
                     use_prep_stmt=True,
+                    state=b'[]',  # clear _config_cache
                 )
 
                 for (

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1511,6 +1511,17 @@ class TestSeparateCluster(tb.TestCase):
                 msg.error_code)
             self.assertEqual(errcls, errors.IdleSessionTimeoutError)
 
+            # Check new connections are fed with the new value
+            conn = await sd.connect()
+            try:
+                sysconfig = conn.get_settings()["system_config"]
+                self.assertEqual(
+                    sysconfig.session_idle_timeout,
+                    datetime.timedelta(milliseconds=10),
+                )
+            finally:
+                await conn.aclose()
+
     async def test_server_config_db_config(self):
         async with tb.start_edgedb_server(
             http_endpoint_security=args.ServerEndpointSecurityMode.Optional,
@@ -1895,6 +1906,12 @@ class TestStaticServerConfig(tb.TestCase):
         ) as sd:
             conn = await sd.connect()
             try:
+                sysconfig = conn.get_settings()["system_config"]
+                self.assertEqual(
+                    sysconfig.session_idle_timeout,
+                    datetime.timedelta(minutes=2, seconds=18),
+                )
+
                 self.assertEqual(
                     await conn.query_single("""\
                         select assert_single(cfg::Config.session_idle_timeout)
@@ -1946,6 +1963,12 @@ class TestStaticServerConfig(tb.TestCase):
         async with tb.start_edgedb_server(env=env) as sd:
             conn = await sd.connect()
             try:
+                sysconfig = conn.get_settings()["system_config"]
+                self.assertEqual(
+                    sysconfig.session_idle_timeout,
+                    datetime.timedelta(minutes=1, seconds=22),
+                )
+
                 self.assertEqual(
                     await conn.query_single("""\
                         select assert_single(cfg::Config.session_idle_timeout)


### PR DESCRIPTION
Refs #6198, sys_pgcon wasn't favored by the `_clear_state` statement to reset the `_config_cache`, leading to the system config reported to clients not being current. This caused failures in client tests like edgedb/edgedb-go#292.

Fix by applying an empty state before running the `report_configs` sys query, so that the `_config_cache` is cleared in the same way as regular pgcons.