### PR TITLE
Treat password reset as a verification event

### DIFF
--- a/edb/server/protocol/auth_ext/local.py
+++ b/edb/server/protocol/auth_ext/local.py
@@ -297,7 +297,14 @@ with
   new_hash := <str>$new_hash,
 update ext::auth::EmailPasswordFactor
 filter .identity.id = identity_id
-set { password_hash := new_hash };""",
+set {
+    password_hash := new_hash,
+    verified_at := (
+        if exists .verified_at
+        then .verified_at
+        else datetime_current()
+    )
+};""",
             variables={
                 'identity_id': identity_id,
                 'new_hash': ph.hash(password),

--- a/edb/server/protocol/auth_ext/local.py
+++ b/edb/server/protocol/auth_ext/local.py
@@ -299,11 +299,7 @@ update ext::auth::EmailPasswordFactor
 filter .identity.id = identity_id
 set {
     password_hash := new_hash,
-    verified_at := (
-        if exists .verified_at
-        then .verified_at
-        else datetime_current()
-    )
+    verified_at := .verified_at ?? datetime_current()
 };""",
             variables={
                 'identity_id': identity_id,


### PR DESCRIPTION
We discovered that we allow you to log in when you reset your password since we don't check if you're verified. Since the purpose of the verification flow in email is to verify that you control the email address, it makes sense to treat a password reset as a verification event and update the verified_at timestamp when the user resets the password.

Closes #6502 