### PR TITLE
Get rid of the need to call qlparser.preload_spec()

### DIFF
--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -38,6 +38,8 @@ ParserError = Tuple[
     Optional[str]
 ]
 
+SPEC_LOADED = False
+
 
 def append_module_aliases(tree, aliases):
     modaliases = []
@@ -124,6 +126,9 @@ def parse(
     source: Union[str, qltokenizer.Source],
     filename: Optional[str] = None,
 ):
+    if not SPEC_LOADED:
+        preload_spec()
+
     if isinstance(source, str):
         source = qltokenizer.Source.from_string(source)
 
@@ -248,8 +253,10 @@ def _cst_to_ast(
 
 
 def preload_spec() -> None:
+    global SPEC_LOADED
     path = get_spec_filepath()
     rust_parser.preload_spec(path)
+    SPEC_LOADED = True
 
 
 def get_spec_filepath():

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -175,24 +175,7 @@ class BaseDocTest(unittest.TestCase, metaclass=DocTestMeta):
         )
 
 
-class PreloadParserGrammarMixin:
-    pass
-
-
-def should_preload_parser(
-    cases: Iterable[unittest.TestCase],
-) -> bool:
-    for cas in cases:
-        if issubclass(cas, PreloadParserGrammarMixin):
-            return True
-    return False
-
-
-def preload_parser() -> None:
-    qlparser.preload_spec()
-
-
-class BaseSyntaxTest(BaseDocTest, PreloadParserGrammarMixin):
+class BaseSyntaxTest(BaseDocTest):
     ast_to_source: Optional[Any] = None
     markup_dump_lexer: Optional[str] = None
 
@@ -300,7 +283,7 @@ def new_compiler():
     )
 
 
-class BaseSchemaTest(BaseDocTest, PreloadParserGrammarMixin):
+class BaseSchemaTest(BaseDocTest):
     DEFAULT_MODULE = 'default'
     SCHEMA: Optional[str] = None
 

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -725,7 +725,6 @@ class EQLFunctionDirective(BaseEQLDirective):
         from edb.edgeql import qltypes
 
         try:
-            edgeql_parser.preload_spec()
             astnode = edgeql_parser.parse(
                 edgeql_grammar.tokens.T_STARTBLOCK,
                 f'create function {sig} using SQL function "xxx";')[0]
@@ -800,7 +799,6 @@ class EQLConstraintDirective(BaseEQLDirective):
         from edb.edgeql import codegen as ql_gen
 
         try:
-            edgeql_parser.preload_spec()
             astnode = edgeql_parser.parse(
                 edgeql_grammar.tokens.T_STARTBLOCK,
                 f'create abstract constraint {sig};'

--- a/edb/tools/parser_demo.py
+++ b/edb/tools/parser_demo.py
@@ -31,8 +31,6 @@ from edb.tools.edb import edbcommands
 @edbcommands.command("parser-demo")
 def main():
 
-    qlparser.preload_spec()
-
     for q in QUERIES[-10:]:
         sdl = q.startswith('sdl')
         if sdl:

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -55,7 +55,6 @@ import click
 import edgedb
 
 from edb.common import devmode
-from edb.testbase import lang as tb_lang
 from edb.testbase import server as tb
 
 from . import cpython_state
@@ -840,8 +839,7 @@ class ParallelTextTestRunner:
         )
         setup = tb.get_test_cases_setup(cases)
         server_used = tb.test_cases_use_server(cases)
-        should_preload_parser = tb_lang.should_preload_parser(cases)
-        worker_init = tb_lang.preload_parser if should_preload_parser else None
+        worker_init = None
         bootstrap_time_taken = 0
         tests_time_taken = 0
         result = None

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -66,7 +66,6 @@ from edb.common.compiler import AliasGenerator
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
 from edb.edgeql import desugar_group
-from edb.edgeql import parser as qlparser
 
 
 from dataclasses import dataclass, replace, field
@@ -1925,8 +1924,6 @@ parser.add_argument('commands', metavar='cmd', type=str, nargs='*',
 
 
 def main() -> None:
-    qlparser.preload_spec()
-
     db = mk_DB1()
 
     args = parser.parse_args()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -41,14 +41,13 @@ except ImportError:
 from graphql.language import parser as graphql_parser
 
 from edb.edgeql import parser as ql_parser
-from edb.testbase import lang
 
 
 def find_edgedb_root():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-class TestDocSnippets(unittest.TestCase, lang.PreloadParserGrammarMixin):
+class TestDocSnippets(unittest.TestCase):
     """Lint and validate EdgeDB documentation files.
 
     Checks:

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -22,12 +22,11 @@ import unittest
 from edb.tools import toy_eval_model as model
 
 from edb.common import assert_data_shape
-from edb.testbase.lang import PreloadParserGrammarMixin
 
 bag = assert_data_shape.bag
 
 
-class TestModelSmokeTests(unittest.TestCase, PreloadParserGrammarMixin):
+class TestModelSmokeTests(unittest.TestCase):
     """Unit tests for the toy evaluator model.
 
     These are intended as smoke tests. Since obviously we don't want

--- a/tests/test_eval_model_group.py
+++ b/tests/test_eval_model_group.py
@@ -20,14 +20,13 @@
 import unittest
 
 from edb.tools import toy_eval_model as model
-from edb.testbase.lang import PreloadParserGrammarMixin
 
 from edb.common import assert_data_shape
 
 bag = assert_data_shape.bag
 
 
-class TestModelGroupTests(unittest.TestCase, PreloadParserGrammarMixin):
+class TestModelGroupTests(unittest.TestCase):
     """Tests for GROUP BY in the toy evaluator model."""
 
     def assert_test_query(

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -379,7 +379,7 @@ class TestServerCompilerPool(tbs.TestCase):
             self.assertEqual(sd.call_system_api('/server/status/ready'), 'OK')
 
 
-class TestCompilerPool(tbs.TestCase, tb.PreloadParserGrammarMixin):
+class TestCompilerPool(tbs.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
It makes tests and tooling more annoying to do; the cost of supporting
lazy loading is an extra branch per parse, which is extremely low.
(I didn't want to fix edgedb-perf to call it, basically.)

I left the calls to preload_spec in the two production use cases, so
it happens at an explicitly predictable time.