### PR TITLE
Drop legacy anonymous statement

### DIFF
--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -58,9 +58,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         object _startup_msg_waiter
 
-        dbview.CompiledQuery _last_anon_compiled
-        int _last_anon_compiled_hash
-
         bint query_cache_enabled
 
         tuple protocol_version


### PR DESCRIPTION
The reason it was kept is explained in #3120, mitigated in #3814 #3837. But the core issue that compiler assumes mutation of transaction state for any compilation even by Parse message still exists. We can drop the `_last_anon_compiled` because the client bindings are no longer sending Parse + Execute for `commit` or `rollback` commands (which triggered two server compilation of the same command) like edgedb/edgedb-python#337. However, we still need to double check all bindings to make sure the transaction control commands are using only one `Execute` message.