### PR TITLE
Pin old Sphinx deps to old versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ test = [
     'Pygments~=2.10.0',
     'Sphinx~=4.2.0',
     'sphinxcontrib-asyncio~=0.3.0',
+    'sphinxcontrib-applehelp<1.0.8',
+    'sphinxcontrib-devhelp<1.0.6',
+    'sphinxcontrib-htmlhelp<2.0.5',
+    'sphinxcontrib-serializinghtml<1.1.10',
+    'sphinxcontrib-qthelp<1.0.7',
     'sphinx_code_tabs~=0.5.3',
 ]
 


### PR DESCRIPTION
The Sphinx dependencies started to mark their Sphinx version requirement at runtime, which stopped old Sphinx 4.* from installing dependencies of the right versions.