### PR TITLE
Add WebAuthn registration flow

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -55,15 +55,42 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     };
 
     create type ext::auth::EmailFactor extending ext::auth::Factor {
-        create required property email: str {
-            create delegated constraint exclusive;
-        };
+        create required property email: str;
         create property verified_at: std::datetime;
     };
 
     create type ext::auth::EmailPasswordFactor
         extending ext::auth::EmailFactor {
+        alter property email {
+            create constraint exclusive;
+        };
         create required property password_hash: std::str;
+    };
+
+    create type ext::auth::WebAuthnFactor extending ext::auth::EmailFactor {
+        create required property user_handle: std::bytes {
+            create constraint exclusive;
+        };
+        create required property credential_id: std::bytes {
+            create constraint exclusive;
+        };
+        create required property public_key: std::bytes {
+            create constraint exclusive;
+        };
+
+        create constraint exclusive on ((.email, .credential_id));
+        create constraint exclusive on ((.email, .user_handle));
+    };
+
+    create type ext::auth::WebAuthnRegistrationChallenge
+        extending ext::auth::Auditable {
+        create required property challenge: std::bytes {
+            create constraint exclusive;
+        };
+        create required property email: std::str;
+        create required property user_handle: std::bytes;
+
+        create constraint exclusive on ((.user_handle, .email, .challenge));
     };
 
     create type ext::auth::PKCEChallenge extending ext::auth::Auditable {
@@ -194,6 +221,25 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         alter property name {
             set default := 'builtin::local_emailpassword';
             set protected := true;
+        };
+
+        create required property require_verification: std::bool {
+            set default := true;
+        };
+    };
+
+    create type ext::auth::WebAuthnProviderConfig
+        extending ext::auth::ProviderConfig {
+        alter property name {
+            set default := 'builtin::local_webauthn';
+            set protected := true;
+        };
+
+        create required property relying_party_origin: std::str {
+            create annotation std::description :=
+                "The full origin of the sign-in page including protocol and \
+                port of the application. If using the built-in UI, this \
+                should be the origin of the EdgeDB server.";
         };
 
         create required property require_verification: std::bool {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -79,7 +79,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         };
 
         create constraint exclusive on ((.email, .credential_id));
-        create constraint exclusive on ((.email, .user_handle));
     };
 
     create type ext::auth::WebAuthnRegistrationChallenge

--- a/edb/server/protocol/auth_ext/_static/utils.js
+++ b/edb/server/protocol/auth_ext/_static/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Decode a base64url encoded string
+ * @param {string} base64UrlString
+ * @returns Uint8Array
+ */
+export function decodeBase64Url(base64UrlString) {
+  return Uint8Array.from(
+    atob(base64UrlString.replace(/-/g, "+").replace(/_/g, "/")),
+    (c) => c.charCodeAt(0)
+  );
+}
+
+/**
+ * Encode a Uint8Array to a base64url encoded string
+ * @param {Uint8Array} bytes
+ * @returns string
+ */
+export function encodeBase64Url(bytes) {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}

--- a/edb/server/protocol/auth_ext/_static/webauthn-register.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn-register.js
@@ -34,7 +34,7 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       const redirectUrl = new URL(redirectTo);
-      redirectUrl.searchParams.append("isSignup", "true");
+      redirectUrl.searchParams.append("isSignUp", "true");
       if (maybeCode !== null) {
         redirectUrl.searchParams.append("code", maybeCode);
       }

--- a/edb/server/protocol/auth_ext/_static/webauthn-register.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn-register.js
@@ -1,0 +1,188 @@
+import { decodeBase64Url, encodeBase64Url } from "./utils.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const registerForm = document.getElementById("email-factor");
+
+  if (registerForm === null) {
+    return;
+  }
+
+  registerForm.addEventListener("submit", async (event) => {
+    if (event.submitter?.id !== "webauthn-signup") {
+      return;
+    }
+    event.preventDefault();
+
+    const formData = new FormData(/** @type {HTMLFormElement} */ registerForm);
+    const email = formData.get("email");
+    const provider = "builtin::local_webauthn";
+    const challenge = formData.get("challenge");
+    const redirectOnFailure = formData.get("redirect_on_failure");
+    const redirectTo = formData.get("redirect_to");
+    const verifyUrl = formData.get("verify_url");
+
+    if (redirectTo === null) {
+      throw new Error("Missing redirect_to parameter");
+    }
+
+    try {
+      const maybeCode = await register({
+        email,
+        provider,
+        challenge,
+        verifyUrl,
+      });
+
+      const redirectUrl = new URL(redirectTo);
+      redirectUrl.searchParams.append("isSignup", "true");
+      if (maybeCode !== null) {
+        redirectUrl.searchParams.append("code", maybeCode);
+      }
+
+      window.location.href = redirectUrl.href;
+    } catch (error) {
+      console.error("Failed to register WebAuthn credentials:", error);
+      const url = new URL(redirectOnFailure ?? redirectTo);
+      url.searchParams.append("error", error.message);
+      window.location.href = url.href;
+    }
+  });
+});
+
+const WEBAUTHN_OPTIONS_URL = new URL(
+  "../webauthn/register/options",
+  window.location
+);
+const WEBAUTHN_REGISTER_URL = new URL("../webauthn/register", window.location);
+
+/**
+ * Register a new WebAuthn credential for the given email address
+ * @param {Object} props - The properties for registration
+ * @param {string} props.email - Email address to register
+ * @param {string} props.provider - WebAuthn provider
+ * @param {string} props.challenge - PKCE challenge
+ * @param {string} props.verifyUrl - URL to verify email after registration
+ * @returns {Promise<string | null>} - The PKCE code or null if the application
+ *   requires email verification
+ */
+export async function register({ email, provider, challenge, verifyUrl }) {
+  // Check if WebAuthn is supported
+  if (!window.PublicKeyCredential) {
+    console.error("WebAuthn is not supported in this browser.");
+    return;
+  }
+
+  // Fetch WebAuthn options from the server
+  const options = await getCreateOptions(email);
+
+  // Register the new credential
+  const credentials = await navigator.credentials.create({
+    publicKey: {
+      ...options,
+      challenge: decodeBase64Url(options.challenge),
+      user: {
+        ...options.user,
+        id: decodeBase64Url(options.user.id),
+      },
+    },
+  });
+
+  // Register the credentials on the server
+  const registerResult = await registerCredentials({
+    email,
+    credentials,
+    provider,
+    challenge,
+    verifyUrl,
+  });
+
+  return registerResult.code ?? null;
+}
+
+/**
+ * Fetch WebAuthn options from the server
+ * @param {string} email - Email address to register
+ * @returns {Promise<globalThis.PublicKeyCredentialCreationOptions>}
+ */
+async function getCreateOptions(email) {
+  const url = new URL(WEBAUTHN_OPTIONS_URL);
+  url.searchParams.set("email", email);
+
+  const optionsResponse = await fetch(url, {
+    method: "GET",
+  });
+
+  if (!optionsResponse.ok) {
+    console.error(
+      "Failed to fetch WebAuthn options:",
+      optionsResponse.statusText
+    );
+    console.error(await optionsResponse.text());
+    throw new Error("Failed to fetch WebAuthn options");
+  }
+
+  try {
+    return await optionsResponse.json();
+  } catch (e) {
+    console.error("Failed to parse WebAuthn options:", e);
+    throw new Error("Failed to parse WebAuthn options");
+  }
+}
+
+/**
+ * Register the credentials on the server
+ * @param {Object} props
+ * @param {string} props.email
+ * @param {Object} props.credentials
+ * @param {string} props.provider
+ * @param {string} props.challenge
+ * @param {string} props.verifyUrl
+ * @returns {Promise<Object>}
+ */
+async function registerCredentials(props) {
+  // Credentials include raw bytes, so need to be encoded as base64url
+  // for transmission
+  const encodedCredentials = {
+    ...props.credentials,
+    rawId: encodeBase64Url(new Uint8Array(props.credentials.rawId)),
+    response: {
+      ...props.credentials.response,
+      attestationObject: encodeBase64Url(
+        new Uint8Array(props.credentials.response.attestationObject)
+      ),
+      clientDataJSON: encodeBase64Url(
+        new Uint8Array(props.credentials.response.clientDataJSON)
+      ),
+    },
+  };
+
+  const registerResponse = await fetch(WEBAUTHN_REGISTER_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email: props.email,
+      credentials: encodedCredentials,
+      provider: props.provider,
+      challenge: props.challenge,
+      verify_url: props.verifyUrl,
+    }),
+  });
+
+  if (!registerResponse.ok) {
+    console.error(
+      "Failed to register WebAuthn credentials:",
+      registerResponse.statusText
+    );
+    console.error(await registerResponse.text());
+    throw new Error("Failed to register WebAuthn credentials");
+  }
+
+  try {
+    return await registerResponse.json();
+  } catch (e) {
+    console.error("Failed to parse WebAuthn registration result:", e);
+    throw new Error("Failed to parse WebAuthn registration result");
+  }
+}

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -19,6 +19,7 @@
 
 from typing import Optional
 from dataclasses import dataclass
+import urllib.parse
 
 
 class UIConfig:
@@ -36,3 +37,28 @@ class AppDetailsConfig:
 
 class ProviderConfig:
     name: str
+
+
+class WebAuthnProviderConfig(ProviderConfig):
+    relying_party_origin: str
+    require_verification: bool
+
+
+@dataclass
+class WebAuthnProvider:
+    name: str
+    relying_party_origin: str
+    require_verification: bool
+
+    def __init__(
+        self, name: str, relying_party_origin: str, require_verification: bool
+    ):
+        self.name = name
+        self.relying_party_origin = relying_party_origin
+        self.require_verification = require_verification
+        parsed_url = urllib.parse.urlparse(self.relying_party_origin)
+        if parsed_url.hostname is None:
+            raise ValueError(
+                "Invalid relying_party_origin, hostname cannot be None"
+            )
+        self.relying_party_id = parsed_url.hostname

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -19,6 +19,8 @@
 
 import dataclasses
 import datetime
+import base64
+
 from typing import Optional, NamedTuple
 
 
@@ -140,3 +142,43 @@ class ProviderConfig(NamedTuple):
     client_id: str
     secret: str
     additional_scope: Optional[str]
+
+
+@dataclasses.dataclass
+class WebAuthnFactor:
+    id: str
+    created_at: datetime.datetime
+    modified_at: datetime.datetime
+    identity: LocalIdentity
+    email: str
+    verified_at: Optional[datetime.datetime]
+    user_handle: bytes
+    credential_id: bytes
+    public_key: bytes
+
+    def __init__(
+        self,
+        *,
+        id,
+        created_at,
+        modified_at,
+        identity,
+        email,
+        verified_at,
+        user_handle,
+        credential_id,
+        public_key,
+    ):
+        self.id = id
+        self.created_at = created_at
+        self.modified_at = modified_at
+        self.identity = (
+            LocalIdentity(**identity)
+            if isinstance(identity, dict)
+            else identity
+        )
+        self.email = email
+        self.verified_at = verified_at
+        self.user_handle = base64.b64decode(user_handle)
+        self.credential_id = base64.b64decode(credential_id)
+        self.public_key = base64.b64decode(public_key)

--- a/edb/server/protocol/auth_ext/email_password.py
+++ b/edb/server/protocol/auth_ext/email_password.py
@@ -1,0 +1,256 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argon2
+import json
+import hashlib
+import base64
+import dataclasses
+
+from typing import Any
+from edb.errors import ConstraintViolationError
+from edb.server.protocol import execute
+
+from . import errors, util, data, local
+
+ph = argon2.PasswordHasher()
+
+
+@dataclasses.dataclass
+class EmailPasswordProviderConfig:
+    name: str
+    require_verification: bool
+
+
+class Client(local.Client):
+    def __init__(self, db: Any):
+        super().__init__(db)
+        self.config = self._get_provider_config("builtin::local_emailpassword")
+
+    async def register(self, input: dict[str, Any]):
+        match (input.get("email"), input.get("password")):
+            case (str(e), str(p)):
+                email = e
+                password = p
+            case _:
+                raise errors.InvalidData(
+                    "Missing 'email' or 'password' in data"
+                )
+
+        try:
+            r = await execute.parse_execute_json(
+                db=self.db,
+                query="""\
+    with
+      email := <optional str>$email,
+      password_hash := <str>$password_hash,
+      identity := (insert ext::auth::LocalIdentity {
+        issuer := "local",
+        subject := "",
+      }),
+      password := (insert ext::auth::EmailPasswordFactor {
+        password_hash := password_hash,
+        email := email,
+        identity := identity,
+      }),
+
+    select identity { * };""",
+                variables={
+                    "email": email,
+                    "password_hash": ph.hash(password),
+                },
+                cached_globally=True,
+            )
+        except Exception as e:
+            exc = await execute.interpret_error(e, self.db)
+            if isinstance(exc, ConstraintViolationError):
+                raise errors.UserAlreadyRegistered()
+            else:
+                raise exc
+
+        result_json = json.loads(r.decode())
+        assert len(result_json) == 1
+
+        return data.LocalIdentity(**result_json[0])
+
+    async def authenticate(self, input: dict[str, Any]):
+        if 'email' not in input or 'password' not in input:
+            raise errors.InvalidData("Missing 'email' or 'password' in data")
+
+        password = input["password"]
+        email = input["email"]
+        r = await execute.parse_execute_json(
+            db=self.db,
+            query="""\
+with
+  email := <str>$email,
+select ext::auth::EmailPasswordFactor { password_hash, identity: { * } }
+filter .email = email;""",
+            variables={
+                "email": email,
+            },
+            cached_globally=True,
+        )
+
+        password_credential_dicts = json.loads(r.decode())
+        if len(password_credential_dicts) != 1:
+            raise errors.NoIdentityFound()
+        password_credential_dict = password_credential_dicts[0]
+
+        password_hash = password_credential_dict["password_hash"]
+        try:
+            ph.verify(password_hash, password)
+        except argon2.exceptions.VerifyMismatchError:
+            raise errors.NoIdentityFound()
+
+        local_identity = data.LocalIdentity(
+            **password_credential_dict["identity"]
+        )
+
+        if ph.check_needs_rehash(password_hash):
+            new_hash = ph.hash(password)
+            await execute.parse_execute_json(
+                db=self.db,
+                query="""\
+with
+  email := <str>$email,
+  new_hash := <str>$new_hash,
+
+update ext::auth::EmailPasswordFactor
+filter .email = email
+set { password_hash := new_hash };""",
+                variables={
+                    "email": email,
+                    "new_hash": new_hash,
+                },
+                cached_globally=True,
+            )
+
+        return local_identity
+
+    async def get_identity_and_secret(self, input: dict[str, Any]):
+        if 'email' not in input:
+            raise errors.InvalidData("Missing 'email' in data")
+
+        email = input["email"]
+        r = await execute.parse_execute_json(
+            db=self.db,
+            query="""
+with
+  email := <str>$email,
+select ext::auth::EmailPasswordFactor {
+  password_hash,
+  identity: { * }
+} filter .email = email""",
+            variables={
+                "email": email,
+            },
+            cached_globally=True,
+        )
+
+        result_json = json.loads(r.decode())
+        if len(result_json) != 1:
+            raise errors.NoIdentityFound()
+        password_cred = result_json[0]
+
+        local_identity = data.LocalIdentity(**password_cred["identity"])
+        secret = base64.b64encode(
+            hashlib.sha256(password_cred['password_hash'].encode()).digest()
+        ).decode()
+
+        return (local_identity, secret)
+
+    async def validate_reset_secret(self, identity_id: str, secret: str):
+        r = await execute.parse_execute_json(
+            db=self.db,
+            query="""\
+with
+  identity_id := <uuid><str>$identity_id,
+select ext::auth::EmailPasswordFactor { password_hash, identity: { * } }
+filter .identity.id = identity_id;""",
+            variables={
+                "identity_id": identity_id,
+            },
+            cached_globally=True,
+        )
+
+        result_json = json.loads(r.decode())
+        if len(result_json) != 1:
+            raise errors.NoIdentityFound()
+        password_cred = result_json[0]
+
+        local_identity = data.LocalIdentity(**password_cred["identity"])
+
+        current_secret = base64.b64encode(
+            hashlib.sha256(password_cred['password_hash'].encode()).digest()
+        ).decode()
+
+        return local_identity if secret == current_secret else None
+
+    async def update_password(
+        self, identity_id: str, secret: str, input: dict[str, Any]
+    ):
+        if 'password' not in input:
+            raise errors.InvalidData("Missing 'password' in data")
+
+        password = input["password"]
+
+        local_identity = await self.validate_reset_secret(identity_id, secret)
+
+        if local_identity is None:
+            raise errors.InvalidData("Invalid 'reset_token'")
+
+        # TODO: check if race between validating secret and updating password
+        #       is a problem
+        await execute.parse_execute_json(
+            db=self.db,
+            query="""\
+with
+  identity_id := <uuid><str>$identity_id,
+  new_hash := <str>$new_hash,
+update ext::auth::EmailPasswordFactor
+filter .identity.id = identity_id
+set {
+    password_hash := new_hash,
+    verified_at := .verified_at ?? datetime_current()
+};""",
+            variables={
+                'identity_id': identity_id,
+                'new_hash': ph.hash(password),
+            },
+            cached_globally=True,
+        )
+
+        return local_identity
+
+    def _get_provider_config(
+        self, provider_name: str
+    ) -> EmailPasswordProviderConfig:
+        provider_client_config = util.get_config(
+            self.db, "ext::auth::AuthConfig::providers", frozenset
+        )
+        for cfg in provider_client_config:
+            if cfg.name == provider_name:
+                return EmailPasswordProviderConfig(
+                    name=cfg.name,
+                    require_verification=cfg.require_verification,
+                )
+
+        raise errors.MissingConfiguration(
+            provider_name, f"Provider is not configured"
+        )

--- a/edb/server/protocol/auth_ext/errors.py
+++ b/edb/server/protocol/auth_ext/errors.py
@@ -231,3 +231,22 @@ class PKCEVerificationFailed(AuthExtError):
 
     def __str__(self) -> str:
         return self.description
+
+
+class WebAuthnAuthenticationFailed(AuthExtError):
+    """WebAuthn authentication failed"""
+
+    def __init__(
+        self, description: str = "WebAuthn authentication failed"
+    ):
+        self.description = description
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"description={self.description!r}"
+            ")"
+        )
+
+    def __str__(self) -> str:
+        return self.description

--- a/edb/server/protocol/auth_ext/local.py
+++ b/edb/server/protocol/auth_ext/local.py
@@ -16,312 +16,30 @@
 # limitations under the License.
 #
 
-import argon2
-import json
-import hashlib
-import base64
-import dataclasses
+
 import datetime
+import json
 
 from typing import Any
-from edb.errors import ConstraintViolationError
 from edb.server.protocol import execute
-
-from . import errors, util, data
-
-ph = argon2.PasswordHasher()
-
-
-@dataclasses.dataclass
-class EmailPasswordProviderConfig:
-    name: str
-    require_verification: bool
 
 
 class Client:
-    def __init__(self, db: Any, provider_name: str):
+    def __init__(self, db: Any):
         self.db = db
 
-        match provider_name:
-            case "builtin::local_emailpassword":
-                provider_config = self._get_provider_config(provider_name)
-                self.provider = EmailPasswordProvider(provider_config)
-            case _:
-                raise errors.InvalidData(f"Invalid provider: {provider_name}")
-
-    async def register(self, *args, **kwargs):
-        return await self.provider.register(self.db, *args, **kwargs)
-
-    async def authenticate(self, *args, **kwargs):
-        return await self.provider.authenticate(self.db, *args, **kwargs)
-
-    async def get_identity_and_secret(self, *args, **kwargs):
-        return await self.provider.get_identity_and_secret(
-            self.db, *args, **kwargs)
-
-    async def validate_reset_secret(self, *args, **kwargs):
-        identity = await self.provider.validate_reset_secret(
-            self.db, *args, **kwargs)
-        return identity is not None
-
-    async def update_password(self, *args, **kwargs):
-        return await self.provider.update_password(
-            self.db, *args, **kwargs)
-
-    async def get_email_by_identity_id(self, identity_id: str):
-        return await self.provider.get_email_by_identity_id(
-            self.db, identity_id
-        )
-
-    async def get_verified_by_identity_id(self, identity_id: str):
-        return await self.provider.get_verified_by_identity_id(
-            self.db, identity_id
-        )
-
-    async def verify_email(self, *args, **kwargs):
-        return await self.provider.verify_email(
-            self.db, *args, **kwargs
-        )
-
-    def _get_provider_config(
-        self, provider_name: str
-    ) -> EmailPasswordProviderConfig:
-        provider_client_config = util.get_config(
-            self.db, "ext::auth::AuthConfig::providers", frozenset
-        )
-        for cfg in provider_client_config:
-            if cfg.name == provider_name:
-                return EmailPasswordProviderConfig(
-                    name=cfg.name,
-                    require_verification=cfg.require_verification,
-                )
-
-        raise errors.MissingConfiguration(
-            provider_name, f"Provider is not configured"
-        )
-
-
-class EmailPasswordProvider:
-    config: EmailPasswordProviderConfig
-
-    def __init__(self, config: EmailPasswordProviderConfig):
-        self.config = config
-
-    async def register(self, db: Any, input: dict[str, Any]):
-        match (input.get("email"), input.get("password")):
-            case (str(e), str(p)):
-                email = e
-                password = p
-            case _:
-                raise errors.InvalidData(
-                    "Missing 'email' or 'password' in data"
-                )
-
-        try:
-            r = await execute.parse_execute_json(
-                db=db,
-                query="""\
-    with
-      email := <optional str>$email,
-      password_hash := <str>$password_hash,
-      identity := (insert ext::auth::LocalIdentity {
-        issuer := "local",
-        subject := "",
-      }),
-      password := (insert ext::auth::EmailPasswordFactor {
-        password_hash := password_hash,
-        email := email,
-        identity := identity,
-      }),
-
-    select identity { * };""",
-                variables={
-                    "email": email,
-                    "password_hash": ph.hash(password),
-                },
-                cached_globally=True,
-            )
-        except Exception as e:
-            exc = await execute.interpret_error(e, db)
-            if isinstance(exc, ConstraintViolationError):
-                raise errors.UserAlreadyRegistered()
-            else:
-                raise exc
-
-        result_json = json.loads(r.decode())
-        assert len(result_json) == 1
-
-        return data.LocalIdentity(**result_json[0])
-
-    async def authenticate(self, db: Any, input: dict[str, Any]):
-        if 'email' not in input or 'password' not in input:
-            raise errors.InvalidData("Missing 'email' or 'password' in data")
-
-        password = input["password"]
-        email = input["email"]
-        r = await execute.parse_execute_json(
-            db=db,
-            query="""\
-with
-  email := <str>$email,
-select ext::auth::EmailPasswordFactor { password_hash, identity: { * } }
-filter .email = email;""",
-            variables={
-                "email": email,
-            },
-            cached_globally=True,
-        )
-
-        password_credential_dicts = json.loads(r.decode())
-        if len(password_credential_dicts) != 1:
-            raise errors.NoIdentityFound()
-        password_credential_dict = password_credential_dicts[0]
-
-        password_hash = password_credential_dict["password_hash"]
-        try:
-            ph.verify(password_hash, password)
-        except argon2.exceptions.VerifyMismatchError:
-            raise errors.NoIdentityFound()
-
-        local_identity = data.LocalIdentity(
-            **password_credential_dict["identity"]
-        )
-
-        if ph.check_needs_rehash(password_hash):
-            new_hash = ph.hash(password)
-            await execute.parse_execute_json(
-                db=db,
-                query="""\
-with
-  email := <str>$email,
-  new_hash := <str>$new_hash,
-
-update ext::auth::EmailPasswordFactor
-filter .email = email
-set { password_hash := new_hash };""",
-                variables={
-                    "email": email,
-                    "new_hash": new_hash,
-                },
-                cached_globally=True,
-            )
-
-        return local_identity
-
-    async def get_identity_and_secret(self, db: Any, input: dict[str, Any]):
-        if 'email' not in input:
-            raise errors.InvalidData("Missing 'email' in data")
-
-        email = input["email"]
-        r = await execute.parse_execute_json(
-            db=db,
-            query="""
-with
-  email := <str>$email,
-select ext::auth::EmailPasswordFactor {
-  password_hash,
-  identity: { * }
-} filter .email = email""",
-            variables={
-                "email": email,
-            },
-            cached_globally=True,
-        )
-
-        result_json = json.loads(r.decode())
-        if len(result_json) != 1:
-            raise errors.NoIdentityFound()
-        password_cred = result_json[0]
-
-        local_identity = data.LocalIdentity(
-            **password_cred["identity"]
-        )
-        secret = base64.b64encode(
-            hashlib.sha256(password_cred['password_hash'].encode()).digest()
-        ).decode()
-
-        return (local_identity, secret)
-
-    async def validate_reset_secret(
-        self, db: Any, identity_id: str, secret: str
-    ):
-        r = await execute.parse_execute_json(
-            db=db,
-            query="""\
-with
-  identity_id := <uuid><str>$identity_id,
-select ext::auth::EmailPasswordFactor { password_hash, identity: { * } }
-filter .identity.id = identity_id;""",
-            variables={
-                "identity_id": identity_id,
-            },
-            cached_globally=True,
-        )
-
-        result_json = json.loads(r.decode())
-        if len(result_json) != 1:
-            raise errors.NoIdentityFound()
-        password_cred = result_json[0]
-
-        local_identity = data.LocalIdentity(
-            **password_cred["identity"]
-        )
-
-        current_secret = base64.b64encode(
-            hashlib.sha256(password_cred['password_hash'].encode()).digest()
-        ).decode()
-
-        return local_identity if secret == current_secret else None
-
-    async def update_password(
-        self, db: Any, identity_id: str, secret: str, input: dict[str, Any]
-    ):
-        if 'password' not in input:
-            raise errors.InvalidData("Missing 'password' in data")
-
-        password = input["password"]
-
-        local_identity = await self.validate_reset_secret(
-            db, identity_id, secret)
-
-        if local_identity is None:
-            raise errors.InvalidData("Invalid 'reset_token'")
-
-        # TODO: check if race between validating secret and updating password
-        #       is a problem
-        await execute.parse_execute_json(
-            db=db,
-            query="""\
-with
-  identity_id := <uuid><str>$identity_id,
-  new_hash := <str>$new_hash,
-update ext::auth::EmailPasswordFactor
-filter .identity.id = identity_id
-set {
-    password_hash := new_hash,
-    verified_at := .verified_at ?? datetime_current()
-};""",
-            variables={
-                'identity_id': identity_id,
-                'new_hash': ph.hash(password),
-            },
-            cached_globally=True,
-        )
-
-        return local_identity
-
     async def verify_email(
-        self, db: Any, identity_id: str, verified_at: datetime.datetime
+        self, identity_id: str, verified_at: datetime.datetime
     ):
         r = await execute.parse_execute_json(
-            db=db,
+            db=self.db,
             query="""\
 with
-  identity_id := <uuid><str>$identity_id,
-  verified_at := <datetime>$verified_at,
-update ext::auth::EmailPasswordFactor
+    identity_id := <uuid><str>$identity_id,
+    verified_at := <datetime>$verified_at,
+update ext::auth::EmailFactor
 filter .identity.id = identity_id
-  and not exists .verified_at ?? false
+    and not exists .verified_at ?? false
 set { verified_at := verified_at };""",
             variables={
                 "identity_id": identity_id,
@@ -332,15 +50,13 @@ set { verified_at := verified_at };""",
 
         return r
 
-    async def get_email_by_identity_id(
-        self, db: Any, identity_id: str
-    ) -> str | None:
+    async def get_email_by_identity_id(self, identity_id: str) -> str | None:
         r = await execute.parse_execute_json(
-            db,
+            self.db,
             """
-            select ext::auth::EmailFactor {
-              email,
-            } filter .identity.id = <uuid>$identity_id;
+select ext::auth::EmailFactor {
+    email,
+} filter .identity.id = <uuid>$identity_id;
             """,
             variables={"identity_id": identity_id},
             cached_globally=True,
@@ -354,15 +70,13 @@ set { verified_at := verified_at };""",
 
         return result_json[0]["email"]
 
-    async def get_verified_by_identity_id(
-        self, db: Any, identity_id: str
-    ) -> str | None:
+    async def get_verified_by_identity_id(self, identity_id: str) -> str | None:
         r = await execute.parse_execute_json(
-            db,
+            self.db,
             """
-            select ext::auth::EmailFactor {
-              verified_at,
-            } filter .identity.id = <uuid>$identity_id;
+select ext::auth::EmailFactor {
+    verified_at,
+} filter .identity.id = <uuid>$identity_id;
             """,
             variables={"identity_id": identity_id},
             cached_globally=True,

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -105,8 +105,8 @@ insert ext::auth::WebAuthnRegistrationChallenge {
     email := email,
 }""",
             variables={
-                "challenge": base64.b64encode(challenge).decode(),
-                "user_handle": base64.b64encode(user_handle).decode(),
+                "challenge": challenge,
+                "user_handle": user_handle,
                 "email": email,
             },
             cached_globally=True,
@@ -157,13 +157,11 @@ with
 select identity { * };""",
                 variables={
                     "email": email,
-                    "user_handle": base64.b64encode(user_handle).decode(),
-                    "credential_id": base64.b64encode(
-                        registration_verification.credential_id
-                    ).decode(),
-                    "public_key": base64.b64encode(
+                    "user_handle": user_handle,
+                    "credential_id": registration_verification.credential_id,
+                    "public_key": (
                         registration_verification.credential_public_key
-                    ).decode(),
+                    ),
                 },
                 cached_globally=True,
             )
@@ -199,7 +197,7 @@ select ext::auth::WebAuthnRegistrationChallenge {
 filter .email = email and .user_handle = user_handle;""",
             variables={
                 "email": email,
-                "user_handle": base64.b64encode(user_handle).decode(),
+                "user_handle": user_handle,
             },
             cached_globally=True,
         )
@@ -229,6 +227,6 @@ delete ext::auth::WebAuthnRegistrationChallenge
 filter .email = email and .user_handle = user_handle;""",
             variables={
                 "email": email,
-                "user_handle": base64.b64encode(user_handle).decode(),
+                "user_handle": user_handle,
             },
         )

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -1,0 +1,232 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2024-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import dataclasses
+import base64
+import json
+import webauthn
+
+from typing import Any, Optional
+
+from edb.errors import ConstraintViolationError
+from edb.server.protocol import execute
+
+from . import config, data, errors, util, local
+
+
+@dataclasses.dataclass(repr=False)
+class WebAuthnRegistrationChallenge:
+    """
+    Object that represents the ext::auth::WebAuthnRegistrationChallenge type
+    """
+
+    id: str
+    challenge: bytes
+    user_handle: bytes
+    email: str
+
+
+class Client(local.Client):
+    def __init__(self, db: Any):
+        self.db = db
+        self.provider = self._get_provider()
+        self.app_name = self._get_app_name()
+
+    def _get_provider(self) -> config.WebAuthnProvider:
+        provider_name = "builtin::local_webauthn"
+        provider_client_config = util.get_config(
+            self.db, "ext::auth::AuthConfig::providers", frozenset
+        )
+        for cfg in provider_client_config:
+            if cfg.name == provider_name:
+                return config.WebAuthnProvider(
+                    name=cfg.name,
+                    relying_party_origin=cfg.relying_party_origin,
+                    require_verification=cfg.require_verification,
+                )
+
+        raise errors.MissingConfiguration(
+            provider_name, f"Provider is not configured"
+        )
+
+    def _get_app_name(self) -> Optional[str]:
+        return util.maybe_get_config(self.db, "ext::auth::AuthConfig::app_name")
+
+    async def create_registration_options_for_email(self, email: str):
+        registration_options = webauthn.generate_registration_options(
+            rp_id=self.provider.relying_party_id,
+            rp_name=(self.app_name or self.provider.relying_party_origin),
+            user_name=email,
+            user_display_name=email,
+        )
+
+        await self._create_registration_challenge(
+            email=email,
+            challenge=registration_options.challenge,
+            user_handle=registration_options.user.id,
+        )
+
+        return (
+            base64.urlsafe_b64encode(registration_options.user.id).decode(),
+            webauthn.options_to_json(registration_options).encode(),
+        )
+
+    async def _create_registration_challenge(
+        self,
+        email: str,
+        challenge: bytes,
+        user_handle: bytes,
+    ):
+        await execute.parse_execute_json(
+            self.db,
+            """
+with
+    challenge := <str>$challenge,
+    user_handle := <str>$user_handle,
+    email := <str>$email,
+insert ext::auth::WebAuthnRegistrationChallenge {
+    challenge := enc::base64_decode(challenge),
+    user_handle := enc::base64_decode(user_handle),
+    email := email,
+}""",
+            variables={
+                "challenge": base64.b64encode(challenge).decode(),
+                "user_handle": base64.b64encode(user_handle).decode(),
+                "email": email,
+            },
+            cached_globally=True,
+        )
+
+    async def register(
+        self,
+        credentials: str,
+        email: str,
+        user_handle: bytes,
+    ):
+        registration_challenge = await self._get_registration_challenge(
+            email=email,
+            user_handle=user_handle,
+        )
+        await self._delete_registration_challenges(
+            email=email,
+            user_handle=user_handle,
+        )
+
+        registration_verification = webauthn.verify_registration_response(
+            credential=credentials,
+            expected_challenge=registration_challenge.challenge,
+            expected_rp_id=self.provider.relying_party_id,
+            expected_origin=self.provider.relying_party_origin,
+        )
+
+        try:
+            result = await execute.parse_execute_json(
+                self.db,
+                """
+with
+    email := <str>$email,
+    user_handle := <str>$user_handle,
+    credential_id := <str>$credential_id,
+    public_key := <str>$public_key,
+    identity := (insert ext::auth::LocalIdentity {
+        issuer := "local",
+        subject := "",
+    }),
+    factor := (insert ext::auth::WebAuthnFactor {
+        email := <str>$email,
+        user_handle := enc::base64_decode(<str>$user_handle),
+        credential_id := enc::base64_decode(<str>$credential_id),
+        public_key := enc::base64_decode(<str>$public_key),
+        identity := identity,
+    }),
+select identity { * };""",
+                variables={
+                    "email": email,
+                    "user_handle": base64.b64encode(user_handle).decode(),
+                    "credential_id": base64.b64encode(
+                        registration_verification.credential_id
+                    ).decode(),
+                    "public_key": base64.b64encode(
+                        registration_verification.credential_public_key
+                    ).decode(),
+                },
+                cached_globally=True,
+            )
+        except Exception as e:
+            exc = await execute.interpret_error(e, self.db)
+            if isinstance(exc, ConstraintViolationError):
+                raise errors.UserAlreadyRegistered()
+            else:
+                raise exc
+
+        result_json = json.loads(result.decode())
+        assert len(result_json) == 1
+
+        return data.LocalIdentity(**result_json[0])
+
+    async def _get_registration_challenge(
+        self,
+        email: str,
+        user_handle: bytes,
+    ) -> WebAuthnRegistrationChallenge:
+        result = await execute.parse_execute_json(
+            self.db,
+            """
+select ext::auth::WebAuthnRegistrationChallenge {
+    id,
+    challenge,
+    user_handle,
+    email,
+}
+filter .email = <str>$email
+and .user_handle = enc::base64_decode(<str>$user_handle);""",
+            variables={
+                "email": email,
+                "user_handle": base64.b64encode(user_handle).decode(),
+            },
+            cached_globally=True,
+        )
+        result_json = json.loads(result.decode())
+        assert len(result_json) == 1
+        challenge_dict = result_json[0]
+
+        return WebAuthnRegistrationChallenge(
+            id=challenge_dict["id"],
+            challenge=base64.b64decode(challenge_dict["challenge"]),
+            user_handle=base64.b64decode(challenge_dict["user_handle"]),
+            email=challenge_dict["email"],
+        )
+
+    async def _delete_registration_challenges(
+        self,
+        email: str,
+        user_handle: bytes,
+    ):
+        await execute.parse_execute_json(
+            self.db,
+            """
+with
+    email := <str>$email,
+    user_handle := enc::base64_decode(<str>$user_handle),
+delete ext::auth::WebAuthnRegistrationChallenge
+filter .email = email and .user_handle = user_handle;""",
+            variables={
+                "email": email,
+                "user_handle": base64.b64encode(user_handle).decode(),
+            },
+        )

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -612,7 +612,7 @@ class DecimalEncoder(json.JSONEncoder):
         if isinstance(obj, list):
             return '[' + ', '.join(map(self.encode, obj)) + ']'
         if isinstance(obj, bytes):
-            return base64.b64encode(obj).decode()
+            return self.encode(base64.b64encode(obj).decode())
         if isinstance(obj, decimal.Decimal):
             return f'{obj:f}'
         return super().encode(obj)

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -611,6 +611,8 @@ class DecimalEncoder(json.JSONEncoder):
                 ) + '}'
         if isinstance(obj, list):
             return '[' + ', '.join(map(self.encode, obj)) + ']'
+        if isinstance(obj, bytes):
+            return base64.b64encode(obj).decode()
         if isinstance(obj, decimal.Decimal):
             return f'{obj:f}'
         return super().encode(obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
     'httpx~=0.24.1',
     'hishel==0.0.21',
+    'webauthn~=2.0.0',
     'argon2-cffi~=23.1.0',
     'aiosmtplib~=2.0',
 ]


### PR DESCRIPTION
- Spec: https://w3c.github.io/webauthn
- WebAuthn Primers
  - https://webauthn.guide/#registration
  - https://webauthn.me/introduction

![WebAuthn Registration Sequence Diagram](https://webauthn.me/img/2-Registration.svg)

For us, the EdgeDB server is acting as the "Relying Party". The Relying Party is the entity that saves a given Public Key and links it to a local concept of "user" or "identity". The Relying Party has two separate pieces: a stateful server that is responsible for registering and verifying credentials and associating them with their "user"/"identity" concept; and a script that runs in the browser (the "user agent"). We currently facilitate the browser script by running it in our built-in UI, and we add API endpoints to configure the script and verify and save the linked credentials. We will add the equivalent scripting to our `auth-core` (and supporting library code) libraries.