### PR TITLE
Fix migrating between aliased and non-aliased computeds

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11630,9 +11630,6 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             type Away2 extending Away;
         ''')
 
-    @test.xfail('''
-        This fails because of the alias nonsense in pointers
-    ''')
     async def test_edgeql_migration_between_computeds_02(self):
         await self.migrate(r'''
             type Away {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -14410,9 +14410,6 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
                 insert Away { x := '2', y := '1' }
             """)
 
-    @test.xerror('''
-        This fails because of the alias nonsense in pointers
-    ''')
     async def test_edgeql_ddl_adjust_computed_16(self):
         # this is caused by the annoying thing where pointers that are
         # a simple alias like this just inherit from the other point.


### PR DESCRIPTION
This version is designed to be cherry-pickable to 4.x, so it doesn't
change how any of our schemas are represented, it just tries to
actually fully make the transition when we switch.

I'm going to do a follow-up where I rip all of this out and the cost
of schema changes.