### PR TITLE
Compile single globals into materialized CTEs

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -525,7 +525,29 @@ def compile_GlobalExpr(
         # Wrap the reference in a subquery so that it does not get
         # factored out or go directly into the scope tree.
         qry = qlast.SelectQuery(result=qlast.Path(steps=[obj_ref]))
-        return dispatch.compile(qry, ctx=ctx)
+        target = dispatch.compile(qry, ctx=ctx)
+
+        # If the global is single, use type_rewrites to make sure it
+        # is computed only once in the SQL query.
+        if glob.get_cardinality(ctx.env.schema).is_single():
+            key = (setgen.get_set_type(target, ctx=ctx), False)
+            if not ctx.env.type_rewrites.get(key):
+                ctx.env.type_rewrites[key] = target
+            rewrite_target = ctx.env.type_rewrites[key]
+
+            # We need to have the set with expr=None, so that the rewrite
+            # will be applied, but we also need to wrap it with a
+            # card_inference_override so that we use the real cardinality
+            # instead of assuming it is MANY.
+            assert isinstance(rewrite_target, irast.Set)
+            target = setgen.new_set_from_set(target, expr=None, ctx=ctx)
+            wrap = irast.SelectStmt(
+                result=target,
+                card_inference_override=rewrite_target,
+            )
+            target = setgen.new_set_from_set(target, expr=wrap, ctx=ctx)
+
+        return target
 
     default = glob.get_default(ctx.env.schema)
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1380,8 +1380,14 @@ def range_for_material_objtype(
 
     env = ctx.env
 
-    if typeref.material_type is not None:
+    # If this is a view type, but it still appears in rewrites, that is
+    # because it is a global that we are caching.
+    if (
+        typeref.material_type is not None
+        and (typeref.id, include_descendants) not in ctx.env.type_rewrites
+    ):
         typeref = typeref.material_type
+    is_global = typeref.material_type is not None
 
     relation: Union[pgast.Relation, pgast.CommonTableExpr]
 
@@ -1393,7 +1399,7 @@ def range_for_material_objtype(
     rw_key = (typeref.id, include_descendants)
     key = rw_key + (dml_source_key,)
     if (
-        not ignore_rewrites
+        (not ignore_rewrites or is_global)
         and (rewrite := ctx.env.type_rewrites.get(rw_key)) is not None
         and rw_key not in ctx.pending_type_ctes
         and not for_mutation
@@ -1428,13 +1434,13 @@ def range_for_material_objtype(
                 # If we are expanding inhviews, we also expand type
                 # rewrites, so don't populate type_ctes. The normal
                 # case is to stick it in a CTE and cache that, though.
-                if ctx.env.expand_inhviews:
+                if ctx.env.expand_inhviews and not is_global:
                     type_rel = sctx.rel
                 else:
                     type_cte = pgast.CommonTableExpr(
                         name=ctx.env.aliases.get('t'),
                         query=sctx.rel,
-                        materialized=False,
+                        materialized=is_global,
                     )
                     ctx.type_ctes[key] = type_cte
                     type_rel = type_cte


### PR DESCRIPTION
Hopefully this will result in a lot less recomputation in certain
cases.