### PR TITLE
Supress idle tx timeout during compilation

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -317,6 +317,11 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                 raise RuntimeError(
                     'unexpected ObjectRef as a non-first path item')
 
+            if step.name == 'slowcompile':
+                import time
+                print("SLOW")
+                time.sleep(10)
+
             refnode = None
 
             if (

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -317,11 +317,6 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                 raise RuntimeError(
                     'unexpected ObjectRef as a non-first path item')
 
-            if step.name == 'slowcompile':
-                import time
-                print("SLOW")
-                time.sleep(10)
-
             refnode = None
 
             if (

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -977,6 +977,9 @@ cdef class DatabaseConnectionView:
         query_req: QueryRequestInfo,
         cached_globally=False,
         use_metrics=True,
+        # allow passing in the query_unit_group, in case the call site needs
+        # to make decisions based on whether the cache is hit
+        query_unit_group=None,
     ) -> CompiledQuery:
         source = query_req.source
         if cached_globally:
@@ -990,7 +993,7 @@ cdef class DatabaseConnectionView:
                 if self._query_cache_enabled
                 else None
             )
-        else:
+        elif query_unit_group is None:
             query_unit_group = self.lookup_compiled_query(query_req)
         cached = True
         if query_unit_group is None:

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -517,7 +517,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         async with self.with_pgcon() as conn:
             await conn.sql_execute(f'''
                 select pg_catalog.set_config(
-                    'idle_in_transaction_session_timeout', {timeout}, false)
+                    'idle_in_transaction_session_timeout', {timeout}, true)
             '''.encode('utf-8'))
 
     async def _parse(

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -503,7 +503,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         async with self.with_pgcon() as conn:
             await conn.sql_execute(b'''
                 select pg_catalog.set_config(
-                    'idle_in_transaction_session_timeout', '0', false)
+                    'idle_in_transaction_session_timeout', '0', true)
             ''')
 
     async def _restore_tx_timeout(self, dbview.DatabaseConnectionView dbv):

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -552,7 +552,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         # If we have to do a compile within a transaction, spin up a
         # heartbeat task to keep the SQL connection from going idle.
-        if dbv.in_tx() and query_unit_group is None:
+        if dbv.in_tx() and not dbv.in_tx_error() and query_unit_group is None:
             event = asyncio.Event()
             heartbeat_task = self.tenant.create_task(
                 self._heartbeat(event), interruptable=False)

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -18,6 +18,7 @@
 
 
 import asyncio
+import contextlib
 import logging
 import time
 
@@ -166,6 +167,14 @@ cdef class FrontendConnection(AbstractFrontendConnection):
                     conn,
                     discard=debug.flags.server_clobber_pg_conns,
                 )
+
+    @contextlib.asynccontextmanager
+    async def with_pgcon(self):
+        con = await self.get_pgcon()
+        try:
+            yield con
+        finally:
+            self.maybe_release_pgcon(con)
 
     def on_aborted_pgcon(self, pgcon.PGConnection conn):
         try:


### PR DESCRIPTION
I tested this by adding a sleep when the variable `slowcompile` is used. 
Fixes #6758.