### PR TITLE
Simplify ?? implementation when RHS is AT_MOST_ONE

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -105,8 +105,7 @@ class BaseExpr(Base):
         for v in kwargs.values():
             if typeutils.is_container(v):
                 items = typing.cast(typing.Iterable, v)
-                # FIXME: Is this right???
-                nullable = all(getattr(vv, 'nullable', False) for vv in items)
+                nullable = any(getattr(vv, 'nullable', False) for vv in items)
 
             elif getattr(v, 'nullable', None):
                 nullable = True
@@ -655,6 +654,9 @@ class SelectStmt(Query):
     # Right operand of set op,
     rarg: typing.Optional[Query] = None
 
+    # When used as a sub-query, it is generally nullable.
+    nullable: bool = True
+
 
 class Expr(ImmutableBaseExpr):
     """Infix, prefix, and postfix expressions."""
@@ -965,6 +967,13 @@ class CoalesceExpr(ImmutableBaseExpr):
 
     # The arguments.
     args: typing.List[Base]
+
+    def _infer_nullability(self, kwargs: typing.Dict[str, typing.Any]) -> bool:
+        # nullability of COALESCE is the nullability of the RHS
+        if 'args' in kwargs:
+            return kwargs['args'][1].nullable
+        else:
+            return True
 
 
 class NullTest(ImmutableBaseExpr):

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -105,6 +105,7 @@ class BaseExpr(Base):
         for v in kwargs.values():
             if typeutils.is_container(v):
                 items = typing.cast(typing.Iterable, v)
+                # FIXME: Is this right???
                 nullable = all(getattr(vv, 'nullable', False) for vv in items)
 
             elif getattr(v, 'nullable', None):

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1804,9 +1804,7 @@ def process_set_as_coalesce(
             )
 
             # Just use scalar COALESCE now
-            set_expr = pgast.CoalesceExpr(
-                args=[left, right], nullable=right_card.can_be_zero()
-            )
+            set_expr = pgast.CoalesceExpr(args=[left, right])
             pathctx.put_path_value_var(ctx.rel, ir_set.path_id, set_expr)
 
         else:
@@ -3404,6 +3402,7 @@ def process_set_as_agg_expr_inner(
                 if for_group_by:
                     arg_ref = set_as_subquery(
                         ir_arg, as_value=True, ctx=argctx)
+                    arg_ref.nullable = False
                 elif aspect == 'serialized':
                     dispatch.visit(ir_arg, ctx=argctx)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1787,72 +1787,28 @@ def process_set_as_coalesce(
             or ir_set.path_id.is_tuple_path()
         )
 
-        # The cardinality optimizations below apply to non-object
-        # expressions only, because we don't want to have to deal
-        # with the complexity of resolving coalesced sources for
-        # potential link or property references.
-        if right_card is qltypes.Cardinality.ONE and not is_object:
-            # Non-optional singleton RHS, simply use scalar COALESCE
-            # without any precautions.
+        # The cardinality optimization below applies only to
+        # non-object/non-tuple expressions, because we don't want to
+        # have to deal with the complexity of resolving coalesced
+        # sources for potential link or property references.
+        if right_card.is_single() and not is_object:
             left = dispatch.compile(left_ir, ctx=newctx)
-            right = dispatch.compile(right_ir, ctx=newctx)
-            set_expr = pgast.CoalesceExpr(args=[left, right])
-            pathctx.put_path_value_var(
-                ctx.rel,
-                ir_set.path_id,
-                set_expr,
+
+            # If the RHS is optional, we compile it in a subquery so that
+            # it becomes NULL instead of potentially joining in zero rows.
+            # If not, just compile it without any protection.
+            right = (
+                set_as_subquery(right_ir, ctx=newctx)
+                if right_card.can_be_zero()
+                else dispatch.compile(right_ir, ctx=newctx)
             )
 
-        elif right_card is qltypes.Cardinality.AT_MOST_ONE and not is_object:
-            # Optional singleton RHS, use scalar COALESCE, but
-            # be careful not to JOIN the RHS as-is and instead
-            # turn it into a value and make sure to filter out
-            # the potential NULL result if both sides turn out
-            # to be empty:
-            #     SELECT
-            #         q.v
-            #     FROM
-            #         (SELECT
-            #             COALESCE(<lhs>, (SELECT (<rhs>))) AS v
-            #         ) AS q
-            #     WHERE
-            #         q.v IS NOT NULL
-            with newctx.subrel() as subctx:
-                left = dispatch.compile(left_ir, ctx=subctx)
-
-                with subctx.subrel() as rightctx:
-                    dispatch.compile(right_ir, ctx=rightctx)
-                    pathctx.get_path_value_output(
-                        rightctx.rel,
-                        right_ir.path_id,
-                        env=rightctx.env,
-                    )
-                    right = rightctx.rel
-
-                set_expr = pgast.CoalesceExpr(args=[left, right])
-
-                pathctx.put_path_value_var_if_not_exists(
-                    subctx.rel, ir_set.path_id, set_expr
-                )
-
-                sub_rvar = relctx.rvar_for_rel(
-                    subctx.rel,
-                    lateral=True,
-                    ctx=subctx,
-                )
-
-                relctx.include_rvar(
-                    ctx.rel, sub_rvar, ir_set.path_id, ctx=subctx
-                )
-
-            rvar = pathctx.get_path_value_var(
-                ctx.rel, path_id=ir_set.path_id, env=ctx.env
+            # Just use scalar COALESCE now
+            set_expr = pgast.CoalesceExpr(
+                args=[left, right], nullable=right_card.can_be_zero()
             )
+            pathctx.put_path_value_var(ctx.rel, ir_set.path_id, set_expr)
 
-            ctx.rel.where_clause = astutils.extend_binop(
-                ctx.rel.where_clause,
-                pgast.NullTest(arg=rvar, negated=True),
-            )
         else:
             # Things become tricky in cases where the RHS is a non-singleton.
             # We cannot use the regular scalar COALESCE over a JOIN,


### PR DESCRIPTION
A lot of the code is dedicated to filtering out NULL results after the
COALESCE is done, but that is avoidable: if we make sure that
`nullable` is properly set on the expression, then this will be
handled automatically at higher levels of the compilation pipeline.

Once that simplification is made, the only difference from the ONE
case is that the RHS needs to be placed in a sub-SELECT, and we can
use set_as_subquery to do that. This lets us merge the two cases,
with the only difference being in how the RHS is compiled.