### PR TITLE
Retry download-artifacts when it fails

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -315,10 +315,12 @@
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -358,10 +358,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -389,10 +389,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |
@@ -593,10 +595,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |
@@ -845,10 +849,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |
@@ -1063,10 +1069,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |
@@ -1269,10 +1277,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -358,10 +358,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -377,10 +377,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -426,10 +426,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |
@@ -561,10 +563,12 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v3
+      uses: Wandalen/wretry.action@1.3.0
       with:
-        name: shared-artifacts
-        path: .tmp
+        action: actions/download-artifact@v3
+        with:
+          name: shared-artifacts
+          path: .tmp
 
     - name: Set environment variables
       run: |


### PR DESCRIPTION
For now, I've only made the change when doing "Download shared
artifacts", which is the place where we have observed flakiness.

Fixes #6429.