### PR TITLE
Fix issue with schema changes when trigger depends on a rewrite

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13203,6 +13203,33 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
             DROP TYPE foo::Tag;
         """)
 
+    async def test_edgeql_ddl_rewrite_and_trigger_01(self):
+        await self.con.execute("""
+            create type Entry {
+                create property x := 0;
+                create property y -> int64 {
+                    create rewrite insert, update using (.x);
+                };
+            };
+            create type Foo {
+                create trigger log0 after insert for each do (insert Entry);
+            };
+            create type Bar {
+                create trigger log1 after insert for each do (insert Foo);
+            };
+        """)
+
+        await self.con.execute(f"""
+            alter type Entry alter property x using (1)
+        """)
+
+        await self.con.execute(f"""
+            alter type Entry alter property y drop rewrite insert, update;
+        """)
+        await self.con.execute(f"""
+            alter type Foo drop trigger log0;
+        """)
+
     async def _simple_rename_ref_test(
         self,
         ddl,


### PR DESCRIPTION
Dependencies on rewrites, policies, and triggers don't get explicitly
tracked as references, but the things they depend on transitively
through those do.

The dummy expression for rewrites is not the correct type, so if a
trigger and a rewrite are being reprocessed in _propagate_if_expr refs
at the same time, and the trigger uses the rewrite, and is processed
first, then it will error.
Fix this by having the rewrite dummy expression have the right type.

I've experimented with having rewrites and triggers explicitly tracked
as dependencies, but it complicates some code and I don't think it
actually fixes any real problems.