### PR TITLE
Bump deps to allow CI host with Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ docs = [
 
 [build-system]
 requires = [
-    "Cython (>=0.29.32, <0.30.0)",
+    "Cython (>=0.29.32, <3.0.0)",
     "packaging >= 21.0",
     "setuptools >= 67",
     "setuptools-rust ~= 0.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "EdgeDB Server"
 requires-python = '>=3.10.0'
 dynamic = ["version"]
 dependencies = [
-    'edgedb==1.3.0',
+    'edgedb==1.3.1',
 
     'httptools>=0.3.0',
     'immutables>=0.18',
@@ -82,7 +82,7 @@ requires = [
     "wheel",
 
     "parsing ~= 2.0",
-    'edgedb == 1.3.0',
+    'edgedb == 1.3.1',
 ]
 # Custom backend needed to set up build-time sys.path because
 # setup.py needs to import `edb.buildmeta`.


### PR DESCRIPTION
[Sample run](https://github.com/edgedb/edgedb/actions/runs/7282140333)