### PR TITLE
Partial rework of how lprop scope tree visibility works

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -543,8 +543,6 @@ def _process_view(
                 ctx=ctx,
             )
 
-        _maybe_fixup_lprop(path_id, ptrcls, ctx=ctx)
-
         set_shape.append((ptr_set, shape_op))
 
     ir_set.shape = tuple(set_shape)
@@ -1236,23 +1234,6 @@ def prepare_rewrite_anchors(
         old_set = None
 
     return (subject_set, specified_set, old_set)
-
-
-def _maybe_fixup_lprop(
-    path_id: irast.PathId,
-    ptrcls: s_pointers.Pointer,
-    *,
-    ctx: context.ContextLevel,
-) -> None:
-    # HACK?: when we see linkprops being used on an intersection,
-    # attach the flattened source path to make linkprops on
-    # computed backlinks work
-    if (
-        isinstance(path_id.rptr(), irast.TypeIntersectionPointerRef)
-        and ptrcls.is_link_property(ctx.env.schema)
-    ):
-        ctx.path_scope.attach_path(
-            path_id, flatten_intersection=True, context=None)
 
 
 def _compile_qlexpr(
@@ -2427,8 +2408,6 @@ def _late_compile_view_shapes_in_set(
                 srcctx=srcctx,
                 ctx=ctx,
             )
-
-            _maybe_fixup_lprop(path_tip.path_id, ptr, ctx=ctx)
 
             element_scope = pathctx.get_set_scope(element, ctx=ctx)
 

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -405,28 +405,21 @@ class ScopeTreeNode:
         self,
         path_id: pathid.PathId,
         *,
-        flatten_intersection: bool=False,
         optional: bool=False,
         context: Optional[pctx.ParserContext],
     ) -> None:
         """Attach a scope subtree representing *path_id*."""
 
         subtree = parent = ScopeTreeNode(fenced=True)
-        is_lprop = flatten_intersection
-
-        for prefix in reversed(list(path_id.iter_prefixes(include_ptr=True))):
-            if prefix.is_ptr_path():
-                is_lprop = True
-                continue
-
+        is_lprop = False
+        lprop_base = None
+        for prefix in reversed(list(path_id.iter_prefixes())):
             new_child = ScopeTreeNode(path_id=prefix,
                                       optional=optional and parent is subtree)
-            parent.attach_child(new_child)
 
-            # If the path is a link property, or a tuple
-            # indirection, then its prefix is added at
-            # the *same* scope level, otherwise, the prefix
-            # is nested.
+            # Normally the prefix is nested, except that tuple
+            # indirection prefixes and the *object* prefixes of link
+            # properties are are at the same level.
             #
             # For example, Foo.bar.baz, where Foo is an object type,
             # forms this scope shape:
@@ -439,24 +432,49 @@ class ScopeTreeNode:
             #   <tuple>.bar
             #   <tuple>.bar.baz
             #
-            # This is because both link properties and tuples are
-            # *always* singletons, and so there is no semantic ambiguity
-            # as to the cardinality of the path prefix in different
-            # contexts.
+            # And Foo.bar[is Typ]@baz results in:
+            #   Foo.bar[is Typ]@baz
+            #    |-Foo.bar[is Typ]
+            #       |-Foo.bar
+            #   Foo
             #
-            # We could include other cases with invariant cardinality here,
-            # like type intersection, but we want to preserve the prefix
-            # visibility information for the sake of possible optimizations.
-            if (
-                not (is_lprop or prefix.is_linkprop_path())
-                and not prefix.is_tuple_indirection_path()
-            ):
+            # I forget why this is necessary for tuples, but it is permissable
+            # because their fields are always singletons.
+            #
+            # For link properties, this is necessary because referring
+            # to a link property at the end of a path suppresses
+            # deduplication of the link, which is realized by forcing
+            # the link source to be visible. We avoid making the rest of
+            # the path visible, to preserve prefix visibility information
+            # for certain optimizations. (Foo.bar[is Typ] can be compiled
+            # such that it joins directly on Typ (instead of on Bar first),
+            # but *only* if Foo.bar isn't visible without the type intersection.
+            target = parent
+
+            if prefix.is_linkprop_path():
+                assert lprop_base is None
+                # If we just saw a linkprop, track where, since we'll
+                # need to come back to this level in the tree once we
+                # reach the "object prefix" of it.
+                lprop_base = parent
+                is_lprop = True
+            elif is_lprop:
+                # Skip through type intersections (i.e [IS Foo]) until
+                # we actually get to the link.
+                if not prefix.is_type_intersection_path():
+                    is_lprop = False
+            else:
+                # If we've reached the "object prefix" of a path
+                # referencing a linkprop, pop back up to the level the
+                # linkprop was attached to.
+                if lprop_base is not None:
+                    target = parent = lprop_base
+                    lprop_base = None
+
+            if not prefix.is_tuple_indirection_path():
                 parent = new_child
 
-            # Skip through type intersections (i.e [IS Foo]) until
-            # we actually get to the link.
-            if not prefix.is_type_intersection_path():
-                is_lprop = False
+            target.attach_child(new_child)
 
         self.attach_subtree(subtree, context=context)
 
@@ -620,14 +638,10 @@ class ScopeTreeNode:
                 ) is None
             )
             and (
-                not path_id.is_type_intersection_path()
-                or (
-                    (src_path := path_id.src_path())
-                    and src_path is not None
-                    and not self.is_visible(src_path)
-                )
+                not (src_path := path_id.src_path())
+                or not self.is_visible(src_path)
             )
-            and not existing._node_paths_are_props()
+            and not existing._node_paths_are_not_links()
         ):
             path_ancestor = descendant.path_ancestor
             if path_ancestor is not None:
@@ -654,13 +668,13 @@ class ScopeTreeNode:
                 context=context,
             )
 
-    def _node_paths_are_props(self) -> bool:
+    def _node_paths_are_not_links(self) -> bool:
         """
-        Check if all the pointers a path might be hoisted past are properties
+        Check if all the pointers a path might be hoisted past are not links
 
         If the node is a path_id node, return true if the rptrs on
-        all of the chain of parent nodes with path_ids are properties
-        (not links).
+        all of the chain of parent nodes with path_ids are not links
+        (that is, they are properties or type intersections).
 
         This is in support of allowing queries like
           select Card.element filter Card.name = 'Imp'
@@ -671,7 +685,10 @@ class ScopeTreeNode:
 
         node: ScopeTreeNode | None = self
         while node and node.path_id:
-            if node.path_id.rptr() and node.path_id.is_objtype_path():
+            if node.path_id.rptr() and (
+                node.path_id.is_objtype_path()
+                and not node.path_id.is_type_intersection_path()
+            ):
                 return False
             node = node.parent
         return True

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -439,7 +439,8 @@ class ScopeTreeNode:
             #       |-Foo.bar
             #   Foo
             #
-            # This is permissable because their fields are always singletons.
+            # For tuples, this is permissable because their fields are always
+            # singletons.
             # FIXME: I think that it should not be *necessary* for tuples,
             # but test_edgeql_volatility_select_tuples_* fail if it is changed,
             # I think for incidental reasons.
@@ -452,8 +453,6 @@ class ScopeTreeNode:
             # for certain optimizations. (Foo.bar[is Typ] can be compiled
             # such that it joins directly on Typ (instead of on Bar first),
             # but *only* if Foo.bar isn't visible without the type intersection.
-            target = parent
-
             if prefix.is_linkprop_path():
                 assert lprop_base is None
                 # If we just saw a linkprop, track where, since we'll
@@ -471,13 +470,12 @@ class ScopeTreeNode:
                 # referencing a linkprop, pop back up to the level the
                 # linkprop was attached to.
                 if lprop_base is not None:
-                    target = parent = lprop_base
+                    parent = lprop_base
                     lprop_base = None
 
+            parent.attach_child(new_child)
             if not prefix.is_tuple_indirection_path():
                 parent = new_child
-
-            target.attach_child(new_child)
 
         self.attach_subtree(subtree, context=context)
 

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -712,6 +712,13 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
+                SELECT User.deck@count FILTER User.deck.element = 'Fire'
+            ''',
+            tb.bag([1, 2, 2]),
+        )
+
+        await self.assert_query_result(
+            r'''
                 SELECT DISTINCT (
                     SELECT User.deck@count FILTER User.deck.element = 'Fire'
                 );

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -39,6 +39,9 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
+    SCHEMA_cards = os.path.join(os.path.dirname(__file__), 'schemas',
+                                'cards.esdl')
+
     def _compile_to_tree(self, source):
         qltree = qlparser.parse_query(source)
         ir = compiler.compile_ast_to_ir(
@@ -319,4 +322,18 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             "uuid_generate",
             sql,
             "unnecessary uuid_generate for FOR loop without volatility",
+        )
+
+    def test_codegen_linkprop_intersection_01(self):
+        # Should have no conflict check because it has no subtypes
+        sql = self._compile('''
+            with module cards
+            select User { deck[is SpecialCard]: { name, @count } }
+        ''')
+
+        card_obj = self.schema.get("cards::Card")
+        self.assertNotIn(
+            str(card_obj.id),
+            sql,
+            "Card being selected when SpecialCard should suffice"
         )


### PR DESCRIPTION
The core motivating thing here is that currently basically any use of
linkprops breaks the `[is Foo]` optimization where we only select from
`Foo`.
So if you have something like:
```
select schema::Constraint {
    ancestors[is schema::Constraint]: { @index },
};
```
it will select all `InheritingObject`s.

This is because `@index` is attached to the scopetree in a *fully*
flattened way, as
```
  Constraint.ancestors[is Constraint]@index
  Constraint.ancestors[is Constraint]
  Constraint.ancestors
  Constraint
```
because referring to a link property requires the source *of the link*
to be visible (to prevent the link from deduplicating), but this is
implemented by forcing the every path element to be visible. This means
that in the backend compiler, `Constraint.ancestors` is visible when we
compile the link property, which suppresses the optimization because
it looks like `Constraint.ancestors` may be getting used somewhere
*without* immediately type intersecting it.

Instead we try to do
```
  Constraint.ancestors[is Constraint]@index
    |-Constraint.ancestors[is Constraint]
      |- Constraint.ancestors
  Constraint
```

I think overall this is a code cleanup (_maybe_fixup_lprop can be
deleted), though I suspect there might still be a cleaner way to
structure the attach_path loop.

Some parts of relgen needed some fixing up in order to still be able
to find linkprop sources now that less is flattened.