### PR TITLE
Speed up introspection of system objects like Database and Role

### DIFF
--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -409,8 +409,11 @@ def fini_toplevel(
     # Type rewrites go first.
     if stmt.ctes is None:
         stmt.ctes = []
-    stmt.ctes[:0] = list(ctx.param_ctes.values())
-    stmt.ctes[:0] = list(ctx.type_ctes.values())
+    stmt.ctes[:0] = [
+        *ctx.param_ctes.values(),
+        *ctx.ptr_ctes.values(),
+        *ctx.type_ctes.values(),
+    ]
 
     if ctx.env.named_param_prefix is None:
         # Adding unused parameters into a CTE

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -220,7 +220,11 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: CTEs representing decoded parameters
     param_ctes: Dict[str, pgast.CommonTableExpr]
 
-    #: CTEs representing schema types, when rewritten based on access policy
+    #: CTEs representing pointer tables that we need to force to be
+    #: materialized for performance reasons.
+    ptr_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
+
+    #: CTEs representing types, when rewritten based on access policy
     type_ctes: Dict[FullRewriteKey, pgast.CommonTableExpr]
 
     #: A set of type CTEs currently being generated
@@ -322,6 +326,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.rel = NO_STMT
             self.rel_hierarchy = {}
             self.param_ctes = {}
+            self.ptr_ctes = {}
             self.type_ctes = {}
             self.pending_type_ctes = set()
             self.dml_stmts = {}
@@ -361,6 +366,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.rel = prevlevel.rel
             self.rel_hierarchy = prevlevel.rel_hierarchy
             self.param_ctes = prevlevel.param_ctes
+            self.ptr_ctes = prevlevel.ptr_ctes
             self.type_ctes = prevlevel.type_ctes
             self.pending_type_ctes = prevlevel.pending_type_ctes
             self.dml_stmts = prevlevel.dml_stmts

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -805,21 +805,6 @@ def generate_structure(
                         sn.UnqualName(f'{refdict.attr}__internal'),
                     )
 
-                # HACK: sys::Database is an AnnotationSubject, but
-                # there is no way to actually put annotations on it,
-                # and fetching them results in some pathological
-                # quadratic queries where each inner iteration does
-                # expensive fetching of metadata and JSON decoding.
-                # Override it to return nothing.
-                # TODO: For future versions, we can probably just
-                # drop it.
-                if (
-                    str(rschema_name) == 'sys::Database'
-                    and refdict.attr == 'annotations'
-                ):
-                    props = {}
-                    read_ptr = f'{read_ptr} := <schema::AnnotationValue>{{}}'
-
                 for field in props:
                     sfn = field.sname
                     prop_shape_els.append(f'@{sfn}')

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1287,13 +1287,15 @@ def compile_intro_queries_stdlib(
             ),
         )
 
-    local_intro_sql = ' UNION ALL '.join(sql_intro_local_parts)
+    local_intro_sql = ' UNION ALL '.join(
+        f'({x})' for x in sql_intro_local_parts)
     local_intro_sql = f'''
         WITH intro(c) AS ({local_intro_sql})
         SELECT json_agg(intro.c) FROM intro
     '''
 
-    global_intro_sql = ' UNION ALL '.join(sql_intro_global_parts)
+    global_intro_sql = ' UNION ALL '.join(
+        f'({x})' for x in sql_intro_global_parts)
     global_intro_sql = f'''
         WITH intro(c) AS ({global_intro_sql})
         SELECT json_agg(intro.c) FROM intro


### PR DESCRIPTION
Currently if there are a lot of roles, doing a query like `select
sys::Role { member_of }` is quite slow. This is because the views for
both `Role` and `member_of` need to extract metadata for *every* Role
and pase it as json, and postgres is planning this as a nested loop.

Unfortunately, startup needs to query all these objects, so having
lots of databases or roles is a problem.

Fix this by forcing sys objects and links to always be materialized
into CTEs. This ensures that we do at most one linear scan of each of
the views. Since there is no way to hit an index when querying any of
these system object views, always doing a linear scan is no worse.

For the objects themselves we can leverage the rewrites mechanism. For
link tables, we add a slightly lighter weight mechanism to handle it.

Tested using 100 roles.

Reverts the now-unnecessary main part of #6633 but keeps the extension
to the patch system. We could actually put annotations on databases now
and have it not be *too* slow.

This can be backported with an empty `edgeql+schema+globalonly` patch.