### PR TITLE
Support `connect_timeout` in backend DSN

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -203,6 +203,7 @@ class BaseCluster:
             'ssl',
             'sslmode',
             'server_settings',
+            'connect_timeout',
         ):
             v = getattr(params, k)
             if v is not None:

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -227,11 +227,13 @@ def _set_tcp_keepalive(transport):
 
 
 async def _create_ssl_connection(protocol_factory, host, port, *,
-                                 loop, ssl_context, ssl_is_advisory):
-    tr, pr = await loop.create_connection(
-        lambda: TLSUpgradeProto(loop, host, port,
-                                ssl_context, ssl_is_advisory),
-        host, port)
+                                 loop, ssl_context, ssl_is_advisory,
+                                 connect_timeout):
+    async with asyncio.timeout(connect_timeout):
+        tr, pr = await loop.create_connection(
+            lambda: TLSUpgradeProto(loop, host, port,
+                                    ssl_context, ssl_is_advisory),
+            host, port)
     _set_tcp_keepalive(tr)
 
     tr.write(struct.pack('!ll', 8, 80877103))  # SSLRequest message.
@@ -274,29 +276,31 @@ async def _connect(connargs, dbname, ssl):
     timeout = connargs.get('connect_timeout')
 
     try:
-        async with asyncio.timeout(timeout):
-            if host.startswith('/'):
-                addr = os.path.join(host, f'.s.PGSQL.{port}')
+        if host.startswith('/'):
+            addr = os.path.join(host, f'.s.PGSQL.{port}')
+            async with asyncio.timeout(timeout):
                 _, pgcon = await loop.create_unix_connection(
                     lambda: PGConnection(dbname, loop, connargs), addr)
 
+        else:
+            if ssl:
+                _, pgcon = await _create_ssl_connection(
+                    lambda: PGConnection(dbname, loop, connargs),
+                    host,
+                    port,
+                    loop=loop,
+                    ssl_context=ssl,
+                    ssl_is_advisory=(
+                        sslmode == pgconnparams.SSLMode.prefer
+                    ),
+                    connect_timeout=timeout,
+                )
             else:
-                if ssl:
-                    _, pgcon = await _create_ssl_connection(
-                        lambda: PGConnection(dbname, loop, connargs),
-                        host,
-                        port,
-                        loop=loop,
-                        ssl_context=ssl,
-                        ssl_is_advisory=(
-                            sslmode == pgconnparams.SSLMode.prefer
-                        ),
-                    )
-                else:
+                async with asyncio.timeout(timeout):
                     trans, pgcon = await loop.create_connection(
                         lambda: PGConnection(dbname, loop, connargs),
                         host=host, port=port)
-                    _set_tcp_keepalive(trans)
+                _set_tcp_keepalive(trans)
     except TimeoutError as ex:
         raise pgerror.new(
             pgerror.ERROR_CONNECTION_FAILURE,

--- a/edb/server/pgconnparams.py
+++ b/edb/server/pgconnparams.py
@@ -482,9 +482,9 @@ def parse_dsn(
                 passfile=passfile_path)
 
     if connect_timeout is None:
-        val = os.getenv('PGCONNECT_TIMEOUT')
-        if val:
-            connect_timeout = int(val)
+        env_val = os.getenv('PGCONNECT_TIMEOUT')
+        if env_val:
+            connect_timeout = int(env_val)
 
     if connect_timeout is not None:
         # Match the same behavior of libpq

--- a/edb/server/pgconnparams.py
+++ b/edb/server/pgconnparams.py
@@ -56,6 +56,7 @@ class ConnectionParameters:
     ssl: Optional[ssl_module.SSLContext] = None
     sslmode: Optional[SSLMode] = None
     server_settings: Dict[str, str] = dataclasses.field(default_factory=dict)
+    connect_timeout: Optional[int] = None
 
 
 _system = platform.uname().system
@@ -294,6 +295,7 @@ def parse_dsn(
     ssl_min_protocol_version = None
     ssl_max_protocol_version = None
     server_settings: Dict[str, str] = {}
+    connect_timeout: Optional[int] = None
 
     parsed = urllib.parse.urlparse(dsn)
 
@@ -397,6 +399,9 @@ def parse_dsn(
         if 'ssl_max_protocol_version' in query:
             ssl_max_protocol_version = query.pop('ssl_max_protocol_version')
 
+        if 'connect_timeout' in query:
+            connect_timeout = int(query.pop('connect_timeout'))
+
         if query:
             server_settings = query
 
@@ -475,6 +480,19 @@ def parse_dsn(
                 hosts=auth_hosts, ports=port,
                 database=database, user=user,
                 passfile=passfile_path)
+
+    if connect_timeout is None:
+        val = os.getenv('PGCONNECT_TIMEOUT')
+        if val:
+            connect_timeout = int(val)
+
+    if connect_timeout is not None:
+        # Match the same behavior of libpq
+        # https://www.postgresql.org/docs/current/libpq-connect.html
+        if connect_timeout <= 0:
+            connect_timeout = None
+        elif connect_timeout < 2:
+            connect_timeout = 2
 
     addrs: List[Tuple[str, int]] = []
     have_tcp_addrs = False
@@ -617,6 +635,7 @@ def parse_dsn(
         ssl=ssl,
         sslmode=sslmode,
         server_settings=server_settings,
+        connect_timeout=connect_timeout,
     )
 
     return tuple(addrs), params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "edgedb-server"
 description = "EdgeDB Server"
-requires-python = '>=3.10.0'
+requires-python = '>=3.11.0'
 dynamic = ["version"]
 dependencies = [
     'edgedb==1.6.0',

--- a/tests/test_backend_connect.py
+++ b/tests/test_backend_connect.py
@@ -770,12 +770,12 @@ class TestConnectParams(tb.TestCase):
                 )
             }
             for given, expected in [
-                ['-8', None],
-                ['-1', None],
-                ['0', None],
-                ['1', 2],
-                ['2', 2],
-                ['3', 3],
+                ('-8', None),
+                ('-1', None),
+                ('0', None),
+                ('1', 2),
+                ('2', 2),
+                ('3', 3),
             ]
         ],
     ]

--- a/tests/test_backend_connect.py
+++ b/tests/test_backend_connect.py
@@ -26,6 +26,7 @@ import os
 import pathlib
 import pickle
 import shutil
+import socket
 import ssl
 import stat
 import sys
@@ -38,6 +39,7 @@ import urllib.parse
 import click
 from click.testing import CliRunner
 
+from edb.pgsql import params as pg_params
 from edb.server import args as edb_args
 from edb.server import bootstrap
 from edb.server import pgcluster
@@ -408,14 +410,17 @@ class TestConnectParams(tb.TestCase):
                 'PGDATABASE': 'testdb',
                 'PGPASSWORD': 'passw',
                 'PGHOST': 'host',
-                'PGPORT': '123'
+                'PGPORT': '123',
+                'PGCONNECT_TIMEOUT': '8',
             },
             'result': ([('host', 123)], {
                 'user': 'user',
                 'password': 'passw',
                 'database': 'testdb',
                 'ssl': True,
-                'sslmode': SSLMode.prefer})
+                'sslmode': SSLMode.prefer,
+                'connect_timeout': 8,
+            })
         },
 
         {
@@ -425,15 +430,18 @@ class TestConnectParams(tb.TestCase):
                 'PGDATABASE': 'testdb',
                 'PGPASSWORD': 'passw',
                 'PGHOST': 'host',
-                'PGPORT': '123'
+                'PGPORT': '123',
+                'PGCONNECT_TIMEOUT': '8',
             },
 
-            'dsn': 'postgres://user2:passw2@host2:456/db2',
+            'dsn': 'postgres://user2:passw2@host2:456/db2?connect_timeout=6',
 
             'result': ([('host2', 456)], {
                 'user': 'user2',
                 'password': 'passw2',
-                'database': 'db2'})
+                'database': 'db2',
+                'connect_timeout': 6,
+            })
         },
 
         {
@@ -747,6 +755,29 @@ class TestConnectParams(tb.TestCase):
                 }
             )
         },
+        *[
+            {
+                'name': f'connect_timeout_{given}',
+                'dsn': f'postgres://spam@127.0.0.1:5432/postgres?'
+                       f'connect_timeout={given}',
+                'result': (
+                    [('127.0.0.1', 5432)],
+                    {
+                        'user': 'spam',
+                        'database': 'postgres',
+                        'connect_timeout': expected,
+                    }
+                )
+            }
+            for given, expected in [
+                ['-8', None],
+                ['-1', None],
+                ['0', None],
+                ['1', 2],
+                ['2', 2],
+                ['3', 3],
+            ]
+        ],
     ]
 
     @contextlib.contextmanager
@@ -1102,6 +1133,56 @@ class TestConnectParams(tb.TestCase):
                     })
                 finally:
                     os.chmod(passdir, stat.S_IRWXU)
+
+    async def test_connection_connect_timeout(self):
+        server = socket.socket()
+        gc = []
+        try:
+            server.bind(('localhost', 0))
+            server.listen(0)
+            host, port = server.getsockname()
+            conn_spec = {
+                'host': host,
+                'port': port,
+                'user': 'foo',
+                'server_settings': {},
+                'connect_timeout': 2,
+            }
+
+            async def placeholder():
+                async with asyncio.timeout(2):
+                    _, w = await asyncio.open_connection(host, port)
+                gc.append(w)
+
+            # Fill up the TCP server backlog so that our future pgcon.connect
+            # could time out reliably
+            i = 0
+            while i < 8:
+                i += 1
+                try:
+                    async with asyncio.TaskGroup() as tg:
+                        for _ in range(4):
+                            tg.create_task(placeholder())
+                except* TimeoutError:
+                    i = 10
+            if i < 10:
+                self.fail("Couldn't fill TCP server backlog within 32 tries")
+
+            with self.assertRaises(errors.BackendConnectionError):
+                async with asyncio.timeout(4):  # failsafe
+                    await pgcon.connect(
+                        conn_spec,
+                        'foo',
+                        pg_params.get_default_runtime_params(),
+                    )
+
+        finally:
+            server.close()
+            for writer in gc:
+                writer.close()
+            await asyncio.wait(
+                [asyncio.create_task(w.wait_closed()) for w in gc]
+            )
 
 
 class TestConnection(ClusterTestCase):


### PR DESCRIPTION
This PR allows setting `connect_timeout` in backend DSN, or the `PGCONNECT_TIMEOUT` environment variable. For HA backend, use the `pg`-prefixed query string. Examples:

* `edgedb-server --backend-dsn postgres://localhost/mydb?connect_timeout=5`
* `edgedb-server --backend-dsn stolon+consul+http://localhost/mydb?pgconnect_timeout=5`
* `PGCONNECT_TIMEOUT=5 edgedb-server --backend-dsn postgres://localhost/mydb`
* `PGCONNECT_TIMEOUT=5 edgedb-server --backend-dsn stolon+consul+http://localhost/mydb`

This only covers one TCP `connect()`, which means:
1. Backend authentication (logging into Postgres) is not counted in this timeout.
2. TLS upgrade is not counted in this timeout.
3. If more than one TCP `connect()` happens within one `pgcon.connect()` due to different `sslmode`, the total time elapsed may be greater than `connect_timeout`. For example, when `sslmode` is `allow` or `prefer` while `connect_timeout=5`, the theoretical total time for one connection attempt to bail may be up to 10 seconds.

See also: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT