### PR TITLE
Add force_database_error documentation

### DIFF
--- a/docs/stdlib/cfg.rst
+++ b/docs/stdlib/cfg.rst
@@ -124,9 +124,10 @@ Query behavior
       This parameter takes a ``str`` instead of a ``bool`` to allow more
       verbose messages when all queries are forced to fail. The database will
       attempt to deserialize this ``str`` into a JSON object that must include
-      a ``type`` (which must be an EdgeDB error type name), and may also
-      include ``message``, ``hint``, and ``details`` which can be set ad-hoc
-      by the user.
+      a ``type`` (which must be an EdgeDB
+      :ref:`error type <ref_protocol_errors>` name), and may also include
+      ``message``, ``hint``, and ``details`` which can be set ad-hoc by
+      the user.
 
       For example, the following is valid input:
       

--- a/docs/stdlib/cfg.rst
+++ b/docs/stdlib/cfg.rst
@@ -116,6 +116,28 @@ Query behavior
       UI session, so you won't have to remember to re-enable it when you're
       done.
 
+:eql:synopsis:`force_database_error -> str`
+  A hook to force all queries to produce an error. Defaults to 'false'.
+
+  .. note::
+
+      This parameter takes a ``str`` instead of a ``bool`` to allow more
+      verbose messages when all queries are forced to fail. The database will
+      attempt to deserialize this ``str`` into a JSON object that must include
+      a ``type`` (which must be an EdgeDB error type name), and may also
+      include ``message``, ``hint``, and ``details`` which can be set ad-hoc
+      by the user.
+
+      For example, the following is valid input:
+      
+      ``'{ "type": "QueryError",
+      "message": "Did not work",
+      "hint": "Try doing something else",
+      "details": "Indeed, something went really wrong" }'``
+
+      As is this:
+
+      ``'{ "type": "UnknownParameterError" }'``
 
 .. _ref_std_cfg_client_connections:
 


### PR DESCRIPTION
Writing documentation for the UI today and noticed that force_database_error takes a str instead of a bool, and that the strs it accepts can be pretty verbose. Pretty nice feature to have compared to a simple bool so added two examples of valid input to get users started.