### PR TITLE
Allow indexes that use user-defined functions to actually get hit

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -2024,7 +2024,9 @@ def get_globals_as_json(
         globs = ()
 
     objctx = ctx.env.options.schema_object_context
-    if globs and objctx in (s_constr.Constraint, s_indexes.Index):
+    is_constraint_like = objctx in (s_constr.Constraint, s_indexes.Index)
+    if globs and is_constraint_like:
+        assert objctx
         typname = objctx.get_schema_class_displayname()
         # XXX: or should we pass in empty globals, in this situation?
         raise errors.SchemaDefinitionError(
@@ -2092,7 +2094,7 @@ def get_globals_as_json(
         if (
             not ctx.env.options.apply_user_access_policies
             or not ctx.env.options.apply_query_rewrites
-        ):
+        ) and not is_constraint_like:
             full_objs.append(qlast.FunctionCall(
                 func=('__std__', 'to_json'),
                 args=[qlast.StringConstant(

--- a/tests/schemas/explain.esdl
+++ b/tests/schemas/explain.esdl
@@ -70,6 +70,8 @@ type Comment extending Text, Owned {
     optional parent: Comment;
 }
 
+function frob(s: str) -> str using (s ++ '!');
+
 type Issue extending Named, Owned, Text {
     overloaded required link owner {
         property since: datetime;
@@ -99,6 +101,10 @@ type Issue extending Named, Owned, Text {
     multi references: File | URL {
         list_order: int64;
     };
+
+    # Pure index testing stuff
+    number2 := frob(.number);
+    index on (.number2);
 }
 
 type File extending Named;

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -1814,6 +1814,14 @@ class TestEdgeQLExplain(tb.QueryTestCase):
             },
         )
 
+    async def test_edgeql_explain_user_func_index_01(self):
+        res = await self.explain('''
+            select Issue {id}
+            filter .number2 = '500!'
+        ''')
+        plan_type = res['fine_grained']['pipeline'][0]['plan_type']
+        self.assertIn(plan_type, ['IndexScan', 'BitmapHeapScan'])
+
     async def test_edgeql_explain_bug_5758(self):
         # Issue #5758
         res = await self.explain('''


### PR DESCRIPTION
In a 4.x regression, indexes/exclusive constraints that use
user-defined functions will have the function called with a json blob
that disables access policies as part of the globals argument.  This
causes the index expressions to not match, so the indexes won't get
used.

Users affected by the bug should either dump/restore or delete the
affected indexes and recreate them.