### PR TITLE
Remove handling for 'releases/*' in get_version_from_scm

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -427,15 +427,6 @@ def get_version_from_scm(root: pathlib.Path) -> str:
     )
 
     proc = subprocess.run(
-        ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-        check=True,
-        cwd=root,
-    )
-    branch = proc.stdout.strip()
-
-    proc = subprocess.run(
         ['git', 'tag', '--list', 'v*'],
         stdout=subprocess.PIPE,
         universal_newlines=True,
@@ -480,17 +471,9 @@ def get_version_from_scm(root: pathlib.Path) -> str:
         ver = f'{major}.{minor}{microkind}{micro}{prekind}{preval}'
     else:
         # Dev/nightly build.
-        if branch.startswith("releases/"):
-            if prekind and preval:
-                pass
-            elif micro:
-                micro = str(int(micro) + 1)
-            else:
-                minor = str(int(minor) + 1)
-        else:
-            microkind = ''
-            micro = ''
-            minor = '0'
+        microkind = ''
+        micro = ''
+        minor = '0'
 
         incremented_ver = f'{major}.{minor}{microkind}{micro}'
 


### PR DESCRIPTION
This has been breaking all of our tests for the `releases/4.x` branch
basically for the entire 4.x cycle.

When that branch was introduced in 8481c088748862922bb360a9711ad5e5617aba25,
it looks like we were creating a 'releases/X.Y' branch
*for each minor version*. It looks like we then stopped
creating 'releases/X.Y' branches some time during the 2.x cycle.

Then for 4.x we decided to switch from using `stable/4.x` to using
`release/4.x`, which I think morphed into `releases/4.x` in some
attempt for consistency with all those old branches, which is now
triggering that version handling code which is resulting in version
numbers like '4.3-dev.8052', which the CLI rejects in certain paths
because it doesn't think -dev should be on a 4.3 version.

Delete that 'releases/*' handling, which doesn't really match our
current workflows.

I *also* think that we should delete all the old `releases/` branches
(they all have equivalent tags) and make the branch `release/4.x`
instead of `releases/4.x`.