### PR TITLE
Docs: Fix up some documentation typos and outdated syntax

### DIFF
--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -404,7 +404,7 @@ making the current user able to see their own ``User`` record.
     This change is being made to simplify reasoning about access policies and
     to allow certain patterns to be express efficiently. Since those who have
     access to modifying the schema can remove unwanted access policies, no
-    additional security is provided by applying access policies to each 
+    additional security is provided by applying access policies to each
     other's expressions.
 
     It is possible (and recommended) to enable this :ref:`future
@@ -426,11 +426,11 @@ policy, you will get a generic error message.
 
 .. note::
 
-    When attempting a ``select`` queries, you simply won't get the data that 
+    When attempting a ``select`` queries, you simply won't get the data that
     is being restricted by the access policy.
 
 If you have multiple access policies, it can be useful to know which policy is
-restricting your query and provide a friendly error message. You can do this 
+restricting your query and provide a friendly error message. You can do this
 by adding a custom error message to your policy.
 
 .. code-block:: sdl-diff

--- a/docs/datamodel/access_policies.rst
+++ b/docs/datamodel/access_policies.rst
@@ -434,62 +434,33 @@ restricting your query and provide a friendly error message. You can do this
 by adding a custom error message to your policy.
 
 .. code-block:: sdl-diff
-    :version-lt: 3.0
 
-    global current_user_id -> uuid;
-    global current_user := (
-      select User filter .id = global current_user_id
-    );
+      global current_user_id: uuid;
+      global current_user := (
+        select User filter .id = global current_user_id
+      );
 
-    type User {
-      required property email -> str { constraint exclusive; };
-      required property is_admin -> bool { default := false };
+      type User {
+        required email: str { constraint exclusive; };
+        required is_admin: bool { default := false };
 
-      access policy admin_only
-        allow all
-  +     using (global current_user.is_admin ?? false) {
-  +       errmessage := 'Only admins may query Users'
-  +     };
-    }
+        access policy admin_only
+          allow all
+    +     using (global current_user.is_admin ?? false) {
+    +       errmessage := 'Only admins may query Users'
+    +     };
+      }
 
-    type BlogPost {
-      required property title -> str;
-      link author -> User;
+      type BlogPost {
+        required title: str;
+        author: User;
 
-      access policy author_has_full_access
-        allow all
-  +     using (global current_user ?= .author) {
-  +       errmessage := 'BlogPosts may only be queried by their authors'
-  +     };
-    }
-.. code-block:: sdl-diff
-
-    global current_user_id: uuid;
-    global current_user := (
-      select User filter .id = global current_user_id
-    );
-
-    type User {
-      required email: str { constraint exclusive; };
-      required is_admin: bool { default := false };
-
-      access policy admin_only
-        allow all
-  +     using (global current_user.is_admin ?? false) {
-  +       errmessage := 'Only admins may query Users'
-  +     };
-    }
-
-    type BlogPost {
-      required title: str;
-      author: User;
-
-      access policy author_has_full_access
-        allow all
-  +     using (global current_user ?= .author) {
-  +       errmessage := 'BlogPosts may only be queried by their authors'
-  +     };
-    }
+        access policy author_has_full_access
+          allow all
+    +     using (global current_user ?= .author) {
+    +       errmessage := 'BlogPosts may only be queried by their authors'
+    +     };
+      }
 
 Now if you attempt, for example, a ``User`` insert as a non-admin user, you
 will receive this error:

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -301,7 +301,7 @@ table <https://en.wikipedia.org/wiki/Associative_entity>`_, whereas a
       }
 
       type User {
-        link posts := (.<author[is Post])
+        multi posts := (.<author[is Post])
       }
 
 .. _ref_guide_one_to_one:

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -295,6 +295,17 @@ table <https://en.wikipedia.org/wiki/Associative_entity>`_, whereas a
   and generally recommended when modeling 1:N relations:
 
   .. code-block:: sdl
+      :version-lt: 4.0
+
+      type Post {
+        required author: User;
+      }
+
+      type User {
+        multi link posts := (.<author[is Post])
+      }
+
+  .. code-block:: sdl
 
       type Post {
         required author: User;

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -447,7 +447,7 @@ constraint, each movie can be liked by multiple users. Thus this is a
 
     type User {
       required property name -> str;
-      multi link watch_history := .<user[Is WatchHistory];
+      multi link watch_history := .<user[is WatchHistory];
     }
     type Movie {
       required property title: str;
@@ -463,7 +463,7 @@ constraint, each movie can be liked by multiple users. Thus this is a
 
     type User {
       required name: str;
-      multi link watch_history := .<user[Is WatchHistory];
+      multi link watch_history := .<user[is WatchHistory];
     }
     type Movie {
       required title: str;
@@ -478,7 +478,7 @@ constraint, each movie can be liked by multiple users. Thus this is a
 
     type User {
       required name: str;
-      multi watch_history := .<user[Is WatchHistory];
+      multi watch_history := .<user[is WatchHistory];
     }
     type Movie {
       required title: str;


### PR DESCRIPTION
I'm new to EdgeDB so I could've gotten some syntax wrong, but:

- (access policies) Added a `version-lt` for the old 3.0 example and a new 4.0 one.
- (access policies) Using the selected global, it now compares `current_user` to `.author` rather than `.author.id`, as it should be `User` to `User` comparisons.
- Add some trailing semicolons to `default` statements
- Use `is` rather than `Is` during link assertions

- Replaced `link` with `multi` in a backlink declaration... I don't know if this is correct though, or if it should be omitted altogether. It isn't exactly clear to me.