### PR TITLE
Fix issues with empty sets leaking out of optional scopes

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -240,6 +240,7 @@ def get_set_rvar(
                 null_query, (pgast.SelectStmt, pgast.NullRelation))
             null_query.where_clause = pgast.BooleanConstant(val=False)
 
+        relctx.update_scope_masks(ir_set, rvars.main.rvar, ctx=subctx)
         result_rvar = _include_rvars(rvars, scope_stmt=scope_stmt, ctx=subctx)
         for aspect in rvars.main.aspects:
             pathctx.put_path_rvar_if_not_exists(

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -4112,3 +4112,22 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 }
             ],
         )
+
+    async def test_edgeql_scope_filter_qeq_01(self):
+        await self.assert_query_result(
+            r'''
+            select User filter .avatar ?= <Card>{} and .name = 'Bob';
+            ''',
+            [
+                {},
+            ],
+        )
+
+        await self.assert_query_result(
+            r'''
+            select User filter .name = 'Bob' and .avatar ?= <Card>{}
+            ''',
+            [
+                {},
+            ],
+        )


### PR DESCRIPTION
For the previous issues, see #5575 and #6526.

The issue here is that in queries like
```
select User filter .avatar ?= <Card>{} and .name = 'Bob'
```
we were returning an empty set, since we were deciding that the
optional wraper we grabbed `.avatar` in was also a reasonable source
for User itself. We have machinery to prevent that (introduced in
the mask of the statement that was a "tentative container" for the
relation, but in this case, that container statement was not being
used, so the masks had no effect.

Instead, set up the masks on the final main rvar before including it.

Fixes #6739.