### PR TITLE
Skip test_dumpv4_restore_compatibility_* without superuser

### DIFF
--- a/tests/test_dump_v4.py
+++ b/tests/test_dump_v4.py
@@ -118,4 +118,4 @@ class TestDumpV4Compat(
     dump_subdir='dumpv4',
     check_method=DumpTestCaseMixin.ensure_schema_data_integrity,
 ):
-    pass
+    BACKEND_SUPERUSER = True


### PR DESCRIPTION
Creating the pgvector extension would require superuser role.

This shall fix the failing CI of non-superuser pg-test

[Sample run](https://github.com/edgedb/edgedb/actions/runs/6774672924)