### PR TITLE
Don't unconditionally populate 'iterator' aspect in include_rvar

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -382,7 +382,9 @@ def merge_iterator(
         put_iterator_bond(iterator, select)
         relctx.include_rvar(
             select, iterator_rvar,
-            aspects=('source', 'value', iterator.aspect),
+            aspects=('value', iterator.aspect) + (
+                ('source',) if iterator.path_id.is_objtype_path() else ()
+            ),
             path_id=iterator.path_id,
             overwrite_path_rvar=True,
             ctx=ctx)

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -382,6 +382,7 @@ def merge_iterator(
         put_iterator_bond(iterator, select)
         relctx.include_rvar(
             select, iterator_rvar,
+            aspects=('source', 'value', iterator.aspect),
             path_id=iterator.path_id,
             overwrite_path_rvar=True,
             ctx=ctx)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -212,7 +212,7 @@ def include_rvar(
         Compiler context.
     """
     if aspects is None:
-        aspects = ('value', 'iterator')
+        aspects = ('value',)
         if path_id.is_objtype_path():
             if isinstance(rvar, pgast.RangeSubselect):
                 if pathctx.has_path_aspect(


### PR DESCRIPTION
That causes us to have lots of incorrect 'iterator' aspects in rvar
maps.  Instead, just properly populate the aspects explicitly at the
one relevant call site.

This might help with #6714.