### PR TITLE
Move app details configuration into `AuthConfig`

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -256,6 +256,27 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
                 UI is disabled.";
         };
 
+        create property app_name: std::str {
+            create annotation std::description :=
+                "The name of your application.";
+        };
+
+        create property logo_url: std::str {
+            create annotation std::description :=
+                "A url to an image of your application's logo.";
+        };
+
+        create property dark_logo_url: std::str {
+            create annotation std::description :=
+                "A url to an image of your application's logo to be used \
+                with the dark theme.";
+        };
+
+        create property brand_color: std::str {
+            create annotation std::description :=
+                "The brand color of your application as a hex string.";
+        };
+
         create property auth_signing_key -> std::str {
             set secret := true;
             create annotation std::description :=

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -18,11 +18,16 @@
 
 
 from typing import Optional
+from dataclasses import dataclass
 
 
 class UIConfig:
     redirect_to: str
     redirect_to_on_signup: Optional[str]
+
+
+@dataclass
+class AppDetailsConfig:
     app_name: Optional[str]
     logo_url: Optional[str]
     dark_logo_url: Optional[str]

--- a/edb/server/protocol/auth_ext/email.py
+++ b/edb/server/protocol/auth_ext/email.py
@@ -2,11 +2,10 @@ import asyncio
 import urllib.parse
 import random
 
-from typing import Any, Coroutine, cast
+from typing import Any, Coroutine
 from edb.server import tenant
-from edb.server.config.types import CompositeConfigType
 
-from . import util, ui, smtp, config
+from . import util, ui, smtp
 
 
 async def send_password_reset_email(
@@ -17,17 +16,15 @@ async def send_password_reset_email(
     test_mode: bool,
 ):
     from_addr = util.get_config(db, "ext::auth::SMTPConfig::sender")
-    ui_config = cast(config.UIConfig, util.maybe_get_config(
-        db, "ext::auth::AuthConfig::ui", CompositeConfigType
-    ))
-    if ui_config is None:
+    app_details_config = util.get_app_details_config(db)
+    if app_details_config is None:
         email_args = {}
     else:
         email_args = dict(
-            app_name=ui_config.app_name,
-            logo_url=ui_config.logo_url,
-            dark_logo_url=ui_config.dark_logo_url,
-            brand_color=ui_config.brand_color,
+            app_name=app_details_config.app_name,
+            logo_url=app_details_config.logo_url,
+            dark_logo_url=app_details_config.dark_logo_url,
+            brand_color=app_details_config.brand_color,
         )
     msg = ui.render_password_reset_email(
         from_addr=from_addr,
@@ -55,9 +52,7 @@ async def send_verification_email(
     test_mode: bool,
 ):
     from_addr = util.get_config(db, "ext::auth::SMTPConfig::sender")
-    ui_config = cast(config.UIConfig, util.maybe_get_config(
-        db, "ext::auth::AuthConfig::ui", CompositeConfigType
-    ))
+    app_details_config = util.get_app_details_config(db)
     verification_token_params = urllib.parse.urlencode(
         {
             "verification_token": verification_token,
@@ -66,14 +61,14 @@ async def send_verification_email(
         }
     )
     verify_url = f"{verify_url}?{verification_token_params}"
-    if ui_config is None:
+    if app_details_config is None:
         email_args = {}
     else:
         email_args = dict(
-            app_name=ui_config.app_name,
-            logo_url=ui_config.logo_url,
-            dark_logo_url=ui_config.dark_logo_url,
-            brand_color=ui_config.brand_color,
+            app_name=app_details_config.app_name,
+            logo_url=app_details_config.logo_url,
+            dark_logo_url=app_details_config.dark_logo_url,
+            brand_color=app_details_config.brand_color,
         )
     msg = ui.render_verification_email(
         from_addr=from_addr,

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1364,25 +1364,7 @@ class Router:
         )
 
     def _get_app_details_config(self):
-        app_name = util.maybe_get_config(
-            self.db, "ext::auth::AuthConfig::app_name"
-        )
-        logo_url = util.maybe_get_config(
-            self.db, "ext::auth::AuthConfig::logo_url"
-        )
-        dark_logo_url = util.maybe_get_config(
-            self.db, "ext::auth::AuthConfig::dark_logo_url"
-        )
-        brand_color = util.maybe_get_config(
-            self.db, "ext::auth::AuthConfig::brand_color"
-        )
-
-        return config.AppDetailsConfig(
-            app_name=app_name,
-            logo_url=logo_url,
-            dark_logo_url=dark_logo_url,
-            brand_color=brand_color,
-        )
+        return util.get_app_details_config(self.db)
 
     def _get_password_provider(self):
         providers = cast(

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -22,20 +22,17 @@ from typing import TypeVar, Type, overload, Any
 from edb.server import config
 
 from . import errors
+from .config import AppDetailsConfig
 
 T = TypeVar("T")
 
 
-def maybe_get_config_unchecked(
-    db: Any, key: str
-) -> Any:
+def maybe_get_config_unchecked(db: Any, key: str) -> Any:
     return config.lookup(key, db.db_config, spec=db.user_config_spec)
 
 
 @overload
-def maybe_get_config(
-    db: Any, key: str, expected_type: Type[T]
-) -> T | None:
+def maybe_get_config(db: Any, key: str, expected_type: Type[T]) -> T | None:
     ...
 
 
@@ -71,9 +68,7 @@ def get_config(db: Any, key: str) -> str:
     ...
 
 
-def get_config(
-    db: Any, key: str, expected_type: Type[object] = str
-) -> object:
+def get_config(db: Any, key: str, expected_type: Type[object] = str) -> object:
     value = maybe_get_config(db, key, expected_type)
     if value is None:
         raise errors.MissingConfiguration(
@@ -83,9 +78,7 @@ def get_config(
     return value
 
 
-def get_config_unchecked(
-    db: Any, key: str
-) -> Any:
+def get_config_unchecked(db: Any, key: str) -> Any:
     value = maybe_get_config_unchecked(db, key)
     if value is None:
         raise errors.MissingConfiguration(
@@ -97,3 +90,14 @@ def get_config_unchecked(
 
 def get_config_typename(config_value: config.SettingValue) -> str:
     return config_value._tspec.name  # type: ignore
+
+
+def get_app_details_config(db: Any) -> AppDetailsConfig:
+    return AppDetailsConfig(
+        app_name=maybe_get_config(db, "ext::auth::AuthConfig::app_name"),
+        logo_url=maybe_get_config(db, "ext::auth::AuthConfig::logo_url"),
+        dark_logo_url=maybe_get_config(
+            db, "ext::auth::AuthConfig::dark_logo_url"
+        ),
+        brand_color=maybe_get_config(db, "ext::auth::AuthConfig::brand_color"),
+    )

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -377,7 +377,6 @@ DARK_LOGO_URL = "http://example.com/darklogo.png"
 BRAND_COLOR = "f0f8ff"
 
 
-
 class TestHttpExtAuth(tb.ExtAuthTestCase):
     TRANSACTION_ISOLATION = False
     PARALLELISM_GRANULARITY = 'suite'

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -267,9 +267,7 @@ class MockAuthProvider:
         headers = {k.lower(): v for k, v in dict(handler.headers).items()}
         query_params = urllib.parse.parse_qs(parsed_path.query)
         if 'content-length' in headers:
-            body = handler.rfile.read(
-                int(headers['content-length'])
-            ).decode()
+            body = handler.rfile.read(int(headers['content-length'])).decode()
         else:
             body = None
 
@@ -373,6 +371,11 @@ AZURE_SECRET = 'c' * 32
 APPLE_SECRET = 'c' * 32
 DISCORD_SECRET = 'd' * 32
 SLACK_SECRET = 'd' * 32
+APP_NAME = "Test App"
+LOGO_URL = "http://example.com/logo.png"
+DARK_LOGO_URL = "http://example.com/darklogo.png"
+BRAND_COLOR = "f0f8ff"
+
 
 
 class TestHttpExtAuth(tb.ExtAuthTestCase):
@@ -386,6 +389,24 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
         CONFIGURE CURRENT DATABASE SET
         ext::auth::AuthConfig::token_time_to_live := <duration>'24 hours';
+
+        CONFIGURE CURRENT DATABASE SET
+        ext::auth::AuthConfig::app_name := '{APP_NAME}';
+
+        CONFIGURE CURRENT DATABASE SET
+        ext::auth::AuthConfig::logo_url := '{LOGO_URL}';
+
+        CONFIGURE CURRENT DATABASE SET
+        ext::auth::AuthConfig::dark_logo_url := '{DARK_LOGO_URL}';
+
+        CONFIGURE CURRENT DATABASE SET
+        ext::auth::AuthConfig::brand_color := '{BRAND_COLOR}';
+
+        CONFIGURE CURRENT DATABASE
+        INSERT ext::auth::UIConfig {{
+          redirect_to := 'https://example.com',
+          redirect_to_on_signup := 'https://example.com/signup',
+        }};
 
         CONFIGURE CURRENT DATABASE SET
         ext::auth::SMTPConfig::sender := 'noreply@example.com';
@@ -3469,6 +3490,25 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
 
             self.assertEqual(status, 400)
+
+    async def test_http_auth_ext_ui_signin(self):
+        with self.http_con() as http_con:
+            challenge = (
+                base64.urlsafe_b64encode(os.urandom(32)).rstrip(b'=').decode()
+            )
+            query_params = urllib.parse.urlencode({"challenge": challenge})
+
+            body, _, status = self.http_con_request(
+                http_con,
+                path=f"ui/signin?{query_params}",
+            )
+
+            body_str = body.decode()
+
+            self.assertIn(APP_NAME, body_str)
+            self.assertIn(LOGO_URL, body_str)
+            self.assertIn(BRAND_COLOR, body_str)
+            self.assertEqual(status, 200)
 
     async def test_client_token_identity_card(self):
         await self.con.query_single(


### PR DESCRIPTION
We need these details in more places (email templates, WebAuthn, etc) so copy the existing `UIConfig` properties into the base `AuthConfig` object.

For now, we have the old properties still there. We are going to discuss if (and how) to migrate any existing user provided values from the old config into the new config as part of the upgrade separately. Going to leave this as a draft for now while we discuss.

(n.b. some Black formatting churn, apologies)