### PR TITLE
Properly support @source/@target on multi-link constraints

### DIFF
--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -325,11 +325,7 @@ def compile_constraint(
         assert isinstance(sub, (s_types.Type, s_pointers.Pointer))
         origin_subject: s_types.Type | s_pointers.Pointer = sub
 
-        origin_path_prefix_anchor = (
-            qlast.Subject().name
-            if isinstance(origin_subject, s_types.Type)
-            else None
-        )
+        origin_path_prefix_anchor = qlast.Subject().name
         singletons = frozenset({(origin_subject, is_optional)})
 
         origin_options = qlcompiler.CompilerOptions(

--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -141,6 +141,19 @@ type UniqueName {
         constraint exclusive on ((__subject__@source, __subject__@lang));
         constraint exclusive on (__subject__@prop1);
     }
+
+    multi link translated_labels extending translated_label -> Label {
+        constraint exclusive on ((@source, @lang));
+        constraint exclusive on (__subject__@prop1);
+    }
+
+    link translated_label_tgt extending translated_label -> Label {
+        constraint exclusive on ((__subject__@target, __subject__@lang));
+    }
+
+    multi link translated_labels_tgt extending translated_label -> Label {
+        constraint exclusive on ((@target, @lang));
+    }
 }
 
 type UniqueNameInherited extending UniqueName {

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1575,3 +1575,30 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ''',
             [{}],
         )
+
+    async def test_edgeql_props_target_06(self):
+        # This should not work
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            r"@target may only be used in index and constraint definitions"
+        ):
+            await self.con.query(
+                r'''
+                SELECT schema::ObjectType {
+                  name,
+                  is_abstract,
+                  bases: {
+                    name,
+                  } ORDER BY @index ASC,
+                  pointers: {
+                    cardinality,
+                    required,
+                    name,
+                    target: {
+                      name,
+                    },
+                    kind := 'link' IF @target IS schema::Link ELSE 'property'
+                  },
+                } FILTER NOT .is_compound_type;
+                '''
+            )

--- a/tests/test_pg_dump.py
+++ b/tests/test_pg_dump.py
@@ -113,12 +113,12 @@ class TestPGDump02(tb.StablePGDumpTestCase):
                 id,
                 num,
                 _single_link := .single_link {
-                    source := @source.id,
+                    source := E.id,
                     lp0 := @lp0,
                     target := .id,
                 },
                 _multi_link := .multi_link {
-                    source := @source.id,
+                    source := E.id,
                     lp1 := @lp1,
                     target := .id,
                 },
@@ -328,7 +328,7 @@ class TestPGDump03(tb.StablePGDumpTestCase):
                 id,
                 `Ł🤞`,
                 `_Ł💯` := .`Ł💯` {
-                    source := @source.id,
+                    source := Łukasz.id,
                     `🙀🚀🚀🚀🙀` := @`🙀🚀🚀🚀🙀`,
                     `🙀مرحبا🙀` := @`🙀مرحبا🙀`,
                     target := .id,


### PR DESCRIPTION
This is useful becase putting exclusive constraints on `(@source,
@lprop)` and `(@target, @lprop)` are both useful.  This is supposed to
be supported, but an overzealous checker blocks it for multi (which of
course is the only time when the @source one would be useful). Fix the
check.
Closes #6570 (by providing a proper way to accomplish what is desired).

While we are at it, disable @source and @target from being used in non
constraint/index contexts, since they are quite broken but
also not worth fixing. (I think @target is basically completely broken.
@source is also in bad shape but apparently at least sometimes works,
since two pgdump tests (of all things) use @source.)
Neither is documented at *all* currently.

Closes #1786.

@raddevon could you add documenting these patterns to your queue?