### PR TITLE
Add a dedicated sql-introspection patch type

### DIFF
--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -75,6 +75,7 @@ The current kinds are:
  * ...+config - updates config views
  * ext-pkg - installs an extension package given a name
  * repair - fix up inconsistencies in *user* schemas
+ * sql-introspection - refresh all sql introspection views
 """
 PATCHES: list[tuple[str, str]] = _setup_patches([
 ])


### PR DESCRIPTION
This lets us refresh sql introspection views without needing to do an
edgeql+schema patch.

It up applying it to 100 dbs from ~90s to ~65s, which isn't as much as
I hoped but is still nicer.