### PR TITLE
Add more metrics

### DIFF
--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -153,6 +153,9 @@ Queries and compilation
 ``query_compilation_duration``
   **Histogram.** Time it takes to compile a query or script, in seconds.
 
+``queries_per_connection``
+  **Histogram.** Number of queries per connection.
+
 Errors
 ^^^^^^
 

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -120,8 +120,8 @@ Client connections
 ``client_connections_idle_total``
   **Counter.** Total number of forcefully closed idle client connections.
 
-Query compilation
-^^^^^^^^^^^^^^^^^
+Queries and compilation
+^^^^^^^^^^^^^^^^^^^^^^^
 
 ``edgeql_query_compilations_total``
   **Counter.** Number of compiled/cached queries or scripts since instance
@@ -129,11 +129,15 @@ Query compilation
   ``path="compiler"`` parameter. Subsequent uses of the same query only use
   the cache, thus only increasing the ``path="cache"`` parameter.
 
-
-
 ``edgeql_query_compilation_duration``
   **Histogram.** Time it takes to compile an EdgeQL query or script, in
   seconds.
+
+``graphql_query_compilations_total``
+  **Counter.** Number of compiled/cached GraphQL queries since instance
+  startup. A query is compiled and then cached on first use, increasing the
+  ``path="compiler"`` parameter. Subsequent uses of the same query only use
+  the cache, thus only increasing the ``path="cache"`` parameter.
 
 Errors
 ^^^^^^

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -171,6 +171,9 @@ Auth Extension
 ``auth_ui_renders_total``
   **Counter.** Number of UI pages rendered by the Auth extension.
 
+``auth_providers``
+  **Histogram.** Number of Auth providers configured.
+
 Errors
 ^^^^^^
 

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -174,6 +174,9 @@ Auth Extension
 ``auth_providers``
   **Histogram.** Number of Auth providers configured.
 
+``auth_successful_logins_total``
+  **Counter.** Number of successful logins in the Auth extension.
+
 Errors
 ^^^^^^
 

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -139,6 +139,12 @@ Queries and compilation
   ``path="compiler"`` parameter. Subsequent uses of the same query only use
   the cache, thus only increasing the ``path="cache"`` parameter.
 
+``sql_queries_total``
+  **Counter.** Number of SQL queries since instance startup.
+
+``sql_compilations_total``
+  **Counter.** Number of SQL compilations since instance startup.
+
 Errors
 ^^^^^^
 

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -162,6 +162,15 @@ Queries and compilation
   GraphQL query, ``=sql`` for a readonly SQL query from the user, and
   ``=compiled`` for a backend SQL query compiled and issued by the server.
 
+Auth Extension
+^^^^^^^^^^^^^^
+
+``auth_api_calls_total``
+  **Counter.** Number of API calls to the Auth extension.
+
+``auth_ui_renders_total``
+  **Counter.** Number of UI pages rendered by the Auth extension.
+
 Errors
 ^^^^^^
 

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -156,6 +156,12 @@ Queries and compilation
 ``queries_per_connection``
   **Histogram.** Number of queries per connection.
 
+``query_size``
+  **Histogram.** Number of bytes in a query, where the label
+  ``interface=edgeql`` means the size of an EdgeQL query, ``=graphql`` for a
+  GraphQL query, ``=sql`` for a readonly SQL query from the user, and
+  ``=compiled`` for a backend SQL query compiled and issued by the server.
+
 Errors
 ^^^^^^
 

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -120,6 +120,9 @@ Client connections
 ``client_connections_idle_total``
   **Counter.** Total number of forcefully closed idle client connections.
 
+``client_connection_duration``
+  **Histogram.** Time a client connection is open.
+
 Queries and compilation
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -76,14 +76,17 @@ Retrieve instance metrics.
 All EdgeDB instances expose a Prometheus-compatible endpoint available via GET
 request. The following metrics are made available.
 
-Processes
-^^^^^^^^^
+System
+^^^^^^
 
 ``compiler_process_spawns_total``
   **Counter.** Total number of compiler processes spawned.
 
 ``compiler_processes_current``
   **Gauge.** Current number of active compiler processes.
+
+``branches_current``
+  **Gauge.** Current number of branches.
 
 Backend connections and performance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,8 +128,8 @@ Query compilation
   startup. A query is compiled and then cached on first use, increasing the
   ``path="compiler"`` parameter. Subsequent uses of the same query only use
   the cache, thus only increasing the ``path="cache"`` parameter.
-  
-  
+
+
 
 ``edgeql_query_compilation_duration``
   **Histogram.** Time it takes to compile an EdgeQL query or script, in

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -130,6 +130,8 @@ Queries and compilation
   the cache, thus only increasing the ``path="cache"`` parameter.
 
 ``edgeql_query_compilation_duration``
+  Deprecated in favor of ``query_compilation_duration[interface="edgeql"]``.
+
   **Histogram.** Time it takes to compile an EdgeQL query or script, in
   seconds.
 
@@ -144,6 +146,9 @@ Queries and compilation
 
 ``sql_compilations_total``
   **Counter.** Number of SQL compilations since instance startup.
+
+``query_compilation_duration``
+  **Histogram.** Time it takes to compile a query or script, in seconds.
 
 Errors
 ^^^^^^

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -162,6 +162,9 @@ Errors
 ``background_errors_total``
   **Counter.** Number of unhandled errors in background server routines.
 
+``transaction_serialization_errors_total``
+  **Counter.** Number of transaction serialization errors.
+
 .. _ref_reference_http_querying:
 
 Querying

--- a/docs/reference/http.rst
+++ b/docs/reference/http.rst
@@ -165,6 +165,9 @@ Errors
 ``transaction_serialization_errors_total``
   **Counter.** Number of transaction serialization errors.
 
+``connection_errors_total``
+  **Counter.** Number of network connection errors.
+
 .. _ref_reference_http_querying:
 
 Querying

--- a/edb/common/prometheus.py
+++ b/edb/common/prometheus.py
@@ -171,7 +171,7 @@ class Registry:
         /,
         *,
         unit: Unit | None = None,
-        labels: tuple[str],
+        labels: tuple[str, ...],
     ) -> LabeledGauge:
         gauge = LabeledGauge(self, name, desc, unit, labels=labels)
         self._add_metric(gauge)
@@ -198,7 +198,7 @@ class Registry:
         *,
         unit: Unit | None = None,
         buckets: list[float] | None = None,
-        labels: tuple[str],
+        labels: tuple[str, ...],
     ) -> LabeledHistogram:
         hist = LabeledHistogram(
             self, name, desc, unit, buckets=buckets, labels=labels

--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -37,7 +37,7 @@ from edb import _graphql_rewrite
 from edb import errors
 from edb.graphql import errors as gql_errors
 from edb.server.dbview cimport dbview
-from edb.server import compiler
+from edb.server import compiler, metrics
 from edb.server import defines as edbdef
 from edb.server.pgcon import errors as pgerrors
 from edb.server.protocol import execute
@@ -348,11 +348,17 @@ async def _execute(db, tenant, query, operation_name, variables, globals):
             query_cache[cache_key2] = qug, gql_op
         else:
             query_cache[cache_key] = qug, gql_op
+        metrics.graphql_query_compilations.inc(
+            1.0, tenant.get_instance_name(), 'compiler'
+        )
     else:
         qug, gql_op = entry
         # This is at least the second time this query is used
         # and it's safe to cache.
         use_prep_stmt = True
+        metrics.graphql_query_compilations.inc(
+            1.0, tenant.get_instance_name(), 'cache'
+        )
 
     compiled = dbview.CompiledQuery(query_unit_group=qug)
 

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -58,6 +58,7 @@ cdef class DatabaseIndex:
         object _cached_compiler_args
 
     cdef invalidate_caches(self)
+    cdef inline set_current_branches(self)
 
 
 cdef class Database:

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -88,6 +88,7 @@ cdef class Database:
     cdef _cache_compiled_query(self, key, compiled)
     cdef _new_view(self, query_cache, protocol_version)
     cdef _remove_view(self, view)
+    cdef _observe_auth_ext_config(self)
     cdef _update_backend_ids(self, new_types)
     cdef _set_and_signal_new_user_schema(
         self,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1352,10 +1352,22 @@ cdef class DatabaseIndex:
                 ext_config_settings=ext_config_settings,
             )
             self._dbs[dbname] = db
+        self.set_current_branches()
         return db
 
     def unregister_db(self, dbname):
         self._dbs.pop(dbname)
+        self.set_current_branches()
+
+    cdef inline set_current_branches(self):
+        metrics.current_branches.set(
+            sum(
+                1
+                for dbname in self._dbs
+                if dbname != defines.EDGEDB_SYSTEM_DB
+            ),
+            self._tenant.get_instance_name(),
+        )
 
     def iter_dbs(self):
         return iter(self._dbs.values())

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1192,6 +1192,11 @@ cdef class DatabaseConnectionView:
                 time.monotonic() - started_at,
                 self.tenant.get_instance_name(),
             )
+            metrics.query_compilation_duration.observe(
+                time.monotonic() - started_at,
+                self.tenant.get_instance_name(),
+                "edgeql",
+            )
 
         unit_group, self._last_comp_state, self._last_comp_state_id = result
 

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -157,6 +157,12 @@ transaction_serialization_errors = registry.new_labeled_counter(
     labels=('tenant',)
 )
 
+connection_errors = registry.new_labeled_counter(
+    'connection_errors_total',
+    'Number of network connection errors.',
+    labels=('tenant',)
+)
+
 ha_events_total = registry.new_labeled_counter(
     "ha_events_total",
     "Number of each high-availability watch event.",

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -175,3 +175,15 @@ ha_events_total = registry.new_labeled_counter(
     "Number of each high-availability watch event.",
     labels=("dsn", "event"),
 )
+
+auth_api_calls = registry.new_labeled_counter(
+    "auth_api_calls_total",
+    "Number of API calls to the Auth extension.",
+    labels=("tenant",),
+)
+
+auth_ui_renders = registry.new_labeled_counter(
+    "auth_ui_renders_total",
+    "Number of UI pages rendered by the Auth extension.",
+    labels=("tenant",),
+)

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -113,6 +113,18 @@ graphql_query_compilations = registry.new_labeled_counter(
     labels=('tenant', 'path')
 )
 
+sql_queries = registry.new_labeled_counter(
+    'sql_queries_total',
+    'Number of SQL queries.',
+    labels=('tenant',)
+)
+
+sql_compilations = registry.new_labeled_counter(
+    'sql_compilations_total',
+    'Number of SQL compilations.',
+    labels=('tenant',)
+)
+
 background_errors = registry.new_labeled_counter(
     'background_errors_total',
     'Number of unhandled errors in background server routines.',

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -151,6 +151,12 @@ background_errors = registry.new_labeled_counter(
     labels=('tenant', 'source')
 )
 
+transaction_serialization_errors = registry.new_labeled_counter(
+    'transaction_serialization_errors_total',
+    'Number of transaction serialization errors.',
+    labels=('tenant',)
+)
+
 ha_events_total = registry.new_labeled_counter(
     "ha_events_total",
     "Number of each high-availability watch event.",

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -94,6 +94,13 @@ idle_client_connections = registry.new_labeled_counter(
     labels=('tenant',),
 )
 
+client_connection_duration = registry.new_labeled_histogram(
+    'client_connection_duration',
+    'Time a client connection is open.',
+    unit=prom.Unit.SECONDS,
+    labels=('tenant', 'interface'),
+)
+
 edgeql_query_compilations = registry.new_labeled_counter(
     'edgeql_query_compilations_total',
     'Number of compiled/cached queries or scripts.',

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -113,6 +113,13 @@ graphql_query_compilations = registry.new_labeled_counter(
     labels=('tenant', 'path')
 )
 
+query_compilation_duration = registry.new_labeled_histogram(
+    'query_compilation_duration',
+    'Time it takes to compile a query or script.',
+    unit=prom.Unit.SECONDS,
+    labels=('tenant', 'interface'),
+)
+
 sql_queries = registry.new_labeled_counter(
     'sql_queries_total',
     'Number of SQL queries.',

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -187,3 +187,9 @@ auth_ui_renders = registry.new_labeled_counter(
     "Number of UI pages rendered by the Auth extension.",
     labels=("tenant",),
 )
+
+auth_providers = registry.new_labeled_gauge(
+    'auth_providers',
+    'Number of Auth providers configured.',
+    labels=('tenant', 'branch'),
+)

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -107,6 +107,12 @@ edgeql_query_compilation_duration = registry.new_labeled_histogram(
     labels=('tenant',),
 )
 
+graphql_query_compilations = registry.new_labeled_counter(
+    'graphql_query_compilations_total',
+    'Number of compiled/cached GraphQL queries.',
+    labels=('tenant', 'path')
+)
+
 background_errors = registry.new_labeled_counter(
     'background_errors_total',
     'Number of unhandled errors in background server routines.',

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -193,3 +193,9 @@ auth_providers = registry.new_labeled_gauge(
     'Number of Auth providers configured.',
     labels=('tenant', 'branch'),
 )
+
+auth_successful_logins = registry.new_labeled_counter(
+    "auth_successful_logins_total",
+    "Number of successful logins in the Auth extension.",
+    labels=("tenant",),
+)

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -32,6 +32,12 @@ current_compiler_processes = registry.new_gauge(
     'Current number of active compiler processes.'
 )
 
+current_branches = registry.new_labeled_gauge(
+    'branches_current',
+    'Current number of branches.',
+    labels=('tenant',),
+)
+
 total_backend_connections = registry.new_labeled_counter(
     'backend_connections_total',
     'Total number of backend connections established.',

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -139,6 +139,12 @@ sql_compilations = registry.new_labeled_counter(
     labels=('tenant',)
 )
 
+queries_per_connection = registry.new_labeled_histogram(
+    'queries_per_connection',
+    'Number of queries per connection.',
+    labels=('tenant', 'interface'),
+)
+
 background_errors = registry.new_labeled_counter(
     'background_errors_total',
     'Number of unhandled errors in background server routines.',

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -145,6 +145,13 @@ queries_per_connection = registry.new_labeled_histogram(
     labels=('tenant', 'interface'),
 )
 
+query_size = registry.new_labeled_histogram(
+    'query_size',
+    'The size of a query.',
+    unit=prom.Unit.BYTES,
+    labels=('tenant', 'interface'),
+)
+
 background_errors = registry.new_labeled_counter(
     'background_errors_total',
     'Number of unhandled errors in background server routines.',

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -968,6 +968,11 @@ cdef class PGConnection:
                     out.write_buffer(buf.end_message())
                     parse_array[idx] = True
                     parsed.add(stmt_name)
+                    metrics.query_size.observe(
+                        len(query_unit.sql[0]),
+                        self.get_tenant_label(),
+                        'compiled',
+                    )
 
                 buf = WriteBuffer.new_message(b'B')
                 buf.write_bytestring(b'')  # portal name
@@ -987,6 +992,9 @@ cdef class PGConnection:
                     buf.write_bytestring(sql)
                     buf.write_int16(0)
                     out.write_buffer(buf.end_message())
+                    metrics.query_size.observe(
+                        len(sql), self.get_tenant_label(), 'compiled'
+                    )
 
                     buf = WriteBuffer.new_message(b'B')
                     buf.write_bytestring(b'')  # portal name
@@ -1233,6 +1241,9 @@ cdef class PGConnection:
                     buf.write_int16(0)
                     out.write_buffer(buf.end_message())
                     i += 1
+                    metrics.query_size.observe(
+                        len(sql), self.get_tenant_label(), 'compiled'
+                    )
             else:
                 if len(query.sql) != 1:
                     raise errors.InternalServerError(
@@ -1244,6 +1255,9 @@ cdef class PGConnection:
                 buf.write_bytestring(query.sql[0])
                 buf.write_int16(0)
                 out.write_buffer(buf.end_message())
+                metrics.query_size.observe(
+                    len(query.sql[0]), self.get_tenant_label(), 'compiled'
+                )
 
         assert bind_data is not None
         if stmt_name == b'' and msgs_num > 1:
@@ -1678,6 +1692,9 @@ cdef class PGConnection:
                     msg_buf.write_bytestring(sql_text)
                     msg_buf.write_bytes(data)
                     buf.write_buffer(msg_buf.end_message())
+                    metrics.query_size.observe(
+                        len(sql_text), self.get_tenant_label(), 'compiled'
+                    )
                     if self.debug:
                         self.debug_print(
                             'Parse', action.stmt_name, sql_text, data

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -38,7 +38,7 @@ from edb import errors as edb_errors
 from edb.common import debug
 from edb.common import markup
 from edb.ir import statypes
-from edb.server import tenant as edbtenant
+from edb.server import tenant as edbtenant, metrics
 from edb.server.config.types import CompositeConfigType
 
 from . import (
@@ -1660,6 +1660,9 @@ class Router:
             claims=claims,
         )
         session_token.make_signed_token(signing_key)
+        metrics.auth_successful_logins.inc(
+            1.0, self.tenant.get_instance_name()
+        )
         return session_token.serialize()
 
     def _get_from_claims(self, state: str, key: str) -> str:

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1141,6 +1141,10 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         fields = {}
         if isinstance(exc, errors.EdgeDBError):
             fields.update(exc._attrs)
+            if isinstance(exc, errors.TransactionSerializationError):
+                metrics.transaction_serialization_errors.inc(
+                    1.0, self.get_tenant_label()
+                )
 
         try:
             formatted_error = exc.__formatted_error__

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -906,6 +906,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
                     extra_blobs=query_req.source.extra_blobs(),
                 )
 
+        self._query_count += 1
+
         # Clear the _last_anon_compiled so that the next Execute - if
         # identical - will always lookup in the cache and honor the
         # `cacheable` flag to compile the query again.

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -148,6 +148,7 @@ cdef inline bint parse_boolean(value: bytes, header: str):
 
 
 cdef class EdgeConnection(frontend.FrontendConnection):
+    interface = "edgeql"
 
     def __init__(
         self,
@@ -1803,6 +1804,7 @@ def new_edge_connection(
     auth_data: bytes = b'',
     protocol_version: edbdef.ProtocolVersion = edbdef.CURRENT_PROTOCOL,
     conn_params: dict[str, str] | None = None,
+    connection_made_at: float | None = None,
 ):
     return EdgeConnection(
         server,
@@ -1813,6 +1815,7 @@ def new_edge_connection(
         auth_data=auth_data,
         protocol_version=protocol_version,
         conn_params=conn_params,
+        connection_made_at=connection_made_at,
     )
 
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -791,6 +791,10 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         if not query:
             raise errors.BinaryProtocolError('empty query')
 
+        metrics.query_size.observe(
+            len(query), self.get_tenant_label(), 'edgeql'
+        )
+
         _dbview = self.get_dbview()
         state_tid = self.buffer.read_bytes(16)
         state_data = self.buffer.read_len_prefixed_bytes()

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -42,6 +42,7 @@ from edb.edgeql import qltypes
 from edb.server import compiler
 from edb.server import config
 from edb.server import defines as edbdef
+from edb.server import metrics
 from edb.server.compiler import errormech
 from edb.server.compiler cimport rpc
 from edb.server.dbview cimport dbview
@@ -694,6 +695,10 @@ async def parse_execute_json(
         query_cache=query_cache_enabled,
         protocol_version=edbdef.CURRENT_PROTOCOL,
     )
+    if use_metrics:
+        metrics.query_size.observe(
+            len(query.encode('utf-8')), tenant.get_instance_name(), 'edgeql'
+        )
 
     query_req = rpc.CompilationRequest(
         db.server.compilation_config_serializer

--- a/edb/server/protocol/frontend.pxd
+++ b/edb/server/protocol/frontend.pxd
@@ -46,6 +46,7 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         object _transport
         WriteBuffer _write_buf
         object _write_waiter
+        object connection_made_at
 
         ReadBuffer buffer
         object _msg_take_waiter

--- a/edb/server/protocol/frontend.pxd
+++ b/edb/server/protocol/frontend.pxd
@@ -47,6 +47,7 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         WriteBuffer _write_buf
         object _write_waiter
         object connection_made_at
+        int _query_count
 
         ReadBuffer buffer
         object _msg_take_waiter

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -888,6 +888,7 @@ cdef class PgConnection(frontend.FrontendConnection):
         metrics.sql_queries.inc(
             len(query_units), self.tenant.get_instance_name()
         )
+        self._query_count += len(query_units)
 
         if not already_in_implicit_tx:
             actions.append(PGMessage(PGAction.START_IMPLICIT_TX))
@@ -1095,6 +1096,7 @@ cdef class PgConnection(frontend.FrontendConnection):
                     self.debug_print("Execute", repr(portal_name), max_rows)
 
                 metrics.sql_queries.inc(1.0, self.tenant.get_instance_name())
+                self._query_count += 1
                 with managed_error():
                     unit = dbv.find_portal(portal_name)
                     actions.append(

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -341,6 +341,8 @@ cdef class ConnectionView:
 
 
 cdef class PgConnection(frontend.FrontendConnection):
+    interface = "sql"
+
     def __init__(self, server, sslctx, endpoint_security, **kwargs):
         super().__init__(server, None, **kwargs)
         self._dbview = ConnectionView()
@@ -1507,7 +1509,7 @@ cdef class PgConnection(frontend.FrontendConnection):
         return qu
 
 
-def new_pg_connection(server, sslctx, endpoint_security):
+def new_pg_connection(server, sslctx, endpoint_security, connection_made_at):
     return PgConnection(
         server,
         sslctx,
@@ -1515,4 +1517,5 @@ def new_pg_connection(server, sslctx, endpoint_security):
         passive=False,
         transport=srvargs.ServerConnTransport.TCP_PG,
         external_auth=False,
+        connection_made_at=connection_made_at,
     )

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -67,6 +67,7 @@ cdef class HttpProtocol:
         object binary_endpoint_security
         object http_endpoint_security
         object tenant
+        object connection_made_at
 
         HttpRequest current_request
 

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -660,9 +660,10 @@ cdef class HttpProtocol:
                     await handler.handle_request(request, response, args)
                     if args:
                         if args[0] == 'ui':
-                            srv_metrics.auth_ui_renders.inc(
-                                1.0, self.get_tenant_label()
-                            )
+                            if not (len(args) > 1 and args[1] == "_static"):
+                                srv_metrics.auth_ui_renders.inc(
+                                    1.0, self.get_tenant_label()
+                                )
                         else:
                             srv_metrics.auth_api_calls.inc(
                                 1.0, self.get_tenant_label()


### PR DESCRIPTION
- [x] Current number of databases.
- [x] Time a client connection is open.
- [x] Number of compiled/cached GraphQL queries.
- [x] Number of SQL queries since instance startup.
- [x] Number of SQL compilations since instance startup.
- [x] Time it takes to compile a query or script.
- [x] Queries per connection (EdgeQL / SQL only).
- [x] Number of transaction serialization errors.
- [x] Number of network errors.
- [x] Number of Auth API calls.
- [x] Number of Auth UI form rendered.
- [x] Number of Auth successful logins.
- [x] Number of OAuth providers configured.
- [x] Average size of queries.