### PR TITLE
Use correct signature for in-memory cache method

### DIFF
--- a/edb/server/protocol/auth_ext/http_client.py
+++ b/edb/server/protocol/auth_ext/http_client.py
@@ -53,7 +53,7 @@ class InMemoryStorage(hishel._async._storages.AsyncBaseStorage):
         super().__init__()
         self._storage = lru.LRUMapping(maxsize=maxsize)
 
-    def store(self, key: str, response, request, metadata):
+    async def store(self, key: str, response, request, metadata):
         self._storage[key] = (response, request, metadata)
 
     async def retreive(self, key: str):


### PR DESCRIPTION
The `store` method on Hishel's `AsyncBaseStorage` is `async`, see: https://github.com/karpetrosyan/hishel/blob/3b3d5287869dc190118fc91c97a4e79a5b586ae2/hishel/_async/_storages.py#L44