### PR TITLE
Bump to latest `cryptography` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     'uvloop~=0.17.0',
 
     'click~=8.0',
-    'cryptography~=35.0',
+    'cryptography~=42.0',
     'graphql-core~=3.1.5',
     'jwcrypto~=1.3.1',
     'psutil~=5.8',


### PR DESCRIPTION
This version is required in a dependency that we would like to use to support WebAuthn ([`webauthn`](https://pypi.org/project/webauthn/) on PyPI).

Looking at the [`CHANGELOG`](https://cryptography.io/en/latest/changelog/#v36-0-0) it doesn't seem like the changes between `v35..v42` touch [anything that we currently use](https://github.com/edgedb/edgedb/blob/master/edb/common/secretkey.py), but here's a short summary of the changes:

- Backward Incompatibilities: Removed default idna dependency, changed OpenSSL linking, deprecated Python 3.6 and OpenSSL < 1.1.1d support, removed signer and verifier methods from key classes.
- Security Enhancements: Updated wheels to be compiled with newer OpenSSL versions, fixed integer overflow bug in symmetric encryption of large payloads.
- Feature Additions: Added support for parsing and generating SSH certificates, introduced type hints across public APIs, added support for newer cryptographic primitives like X448, SHA3, and SHAKE128/256.
- Deprecations: Deprecated DSA keys in SSH key loading, OpenSSH serialization, LibreSSL < 3.1, and certain environment variables for custom OpenSSL builds.
- Miscellaneous: Removed many unused CFFI OpenSSL bindings, updated minimum supported Rust version for building from source, dropped Python 2 support, added support for distinguished names containing a bit string, restored support for signing certificates with SHA3 hash algorithms.