### PR TITLE
Don't eval ext::auth::ClientTokenIdentity on every row in a filter

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -153,6 +153,7 @@ def new_set_from_set(
         expr: Optional[irast.Expr | KeepCurrentT]=KeepCurrent,
         context: Optional[parsing.ParserContext]=None,
         is_binding: Optional[irast.BindingKind]=None,
+        is_schema_alias: Optional[bool]=None,
         is_materialized_ref: Optional[bool]=None,
         is_visible_binding_ref: Optional[bool]=None,
         skip_subtypes: Optional[bool]=None,
@@ -182,6 +183,8 @@ def new_set_from_set(
         context = ir_set.context
     if is_binding is None:
         is_binding = ir_set.is_binding
+    if is_schema_alias is None:
+        is_schema_alias = ir_set.is_schema_alias
     if is_materialized_ref is None:
         is_materialized_ref = ir_set.is_materialized_ref
     if is_visible_binding_ref is None:
@@ -198,6 +201,7 @@ def new_set_from_set(
         rptr=rptr,
         context=context,
         is_binding=is_binding,
+        is_schema_alias=is_schema_alias,
         is_materialized_ref=is_materialized_ref,
         is_visible_binding_ref=is_visible_binding_ref,
         skip_subtypes=skip_subtypes,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -757,6 +757,7 @@ def _declare_view_from_schema(
                                 fully_detached=True, ctx=subctx)
         # The view path id _itself_ should not be in the nested namespace.
         view_set.path_id = view_set.path_id.replace_namespace(frozenset())
+        view_set.is_schema_alias = True
 
         vs = subctx.aliased_views[viewcls_name]
         assert vs is not None

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -526,6 +526,7 @@ class Set(Base):
     # typeref, if such a set exists.
     shape_source: typing.Optional[Set] = None
     is_binding: typing.Optional[BindingKind] = None
+    is_schema_alias: bool = False
 
     is_materialized_ref: bool = False
     # A ref to a visible binding (like a for iterator variable) should

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1349,6 +1349,15 @@ def process_set_as_subquery(
         source_is_visible = False
 
     with ctx.new() as newctx:
+        # Suppress volatility refs while compiling schema
+        # aliases/globals.  While they might try to apply volatility
+        # refs due to FOR/free objects, it shouldn't be semantically
+        # necessary that they actually are attached to the enclosing
+        # location. This turns out to be an important optimization for
+        # ext::auth::ClientTokenIdentity.
+        if ir_set.is_schema_alias:
+            newctx.volatility_ref = ()
+
         outer_id = ir_set.path_id
         semi_join = False
 


### PR DESCRIPTION
Since ext::auth::ClientTokenIdentity uses a free object internally,
we were applying a volatility ref, which forces
ext::auth::ClientTokenIdentity to be evaluated on every object
in queries like:
```
select User
filter .identity ?= global ext::auth::ClientTokenIdentity
```

Suppress volatility refs when compiling aliases/globals.
Fixes #6517.

I am still going to try to materialize single globals in CTEs, which
should help in a number of other cases too, but this is ready now and
is definitely cherry-pickable.