### PR TITLE
Eliminate some uuid_generates in FOR cases where they aren't needed

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -554,7 +554,8 @@ def compile_iterator_cte(
         merge_iterator(last_iterator, ictx.rel, ctx=ictx)
         clauses.setup_iterator_volatility(last_iterator, ctx=ictx)
 
-        clauses.compile_iterator_expr(ictx.rel, iterator_set, ctx=ictx)
+        clauses.compile_iterator_expr(
+            ictx.rel, iterator_set, is_dml=True, ctx=ictx)
         if iterator_set.path_id.is_objtype_path():
             relgen.ensure_source_rvar(iterator_set, ictx.rel, ctx=ictx)
         ictx.rel.path_id = iterator_set.path_id

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -736,6 +736,7 @@ def create_iterator_identity_for_path(
     stmt: pgast.BaseRelation,
     *,
     ctx: context.CompilerContextLevel,
+    apply_volatility: bool=True,
 ) -> None:
 
     id_expr = pgast.FuncCall(
@@ -745,7 +746,8 @@ def create_iterator_identity_for_path(
 
     if isinstance(stmt, pgast.SelectStmt):
         path_id = pathctx.map_path_id(path_id, stmt.view_path_id_map)
-        apply_volatility_ref(stmt, ctx=ctx)
+        if apply_volatility:
+            apply_volatility_ref(stmt, ctx=ctx)
 
     pathctx.put_path_var(stmt, path_id, id_expr, force=True, aspect='iterator')
     pathctx.put_path_bond(stmt, path_id, iterator=True)

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -79,7 +79,7 @@ def compile_SelectStmt(
                 with ctx.new() as ictx:
                     clauses.setup_iterator_volatility(last_iterator, ctx=ictx)
                     iterator_rvar = clauses.compile_iterator_expr(
-                        query, iterator_set, ctx=ictx)
+                        query, iterator_set, is_dml=False, ctx=ictx)
                 for aspect in {'identity', 'value'}:
                     pathctx.put_path_rvar(
                         query,

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -307,3 +307,16 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             sql,
             "typeid injection shouldn't joining ObjectType table",
         )
+
+    def test_codegen_nested_for_no_uuid(self):
+        sql = self._compile(
+            '''
+            for x in {1,2,3} union (for y in {3,4,5} union (x+y))
+            '''
+        )
+
+        self.assertNotIn(
+            "uuid_generate",
+            sql,
+            "unnecessary uuid_generate for FOR loop without volatility",
+        )


### PR DESCRIPTION
Currently if we have a nested for loop like
```
for x in {1,2,3} union (for y in {3,4,5} union (x+y))
```
we will apply volatility refs when creating an iterator aspect
for y, which will cause the iterator aspect for x to be inserted
into the query.  This is all despite there not being anything at
all in the body that should require using the volatility refs.

Fix this by only creating the transient iterator aspect when
the FOR contains DML (or is optional).

This also means that for non-DML FORs, scalar iterators will fallback
to using row_number to force volatility (see get_volatility_ref)
while object type iterators will return to using their ids
(like before #6609).

(Wanting to fix this after thinking about it when dealing with the
auth performance situation is what sent me down on this whole rabbit
hole.)