### PR TITLE
Bump test parallelization in CI to 4

### DIFF
--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -119,7 +119,7 @@ jobs:
       run: |
         mkdir -p .results/
         cp .tmp/time_stats.csv .results/shard_${SHARD/\//_}.csv
-        edb test -j2 -v -s ${SHARD} --running-times-log=.results/shard_${SHARD/\//_}.csv
+        edb test -j4 -v -s ${SHARD} --running-times-log=.results/shard_${SHARD/\//_}.csv
 
     - name: Upload test results
       uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -523,7 +523,7 @@ jobs:
       run: |
         mkdir -p .results/
         cp .tmp/time_stats.csv .results/shard_${SHARD/\//_}.csv
-        edb test -j2 -v -s ${SHARD} --running-times-log=.results/shard_${SHARD/\//_}.csv
+        edb test -j4 -v -s ${SHARD} --running-times-log=.results/shard_${SHARD/\//_}.csv
 
     - name: Upload test results
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Github now runs 4-core VMs by default.
