### PR TITLE
Fix reloading readiness state and JWT *_list files in multi-tenant mode

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -128,6 +128,29 @@ class ServerConnTransport(enum.StrEnum):
     SIMPLE_HTTP = "SIMPLE_HTTP"
 
 
+class ReloadTrigger(enum.StrEnum):
+    """
+    Configure what triggers the reload of the following config files:
+    1. TLS certificate and key (server config)
+    2. JWS key (server config)
+    3. Multi-tenant config file (server config)
+    4. Readiness state (server or tenant config)
+    5. JWT sub allowlist and revocation list (server or tenant config)
+    """
+
+    Default = "default"
+    """By default, reload on both SIGHUP and fsevent."""
+
+    Never = "never"
+    """Disable the reload function."""
+
+    Signal = "signal"
+    """Only reload on SIGHUP."""
+
+    FileSystemEvent = "fsevent"
+    """Watch the files for changes and reload when it happens."""
+
+
 class ServerAuthMethods:
 
     def __init__(
@@ -212,6 +235,7 @@ class ServerConfig(NamedTuple):
     auto_shutdown_after: float
     readiness_state_file: Optional[pathlib.Path]
     disable_dynamic_system_config: bool
+    reload_config_files: ReloadTrigger
 
     startup_script: Optional[StartupScript]
     status_sinks: List[Callable[[str], None]]
@@ -928,7 +952,18 @@ _server_options = [
         envvar="EDGEDB_SERVER_DISABLE_DYNAMIC_SYSTEM_CONFIG",
         cls=EnvvarResolver,
         help="Disable dynamic configuration of system config values",
-    )
+    ),
+    click.option(
+        "--reload-config-files",
+        envvar="EDGEDB_SERVER_RELOAD_CONFIG_FILES", cls=EnvvarResolver,
+        type=click.Choice(
+            list(ReloadTrigger.__members__.values()), case_sensitive=True
+        ),
+        hidden=True,
+        default='default',
+        help='Specifies when to reload the config files. See the docstring of '
+             'ReloadTrigger for more information.',
+    ),
 ]
 
 
@@ -1393,6 +1428,10 @@ def parse_args(**kwargs: Any):
             kwargs['instance_name'] = '_localdev'
         else:
             kwargs['instance_name'] = '_unknown'
+
+    kwargs['reload_config_files'] = ReloadTrigger(
+        kwargs['reload_config_files']
+    )
 
     if 'EDGEDB_SERVER_CONFIG_cfg::listen_addresses' in os.environ:
         abort(

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -210,7 +210,7 @@ class ServerConfig(NamedTuple):
     emit_server_status: str
     temp_dir: bool
     auto_shutdown_after: float
-    readiness_state_file: Optional[str]
+    readiness_state_file: Optional[pathlib.Path]
     disable_dynamic_system_config: bool
 
     startup_script: Optional[StartupScript]

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -210,6 +210,8 @@ async def _run_server(
             instance_name=args.instance_name,
             max_backend_connections=args.max_backend_connections,
             backend_adaptive_ha=args.backend_adaptive_ha,
+        )
+        tenant.set_reloadable_files(
             readiness_state_file=args.readiness_state_file,
             jwt_sub_allowlist_file=args.jwt_sub_allowlist_file,
             jwt_revocation_list_file=args.jwt_revocation_list_file,

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -240,6 +240,10 @@ async def _run_server(
             disable_dynamic_system_config=args.disable_dynamic_system_config,
             compiler_state=compiler_state,
             tenant=tenant,
+            use_monitor_fs=args.reload_config_files in [
+                srvargs.ReloadTrigger.Default,
+                srvargs.ReloadTrigger.FileSystemEvent,
+            ],
         )
         # This coroutine runs as long as the server,
         # and compiler_state is *heavy*, so make sure we don't
@@ -262,6 +266,15 @@ async def _run_server(
         ss.init_jwcrypto(args.jws_key_file, jws_keys_newly_generated)
 
         def load_configuration(_signum):
+            if args.reload_config_files not in [
+                srvargs.ReloadTrigger.Default,
+                srvargs.ReloadTrigger.Signal,
+            ]:
+                logger.info(
+                    "SIGHUP received, but reload on signal is disabled"
+                )
+                return
+
             logger.info("reloading configuration")
             try:
                 if args.readiness_state_file:

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -173,7 +173,11 @@ class MultiTenantServer(server.BaseServer):
                     self._create_task(self._add_tenant, sni, tenant_conf)
                 )
         for sni in self._tenants_conf:
-            if sni not in conf:
+            if sni in conf:
+                rv.append(
+                    self._create_task(self._reload_tenant, sni, conf[sni])
+                )
+            else:
                 rv.append(self._create_task(self._remove_tenant, sni))
         self._tenants_conf = conf
         return rv
@@ -314,6 +318,32 @@ class MultiTenantServer(server.BaseServer):
                     self._tenants_serial[sni] = serial
         except Exception:
             logger.critical("Failed to remove Tenant %s", sni, exc_info=True)
+
+    async def _reload_tenant(self, serial: int, sni: str, conf: TenantConfig):
+        try:
+            async with self._tenants_lock[sni]:
+                if serial > self._tenants_serial.get(sni, 0):
+                    if tenant := self._tenants.get(sni):
+                        tenant.set_reloadable_files(
+                            readiness_state_file=conf.get(
+                                "readiness-state-file"),
+                            jwt_sub_allowlist_file=conf.get(
+                                "jwt-sub-allowlist-file"),
+                            jwt_revocation_list_file=conf.get(
+                                "jwt-revocation-list-file"),
+                        )
+                        # XXX: Changing other config values like `backend-dsn`
+                        # is NOT supported currently. Ideally we should raise
+                        # warnings here if unsupported changes are detected.
+
+                        tenant.reload()
+                        logger.info("Reloaded Tenant %s", sni)
+
+                    # GOTCHA: reloading tenant doesn't increase the tenant
+                    # serial because a reload shouldn't prevent a concurrent
+                    # removing of the tenant.
+        except Exception:
+            logger.critical("Failed to reload Tenant %s", sni, exc_info=True)
 
     def get_debug_info(self):
         parent = super().get_debug_info()

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -220,30 +220,16 @@ class MultiTenantServer(server.BaseServer):
         )
         cluster.set_connection_params(conn_params)
 
-        if "jwt-sub-allowlist-file" in conf:
-            jwt_sub_allowlist_file = pathlib.Path(
-                conf["jwt-sub-allowlist-file"]
-            )
-        else:
-            jwt_sub_allowlist_file = None
-        if "jwt-revocation-list-file" in conf:
-            jwt_revocation_list_file = pathlib.Path(
-                conf["jwt-revocation-list-file"]
-            )
-        else:
-            jwt_revocation_list_file = None
-        if "readiness-state-file" in conf:
-            readiness_state_file = pathlib.Path(conf["readiness-state-file"])
-        else:
-            readiness_state_file = None
         tenant = edbtenant.Tenant(
             cluster,
             instance_name=conf["instance-name"],
             max_backend_connections=max_conns,
             backend_adaptive_ha=conf.get("backend-adaptive-ha", False),
-            readiness_state_file=readiness_state_file,
-            jwt_sub_allowlist_file=jwt_sub_allowlist_file,
-            jwt_revocation_list_file=jwt_revocation_list_file,
+        )
+        tenant.set_reloadable_files(
+            readiness_state_file=conf.get("readiness-state-file"),
+            jwt_sub_allowlist_file=conf.get("jwt-sub-allowlist-file"),
+            jwt_revocation_list_file=conf.get("jwt-revocation-list-file"),
         )
         tenant.set_server(self)
         tenant.load_jwcrypto()

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -232,12 +232,16 @@ class MultiTenantServer(server.BaseServer):
             )
         else:
             jwt_revocation_list_file = None
+        if "readiness-state-file" in conf:
+            readiness_state_file = pathlib.Path(conf["readiness-state-file"])
+        else:
+            readiness_state_file = None
         tenant = edbtenant.Tenant(
             cluster,
             instance_name=conf["instance-name"],
             max_backend_connections=max_conns,
             backend_adaptive_ha=conf.get("backend-adaptive-ha", False),
-            readiness_state_file=conf.get("readiness-state-file"),
+            readiness_state_file=readiness_state_file,
             jwt_sub_allowlist_file=jwt_sub_allowlist_file,
             jwt_revocation_list_file=jwt_revocation_list_file,
         )

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -847,10 +847,9 @@ class BaseServer:
                 )
                 self.request_shutdown()
 
-        if not os.getenv("EDGEDB_SERVER_DISABLE_MONITOR_FS"):
-            self.monitor_fs(tls_cert_file, reload_tls)
-            if tls_cert_file != tls_key_file:
-                self.monitor_fs(tls_key_file, reload_tls)
+        self.monitor_fs(tls_cert_file, reload_tls)
+        if tls_cert_file != tls_key_file:
+            self.monitor_fs(tls_key_file, reload_tls)
 
     def load_jwcrypto(self, jws_key_file: pathlib.Path) -> None:
         try:

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -92,6 +92,7 @@ class BaseServer:
     _local_intro_query: bytes
     _global_intro_query: bytes
     _report_config_typedesc: dict[defines.ProtocolVersion, bytes]
+    _use_monitor_fs: bool
     _file_watch_handles: list[asyncio.Handle]
 
     _std_schema: s_schema.Schema
@@ -145,8 +146,10 @@ class BaseServer:
         admin_ui: bool = False,
         disable_dynamic_system_config: bool = False,
         compiler_state: edbcompiler.CompilerState,
+        use_monitor_fs: bool = False,
     ):
         self.__loop = asyncio.get_running_loop()
+        self._use_monitor_fs = use_monitor_fs
 
         self._schema_class_layout = compiler_state.schema_class_layout
         self._config_settings = compiler_state.config_spec
@@ -338,6 +341,9 @@ class BaseServer:
         self, path: str | pathlib.Path,
         cb: Callable[[str, int], None],
     ) -> Callable[[], None]:
+        if not self._use_monitor_fs:
+            return lambda: None
+
         # ... we depend on an event loop internal _monitor_fs
         handle = self.__loop._monitor_fs(str(path), cb)  # type: ignore
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -847,9 +847,10 @@ class BaseServer:
                 )
                 self.request_shutdown()
 
-        self.monitor_fs(tls_cert_file, reload_tls)
-        if tls_cert_file != tls_key_file:
-            self.monitor_fs(tls_key_file, reload_tls)
+        if not os.getenv("EDGEDB_SERVER_DISABLE_MONITOR_FS"):
+            self.monitor_fs(tls_cert_file, reload_tls)
+            if tls_cert_file != tls_key_file:
+                self.monitor_fs(tls_key_file, reload_tls)
 
     def load_jwcrypto(self, jws_key_file: pathlib.Path) -> None:
         try:

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1134,6 +1134,18 @@ class Tenant(ha_base.ClusterProtocol):
 
         self._accepting_connections = self.is_online()
 
+    def reload(self):
+        # In multi-tenant mode, the file paths for the following states may be
+        # unset in a reload, while it's impossible in a regular server.
+        # Therefore, we are clearing the states here first, rather than doing
+        # so in reload_readiness_state() or load_jwcrypto().
+        self._readiness = srvargs.ReadinessState.Default
+        self._jwt_sub_allowlist = None
+        self._jwt_revocation_list = None
+
+        self.reload_readiness_state()
+        self.load_jwcrypto()
+
     async def on_before_drop_db(
         self, dbname: str, current_dbname: str
     ) -> None:

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -24,6 +24,7 @@ import contextlib
 import functools
 import json
 import logging
+import os
 import pathlib
 import pickle
 import struct
@@ -371,13 +372,15 @@ class Tenant(ha_base.ClusterProtocol):
 
         if self._readiness_state_file is not None:
 
-            def reload_state_file(_file_modified, _event):
-                self.reload_readiness_state()
-
             self.reload_readiness_state()
-            self._server.monitor_fs(
-                self._readiness_state_file, reload_state_file
-            )
+
+            if not os.getenv("EDGEDB_SERVER_DISABLE_MONITOR_FS"):
+                def reload_state_file(_file_modified, _event):
+                    self.reload_readiness_state()
+
+                self._server.monitor_fs(
+                    self._readiness_state_file, reload_state_file
+                )
 
         self._initing = False
 

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -90,7 +90,7 @@ class Tenant(ha_base.ClusterProtocol):
 
     _ha_master_serial: int
     _backend_adaptive_ha: adaptive_ha.AdaptiveHASupport | None
-    _readiness_state_file: str | None
+    _readiness_state_file: pathlib.Path | None
     _readiness: srvargs.ReadinessState
     _readiness_reason: str
 
@@ -112,7 +112,7 @@ class Tenant(ha_base.ClusterProtocol):
         instance_name: str,
         max_backend_connections: int,
         backend_adaptive_ha: bool = False,
-        readiness_state_file: str | None = None,
+        readiness_state_file: pathlib.Path | None = None,
         jwt_sub_allowlist_file: pathlib.Path | None = None,
         jwt_revocation_list_file: pathlib.Path | None = None,
     ):
@@ -1081,7 +1081,7 @@ class Tenant(ha_base.ClusterProtocol):
         if self._readiness_state_file is None:
             return
         try:
-            with open(self._readiness_state_file, "rt") as rt:
+            with self._readiness_state_file.open("rt") as rt:
                 line = rt.readline().strip()
                 try:
                     state, _, reason = line.partition(":")

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -24,7 +24,6 @@ import contextlib
 import functools
 import json
 import logging
-import os
 import pathlib
 import pickle
 import struct
@@ -372,15 +371,13 @@ class Tenant(ha_base.ClusterProtocol):
 
         if self._readiness_state_file is not None:
 
+            def reload_state_file(_file_modified, _event):
+                self.reload_readiness_state()
+
             self.reload_readiness_state()
-
-            if not os.getenv("EDGEDB_SERVER_DISABLE_MONITOR_FS"):
-                def reload_state_file(_file_modified, _event):
-                    self.reload_readiness_state()
-
-                self._server.monitor_fs(
-                    self._readiness_state_file, reload_state_file
-                )
+            self._server.monitor_fs(
+                self._readiness_state_file, reload_state_file
+            )
 
         self._initing = False
 

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -112,9 +112,6 @@ class Tenant(ha_base.ClusterProtocol):
         instance_name: str,
         max_backend_connections: int,
         backend_adaptive_ha: bool = False,
-        readiness_state_file: pathlib.Path | None = None,
-        jwt_sub_allowlist_file: pathlib.Path | None = None,
-        jwt_revocation_list_file: pathlib.Path | None = None,
     ):
         self._cluster = cluster
         self._tenant_id = self.get_backend_runtime_params().tenant_id
@@ -140,7 +137,7 @@ class Tenant(ha_base.ClusterProtocol):
             )
         else:
             self._backend_adaptive_ha = None
-        self._readiness_state_file = readiness_state_file
+        self._readiness_state_file = None
         self._readiness = srvargs.ReadinessState.Default
         self._readiness_reason = ""
 
@@ -166,10 +163,26 @@ class Tenant(ha_base.ClusterProtocol):
 
         self._roles = immutables.Map()
         self._sys_auth = tuple()
-        self._jwt_sub_allowlist_file = jwt_sub_allowlist_file
+        self._jwt_sub_allowlist_file = None
         self._jwt_sub_allowlist = None
-        self._jwt_revocation_list_file = jwt_revocation_list_file
+        self._jwt_revocation_list_file = None
         self._jwt_revocation_list = None
+
+    def set_reloadable_files(
+        self,
+        readiness_state_file: str | pathlib.Path | None = None,
+        jwt_sub_allowlist_file: str | pathlib.Path | None = None,
+        jwt_revocation_list_file: str | pathlib.Path | None = None,
+    ) -> None:
+        if isinstance(readiness_state_file, str):
+            readiness_state_file = pathlib.Path(readiness_state_file)
+        self._readiness_state_file = readiness_state_file
+        if isinstance(jwt_sub_allowlist_file, str):
+            jwt_sub_allowlist_file = pathlib.Path(jwt_sub_allowlist_file)
+        self._jwt_sub_allowlist_file = jwt_sub_allowlist_file
+        if isinstance(jwt_revocation_list_file, str):
+            jwt_revocation_list_file = pathlib.Path(jwt_revocation_list_file)
+        self._jwt_revocation_list_file = jwt_revocation_list_file
 
     def set_server(self, server: edbserver.BaseServer) -> None:
         self._server = server


### PR DESCRIPTION
* SIGHUP will now read `readiness-state-file`, `jwt-sub-allowlist-file` and `jwt-revocation-list-file` (if set) of all tenants
* ~Set `EDGEDB_SERVER_DISABLE_MONITOR_FS=1` to disable all `monitor_fs()`~
* Added option `--reload-config-files` / env var `EDGEDB_SERVER_RELOAD_CONFIG_FILES` to configure when to reload:
  * `default`: reload on both SIGHUP and fsevent
  * `never`: disable the reload function
  * `signal`: only reload on SIGHUP
  * `fsevent`: watch the files for changes and reload when it happens

- [x] Manual test
- [ ] Under `default` / `fsevent`, also watch the JWT-related files, as well as the multitenant-config file
- [ ] Add test

Please review each commit.