### PR TITLE
GH job to check that postgres/ has not been unintentianally changed, take 2

### DIFF
--- a/.github/workflows/pull-request-meta.yml
+++ b/.github/workflows/pull-request-meta.yml
@@ -30,7 +30,7 @@ jobs:
 
         git diff --quiet \
           ${{ github.event.pull_request.base.sha }} \
-          ${{ github.event.pull_request.head.sha }} -- postgres/
+          ${{ github.event.pull_request.head.sha }} -- postgres/ || echo 'no'
         if [ $? != 0 ]; then
           echo "postgres/ submodule has been changed,"\
             "but PR title does not indicate that"

--- a/.github/workflows/pull-request-meta.yml
+++ b/.github/workflows/pull-request-meta.yml
@@ -33,8 +33,8 @@ jobs:
           ${{ github.event.pull_request.head.sha }} -- postgres/
         if [ $? != 0 ]; then
           echo "postgres/ submodule has been changed,"\
-            "but PR title does not indicate that" 1>&2
-          echo "(it should start with '$required_prefix')" 1>&2
+            "but PR title does not indicate that"
+          echo "(it should start with '$required_prefix')"
           exit 1
         fi
         echo 'all ok'

--- a/.github/workflows/pull-request-meta.yml
+++ b/.github/workflows/pull-request-meta.yml
@@ -28,10 +28,10 @@ jobs:
           exit 0
         fi
 
-        git diff --quiet \
+        if git diff --quiet \
           ${{ github.event.pull_request.base.sha }} \
-          ${{ github.event.pull_request.head.sha }} -- postgres/ || echo 'no'
-        if [ $? != 0 ]; then
+          ${{ github.event.pull_request.head.sha }} -- postgres/ ; then
+
           echo "postgres/ submodule has been changed,"\
             "but PR title does not indicate that"
           echo "(it should start with '$required_prefix')"

--- a/.github/workflows/pull-request-meta.yml
+++ b/.github/workflows/pull-request-meta.yml
@@ -30,11 +30,12 @@ jobs:
 
         if git diff --quiet \
           ${{ github.event.pull_request.base.sha }} \
-          ${{ github.event.pull_request.head.sha }} -- postgres/ ; then
-
+          ${{ github.event.pull_request.head.sha }} -- postgres/
+        then
+          echo 'all ok'
+        else
           echo "postgres/ submodule has been changed,"\
             "but PR title does not indicate that"
           echo "(it should start with '$required_prefix')"
           exit 1
         fi
-        echo 'all ok'

--- a/.github/workflows/pull-request-meta.yml
+++ b/.github/workflows/pull-request-meta.yml
@@ -1,7 +1,7 @@
-name: Pull Request
+name: Pull Request Meta
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, labeled, closed]
 
 concurrency:

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -30,10 +30,11 @@ jobs:
 
         git diff --quiet \
           ${{ github.event.pull_request.base.sha }} \
-          ${{ github.event.pull_request.head.sha }}
+          ${{ github.event.pull_request.head.sha }} -- postgres/
         if [ $? != 0 ]; then
           echo "postgres/ submodule has been changed,"\
             "but PR title does not indicate that" 1>&2
           echo "(it should start with '$required_prefix')" 1>&2
           exit 1
         fi
+        echo 'all ok'


### PR DESCRIPTION
Fix for #6710

~Apparently, GH won't use the .yml file from the PR branch to run the actions, but from the main branch? This prevented me from testing if my contraption really worked and is still preventing me now.~

~There must be a better way to develop such things than *merging into master*?~

~Also, I must be doing something wrong, becase all runs of the shell script just exit with 1, without printing anything.~

It looks like it works now. I had to change `pull_request_target` event to `pull_request`.