### PR TITLE
Automatically allow redirect URLs from UI config

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1386,6 +1386,17 @@ class Router:
         allowed_urls = cast(FrozenSet[str], allowed_urls).union(
             {self.base_path}
         )
+
+        ui_config = self._get_ui_config()
+        if ui_config:
+            allowed_urls = allowed_urls.union(
+                {ui_config.redirect_to}
+            )
+            if ui_config.redirect_to_on_signup:
+                allowed_urls = allowed_urls.union(
+                    {ui_config.redirect_to_on_signup}
+                )
+
         lower_url = url.lower()
 
         for allowed_url in allowed_urls:


### PR DESCRIPTION
We were automatically adding the built-in Auth UI to the allow list, but we should also add any explicitly set redirect URLs from the UI config to save you from having the add them in two places.

Close #6433 