### PR TITLE
Remove advice to use language's null in clients

### DIFF
--- a/docs/edgeql/parameters.rst
+++ b/docs/edgeql/parameters.rst
@@ -136,9 +136,6 @@ the type cast if the parameter is optional.
   Parameter <str>$name (Ctrl+D for empty set `{}`):
   {}
 
-When using a client library, pass the idiomatic null pointer for your language:
-``null``, ``None``, ``nil``, etc.
-
 .. note::
 
   The ``<required foo>`` type cast is also valid (though redundant) syntax.


### PR DESCRIPTION
This doesn't work in 100% of cases, so it will be less confusing to just take this out. See https://discord.com/channels/841451783728529451/1186387493919133786/1186389119207743528