### PR TITLE
Make overloading a link when omitting link keyword work

### DIFF
--- a/edb/schema/unknown_pointers.py
+++ b/edb/schema/unknown_pointers.py
@@ -166,6 +166,10 @@ class AlterUnknownPointer(
             qlast.AlterConcreteProperty
             if isinstance(obj, s_props.Property)
             else qlast.AlterConcreteLink
+        ) if isinstance(astnode, qlast.AlterObject) else (
+            qlast.CreateConcreteProperty
+            if isinstance(obj, s_props.Property)
+            else qlast.CreateConcreteLink
         )
         astnode = astnode.replace(__class__=astcls)
         qlparser.append_module_aliases(astnode, context.modaliases)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10200,6 +10200,27 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
         )
 
+    def test_schema_describe_overload_01(self):
+        self._assert_describe(
+            """
+            abstract type Animal {
+                name: str;
+                parent: Animal;
+            }
+            type Human extending Animal {
+                overloaded parent: Human;
+            }
+            """,
+
+            'describe type test::Human as sdl',
+
+            """
+            type test::Human extending test::Animal {
+                overloaded link parent: test::Human;
+            };
+            """,
+        )
+
 
 class TestCreateMigration(tb.BaseSchemaTest):
 


### PR DESCRIPTION
AlterUnknownPointer works by converting the AST node into an operation
on the relevant concrete pointer sort. It always converted into an
Alter, though, which meant that the overload case, where
AlterObject._cmd_tree_from_ast is called with a Create node, didn't
work right.

Fixes #6716.