### PR TITLE
Docs: Update `array_join()`

### DIFF
--- a/docs/stdlib/array.rst
+++ b/docs/stdlib/array.rst
@@ -322,7 +322,7 @@ Reference
 
     .. code-block:: edgeql-repl
 
-        db> select to_str(['one', 'two', 'three'], ', ');
+        db> select array_join(['one', 'two', 'three'], ', ');
         {'one, two, three'}
 
 


### PR DESCRIPTION
I recommend utilizing `array_join()` in this context instead of `to_str()` since the documentation specifically covers `array_join()`. 

Additionally, it's worth noting that [`the documentation for to_str()`](https://www.edgedb.com/docs/stdlib/string#function::std::to_str) indicates that its support for operations on arrays is deprecated.