### PR TITLE
Docs: Fully qualify type name used in nested module

### DIFF
--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -158,7 +158,10 @@ called ``default``.
             }
 
             module combat {
-                function fight(one: Person, two: Person) -> str
+                function fight(
+                  one: dracula::Person,
+                  two: dracula::Person
+                ) -> str
                   using (
                     (one.name ?? 'Fighter 1') ++ ' wins!'
                     IF (one.strength ?? 0) > (two.strength ?? 0)


### PR DESCRIPTION
User discovered this schema in our nested module note doesn't actually work because `Person` is not fully-qualified in a nested module.