### PR TITLE
Increase some test timeouts

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2034,7 +2034,7 @@ class _EdgeDBServer:
     async def kill_process(self, proc: asyncio.Process):
         proc.terminate()
         try:
-            await asyncio.wait_for(proc.wait(), timeout=20)
+            await asyncio.wait_for(proc.wait(), timeout=60)
         except TimeoutError:
             proc.kill()
 

--- a/tests/test_pgext.py
+++ b/tests/test_pgext.py
@@ -552,7 +552,7 @@ class PgProtocol(asyncio.Protocol):
         self.messages.put_nowait(None)
 
     async def read(self, expect=None):
-        rv = await asyncio.wait_for(self.messages.get(), 5)
+        rv = await asyncio.wait_for(self.messages.get(), 60)
         if expect is not None and not isinstance(rv, expect):
             raise AssertionError(f"expect {expect}, got {rv}")
         return rv

--- a/tests/test_server_concurrency.py
+++ b/tests/test_server_concurrency.py
@@ -186,7 +186,7 @@ class TestServerConcurrentTransactions(tb.QueryTestCase):
             transaction1(con, f1),
             transaction1(con2, f2),
             return_exceptions=True,
-        ), 10)
+        ), 60)
         for e in results:
             if isinstance(e, BaseException):
                 raise e


### PR DESCRIPTION
We were having failures on our macos-aarch64 release test runner, so I
bumped some timeouts in 3.x and they fixed it. It turns out that
runner was running in a heavily degraded state, so probably shouldn't
have needed these timeouts increased, but they still seem a little low
so I'm forward porting anyway.

Also bump the timeout that failed on the test run *after* I changed
those.