### PR TITLE
Docs: Add offending code block to error message in docs tests

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -375,7 +375,8 @@ class TestDocSnippets(unittest.TestCase):
         except Exception as ex:
             raise AssertionError(
                 f'unable to parse {block.lang} code block in '
-                f'{block.filename}, around line {block.lineno}') from ex
+                f'{block.filename}, around line {block.lineno}: '
+                f'{code}') from ex
 
     @unittest.skipIf(docutils is None, 'docutils is missing')
     def test_cqa_doc_snippets(self):


### PR DESCRIPTION
Sometimes the reported approximate line number of broken code blocks in the docs tests are not particularly accurate, so also output the code block itself in the error message.