### PR TITLE
nix code block -> bare code block

### DIFF
--- a/docs/guides/contributing/code.rst
+++ b/docs/guides/contributing/code.rst
@@ -54,7 +54,7 @@ On Ubuntu 22.10, these can be installed by running:
 A Nix shell with all dependencies and a Python virtual environment can
 be built with the following ``shell.nix`` file.
 
-.. code:: nix
+.. code::
 
    with import <nixpkgs> {};
    pkgs.mkShell {


### PR DESCRIPTION
We seemingly don't support nix syntax highlighting. It breaks the build.