### PR TITLE
Fix DML-containing FOR when the iterator is an object set with duplicates

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -148,7 +148,7 @@ class EdgeQLPathInfo(Base):
 
     # Ignore the below fields in AST visitor/transformer.
     __ast_meta__ = {
-        'path_id', 'path_scope', 'path_outputs', 'is_distinct',
+        'path_id', 'path_bonds', 'path_outputs', 'is_distinct',
         'path_id_mask', 'path_namespace',
         'packed_path_outputs', 'packed_path_namespace',
     }
@@ -160,7 +160,7 @@ class EdgeQLPathInfo(Base):
     is_distinct: bool = True
 
     # A subset of paths necessary to perform joining.
-    path_scope: typing.Set[irast.PathId] = ast.field(factory=set)
+    path_bonds: typing.Set[tuple[irast.PathId, bool]] = ast.field(factory=set)
 
     # Map of res target names corresponding to paths.
     path_outputs: typing.Dict[
@@ -880,7 +880,7 @@ class RangeSubselect(PathRangeVar):
     subquery: Query
 
     @property
-    def query(self):
+    def query(self) -> Query:
         return self.subquery
 
 
@@ -1056,6 +1056,11 @@ class IteratorCTE(ImmutableBase):
     # A list of other paths to *also* register the iterator rvar as
     # providing when it is merged into a statement.
     other_paths: tuple[tuple[irast.PathId, str], ...] = ()
+    iterator_bond: bool = False
+
+    @property
+    def aspect(self) -> str:
+        return 'iterator' if self.iterator_bond else 'identity'
 
 
 class Statement(Base):

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -48,7 +48,10 @@ def get_volatility_ref(
     """Produce an appropriate volatility_ref from a path_id."""
 
     ref: Optional[pgast.BaseExpr] = relctx.maybe_get_path_var(
-        stmt, path_id, aspect='identity', ctx=ctx)
+        stmt, path_id, aspect='iterator', ctx=ctx)
+    if not ref:
+        ref = relctx.maybe_get_path_var(
+            stmt, path_id, aspect='identity', ctx=ctx)
     if not ref:
         rvar = relctx.maybe_get_path_rvar(
             stmt, path_id, aspect='value', ctx=ctx)
@@ -179,8 +182,6 @@ def compile_iterator_expr(
         subctx.expr_exposed = False
         subctx.rel = query
 
-        already_existed = bool(relctx.maybe_get_path_rvar(
-            query, iterator_expr.path_id, aspect='value', ctx=ctx))
         dispatch.visit(iterator_expr, ctx=subctx)
         iterator_rvar = relctx.get_path_rvar(
             query, iterator_expr.path_id, aspect='value', ctx=ctx)
@@ -190,6 +191,9 @@ def compile_iterator_expr(
         # makes sure that we don't spuriously produce output when
         # iterating over optional pointers.
         is_optional = ctx.scope_tree.is_optional(iterator_expr.path_id)
+        if isinstance(iterator_query, pgast.SelectStmt):
+            iterator_var = pathctx.get_path_value_var(
+                iterator_query, path_id=iterator_expr.path_id, env=ctx.env)
         if not is_optional:
             if isinstance(iterator_query, pgast.SelectStmt):
                 iterator_var = pathctx.get_path_value_var(
@@ -204,18 +208,19 @@ def compile_iterator_expr(
             else:
                 raise NotImplementedError()
 
-        # Regardless of result type, we use transient identity,
-        # for path identity of the iterator expression.  This is
-        # necessary to maintain correct correlation for the state
-        # of iteration in DML statements.
-        # The already_existed check is to avoid adding in bogus volatility refs
-        # when we reprocess an iterator that was hoisted.
-        if not already_existed:
-            relctx.ensure_bond_for_expr(
-                iterator_expr.expr.result, iterator_query, ctx=subctx)
-            if is_optional:
-                relctx.ensure_bond_for_expr(
-                    iterator_expr, iterator_query, ctx=subctx)
+        # Regardless of result type, iterators need their own
+        # transient identity for path identity of the iterator
+        # expression in order maintain correct correlation for the
+        # state of iteration in DML statements, even when there
+        # are duplicates in the iterator.
+        # This gets tracked as a special 'iterator' aspect in order
+        # to distinguish it from actual object identity.
+        relctx.create_iterator_identity_for_path(
+            iterator_expr.path_id, iterator_query, ctx=subctx)
+
+        pathctx.put_path_rvar(
+            query, iterator_expr.path_id, iterator_rvar,
+            aspect='iterator')
 
     return iterator_rvar
 

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -45,6 +45,7 @@ class PathAspect(s_enum.StrEnum):
     VALUE = 'value'
     SOURCE = 'source'
     SERIALIZED = 'serialized'
+    ITERATOR = 'iterator'
 
 
 # A mapping of more specific aspect -> less specific aspect for objects
@@ -698,8 +699,14 @@ def put_path_serialized_var_if_not_exists(
 
 
 def put_path_bond(
-        stmt: pgast.BaseRelation, path_id: irast.PathId) -> None:
-    stmt.path_scope.add(path_id)
+    stmt: pgast.BaseRelation, path_id: irast.PathId, iterator: bool=False
+) -> None:
+    '''Register a path id that should be joined on when joining stmt
+
+    iterator indicates whether the identity or iterator aspect should
+    be used.
+    '''
+    stmt.path_bonds.add((path_id, iterator))
 
 
 def put_rvar_path_bond(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1992,7 +1992,6 @@ def process_set_as_tuple(
             typeref=ir_set.typeref,
         )
 
-    relctx.ensure_bond_for_expr(ir_set, stmt, ctx=ctx)
     pathctx.put_path_value_var(stmt, ir_set.path_id, set_expr)
 
     # This is an unfortunate hack. If any of those types that we

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1737,6 +1737,35 @@ class TestInsert(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_insert_for_23(self):
+        await self.con.execute(r"""
+            INSERT Subordinate { name := "a" }
+        """)
+
+        await self.assert_query_result(
+            """
+            for x in {Subordinate, Subordinate} union (
+              (x { name }, (insert Note { name := '', subject := x }))
+            );
+            """,
+            [
+                [{'name': "a"}, {}],
+                [{'name': "a"}, {}],
+            ],
+        )
+
+        await self.assert_query_result(
+            """
+            for x in {Subordinate, Subordinate} union (
+              (x { name }, (insert InsertTest { l2 := 0, sub := x }))
+            );
+            """,
+            [
+                [{'name': "a"}, {}],
+                [{'name': "a"}, {}],
+            ],
+        )
+
     async def test_edgeql_insert_for_bad_01(self):
         with self.assertRaisesRegex(
             edgedb.errors.QueryError,


### PR DESCRIPTION
DML-containing FOR loops get compiled into CTEs, and after the DML is
performed, the CTEs need to get joined back with the DML CTEs in order
to produce the output. Currently we do these joins on the 'identity'
of the iterator set; for non-object sets, we generate a transient
identity with uuid_generate_v4, and for object sets we ues the actual
object id.

That works ok if all the objects in the iterator set are unique, but
if they aren't we produce a lot of duplicate output rows.

To solve this, we need to use transient ids for object types too, but
overriding object identity with something transient causes problems:
if we need to actually join the object against some *actual* table, we
are in trouble, since we've overriden the identity.

Solve this by introducing a new 'iterator' aspect and distinguishing
between whether we want to join on an iterator aspect or a real identity
when making path bonds.

Fixes #6608