### PR TITLE
Fix coalesced DML in FOR loops over objects

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -818,7 +818,7 @@ def update_scope(
     # with some DML linkprop cases (probably easy to fix) and a number
     # of materialization cases (possibly hard to fix), so I'm going
     # with a more conservative approach.
-    if scope_tree.optional:
+    if scope_tree.is_optional(ir_set.path_id):
         # Since compilation is done, anything visible to us *will* be
         # up on the spine. Anything tucked away under a node must have
         # been pulled up.

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -1107,6 +1107,25 @@ class TestEdgeQLFor(tb.QueryTestCase):
             [{"key": "Earth"}, {"key": "Water"}]
         )
 
+    async def test_edgeql_for_tuple_optional_01(self):
+        await self.assert_query_result(
+            r'''
+                for user in User union (
+                  ((select (1,) filter false) ?? (2,)).0
+                );
+            ''',
+            [2, 2, 2, 2],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for user in User union (
+                  ((select (1,) filter user.name = 'Alice') ?? (2,)).0
+                );
+            ''',
+            tb.bag([1, 2, 2, 2]),
+        )
+
     async def test_edgeql_for_optional_01(self):
         # Lol FOR OPTIONAL doesn't work for object-type iterators
         # but it does work for 1-ary tuples
@@ -1161,6 +1180,39 @@ class TestEdgeQLFor(tb.QueryTestCase):
                 union (insert Award { name := "Participation!" })
             ''',
             [{}],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for user in (select User filter .name = 'Alice') union (
+                  for optional x in (<Card>{},) union (
+                    1
+                  )
+                );
+            ''',
+            [1],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for user in (select User filter .name = 'Alice') union (
+                  for optional x in (<Card>{},) union (
+                    user.name
+                  )
+                );
+            ''',
+            ['Alice'],
+        )
+
+        await self.assert_query_result(
+            r'''
+                for user in (select User filter .name = 'Alice') union (
+                  for optional x in (<Card>{},) union (
+                    user.name ++ (x.0.name ?? "!")
+                  )
+                );
+            ''',
+            ['Alice!'],
         )
 
     @test.xerror('''


### PR DESCRIPTION
More generally, the issue here is that is that because of
pull_path_namespace, the outer iterator was being routed to an
optional wrapper that has the iterator in its non-NULL case, but which
would produce NULL in the NULL branch. We already have code to prevent
this sort of thing by putting visible paths in the path_id_mask in
update_scope (see #5575), but it was a little too limited.

I do still think that we probably should be doing this masking
unconditionally, but it causes lots of trouble with materialization
cases. I should follow up on that.

I also need to spend some time deciding whether the entire
pull_path_namespace system actually makes any sense at all
or whether it is just a hack we should hope to eliminate.

Fixes #6464