### PR TITLE
Fix inserts silently failing when a json->array handles 'null'

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -1116,11 +1116,12 @@ def _cast_array(
             correlated_elements = astutils.extend_path(
                 qlast.Tuple(elements=[source_path, elements]), '1'
             )
+            correlated_query = qlast.SelectQuery(result=correlated_elements)
 
             if el_type.contains_json(subctx.env.schema):
                 subctx.inhibit_implicit_limit = True
 
-            array_ir = dispatch.compile(correlated_elements, ctx=subctx)
+            array_ir = dispatch.compile(correlated_query, ctx=subctx)
             assert isinstance(array_ir, irast.Set)
 
             if direct_cast is not None:

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -601,9 +601,13 @@ def can_omit_optional_wrapper(
             ctx=ctx,
         )
 
+    if isinstance(ir_set.rptr, irast.TupleIndirectionPointer):
+        return can_omit_optional_wrapper(ir_set.rptr.source, new_scope, ctx=ctx)
+
     return bool(
         ir_set.expr is None
         and not ir_set.path_id.is_objtype_path()
+        and not ir_set.path_id.is_type_intersection_path()
         and ir_set.rptr
         and new_scope.is_visible(ir_set.rptr.source.path_id)
         and not ir_set.rptr.is_inbound

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -1890,3 +1890,19 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ''',
             [True],
         )
+
+    async def test_edgeql_optional_array_cast_01(self):
+        await self.assert_query_result(
+            '''
+            select <array<str>>to_json('null') ?? [];
+            ''',
+            [[]],
+        )
+
+    async def test_edgeql_optional_array_cast_02(self):
+        await self.assert_query_result(
+            '''
+            select {<array<str>>to_json('null')} ?? [];
+            ''',
+            [[]],
+        )

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5925,6 +5925,16 @@ class TestInsert(tb.QueryTestCase):
                 }
             ''')
 
+    async def test_edgeql_insert_optional_cast_01(self):
+        await self.assert_query_result(
+            r'''
+                insert CollectionTest {
+                    str_array := <array<str>>to_json('null')
+                };
+            ''',
+            [{}],
+        )
+
     async def test_edgeql_insert_except_constraint_01(self):
         # Test basic behavior of a constraint using except
         await self.con.execute('''


### PR DESCRIPTION
The issue is that the json -> array pass internally does something
involving tuples, and the can_omit_optional_wrapper optimization code
is too permissive on tuple indirections.

Also fix an issue I hit with json->array casts appearing in coalesces,
where a scope was going missing.