### PR TITLE
Add a couple testmode config tunables for debugging

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2023_12_05_00_00
+EDGEDB_CATALOG_VERSION = 2024_01_03_00_00
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -78,6 +78,21 @@ ALTER TYPE cfg::AbstractConfig {
         SET default := false;
     };
 
+    # Fully suppress apply_query_rewrites, like is done for internal
+    # reflection queries.
+    CREATE PROPERTY __internal_no_apply_query_rewrites -> std::bool {
+        CREATE ANNOTATION cfg::internal := 'true';
+        SET default := false;
+    };
+
+    # Use the "reflection schema" as the base schema instead of the
+    # normal std schema. This allows looking at all the schema fields
+    # that are hidden in the public introspection schema.
+    CREATE PROPERTY __internal_query_reflschema -> std::bool {
+        CREATE ANNOTATION cfg::internal := 'true';
+        SET default := false;
+    };
+
     CREATE PROPERTY __internal_restart -> std::bool {
         CREATE ANNOTATION cfg::internal := 'true';
         CREATE ANNOTATION cfg::system := 'true';


### PR DESCRIPTION
* __internal_no_apply_query_rewrites forces apply_query_rewrites to
  be false, disabling them in the same way that reflection queries
  do.
* Use the "reflection schema" as the base schema instead of the
  normal std schema. This allows looking at all the schema fields
  that are hidden in the public introspection schema.

Both of these (and *especially* the first) are things that I've
manually done in the code enough times that I've gotten fed up with
it.