### PR TITLE
Add note relating `migrate --dev-mode` to `watch`

### DIFF
--- a/docs/cli/edgedb_watch.rst
+++ b/docs/cli/edgedb_watch.rst
@@ -26,6 +26,12 @@ real time.
 To learn about our recommended development migration workflow using ``edgedb
 watch``, read our :ref:`intro to migrations <ref_intro_migrations>`.
 
+.. note::
+
+    If you want to apply a migration in the same manner as ``watch`` but
+    without the long-running process, use ``edgedb migrate --dev-mode``. See
+    :ref:`ref_cli_edgedb_migration_apply` for more details.
+
 Demo
 ====
 

--- a/docs/cli/edgedb_watch.rst
+++ b/docs/cli/edgedb_watch.rst
@@ -11,7 +11,7 @@ edgedb watch
 
 Start a long-running process that watches for changes in schema files in your
 project's ``dbschema`` directory and applies those changes to your database in
-real time.
+real time. Starting it is as simple as running this command:
 
 .. cli:synopsis::
 


### PR DESCRIPTION
This question came up in a recent issue (https://github.com/edgedb/edgedb-cli/issues/1170). This note should make it easier for users to discover in the future.