### PR TITLE
Avoid doing a join when injecting type ids

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1089,7 +1089,8 @@ def process_set_as_path(
             and not source_rptr.is_inbound
             and not irtyputils.is_computable_ptrref(source_rptr.ptrref)
             and not irutils.is_type_intersection_reference(ir_set)
-            and not pathctx.has_type_rewrite(ir_source.typeref, env=ctx.env)):
+            and not pathctx.link_needs_type_rewrite(
+                ir_source.typeref, env=ctx.env)):
 
         src_src_is_visible = ctx.scope_tree.is_visible(
             source_rptr.source.path_id)

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -294,3 +294,16 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             sql,
             "fts::search score should not be serialized when not needed",
         )
+
+    def test_codegen_typeid_no_join(self):
+        sql = self._compile(
+            '''
+            select Issue { name, number, tid := .__type__.id }
+            '''
+        )
+
+        self.assertNotIn(
+            "edgedbstd",
+            sql,
+            "typeid injection shouldn't joining ObjectType table",
+        )


### PR DESCRIPTION
We have an optimization to allow skipping joins when all we want is
the id of a link, but it is suppressed if there is an access policy on
the target. Unsuppress it when the target is schema::ObjectType, since
there shouldn't be any user-visible links to an internal ObjectType
anyway, and it lets us avoid a join when injecting typeids.

Even better, this will in practice let us do type name injection
without a join also, since clients get a type mapping in the new
protocol.

Fixes #6599.