### PR TITLE
Fix some bugs involving union and coalescing of optional values

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -393,7 +393,8 @@ def _compile_dml_coalesce(
         res = dispatch.compile(full, ctx=subctx)
         # Indicate that the original ?? code should determine the
         # cardinality/multiplicity.
-        res.card_inference_override = ir
+        assert isinstance(res.expr, irast.SelectStmt)
+        res.expr.card_inference_override = ir
 
         return res
 
@@ -479,7 +480,8 @@ def _compile_dml_ifelse(
         res = dispatch.compile(full, ctx=subctx)
         # Indicate that the original IF/ELSE code should determine the
         # cardinality/multiplicity.
-        res.card_inference_override = ir
+        assert isinstance(res.expr, irast.SelectStmt)
+        res.expr.card_inference_override = ir
 
         return res
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -519,12 +519,6 @@ def _infer_set(
             ir, is_mutation=is_mutation,
             scope_tree=scope_tree, ctx=ctx)
 
-        # But actually! Check if it is overridden
-        if ir.card_inference_override:
-            result = _infer_set_inner(
-                ir.card_inference_override, is_mutation=is_mutation,
-                scope_tree=scope_tree, ctx=ctx)
-
         # We need to cache the main result before doing the shape,
         # since sometimes the shape will refer to the enclosing set.
         ctx.inferred_cardinality[ir] = result
@@ -1272,6 +1266,11 @@ def __infer_select_stmt(
 
     if ir.iterator_stmt:
         stmt_card = cartesian_cardinality((stmt_card, iter_card))
+
+    # But actually! Check if it is overridden
+    if ir.card_inference_override:
+        stmt_card = infer_cardinality(
+            ir.card_inference_override, scope_tree=scope_tree, ctx=ctx)
 
     return stmt_card
 

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -227,11 +227,6 @@ def _infer_set(
     result = _infer_set_inner(
         ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx
     )
-    if ir.card_inference_override:
-        result = _infer_set_inner(
-            ir.card_inference_override, is_mutation=is_mutation,
-            scope_tree=scope_tree, ctx=ctx)
-
     ctx.inferred_multiplicity[ir, scope_tree, ctx.distinct_iterator] = result
 
     # The shape doesn't affect multiplicity, but requires validation.
@@ -625,7 +620,7 @@ def __infer_select_stmt(
 ) -> inf_ctx.MultiplicityInfo:
 
     if ir.iterator_stmt is not None:
-        return _infer_for_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+        stmt_mult = _infer_for_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
     else:
         stmt_mult = _infer_stmt_multiplicity(
             ir, scope_tree=scope_tree, ctx=ctx)
@@ -639,7 +634,11 @@ def __infer_select_stmt(
             new_scope = inf_utils.get_set_scope(clause, scope_tree, ctx=ctx)
             infer_multiplicity(clause, scope_tree=new_scope, ctx=ctx)
 
-        return stmt_mult
+    if ir.card_inference_override:
+        stmt_mult = infer_multiplicity(
+            ir.card_inference_override, scope_tree=scope_tree, ctx=ctx)
+
+    return stmt_mult
 
 
 @_infer_multiplicity.register

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -540,12 +540,6 @@ class Set(Base):
     # insertions to BaseObject.
     ignore_rewrites: bool = False
 
-    # An expression to use instead of this one for the purpose of
-    # cardinality/multiplicity inference. This is used for when something
-    # is desugared in a way that doesn't preserve cardinality, but we
-    # need to anyway.
-    card_inference_override: typing.Optional[Set] = None
-
     def __repr__(self) -> str:
         return f'<ir.Set \'{self.path_id}\' at 0x{id(self):x}>'
 
@@ -1075,6 +1069,12 @@ class SelectStmt(FilteredStmt):
     offset: typing.Optional[Set] = None
     limit: typing.Optional[Set] = None
     implicit_wrapper: bool = False
+
+    # An expression to use instead of this one for the purpose of
+    # cardinality/multiplicity inference. This is used for when something
+    # is desugared in a way that doesn't preserve cardinality, but we
+    # need to anyway.
+    card_inference_override: typing.Optional[Set] = None
 
 
 class GroupStmt(FilteredStmt):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -159,6 +159,7 @@ def is_trivial_select(ir_expr: irast.Base) -> TypeGuard[irast.SelectStmt]:
         and ir_expr.where is None
         and ir_expr.limit is None
         and ir_expr.offset is None
+        and ir_expr.card_inference_override is None
     )
 
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1089,12 +1089,11 @@ def compile_insert_shape_element(
         if shape_el.rptr.dir_cardinality.can_be_zero() or force_optional:
             # If the element can be empty, compile it in a subquery to force it
             # to be NULL.
-            value: pgast.BaseExpr = relgen.set_as_subquery(
+            value = relgen.set_as_subquery(
                 shape_el, as_value=True, ctx=insvalctx)
             pathctx.put_path_value_var(insvalctx.rel, shape_el.path_id, value)
         else:
-            value = dispatch.compile(shape_el, ctx=insvalctx)
-            output.add_null_test(value, ctx.rel)
+            dispatch.visit(shape_el, ctx=insvalctx)
 
 
 def merge_overlays_globally(
@@ -2002,24 +2001,52 @@ def process_update_shape(
                 scopectx.expr_exposed = False
                 val: pgast.BaseExpr
 
-                val = relgen.set_as_subquery(
-                    element,
-                    as_value=True,
-                    explicit_cast=ptr_info.column_type,
-                    ctx=scopectx,
-                )
+                if irtyputils.is_tuple(element.typeref):
+                    # When target is a tuple type, make sure
+                    # the expression is compiled into a subquery
+                    # returning a single column that is explicitly
+                    # cast into the appropriate composite type.
+                    val = relgen.set_as_subquery(
+                        element,
+                        as_value=True,
+                        explicit_cast=ptr_info.column_type,
+                        ctx=scopectx,
+                    )
+                else:
+                    if (
+                        isinstance(updvalue, irast.MutatingStmt)
+                        and updvalue in ctx.dml_stmts
+                    ):
+                        with scopectx.substmt() as srelctx:
+                            dml_cte = ctx.dml_stmts[updvalue]
+                            wrap_dml_cte(updvalue, dml_cte, ctx=srelctx)
+                            pathctx.get_path_identity_output(
+                                srelctx.rel,
+                                updvalue.subject.path_id,
+                                env=srelctx.env,
+                            )
+                            val = srelctx.rel
+                    else:
+                        # base case
+                        val = dispatch.compile(updvalue, ctx=scopectx)
 
-                assert isinstance(updvalue, irast.Stmt)
-                val = check_update_type(
-                    val,
-                    val,
-                    is_subquery=True,
-                    ir_stmt=ir_stmt,
-                    ir_set=element,
-                    shape_ptrref=shape_ptrref,
-                    actual_ptrref=actual_ptrref,
-                    ctx=scopectx,
-                )
+                    assert isinstance(updvalue, irast.Stmt)
+
+                    val = check_update_type(
+                        val,
+                        val,
+                        is_subquery=True,
+                        ir_stmt=ir_stmt,
+                        ir_set=updvalue.result,
+                        shape_ptrref=shape_ptrref,
+                        actual_ptrref=actual_ptrref,
+                        ctx=scopectx,
+                    )
+
+                    val = pgast.TypeCast(
+                        arg=val,
+                        type_name=pgast.TypeName(name=ptr_info.column_type),
+                    )
 
                 if shape_op is qlast.ShapeOp.SUBTRACT:
                     val = pgast.FuncCall(

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -526,6 +526,19 @@ def output_as_value(
     return val
 
 
+def add_null_test(expr: pgast.BaseExpr, query: pgast.SelectStmt) -> None:
+    if not expr.nullable:
+        return
+
+    while isinstance(expr, pgast.TupleVar) and expr.elements:
+        expr = expr.elements[0].val
+
+    query.where_clause = astutils.extend_binop(
+        query.where_clause,
+        pgast.NullTest(arg=expr, negated=True)
+    )
+
+
 def serialize_expr_if_needed(
         expr: pgast.BaseExpr, *,
         path_id: irast.PathId,

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -486,7 +486,7 @@ def in_serialization_ctx(ctx: context.CompilerContextLevel) -> bool:
 
 def output_as_value(
         expr: pgast.BaseExpr, *,
-        env: context.Environment) -> pgast.BaseExpr:
+        env: Optional[context.Environment]) -> pgast.BaseExpr:
 
     val = expr
     if isinstance(expr, pgast.TupleVar):
@@ -494,7 +494,8 @@ def output_as_value(
                       Type[pgast.RowExpr]]
 
         if (
-            env.output_format is context.OutputFormat.NATIVE_INTERNAL
+            env
+            and env.output_format is context.OutputFormat.NATIVE_INTERNAL
             and len(expr.elements) == 1
             and (path_id := (el0 := expr.elements[0]).path_id) is not None
             and (rptr_name := path_id.rptr_name()) is not None
@@ -513,7 +514,7 @@ def output_as_value(
         ])
 
         if (expr.typeref is not None
-                and not env.singleton_mode
+                and not (env and env.singleton_mode)
                 and irtyputils.is_persistent_tuple(expr.typeref)):
             pg_type = pgtypes.pg_type_from_ir_typeref(expr.typeref)
             val = pgast.TypeCast(
@@ -524,6 +525,19 @@ def output_as_value(
             )
 
     return val
+
+
+def add_null_test(expr: pgast.BaseExpr, query: pgast.SelectStmt) -> None:
+    if not expr.nullable:
+        return
+
+    while isinstance(expr, pgast.TupleVar) and expr.elements:
+        expr = expr.elements[0].val
+
+    query.where_clause = astutils.extend_binop(
+        query.where_clause,
+        pgast.NullTest(arg=expr, negated=True)
+    )
 
 
 def serialize_expr_if_needed(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -527,10 +527,6 @@ def set_as_subquery(
         wrapper.name = ctx.env.aliases.get('set_as_subquery')
         dispatch.visit(ir_set, ctx=subctx)
 
-        var = pathctx.get_path_value_var(
-            rel=wrapper, path_id=ir_set.path_id, env=ctx.env)
-        output.add_null_test(var, subctx.rel)
-
         if as_value:
 
             if output.in_serialization_ctx(ctx):
@@ -550,7 +546,6 @@ def set_as_subquery(
                         type_name=pgast.TypeName(name=explicit_cast),
                     )
 
-                wrapper.path_outputs.clear()
                 wrapper.target_list = [
                     pgast.ResTarget(val=value)
                 ]
@@ -2291,8 +2286,6 @@ def process_set_as_singleton_assertion(
                 ),
             ],
         )
-
-        output.add_null_test(arg_ref, newctx.rel)
 
         # Force Postgres to actually evaluate the result target
         # by putting it into an ORDER BY.

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2287,6 +2287,8 @@ def process_set_as_singleton_assertion(
             ],
         )
 
+        output.add_null_test(arg_ref, newctx.rel)
+
         # Force Postgres to actually evaluate the result target
         # by putting it into an ORDER BY.
         newctx.rel.target_list.append(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -527,6 +527,10 @@ def set_as_subquery(
         wrapper.name = ctx.env.aliases.get('set_as_subquery')
         dispatch.visit(ir_set, ctx=subctx)
 
+        var = pathctx.get_path_value_var(
+            rel=wrapper, path_id=ir_set.path_id, env=ctx.env)
+        output.add_null_test(var, subctx.rel)
+
         if as_value:
 
             if output.in_serialization_ctx(ctx):
@@ -546,6 +550,7 @@ def set_as_subquery(
                         type_name=pgast.TypeName(name=explicit_cast),
                     )
 
+                wrapper.path_outputs.clear()
                 wrapper.target_list = [
                     pgast.ResTarget(val=value)
                 ]
@@ -2286,6 +2291,8 @@ def process_set_as_singleton_assertion(
                 ),
             ],
         )
+
+        output.add_null_test(arg_ref, newctx.rel)
 
         # Force Postgres to actually evaluate the result target
         # by putting it into an ORDER BY.

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -9155,6 +9155,15 @@ aa \
             );
         """)
 
+        await self.con.query("""
+            select {
+                xy := assert_single({<optional str>$0, <optional str>$1}) };
+        """, None, None)
+        await self.con.query("""
+            select {
+                xy := assert_single({<optional str>$0, <optional str>$1}) };
+        """, None, 'test')
+
     async def test_edgeql_assert_single_02(self):
         await self.con.execute("""
             FOR name IN {"Hunter B-15", "Hunter B-22"}

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1319,6 +1319,23 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 SELECT 1 LIMIT -1
             """)
 
+    async def test_edgeql_select_limit_11(self):
+        await self.assert_query_result(
+            r'''
+            SELECT (SELECT {<optional str>$0, 'x'} LIMIT 1)
+            ''',
+            ['x'],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
+            r'''
+            SELECT (SELECT {<optional str>$0, 'x'} OFFSET 1)
+            ''',
+            [],
+            variables=(None,),
+        )
+
     async def test_edgeql_select_offset_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidValueError,


### PR DESCRIPTION
There are a number of places that improperly handle a set that has
multiple NULL values in it:
 * INSERT on single values
 * UPDATE on single values
 * assert_single

The assert_single case is a long standing bug that can be triggered
without much trouble. The INSERT/UPDATE bugs are new, and stem from
the new ?? on DML, since I think it that was the first thing in the
compiler backend where extra NULLS might be produced for something
with single cardinality.

Fix this by adding null checks at the consumer sites. One of the
consumer sites is set_as_subquery, and I modified update to always use
that.
I also added a helper function to add the null checks, and I'll be
going back and changing lots of other code to use the helper.

We could also flip this around a bit and try saying that we shouldn't
ever produce extra NULLs in a single set, and try to stamp it out on
the producer side, though that seems a little less consistent to me?

Fixes #6438.