### PR TITLE
Get rid of computeds subtyping other pointers in same object

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_10_25_00_00
+EDGEDB_CATALOG_VERSION = 2023_12_05_00_00
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -309,7 +309,8 @@ def derive_ptr(
     # actually deriving from it.
     if derive_backlink:
         attrs = attrs.copy() if attrs else {}
-        attrs['computed_backlink'] = ptr
+        attrs['computed_link_alias'] = ptr
+        attrs['computed_link_alias_is_backward'] = True
         ptr = ctx.env.schema.get('std::link', type=s_pointers.Pointer)
 
     ctx.env.schema, derived = ptr.derive_ref(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -756,17 +756,15 @@ def resolve_ptr_with_intersections(
             s_name.UnqualName(pointer_name),
         )
 
-        # If we couldn't anything, but the source is a computed backlink,
-        # look for a link property on the reverse side of it. This allows
-        # us to access link properties in both directions on links, including
-        # when the backlink has been stuck in a computed.
+        # If we couldn't anything, but the source is a computed link
+        # that aliases some other link, look for a link property on
+        # it. This allows us to access link properties in both
+        # directions on links, including when the backlink has been
+        # stuck in a computed.
         if (
             ptr is None
             and isinstance(near_endpoint, s_links.Link)
-            and (
-                (back := near_endpoint.get_computed_backlink(ctx.env.schema))
-                or (back := near_endpoint.get_computed_link(ctx.env.schema))
-            )
+            and (back := near_endpoint.get_computed_link_alias(ctx.env.schema))
             and isinstance(back, s_links.Link)
             and (nptr := back.maybe_get_ptr(
                 ctx.env.schema,

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -762,8 +762,11 @@ def resolve_ptr_with_intersections(
         # when the backlink has been stuck in a computed.
         if (
             ptr is None
-            and isinstance(near_endpoint, s_pointers.Pointer)
-            and (back := near_endpoint.get_computed_backlink(ctx.env.schema))
+            and isinstance(near_endpoint, s_links.Link)
+            and (
+                (back := near_endpoint.get_computed_backlink(ctx.env.schema))
+                or (back := near_endpoint.get_computed_link(ctx.env.schema))
+            )
             and isinstance(back, s_links.Link)
             and (nptr := back.maybe_get_ptr(
                 ctx.env.schema,

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -778,8 +778,9 @@ def resolve_ptr_with_intersections(
                 s_types.Type, near_endpoint.get_source(ctx.env.schema)
             )
             if not src_type.is_view(ctx.env.schema):
-                # XXX: This is *beyond* sketchy.
-                # And we should only do it once!
+                # HACK: If the source is in the standard library, and
+                # not a view, we can't add a derived pointer.  For
+                # consistency, just always require it be a view.
                 new_source = downcast(
                     s_objtypes.ObjectType,
                     schemactx.derive_view(src_type, ctx=ctx),

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -248,8 +248,8 @@ class BasePointerRef(ImmutableBase):
     # Inbound cardinality of the pointer.
     in_cardinality: qltypes.Cardinality = qltypes.Cardinality.MANY
     defined_here: bool = False
-    computed_link: typing.Optional[BasePointerRef] = None
-    computed_backlink: typing.Optional[BasePointerRef] = None
+    computed_link_alias: typing.Optional[BasePointerRef] = None
+    computed_link_alias_is_backward: typing.Optional[bool] = None
 
     def dir_target(self, direction: s_pointers.PointerDirection) -> TypeRef:
         if direction is s_pointers.PointerDirection.Outbound:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -248,6 +248,7 @@ class BasePointerRef(ImmutableBase):
     # Inbound cardinality of the pointer.
     in_cardinality: qltypes.Cardinality = qltypes.Cardinality.MANY
     defined_here: bool = False
+    computed_link: typing.Optional[BasePointerRef] = None
     computed_backlink: typing.Optional[BasePointerRef] = None
 
     def dir_target(self, direction: s_pointers.PointerDirection) -> TypeRef:

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -583,18 +583,14 @@ def ptrref_from_ptrcls(
         ircls = irast.PointerRef
         kwargs['id'] = ptrcls.id
         kwargs['defined_here'] = ptrcls.get_defined_here(schema)
-        if backlink := ptrcls.get_computed_backlink(schema):
+        if backlink := ptrcls.get_computed_link_alias(schema):
             assert isinstance(backlink, s_pointers.Pointer)
-            kwargs['computed_backlink'] = ptrref_from_ptrcls(
+            kwargs['computed_link_alias'] = ptrref_from_ptrcls(
                 ptrcls=backlink, schema=schema,
                 cache=cache, typeref_cache=typeref_cache,
             )
-        if backlink := ptrcls.get_computed_link(schema):
-            assert isinstance(backlink, s_pointers.Pointer)
-            kwargs['computed_link'] = ptrref_from_ptrcls(
-                ptrcls=backlink, schema=schema,
-                cache=cache, typeref_cache=typeref_cache,
-            )
+            kwargs['computed_link_alias_is_backward'] = (
+                ptrcls.get_computed_link_alias_is_backward(schema))
 
     else:
         raise AssertionError(f'unexpected pointer class: {ptrcls}')

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -589,6 +589,12 @@ def ptrref_from_ptrcls(
                 ptrcls=backlink, schema=schema,
                 cache=cache, typeref_cache=typeref_cache,
             )
+        if backlink := ptrcls.get_computed_link(schema):
+            assert isinstance(backlink, s_pointers.Pointer)
+            kwargs['computed_link'] = ptrref_from_ptrcls(
+                ptrcls=backlink, schema=schema,
+                cache=cache, typeref_cache=typeref_cache,
+            )
 
     else:
         raise AssertionError(f'unexpected pointer class: {ptrcls}')

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1856,6 +1856,8 @@ def range_for_ptrref(
         refs = {next(iter((ptrref.intersection_components)))}
     elif ptrref.computed_backlink:
         refs = {ptrref.computed_backlink}
+    elif ptrref.computed_link:
+        refs = {ptrref.computed_link}
     else:
         refs = {ptrref}
         assert isinstance(ptrref, irast.PointerRef), \

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -621,10 +621,9 @@ def _new_mapped_pointer_rvar(
         name=[tgt_col],
         nullable=not ptrref.required)
 
-    # Set up references according to the link direction.
     if (
         ir_ptr.direction == s_pointers.PointerDirection.Inbound
-        or ptrref.computed_backlink
+        or ptrref.computed_link_alias_is_backward
     ):
         near_ref = target_ref
         far_ref = source_ref
@@ -1854,10 +1853,8 @@ def range_for_ptrref(
         # needs to appear in *all* of the tables, so we just pick any
         # one of them.
         refs = {next(iter((ptrref.intersection_components)))}
-    elif ptrref.computed_backlink:
-        refs = {ptrref.computed_backlink}
-    elif ptrref.computed_link:
-        refs = {ptrref.computed_link}
+    elif ptrref.computed_link_alias:
+        refs = {ptrref.computed_link_alias}
     else:
         refs = {ptrref}
         assert isinstance(ptrref, irast.PointerRef), \

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -535,6 +535,11 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         type_is_generic_self=True,
     )
 
+    computed_link = so.SchemaField(
+        so.Object,
+        default=None,
+        compcoef=0.99,
+    )
     computed_backlink = so.SchemaField(
         so.Object,
         default=None,

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1300,6 +1300,27 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @test.xerror('Stack overflow!')
+    async def test_edgeql_props_back_09(self):
+        await self.assert_query_result(
+            r'''
+            select assert_exists((
+                select Card { name, z := .<deck[IS User] {
+                  name, @count := @count }}
+                filter .name = 'Dragon'
+            ));
+            ''',
+            [
+                {
+                    "name": "Dragon",
+                    "z": tb.bag([
+                        {"x": 2, "name": "Alice"},
+                        {"x": 1, "name": "Dave"},
+                    ])
+                }
+            ]
+        )
+
     async def test_edgeql_props_schema_back_00(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,


### PR DESCRIPTION
Currently if we have something like:
```
type T;
type S {
    s: T;
    s2 := .s;
};
```
`s2` will actually be derived from *`s`*. The point of this is that that if `s` has linkprops, they get inherited by `s2`, but this implementation strategy has caused a *lot* of bugs.

Ditch that and basically use the same approach we use for getting linkprops on backlinks