### PR TITLE
Fixes to auth redirect urls

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -803,6 +803,7 @@ class Router:
                 base_path=self.base_path,
                 providers=providers,
                 redirect_to=ui_config.redirect_to,
+                redirect_to_on_signup=ui_config.redirect_to_on_signup,
                 error_message=_maybe_get_search_param(query, 'error'),
                 email=_maybe_get_search_param(query, 'email'),
                 challenge=maybe_challenge,
@@ -848,9 +849,8 @@ class Router:
             response.body = ui.render_signup_page(
                 base_path=self.base_path,
                 providers=providers,
-                redirect_to=(
-                    ui_config.redirect_to_on_signup or ui_config.redirect_to
-                ),
+                redirect_to=ui_config.redirect_to,
+                redirect_to_on_signup=ui_config.redirect_to_on_signup,
                 error_message=_maybe_get_search_param(query, 'error'),
                 email=_maybe_get_search_param(query, 'email'),
                 challenge=maybe_challenge,

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -333,7 +333,7 @@ class Router:
         new_url = _join_url_params(
             (redirect_to_on_signup or redirect_to)
             if new_identity else redirect_to,
-            {"code": pkce_code}
+            {"code": pkce_code, "provider": provider_name}
         )
         session_token = self._make_session_token(identity.id)
         response.status = http.HTTPStatus.FOUND
@@ -436,7 +436,10 @@ class Router:
                 redirect_params = (
                     {"verification_email_sent_at": now_iso8601}
                     if require_verification
-                    else {"code": cast(str, pkce_code)}
+                    else {
+                        "code": cast(str, pkce_code),
+                        "provider": register_provider_name
+                    }
                 )
                 response.custom_headers["Location"] = _join_url_params(
                     maybe_redirect_to, redirect_params
@@ -451,7 +454,10 @@ class Router:
                 else:
                     if pkce_code is None:
                         raise errors.PKCECreationFailed
-                    response.body = json.dumps({"code": pkce_code}).encode()
+                    response.body = json.dumps({
+                        "code": pkce_code,
+                        "provider": register_provider_name
+                    }).encode()
         except Exception as ex:
             redirect_on_failure = data.get(
                 "redirect_on_failure", maybe_redirect_to

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -176,6 +176,7 @@ def render_signup_page(
     challenge: str,
     # config
     redirect_to: str,
+    redirect_to_on_signup: Optional[str] = None,
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
@@ -194,8 +195,10 @@ def render_signup_page(
     oauth_params = {
         'redirect_to': redirect_to,
         'challenge': challenge,
-        'redirect_to_on_signup': redirect_to,
     }
+
+    if redirect_to_on_signup:
+        oauth_params['redirect_to_on_signup'] = redirect_to_on_signup
 
     oauth_label = "Sign up with" if password_provider else "Continue with"
     oauth_buttons = '\n'.join(
@@ -246,7 +249,8 @@ def render_signup_page(
       <input type="hidden" name="provider" value="{password_provider.name}" />
       <input type="hidden" name="redirect_on_failure" value="{
         base_path}/ui/signup" />
-      <input type="hidden" name="redirect_to" value="{redirect_to}" />
+      <input type="hidden" name="redirect_to" value="{
+          redirect_to_on_signup or redirect_to}" />
       <input type="hidden" name="challenge" value="{challenge}" />
       <input type="hidden" name="verify_url" value="{base_path}/ui/verify" />
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -1824,7 +1824,10 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(parsed_location.path, "/some/path")
             self.assertEqual(
                 parsed_query,
-                {"code": [str(pkce_challenge.id)]},
+                {
+                    "code": [str(pkce_challenge.id)],
+                    "provider": ["builtin::local_emailpassword"]
+                },
             )
 
             password_credential = await self.con.query(
@@ -2015,7 +2018,8 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(
                 json.loads(body),
                 {
-                    "code": str(pkce_challenge.id)
+                    "code": str(pkce_challenge.id),
+                    "provider": "builtin::local_emailpassword"
                 },
             )
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -1967,7 +1967,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
 
-            self.assertEquals(status, 400)
+            self.assertEqual(status, 400)
 
     async def test_http_auth_ext_local_password_register_json_02(self):
         with self.http_con() as http_con:
@@ -2611,7 +2611,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 body=form_data_encoded,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
-            self.assertEquals(status, 400)
+            self.assertEqual(status, 400)
 
     async def test_http_auth_ext_local_password_reset_form_01(self):
         with self.http_con() as http_con:


### PR DESCRIPTION
Fixes multiple issues with auth redirects:
- Fix `redirect_to_on_signup` not being used/being used when it shouldn't as the redirect url in the builtin ui
- Fix broken joining of params to redirect urls when the url already contains query params
- Add `provider` name to the params of redirects from the oauth and email/password register flows
- Add verify_url to verification_token claims for use in resend verification flow + check `verify_url` is an allowed url