### PR TITLE
Stop having sys::Database be an AnnotationSubject

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_12_05_00_00
+EDGEDB_CATALOG_VERSION = 2023_12_21_00_00
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -33,9 +33,7 @@ CREATE ABSTRACT TYPE sys::SystemObject EXTENDING schema::Object;
 CREATE ABSTRACT TYPE sys::ExternalObject EXTENDING sys::SystemObject;
 
 
-CREATE TYPE sys::Database EXTENDING
-        sys::ExternalObject,
-        schema::AnnotationSubject {
+CREATE TYPE sys::Database EXTENDING sys::ExternalObject {
     ALTER PROPERTY name {
         CREATE CONSTRAINT std::exclusive;
     };

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -28,7 +28,6 @@ from edb.edgeql import qltypes
 from edb.schema import defines as s_def
 
 from . import abc as s_abc
-from . import annos as s_anno
 from . import delta as sd
 from . import objects as so
 from . import schema as s_schema
@@ -36,7 +35,6 @@ from . import schema as s_schema
 
 class Database(
     so.ExternalObject,
-    s_anno.AnnotationSubject,
     s_abc.Database,
     qlkind=qltypes.SchemaObjectClass.DATABASE,
     data_safe=False,

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -805,21 +805,6 @@ def generate_structure(
                         sn.UnqualName(f'{refdict.attr}__internal'),
                     )
 
-                # HACK: sys::Database is an AnnotationSubject, but
-                # there is no way to actually put annotations on it,
-                # and fetching them results in some pathological
-                # quadratic queries where each inner iteration does
-                # expensive fetching of metadata and JSON decoding.
-                # Override it to return nothing.
-                # TODO: For future versions, we can probably just
-                # drop it.
-                if (
-                    str(rschema_name) == 'sys::Database'
-                    and refdict.attr == 'annotations'
-                ):
-                    props = {}
-                    read_ptr = f'{read_ptr} := <schema::AnnotationValue>{{}}'
-
                 for field in props:
                     sfn = field.sname
                     prop_shape_els.append(f'@{sfn}')


### PR DESCRIPTION
Follow-up on #6633. That can be cherry-picked, this is for 5.0.

This is technically a backwards compatability break but a super
trivial one.