### PR TITLE
[4.x] Fix spurious delete/create of constraints with arguments in migrations

### DIFF
--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -102,4 +102,6 @@ alter type ext::auth::AuthConfig  {
 '''),
     ('edgeql+schema', ''),  # pg_attribute, pg_attribute_ext, edgedbsql.columns
     ('edgeql+schema', ''),  # __type__
+    # === 4.6
+    ('edgeql+schema+globalonly', ''),  # recreate introspection query
 ])

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -299,12 +299,13 @@ def _build_object_mutation_shape(
             # an ObjectKeyDict collection that allow associating objects
             # with arbitrary values (a transposed ObjectDict).
             target_expr = f"""assert_distinct((
-                FOR v IN {{ json_array_unpack(<json>${var_n}) }}
+                FOR v IN {{ enumerate(json_array_unpack(<json>${var_n})) }}
                 UNION (
                     SELECT {target.get_name(schema)} {{
-                        @value := <str>v[1]
+                        @index := v.0,
+                        @value := <str>v.1[1],
                     }}
-                    FILTER .id = <uuid>v[0]
+                    FILTER .id = <uuid>v.1[0]
                 )
             ))"""
             args = props.get('args', [])

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10190,6 +10190,26 @@ type default::Foo {
             CREATE TYPE Comment EXTENDING Text;
         """)
 
+        await self.assert_query_result(
+            """
+            select schema::Constraint {
+                name, params: {name, @index} order by @index
+            }
+            filter .name = 'std::max_len_value'
+            and .subject.name = 'body'
+            and .subject[is schema::Pointer].source.name ='default::Text';
+            """,
+            [
+                {
+                    "name": "std::max_len_value",
+                    "params": [
+                        {"name": "__subject__", "@index": 0},
+                        {"name": "max", "@index": 1}
+                    ]
+                }
+            ],
+        )
+
         await self.con.execute("""
             ALTER TYPE Text
                 ALTER PROPERTY body


### PR DESCRIPTION
The bug here was that `@index` was not populated in the `params` link
for concrete constraints by the reflection writer, and so when we
reloaded the schema from the database, it came back in an arbitrary
order.
This bug has been present for a *long* time, as far as I can tell, but
we tended to get "lucky" with the order pg returned the params.

Unfortunately fixing newly created constraints doesn't help us on 4.x
where https://github.com/Index may already be missing.
So for this backport, fix this during introspection by
falling back to the nearest abstract ancestor, which will have a
correct https://github.com/Index.

I've only been able to reproduce this issue with fairly large schemas,
so there's no test attached, but I tested with:
https://github.com/SeedCompany/cord-api-v3/tree/5d46b5de2828a787e1a43f28c095fa78ef6a50f2/dbschema
which is from the originally reported issue.

Fixes https://github.com/edgedb/edgedb/issues/6699.