### PR TITLE
Fix some major issues with the error context printer

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -7272,11 +7272,11 @@ async def execute_sql_script(
         text = None
 
         if position is not None:
-            point = int(position)
+            point = int(position) - 1
             text = sql_text
 
         elif internal_position is not None:
-            point = int(internal_position)
+            point = int(internal_position) - 1
             text = e.get_field('q')
 
         elif pl_func_line:


### PR DESCRIPTION
There were two major problems:
 * The line immediately before the error was always skipped in the context
 * The long line truncating, which would try to show the contents around
   the error column, would try to do that when truncating context lines too,
   which made no sense and meant that truncated context lines often
   contained newlines.

Additionally, things were complicated by doing a search for each line
instead of doing one search for the error line and indexing from it.

I decided to just get rid of all the truncation logic, since it would mostly
just serve to impede debugging, though it would be possible to do
something more correct than what we do know. (Though I'd bump the
limit up from 120, which is very low.)

Hopefully now this will actually be useful in debugging bootstrap SQL
failures.