### PR TITLE
+Note on compiler vs. cache parameters

### DIFF
--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -121,7 +121,12 @@ Query compilation
 ^^^^^^^^^^^^^^^^^
 
 ``edgeql_query_compilations_total``
-  **Counter.** Number of compiled/cached queries or scripts.
+  **Counter.** Number of compiled/cached queries or scripts since instance
+  startup. A query is compiled and then cached on first use, increasing the
+  ``path="compiler"`` parameter. Subsequent uses of the same query only use
+  the cache, thus only increasing the ``path="cache"`` parameter.
+  
+  
 
 ``edgeql_query_compilation_duration``
   **Histogram.** Time it takes to compile an EdgeQL query or script, in


### PR DESCRIPTION
I have an issue here https://github.com/edgedb/edgedb/issues/6387 about adding information on compiler caching and how it works, but since as far as I can tell users only interact with it via the HTTP API metrics, maybe this quick explanation of how to understand those numbers could be enough.

Also apparently the cache is also reset when doing a migration or using a DDL command, but inside the metrics page it only resets when an instance is restarted so that's the relevant information a user has access to.