### PR TITLE
Generate better code for ?? with multi RHS or object type

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -725,7 +725,7 @@ def finalize_optional_rel(
 
         if lvar.nullable:
             # The left var is still nullable, which may be the
-            # case for non-required singleton scalar links.
+            # case for non-required singleton properties.
             # Filter out NULLs.
             setrel.where_clause = astutils.extend_binop(
                 setrel.where_clause,
@@ -1808,27 +1808,32 @@ def process_set_as_coalesce(
             pathctx.put_path_value_var(ctx.rel, ir_set.path_id, set_expr)
 
         else:
-            # Things become tricky in cases where the RHS is a non-singleton.
+            # Things become tricky in cases where the RHS is a non-singleton
+            # or where we need to worry about source aspects.
             # We cannot use the regular scalar COALESCE over a JOIN,
-            # as that'll blow up the result cardinality. Instead, we
-            # compute a UNION of both sides and annotate each side with
-            # a marker.  We then select only rows that match the marker
-            # of the first row:
+            # as that'll blow up the result cardinality. Instead, we do
+            # something like:
             #
-            #     SELECT
-            #         q.*
-            #     FROM
-            #         (SELECT
-            #             marker = first_value(marker) OVER () AS marker,
-            #             ...
-            #          FROM
-            #             (SELECT 1 AS marker, * FROM left
-            #              UNION ALL
-            #              SELECT 2 AS marker, * FROM right) AS u
-            #         ) AS q
-            #     WHERE marker
-            with newctx.subrel() as subctx:
-                subqry = subctx.rel
+            #     CROSS JOIN LATERAL
+            #       (<left>) as lhs
+            #     CROSS JOIN LATERAL (
+            #       SELECT * FROM lhs WHERE lhs.value IS NOT NULL
+            #       UNION ALL
+            #       SELECT * FROM <right> as rhs WHERE lhs.value IS NULL
+            #     ) as q
+            #
+            # Note that <left> will be compiled with optional wrapping,
+            # so it shouldn't ever produce zero rows.
+            #
+            # TODO: subctx maintained to avoid indentation churn in the PR.
+            # Remove once the changes here are finalized.
+            # (We can drop sub2ctx too, with a tiny bit more work.)
+            with newctx.new() as subctx:
+                lhs_rvar = get_set_rvar(left_ir, ctx=subctx)
+                lvar = pathctx.get_rvar_path_var(
+                    lhs_rvar, left_ir.path_id, aspect='value', env=ctx.env
+                )
+                lval = output.output_as_value(lvar, env=ctx.env)
 
                 with subctx.subrel() as sub2ctx:
 
@@ -1836,18 +1841,27 @@ def process_set_as_coalesce(
                         larg = scopectx.rel
                         pathctx.put_path_id_map(
                             larg, ir_set.path_id, left_ir.path_id)
-                        lvar = dispatch.compile(left_ir, ctx=scopectx)
 
-                        if lvar.nullable:
-                            # The left var is still nullable, which may be the
-                            # case for non-required singleton scalar links.
-                            # Filter out NULLs.
-                            larg.where_clause = astutils.extend_binop(
-                                larg.where_clause,
-                                pgast.NullTest(
-                                    arg=lvar, negated=True
-                                )
+                        relctx.include_rvar(
+                            larg,
+                            lhs_rvar,
+                            path_id=left_ir.path_id,
+                            ctx=scopectx,
+                            # Only include the aspects that got included
+                            # into our rel; it's possible some were explicitly
+                            # left out, and we should respect that.
+                            aspects=pathctx.list_path_aspects(
+                                subctx.rel, left_ir.path_id
+                            ),
+                        )
+
+                        # Include the LHS when it is not NULL.
+                        larg.where_clause = astutils.extend_binop(
+                            larg.where_clause,
+                            pgast.NullTest(
+                                arg=lval, negated=True
                             )
+                        )
 
                     with sub2ctx.subrel() as scopectx:
                         rarg = scopectx.rel
@@ -1855,22 +1869,26 @@ def process_set_as_coalesce(
                             rarg, ir_set.path_id, right_ir.path_id)
                         rvar = dispatch.compile(right_ir, ctx=scopectx)
 
+                        # Include the RHS when the LHS is NULL.
+                        # Note that an important precondition of this is that
+                        # there are not "stray" NULLs in the LHS input set.
+                        #
+                        # HACK: We need to use IS NOT DISTINCT FROM
+                        # because ROW() IS NULL is true, and that
+                        # breaks some things.
+                        rarg.where_clause = astutils.extend_binop(
+                            rarg.where_clause,
+                            astutils.new_binop(
+                                lval, pgast.NullConstant(),
+                                'IS NOT DISTINCT FROM',
+                            ),
+                        )
+
                         if rvar.nullable:
                             rarg.where_clause = astutils.extend_binop(
                                 rarg.where_clause,
                                 pgast.NullTest(arg=rvar, negated=True)
                             )
-
-                    marker = sub2ctx.env.aliases.get('m')
-
-                    larg.target_list.insert(
-                        0,
-                        pgast.ResTarget(val=pgast.NumericConstant(val='1'),
-                                        name=marker))
-                    rarg.target_list.insert(
-                        0,
-                        pgast.ResTarget(val=pgast.NumericConstant(val='2'),
-                                        name=marker))
 
                     unionqry = sub2ctx.rel
                     unionqry.op = 'UNION'
@@ -1881,48 +1899,20 @@ def process_set_as_coalesce(
                 union_rvar = relctx.rvar_for_rel(
                     unionqry, lateral=True, ctx=subctx)
 
-                relctx.include_rvar(
-                    subqry, union_rvar, path_id=ir_set.path_id, ctx=subctx)
-
-                lagged_marker = pgast.FuncCall(
-                    name=('first_value',),
-                    args=[pgast.ColumnRef(name=[marker])],
-                    over=pgast.WindowDef()
-                )
-
-                marker_ok = astutils.new_binop(
-                    pgast.ColumnRef(name=[marker]),
-                    lagged_marker,
-                    op='=',
-                )
-
-                subqry.target_list.append(
-                    pgast.ResTarget(
-                        name=marker,
-                        val=marker_ok
-                    )
-                )
-
             aspects = pathctx.list_path_aspects(
                 larg, left_ir.path_id
             ) & pathctx.list_path_aspects(rarg, right_ir.path_id)
-
-            subrvar = relctx.rvar_for_rel(subqry, lateral=True, ctx=newctx)
 
             # No pull_namespace because we don't want the coalesce arguments to
             # escape, just the final result.
             relctx.include_rvar(
                 ctx.rel,
-                subrvar,
+                union_rvar,
                 path_id=ir_set.path_id,
                 aspects=aspects,
                 pull_namespace=False,
                 ctx=newctx,
             )
-
-            ctx.rel.where_clause = astutils.extend_binop(
-                ctx.rel.where_clause,
-                astutils.get_column(subrvar, marker, nullable=False))
 
     return new_stmt_set_rvar(ir_set, ctx.rel, ctx=ctx)
 


### PR DESCRIPTION
The multi RHS/object coalesce path basically replicated the optional 
wrapper machinery. This shouldn't be necessary, since the LHS input is
*already* being placed in an optional wrapper, which means that we are 
doing the optional machinery twice.

In practice, this means that the RHS gets executed unconditionally. Change
things to *not* repeat the optional wrapping, but to instead compile the
LHS on its own, and then do a union in which the RHS filters on whether the
LHS was NULL. This lets the RHS only be executed conditionally.

Fixes #6528.

The PR is split into two commits. The first does all of the
substantative changes, and the second gets rid of some now-unnecessary
ctx.new() calls and does some other cleanups.