### PR TITLE
Use newly released hishel in-memory cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'setproctitle~=1.2',
 
     'httpx~=0.24.1',
-    'hishel==0.0.18',
+    'hishel==0.0.21',
     'argon2-cffi~=23.1.0',
     'aiosmtplib~=2.0',
 ]


### PR DESCRIPTION
An alternative to #6643 , not sure which approach we would prefer to take, honestly.

Hishel released a new in-memory cache last week in [`0.0.20`](https://github.com/karpetrosyan/hishel/releases/tag/0.0.20) which negates our need to specify our own.