### PR TITLE
Expose __type__ via SQL adapter

### DIFF
--- a/edb/common/assert_data_shape.py
+++ b/edb/common/assert_data_shape.py
@@ -270,7 +270,7 @@ def assert_data_shape(data, shape, fail, message=None, from_sql=False):
                         f'{message}: not isclose({data}, {shape}) '
                         f'{_format_path(path)}')
             elif isinstance(shape, uuid.UUID):
-                # If data comde from SQL, we expect UUID.
+                # If data comes from SQL, we expect UUID.
                 if data != shape:
                     fail(
                         f'{message}: {data!r} != {shape!r} '

--- a/edb/pgsql/resolver/context.py
+++ b/edb/pgsql/resolver/context.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from typing import *
 from dataclasses import dataclass, field
 import enum
+import uuid
 
 from edb.common import compiler
 from edb.schema import schema as s_schema
@@ -103,6 +104,10 @@ class Column:
     # Used for system columns
     # https://www.postgresql.org/docs/14/ddl-system-columns.html
     hidden: bool = False
+
+    # Value that can be used instead referencing the column.
+    # Used from __type__ only, so that's why it is UUID (for now).
+    static_val: Optional[uuid.UUID] = None
 
     def __str__(self) -> str:
         return self.name or '<unnamed>'

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -50,7 +50,6 @@ def infer_alias(res_target: pgast.ResTarget) -> Optional[str]:
 def resolve_ResTarget(
     res_target: pgast.ResTarget, *, ctx: Context
 ) -> Tuple[Sequence[pgast.ResTarget], Sequence[context.Column]]:
-
     alias = infer_alias(res_target)
 
     # special case for ColumnRef for handing wildcards
@@ -87,16 +86,15 @@ def resolve_ResTarget(
 
     col = context.Column(name=alias, reference_as=alias)
     new_target = pgast.ResTarget(
-        val=val,
-        name=alias,
-        context=res_target.context)
+        val=val, name=alias, context=res_target.context
+    )
     return (new_target,), (col,)
 
 
 @dispatch._resolve.register
 def resolve_ColumnRef(
     column_ref: pgast.ColumnRef, *, ctx: Context
-) -> pgast.ColumnRef:
+) -> pgast.BaseExpr:
     res = _lookup_column(column_ref, ctx)
     table, column = res[0]
 
@@ -104,6 +102,12 @@ def resolve_ColumnRef(
         # Lookup can have multiple results only when using *.
         assert table.reference_as
         return pgast.ColumnRef(name=(table.reference_as, pgast.Star()))
+
+    if column.static_val:
+        return pgast.TypeCast(
+            arg=pgast.StringConstant(val=str(column.static_val)),
+            type_name=pgast.TypeName(name=('uuid',)),
+        )
 
     assert column.reference_as
 
@@ -135,9 +139,9 @@ def _lookup_column(
                 for c in t.columns
                 if not c.hidden
             ]
-        else:
-            for table in ctx.scope.tables:
-                matched_columns.extend(_lookup_in_table(col_name, table))
+
+        for table in ctx.scope.tables:
+            matched_columns.extend(_lookup_in_table(col_name, table))
 
         if not matched_columns:
             # is it a reference to a rel var?
@@ -172,15 +176,11 @@ def _lookup_column(
     if len(matched_columns) > 1:
         max_precedence = max(t.precedence for t, _ in matched_columns)
         matched_columns = [
-            (t, c)
-            for t, c in matched_columns
-            if t.precedence == max_precedence
+            (t, c) for t, c in matched_columns if t.precedence == max_precedence
         ]
 
     if len(matched_columns) > 1:
-        potential_tables = ', '.join(
-            [t.name or '' for t, _ in matched_columns]
-        )
+        potential_tables = ', '.join([t.name or '' for t, _ in matched_columns])
         raise errors.QueryError(
             f'ambiguous column `{col_name}` could belong to '
             f'following tables: {potential_tables}',
@@ -321,7 +321,6 @@ def resolve_FuncCall(
     *,
     ctx: Context,
 ) -> pgast.BaseExpr:
-
     # Special case: some function calls (mostly from pg_catalog) are
     # intercepted and statically evaluated.
     if res := static.eval_FuncCall(call, ctx=ctx):

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -20,6 +20,7 @@
 in our internal Postgres instance."""
 
 from typing import *
+import uuid
 
 from edb import errors
 
@@ -62,12 +63,17 @@ def resolve_ResTarget(
             columns.append(column)
 
             assert table.reference_as
-            assert column.reference_as
+            if column.static_val:
+                # special case: __type__ static value
+                val = _uuid_const(column.static_val)
+            else:
+                assert column.reference_as
+                val = pgast.ColumnRef(
+                    name=(table.reference_as, column.reference_as)
+                )
             res.append(
                 pgast.ResTarget(
-                    val=pgast.ColumnRef(
-                        name=(table.reference_as, column.reference_as)
-                    ),
+                    val=val,
                     name=column.name,
                 )
             )
@@ -104,10 +110,7 @@ def resolve_ColumnRef(
         return pgast.ColumnRef(name=(table.reference_as, pgast.Star()))
 
     if column.static_val:
-        return pgast.TypeCast(
-            arg=pgast.StringConstant(val=str(column.static_val)),
-            type_name=pgast.TypeName(name=('uuid',)),
-        )
+        return _uuid_const(column.static_val)
 
     assert column.reference_as
 
@@ -117,6 +120,13 @@ def resolve_ColumnRef(
     else:
         # this is a reference to a local column, so it doesn't need table name
         return pgast.ColumnRef(name=(column.reference_as,))
+
+
+def _uuid_const(val: uuid.UUID):
+    return pgast.TypeCast(
+        arg=pgast.StringConstant(val=str(val)),
+        type_name=pgast.TypeName(name=('uuid',)),
+    )
 
 
 def _lookup_column(

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -103,6 +103,7 @@ def _resolve_RelRangeVar(
             name=alias or col.name,
             reference_as=alias or col.reference_as,
             hidden=col.hidden,
+            static_val=col.static_val,
         )
         for col, alias in _zip_column_alias(
             table.columns, alias, ctx=range_var.context

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -48,7 +48,6 @@ Context = context.ResolverContextLevel
 def resolve_SelectStmt(
     stmt: pgast.SelectStmt, *, ctx: Context
 ) -> Tuple[pgast.SelectStmt, context.Table]:
-
     # VALUES
     if stmt.values:
         values = dispatch.resolve_list(stmt.values, ctx=ctx)
@@ -234,9 +233,7 @@ def resolve_relation(
 
     # try a CTE
     if not schema_name or schema_name == 'public':
-        cte = next(
-            (t for t in ctx.scope.ctes if t.name == relation.name), None
-        )
+        cte = next((t for t in ctx.scope.ctes if t.name == relation.name), None)
         if cte:
             table = context.Table(name=cte.name, columns=cte.columns.copy())
             return pgast.Relation(name=cte.name, schemaname=None), table
@@ -291,16 +288,13 @@ def resolve_relation(
         pointers = obj.get_pointers(ctx.schema).objects(ctx.schema)
 
         for p in pointers:
-            # TODO: We ought to support type
-            if p.get_shortname(ctx.schema).name == '__type__':
-                continue
             card = p.get_cardinality(ctx.schema)
             if card.is_multi():
                 continue
             if p.get_computable(ctx.schema):
                 continue
 
-            columns.append(_construct_column(p, ctx))
+            columns.append(_construct_column(p, ctx, ctx.include_inherited))
     else:
         for c in ['source', 'target']:
             columns.append(context.Column(name=c, reference_as=c))
@@ -372,11 +366,14 @@ def _lookup_pointer_table(
     raise NotImplementedError()
 
 
-def _construct_column(p: s_pointers.Pointer, ctx: Context) -> context.Column:
+def _construct_column(
+    p: s_pointers.Pointer, ctx: Context, include_inherited: bool
+) -> context.Column:
     col = context.Column()
+    short_name = p.get_shortname(ctx.schema)
 
     if isinstance(p, s_properties.Property):
-        col.name = p.get_shortname(ctx.schema).name
+        col.name = short_name.name
 
         if p.is_link_source_property(ctx.schema):
             col.reference_as = 'source'
@@ -385,16 +382,26 @@ def _construct_column(p: s_pointers.Pointer, ctx: Context) -> context.Column:
         elif p.is_id_pointer(ctx.schema):
             col.reference_as = 'id'
         else:
-            _, dbname = pgcommon.get_backend_name(
-                ctx.schema, p, catenate=False
-            )
+            _, dbname = pgcommon.get_backend_name(ctx.schema, p, catenate=False)
             col.reference_as = dbname
 
-    if isinstance(p, s_links.Link):
-        col.name = p.get_shortname(ctx.schema).name + '_id'
+    elif isinstance(p, s_links.Link):
+        if short_name.name == '__type__':
+            col.name = '__type__'
+            col.reference_as = '__type__'
 
-        _, dbname = pgcommon.get_backend_name(ctx.schema, p, catenate=False)
-        col.reference_as = dbname
+            if not include_inherited:
+                # When using FROM ONLY, we will be referencing actual tables
+                # and not inheritance views. Actual tables don't contain
+                # __type__ column, which means that we have to provide value
+                # in some other way. Fortunately, it is a constant value, so we
+                # can compute it statically.
+                source_id = p.get_source_type(ctx.schema).get_id(ctx.schema)
+                col.static_val = source_id
+        else:
+            col.name = short_name.name + '_id'
+            _, dbname = pgcommon.get_backend_name(ctx.schema, p, catenate=False)
+            col.reference_as = dbname
 
     return col
 

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -299,8 +299,16 @@ def resolve_relation(
         for c in ['source', 'target']:
             columns.append(context.Column(name=c, reference_as=c))
 
+    def column_order_key(c: context.Column) -> Tuple[int, str]:
+        spec = {
+            'id': 0,
+            'source': 0,
+            'target': 1
+        }
+        return (spec.get(c.reference_as or '', 2), c.name or '')
+
     # sort by name but put `id` first
-    columns.sort(key=lambda c: () if c.name == 'id' else (c.name or '',))
+    columns.sort(key=column_order_key)
     table.columns.extend(columns)
 
     aspect = 'inhview' if ctx.include_inherited else 'table'

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -161,6 +161,10 @@ class Source(
         Returns a list of columns that are present in the backing table of
         this source, apart from the columns for pointers.
         """
+        # Beware: when adding columns here, make sure to update SQL
+        # introspection views. If you do not, these new addon columns will
+        # appear in pg_attribute and information_schema.column, but will not
+        # be queryable.
         res = []
         from edb.common import debug
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1342,7 +1342,7 @@ class SQLQueryTestCase(BaseQueryTestCase):
         res = await self.scon.fetch(query)
         return [list(r.values()) for r in res]
 
-    def assert_shape(self, res, rows, cols, column_names=None):
+    def assert_shape(self, res: Any, rows: int, columns: int | List[str]):
         """
         Fail if query result does not confront the specified shape, defined in
         terms of:
@@ -1352,10 +1352,12 @@ class SQLQueryTestCase(BaseQueryTestCase):
         """
 
         self.assertEqual(len(res), rows)
-        if rows > 0:
-            self.assertEqual(len(res[0]), cols)
-        if column_names:
-            self.assertListEqual(column_names, list(res[0].keys()))
+
+        if isinstance(columns, int):
+            if rows > 0:
+                self.assertEqual(len(res[0]), columns)
+        elif isinstance(columns, list):
+            self.assertListEqual(columns, list(res[0].keys()))
 
 
 class CLITestCaseMixin:

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -20,7 +20,6 @@ import csv
 import io
 import os.path
 import unittest
-import uuid
 
 from edb.testbase import server as tb
 from edb.tools import test

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -66,7 +66,7 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT * FROM "Content"
             '''
         )
-        self.assert_shape(res, 5, 3, ['id', 'genre_id', 'title'])
+        self.assert_shape(res, 5, ['id', 'genre_id', 'title'])
 
     async def test_sql_query_03(self):
         # SELECT FROM parent type only
@@ -75,7 +75,7 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT * FROM ONLY "Content" -- should have only one result
             '''
         )
-        self.assert_shape(res, 1, 3, ['id', 'genre_id', 'title'])
+        self.assert_shape(res, 1, ['id', 'genre_id', 'title'])
 
     async def test_sql_query_04(self):
         # multiple FROMs
@@ -85,7 +85,7 @@ class TestSQL(tb.SQLQueryTestCase):
             FROM "Movie" mve, "Person" WHERE mve.director_id = "Person".id
             '''
         )
-        self.assert_shape(res, 1, 2, ['title', 'first_name'])
+        self.assert_shape(res, 1, ['title', 'first_name'])
 
     async def test_sql_query_05(self):
         res = await self.scon.fetch(
@@ -94,7 +94,7 @@ class TestSQL(tb.SQLQueryTestCase):
             FROM "Movie" mve, "Person" person
             '''
         )
-        self.assert_shape(res, 6, 2, ['tit', 'first_name'])
+        self.assert_shape(res, 6, ['tit', 'first_name'])
 
     async def test_sql_query_06(self):
         # sub relations
@@ -104,7 +104,7 @@ class TestSQL(tb.SQLQueryTestCase):
             FROM "Movie" mve, (SELECT first_name FROM "Person") prs
             '''
         )
-        self.assert_shape(res, 6, 3, ['id', 'title', 'first_name'])
+        self.assert_shape(res, 6, ['id', 'title', 'first_name'])
 
     async def test_sql_query_07(self):
         # quoted case sensitive
@@ -113,7 +113,7 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT tItLe, release_year "RL year" FROM "Movie" ORDER BY titLe;
             '''
         )
-        self.assert_shape(res, 2, 2, ['title', 'RL year'])
+        self.assert_shape(res, 2, ['title', 'RL year'])
 
     async def test_sql_query_08(self):
         # JOIN
@@ -123,7 +123,7 @@ class TestSQL(tb.SQLQueryTestCase):
             FROM "Movie" JOIN "Genre" ON "Movie".genre_id = "Genre".id
             '''
         )
-        self.assert_shape(res, 2, 2, ['id', 'id'])
+        self.assert_shape(res, 2, ['id', 'id'])
 
     async def test_sql_query_09(self):
         # resolve columns without table names
@@ -133,7 +133,7 @@ class TestSQL(tb.SQLQueryTestCase):
             FROM "Movie" JOIN "Genre" ON "Movie".genre_id = "Genre".id
             '''
         )
-        self.assert_shape(res, 2, 3, ['id', 'title', 'name'])
+        self.assert_shape(res, 2, ['id', 'title', 'name'])
 
     async def test_sql_query_10(self):
         # wildcard SELECT
@@ -145,7 +145,6 @@ class TestSQL(tb.SQLQueryTestCase):
         self.assert_shape(
             res,
             2,
-            5,
             ['id', 'director_id', 'genre_id', 'release_year', 'title'],
         )
 
@@ -384,18 +383,18 @@ class TestSQL(tb.SQLQueryTestCase):
             ORDER BY title
         '''
         )
-        self.assert_shape(res, 2, 2, ['name', 'title'])
+        self.assert_shape(res, 2, ['name', 'title'])
 
     async def test_sql_query_29(self):
         # link tables
 
         # multi
         res = await self.scon.fetch('SELECT * FROM "Movie.actors"')
-        self.assert_shape(res, 3, 3, ['role', 'source', 'target'])
+        self.assert_shape(res, 3, ['role', 'source', 'target'])
 
         # single with properties
         res = await self.scon.fetch('SELECT * FROM "Movie.director"')
-        self.assert_shape(res, 1, 3, ['bar', 'source', 'target'])
+        self.assert_shape(res, 1, ['bar', 'source', 'target'])
 
         # single without properties
         with self.assertRaisesRegex(
@@ -411,7 +410,7 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT * FROM (VALUES (1, 2), (3, 4)) AS vals(c, d)
             '''
         )
-        self.assert_shape(res, 2, 2, ['c', 'd'])
+        self.assert_shape(res, 2, ['c', 'd'])
 
         with self.assertRaisesRegex(
             asyncpg.InvalidColumnReferenceError, "query resolves to 2"
@@ -430,7 +429,7 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT * FROM common
             '''
         )
-        self.assert_shape(res, 1, 2, ['a', 'b'])
+        self.assert_shape(res, 1, ['a', 'b'])
 
         res = await self.scon.fetch(
             '''
@@ -438,7 +437,7 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT * FROM common
             '''
         )
-        self.assert_shape(res, 1, 2, ['c', 'd'])
+        self.assert_shape(res, 1, ['c', 'd'])
 
         res = await self.scon.fetch(
             '''
@@ -446,7 +445,7 @@ class TestSQL(tb.SQLQueryTestCase):
             SELECT * FROM common as cmn(e, f)
             '''
         )
-        self.assert_shape(res, 1, 2, ['e', 'f'])
+        self.assert_shape(res, 1, ['e', 'f'])
 
         with self.assertRaisesRegex(
             asyncpg.InvalidColumnReferenceError, "query resolves to 2"
@@ -476,14 +475,14 @@ class TestSQL(tb.SQLQueryTestCase):
                 LATERAL unnest(a, b)
             '''
         )
-        self.assert_shape(res, 3, 4, ['a', 'b', 'unnest', 'unnest'])
+        self.assert_shape(res, 3, ['a', 'b', 'unnest', 'unnest'])
 
         res = await self.scon.fetch(
             '''
             SELECT unnest(ARRAY[1, 2, 3]) a
             '''
         )
-        self.assert_shape(res, 3, 1, ['a'])
+        self.assert_shape(res, 3, ['a'])
 
         res = await self.scon.fetch(
             '''
@@ -494,7 +493,7 @@ class TestSQL(tb.SQLQueryTestCase):
             '''
         )
         self.assert_shape(
-            res, 3, 5, ['a', 'b', 'unnested_a', 'unnested_b', 'computed']
+            res, 3, ['a', 'b', 'unnested_a', 'unnested_b', 'computed']
         )
 
     async def test_sql_query_33(self):

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -20,6 +20,7 @@ import csv
 import io
 import os.path
 import unittest
+import uuid
 
 from edb.testbase import server as tb
 from edb.tools import test
@@ -585,6 +586,29 @@ class TestSQL(tb.SQLQueryTestCase):
             [1, None],
             [2, 1],
         ])
+
+    async def test_sql_query_39(self):
+        res = await self.squery_values(
+            '''
+            SELECT pages, __type__ FROM "Book" ORDER BY pages;
+            '''
+        )
+        self.assert_data_shape(res, [
+            [206, str],
+            [374, str],
+        ])
+        # there should be one `Book` and one `novel`
+        self.assertNotEqual(res[0][1], res[1][1])
+
+        res2 = await self.squery_values(
+            '''
+            SELECT pages, __type__ FROM ONLY "Book" ORDER BY pages;
+            '''
+        )
+        self.assert_data_shape(res2, [
+            [206, str],
+        ])
+        self.assertEqual(res[0][1], res2[0][1])
 
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -407,11 +407,11 @@ class TestSQL(tb.SQLQueryTestCase):
 
         # multi
         res = await self.scon.fetch('SELECT * FROM "Movie.actors"')
-        self.assert_shape(res, 3, ['role', 'source', 'target'])
+        self.assert_shape(res, 3, ['source', 'target', 'role'])
 
         # single with properties
         res = await self.scon.fetch('SELECT * FROM "Movie.director"')
-        self.assert_shape(res, 1, ['bar', 'source', 'target'])
+        self.assert_shape(res, 1, ['source', 'target', 'bar'])
 
         # single without properties
         with self.assertRaisesRegex(
@@ -674,35 +674,41 @@ class TestSQL(tb.SQLQueryTestCase):
             res,
             [
                 ['Book', 'id', 'NO', 1],
-                ['Book', 'genre_id', 'YES', 2],
-                ['Book', 'pages', 'NO', 3],
-                ['Book', 'title', 'NO', 4],
+                ['Book', '__type__', 'NO', 2],
+                ['Book', 'genre_id', 'YES', 3],
+                ['Book', 'pages', 'NO', 4],
+                ['Book', 'title', 'NO', 5],
                 ['Book.chapters', 'source', 'NO', 1],
                 ['Book.chapters', 'target', 'NO', 2],
                 ['Content', 'id', 'NO', 1],
-                ['Content', 'genre_id', 'YES', 2],
-                ['Content', 'title', 'NO', 3],
+                ['Content', '__type__', 'NO', 2],
+                ['Content', 'genre_id', 'YES', 3],
+                ['Content', 'title', 'NO', 4],
                 ['Genre', 'id', 'NO', 1],
-                ['Genre', 'name', 'NO', 2],
+                ['Genre', '__type__', 'NO', 2],
+                ['Genre', 'name', 'NO', 3],
                 ['Movie', 'id', 'NO', 1],
-                ['Movie', 'director_id', 'YES', 2],
-                ['Movie', 'genre_id', 'YES', 3],
-                ['Movie', 'release_year', 'YES', 4],
-                ['Movie', 'title', 'NO', 5],
-                ['Movie.actors', 'role', 'YES', 1],
-                ['Movie.actors', 'source', 'NO', 2],
-                ['Movie.actors', 'target', 'NO', 3],
-                ['Movie.director', 'bar', 'YES', 1],
-                ['Movie.director', 'source', 'NO', 2],
-                ['Movie.director', 'target', 'NO', 3],
+                ['Movie', '__type__', 'NO', 2],
+                ['Movie', 'director_id', 'YES', 3],
+                ['Movie', 'genre_id', 'YES', 4],
+                ['Movie', 'release_year', 'YES', 5],
+                ['Movie', 'title', 'NO', 6],
+                ['Movie.actors', 'source', 'NO', 1],
+                ['Movie.actors', 'target', 'NO', 2],
+                ['Movie.actors', 'role', 'YES', 3],
+                ['Movie.director', 'source', 'NO', 1],
+                ['Movie.director', 'target', 'NO', 2],
+                ['Movie.director', 'bar', 'YES', 3],
                 ['Person', 'id', 'NO', 1],
-                ['Person', 'first_name', 'NO', 2],
-                ['Person', 'last_name', 'YES', 3],
+                ['Person', '__type__', 'NO', 2],
+                ['Person', 'first_name', 'NO', 3],
+                ['Person', 'last_name', 'YES', 4],
                 ['novel', 'id', 'NO', 1],
-                ['novel', 'foo', 'YES', 2],
-                ['novel', 'genre_id', 'YES', 3],
-                ['novel', 'pages', 'NO', 4],
-                ['novel', 'title', 'NO', 5],
+                ['novel', '__type__', 'NO', 2],
+                ['novel', 'foo', 'YES', 3],
+                ['novel', 'genre_id', 'YES', 4],
+                ['novel', 'pages', 'NO', 5],
+                ['novel', 'title', 'NO', 6],
                 ['novel.chapters', 'source', 'NO', 1],
                 ['novel.chapters', 'target', 'NO', 2],
             ],


### PR DESCRIPTION
Closes #6208

Exposes __type__ as an UUID columns of every table, including when using `FROM ONLY` (and we are compiling SQL to load data from tables that actually *do not* have the `__type__` column).

If using SQL adapter only, values of `__type__` are useless, as there is not way to query which type is associated with this id, as we don't expose `schema::ObjectType` (or anything from `schema` module) over SQL.

TODO:
- [x] add introspection