### PR TITLE
Fix another DROP DATABASE test flake

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -120,7 +120,7 @@ class TestDatabase(tb.ConnectedTestCase):
                 await conn.aclose()
 
         finally:
-            await self.con.execute('DROP DATABASE test_db_drop;')
+            await tb.drop_db(self.con, 'test_db_drop')
 
     async def test_database_non_exist_template(self):
         if not self.has_create_database:
@@ -141,4 +141,4 @@ class TestDatabase(tb.ConnectedTestCase):
                 await conn.aclose()
 
         finally:
-            await self.con.execute('DROP DATABASE test_tpl;')
+            await tb.drop_db(self.con, 'test_tpl')


### PR DESCRIPTION
In #4629 we introduced a `drop_tb` testbase function for dropping
databases in tests that works around #4567, but #5032 added some new
tests that used `DROP DATABASE` directly.

This caused a test flake on a 3.x release build today; hopefully it
passes on the retry without me needing to cherry-pick this fix first.