### PR TITLE
Fix constant extraction's interaction with the new if-then-else

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -8293,6 +8293,39 @@ aa \
             [[]],
         )
 
+    async def test_edgeql_expr_if_else_11(self):
+        await self.assert_query_result(
+            r"""
+                select if 1 = <int64>$x then 2 else 3
+            """,
+            [2],
+            variables=dict(x=1),
+        )
+
+        await self.assert_query_result(
+            r"""
+                select if 1 = <int64>$x then 2 else 3
+            """,
+            [3],
+            variables=dict(x=-1),
+        )
+
+        await self.assert_query_result(
+            r"""
+                select 2 if 1 = <int64>$x else 3
+            """,
+            [2],
+            variables=dict(x=1),
+        )
+
+        await self.assert_query_result(
+            r"""
+                select 2 if 1 = <int64>$x else 3
+            """,
+            [3],
+            variables=dict(x=-1),
+        )
+
     async def test_edgeql_expr_if_else_toplevel(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
There is a problem that when there is a named argument and extracted
args, the extracted arguments get ordered based on the order they are
processed during compilation. This creates a bug when the ast nodes
aren't processed in source order, which they happen to not be for new
if-then-else.

Fixes #6494.