### PR TITLE
Make a more trimmed debug view for delta scripts

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -130,6 +130,9 @@ class flags(metaclass=FlagsMeta):
     delta_execute = Flag(
         doc="Output SQL commands as executed during migration.")
 
+    delta_execute_ddl = Flag(
+        doc="Output just the DDL commands as executed during migration.")
+
     server = Flag(
         doc="Print server errors.")
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3071,9 +3071,9 @@ class CompositeMetaCommand(MetaCommand):
         if dbops.AlterTable not in self._multicommands:
             mod, name = common.get_backend_name(
                 schema, self.scls, aspect='inhview', catenate=False)
-            self.pgops.add(dbops.Query(f'''\
+            self.pgops.add(dbops.Query(textwrap.dedent(f'''\
                 ALTER VIEW IF EXISTS {mod}."{name}" SET SCHEMA {mod};
-            '''))
+            ''')))
 
         return self._get_multicommand(
             context, dbops.AlterTable, tabname,

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -255,6 +255,12 @@ def compile_and_apply_ddl_stmt(
         create_db = stmt.name.name
         create_db_template = stmt.template.name if stmt.template else None
 
+    if debug.flags.delta_execute_ddl:
+        debug.header('Delta Script (DDL Only)')
+        # The schema updates are always the last statement, so grab
+        # everything but
+        code = '\n\n'.join(block.get_statements()[:-1])
+        debug.dump_code(code, lexer='sql')
     if debug.flags.delta_execute:
         debug.header('Delta Script')
         debug.dump_code(b'\n'.join(sql), lexer='sql')


### PR DESCRIPTION
I always get really frustrated having to scroll through all the schema
modification gunk in order to see the important DDL.
(I might make more toggles later, like to elide inhview updates maybe.)

Also, sort the schema storage scripts so that all of the function
create comes before the series of function calls.