### PR TITLE
Add WebAuthn authentication flow

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -92,6 +92,16 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create constraint exclusive on ((.user_handle, .email, .challenge));
     };
 
+    create type ext::auth::WebAuthnAuthenticationChallenge
+        extending ext::auth::Auditable {
+        create required property challenge: std::bytes {
+            create constraint exclusive;
+        };
+        create required link factor: ext::auth::WebAuthnFactor {
+            create constraint exclusive;
+        };
+    };
+
     create type ext::auth::PKCEChallenge extending ext::auth::Auditable {
         create required property challenge: std::str {
             create constraint exclusive;

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -76,6 +76,16 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             create constraint exclusive;
         };
 
+        create trigger email_shares_user_handle after insert for each do (
+            std::assert(
+                (__new__.user_handle = (
+                    select detached ext::auth::WebAuthnFactor
+                    filter .email = __new__.email
+                    and not .id = __new__.id
+                ).user_handle) ?? true,
+                message := "user_handle must be the same for a given email"
+            )
+        );
         create constraint exclusive on ((.email, .credential_id));
     };
 

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -68,9 +68,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     };
 
     create type ext::auth::WebAuthnFactor extending ext::auth::EmailFactor {
-        create required property user_handle: std::bytes {
-            create constraint exclusive;
-        };
+        create required property user_handle: std::bytes;
         create required property credential_id: std::bytes {
             create constraint exclusive;
         };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -78,11 +78,11 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
         create trigger email_shares_user_handle after insert for each do (
             std::assert(
-                (__new__.user_handle = (
+                __new__.user_handle = (
                     select detached ext::auth::WebAuthnFactor
                     filter .email = __new__.email
                     and not .id = __new__.id
-                ).user_handle) ?? true,
+                ).user_handle,
                 message := "user_handle must be the same for a given email"
             )
         );

--- a/edb/server/protocol/auth_ext/_static/utils.js
+++ b/edb/server/protocol/auth_ext/_static/utils.js
@@ -21,3 +21,35 @@ export function encodeBase64Url(bytes) {
     .replace(/\//g, "_")
     .replace(/=/g, "");
 }
+
+/**
+ * Parse an HTTP Response object. Allows passing in custom handlers for
+ * different status codes and error.type values
+ *
+ * @param {Response} response
+ * @param {Function[]=} handlers
+ */
+export async function parseResponseAsJSON(response, handlers = []) {
+  const bodyText = await response.text();
+
+  if (!response.ok) {
+    let error;
+    try {
+      error = JSON.parse(bodyText);
+    } catch (e) {
+      throw new Error(
+        `Failed to parse body as JSON. Status: ${response.status} ${response.statusText}. Body: ${bodyText}`
+      );
+    }
+
+    for (const handler of handlers) {
+      handler(response, error);
+    }
+
+    throw new Error(
+      `Response was not OK. Status: ${response.status} ${response.statusText}. Body: ${bodyText}`
+    );
+  }
+
+  return response.json();
+}

--- a/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
@@ -183,7 +183,7 @@ async function authenticateAssertion(props) {
         console.error(
           "User's email is not verified",
           response.statusText,
-          error
+          JSON.stringify(error)
         );
         throw new Error(
           "Please verify your email before attempting to sign in."
@@ -194,7 +194,7 @@ async function authenticateAssertion(props) {
       console.error(
         "Failed to authenticate WebAuthn credentials:",
         response.statusText,
-        error
+        JSON.stringify(error)
       );
       throw new Error("Failed to authenticate WebAuthn credentials");
     },

--- a/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
@@ -1,0 +1,188 @@
+import { decodeBase64Url, encodeBase64Url } from "./utils.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const registerForm = document.getElementById("email-factor");
+
+  if (registerForm === null) {
+    return;
+  }
+
+  registerForm.addEventListener("submit", async (event) => {
+    if (event.submitter?.id !== "webauthn-signin") {
+      return;
+    }
+    event.preventDefault();
+
+    const formData = new FormData(/** @type {HTMLFormElement} */ registerForm);
+    const email = formData.get("email");
+    const provider = "builtin::local_webauthn";
+    const challenge = formData.get("challenge");
+    const redirectOnFailure = formData.get("redirect_on_failure");
+    const redirectTo = formData.get("redirect_to");
+
+    if (redirectTo === null) {
+      throw new Error("Missing redirect_to parameter");
+    }
+
+    try {
+      const maybeCode = await authenticate({
+        email,
+        provider,
+        challenge,
+      });
+
+      const redirectUrl = new URL(redirectTo);
+      if (maybeCode !== null) {
+        redirectUrl.searchParams.append("code", maybeCode);
+      }
+
+      window.location.href = redirectUrl.href;
+    } catch (error) {
+      console.error("Failed to register WebAuthn credentials:", error);
+      const url = new URL(redirectOnFailure ?? redirectTo);
+      url.searchParams.append("error", error.message);
+      window.location.href = url.href;
+    }
+  });
+});
+
+const WEBAUTHN_OPTIONS_URL = new URL(
+  "../webauthn/authenticate/options",
+  window.location
+);
+const WEBAUTHN_AUTHENTICATE_URL = new URL(
+  "../webauthn/authenticate",
+  window.location
+);
+/**
+ * Authenticate an existing WebAuthn credential for the given email address
+ * @param {Object} props - The properties for registration
+ * @param {string} props.email - Email address to register
+ * @param {string} props.provider - WebAuthn provider
+ * @param {string} props.challenge - PKCE challenge
+ * @returns {Promise<string | null>} - The PKCE code or null if the application
+ *   requires email verification
+ */
+export async function authenticate({ email, provider, challenge }) {
+  // Check if WebAuthn is supported
+  if (!window.PublicKeyCredential) {
+    console.error("WebAuthn is not supported in this browser.");
+    return;
+  }
+
+  // Fetch WebAuthn options from the server
+  const options = await getAuthenticateOptions(email);
+
+  // Get the existing credentials assertion
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      ...options,
+      challenge: decodeBase64Url(options.challenge),
+      allowCredentials: options.allowCredentials.map((credential) => ({
+        ...credential,
+        id: decodeBase64Url(credential.id),
+      })),
+    },
+  });
+
+  // Register the credentials on the server
+  const registerResult = await authenticateAssertion({
+    email,
+    assertion,
+    challenge,
+  });
+
+  return registerResult.code ?? null;
+}
+
+/**
+ * Fetch WebAuthn options from the server
+ * @param {string} email - Email address to register
+ * @returns {Promise<globalThis.PublicKeyCredentialCreationOptions>}
+ */
+async function getAuthenticateOptions(email) {
+  const url = new URL(WEBAUTHN_OPTIONS_URL);
+  url.searchParams.set("email", email);
+
+  const optionsResponse = await fetch(url, {
+    method: "GET",
+  });
+
+  if (!optionsResponse.ok) {
+    console.error(
+      "Failed to fetch WebAuthn options:",
+      optionsResponse.statusText
+    );
+    console.error(await optionsResponse.text());
+    throw new Error("Failed to fetch WebAuthn options");
+  }
+
+  try {
+    return await optionsResponse.json();
+  } catch (e) {
+    console.error("Failed to parse WebAuthn options:", e);
+    throw new Error("Failed to parse WebAuthn options");
+  }
+}
+
+/**
+ * Authenticate the credentials on the server
+ * @param {Object} props
+ * @param {string} props.email
+ * @param {Object} props.assertion
+ * @param {string} props.provider
+ * @param {string} props.challenge
+ * @returns {Promise<Object>}
+ */
+async function authenticateAssertion(props) {
+  // Assertion includes raw bytes, so need to be encoded as base64url
+  // for transmission
+  const encodedAssertion = {
+    ...props.assertion,
+    rawId: encodeBase64Url(new Uint8Array(props.assertion.rawId)),
+    response: {
+      ...props.assertion.response,
+      authenticatorData: encodeBase64Url(
+        new Uint8Array(props.assertion.response.authenticatorData)
+      ),
+      clientDataJSON: encodeBase64Url(
+        new Uint8Array(props.assertion.response.clientDataJSON)
+      ),
+      signature: encodeBase64Url(
+        new Uint8Array(props.assertion.response.signature)
+      ),
+      userHandle: props.assertion.response.userHandle ? encodeBase64Url(
+        new Uint8Array(props.assertion.response.userHandle)
+      ) : null,
+    },
+  };
+
+  const authenticateResponse = await fetch(WEBAUTHN_AUTHENTICATE_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email: props.email,
+      assertion: encodedAssertion,
+      provider: props.provider,
+      challenge: props.challenge,
+    }),
+  });
+
+  if (!authenticateResponse.ok) {
+    console.error(
+      "Failed to authenticate WebAuthn credentials:",
+      authenticateResponse.statusText
+    );
+    console.error(await authenticateResponse.text());
+    throw new Error("Failed to authenticate WebAuthn credentials");
+  }
+
+  try {
+    return await authenticateResponse.json();
+  } catch (e) {
+    console.error("Failed to parse WebAuthn registration result:", e);
+    throw new Error("Failed to parse WebAuthn registration result");
+  }
+}

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -182,3 +182,21 @@ class WebAuthnFactor:
         self.user_handle = base64.b64decode(user_handle)
         self.credential_id = base64.b64decode(credential_id)
         self.public_key = base64.b64decode(public_key)
+
+
+@dataclasses.dataclass
+class WebAuthnAuthenticationChallenge:
+    id: str
+    created_at: datetime.datetime
+    modified_at: datetime.datetime
+    challenge: bytes
+    factor: WebAuthnFactor
+
+    def __init__(self, *, id, created_at, modified_at, challenge, factor):
+        self.id = id
+        self.created_at = created_at
+        self.modified_at = modified_at
+        self.challenge = base64.b64decode(challenge)
+        self.factor = (
+            WebAuthnFactor(**factor) if isinstance(factor, dict) else factor
+        )

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -983,18 +983,19 @@ class Router:
                 " cookie"
             ) from e
 
-        require_verification = webauthn_client.provider.require_verification
-        if require_verification:
-            email_is_verified = await webauthn_client.is_email_verified(
-                email, user_handle
-            )
-            if not email_is_verified:
-                raise errors.VerificationRequired()
         identity = await webauthn_client.authenticate(
             assertion=assertion,
             email=email,
             user_handle=user_handle,
         )
+
+        require_verification = webauthn_client.provider.require_verification
+        if require_verification:
+            email_is_verified = await webauthn_client.is_email_verified(
+                email, assertion
+            )
+            if not email_is_verified:
+                raise errors.VerificationRequired()
 
         await pkce.create(self.db, pkce_challenge)
         code = await pkce.link_identity_challenge(

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -114,6 +114,15 @@ class Router:
                     return await self.handle_webauthn_register_options(
                         *handler_args
                     )
+                case ('webauthn', 'authenticate'):
+                    return await self.handle_webauthn_authenticate(
+                        *handler_args
+                    )
+                case ('webauthn', 'authenticate', 'options'):
+                    return await self.handle_webauthn_authenticate_options(
+                        *handler_args
+                    )
+
                 # UI routes
                 case ('ui', 'signin'):
                     return await self.handle_ui_signin(*handler_args)
@@ -914,6 +923,97 @@ class Router:
             response.body = json.dumps(
                 {"code": pkce_code, "provider": provider_name}
             ).encode()
+
+    async def handle_webauthn_authenticate_options(
+        self, request: Any, response: Any
+    ):
+        query = urllib.parse.parse_qs(
+            request.url.query.decode("ascii") if request.url.query else ""
+        )
+        email = _get_search_param(query, "email")
+        webauthn_provider = self._get_webauthn_provider()
+        if webauthn_provider is None:
+            raise errors.MissingConfiguration(
+                "ext::auth::AuthConfig::providers",
+                "WebAuthn provider is not configured",
+            )
+        webauthn_client = webauthn.Client(self.db)
+
+        (user_handle, registration_options) = (
+            await webauthn_client.create_authentication_options_for_email(
+                email=email, webauthn_provider=webauthn_provider
+            )
+        )
+
+        _set_cookie(
+            response,
+            "edgedb-webauthn-authentication-user-handle",
+            user_handle,
+            path="/",
+        )
+        response.status = http.HTTPStatus.OK
+        response.content_type = b"application/json"
+        response.body = registration_options
+
+    async def handle_webauthn_authenticate(self, request: Any, response: Any):
+        data = self._get_data_from_request(request)
+
+        _check_keyset(
+            data,
+            {"challenge", "email", "assertion"},
+        )
+        webauthn_client = webauthn.Client(self.db)
+
+        email: str = data["email"]
+        assertion: str = data["assertion"]
+        pkce_challenge: str = data["challenge"]
+
+        user_handle_cookie = request.cookies.get(
+            "edgedb-webauthn-authentication-user-handle"
+        ).value
+        if user_handle_cookie is None:
+            raise errors.InvalidData(
+                "Missing 'edgedb-webauthn-authentication-user-handle' cookie"
+            )
+        try:
+            user_handle = base64.urlsafe_b64decode(user_handle_cookie)
+        except Exception as e:
+            raise errors.InvalidData(
+                "Failed to decode 'edgedb-webauthn-authentication-user-handle'"
+                " cookie"
+            ) from e
+
+        require_verification = webauthn_client.provider.require_verification
+        if require_verification:
+            email_is_verified = await webauthn_client.is_email_verified(
+                email, user_handle
+            )
+            if not email_is_verified:
+                raise errors.VerificationRequired()
+        identity = await webauthn_client.authenticate(
+            assertion=assertion,
+            email=email,
+            user_handle=user_handle,
+        )
+
+        await pkce.create(self.db, pkce_challenge)
+        code = await pkce.link_identity_challenge(
+            self.db, identity.id, pkce_challenge
+        )
+
+        _set_cookie(
+            response,
+            "edgedb-webauthn-authentication-user-handle",
+            "",
+            path="/",
+        )
+        response.status = http.HTTPStatus.OK
+        response.content_type = b"application/json"
+        response.body = json.dumps(
+            {
+                "code": code,
+            }
+        ).encode()
 
     async def handle_ui_signin(self, request: Any, response: Any):
         ui_config = self._get_ui_config()

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -59,10 +59,14 @@ def _render_oauth_buttons(
         }
         for p in oauth_providers
     ]
-    return '<div class="oauth-buttons">' + "\n".join(
-        f'<a href="../authorize?{b["authparams"]}>{b["image"]}</a>'
-        for b in oauth_buttons
-    ) + '</div>'
+    return (
+        '<div class="oauth-buttons">'
+        + "\n".join(
+            f'<a href="../authorize?{b["authparams"]}>{b["image"]}</a>'
+            for b in oauth_buttons
+        )
+        + '</div>'
+    )
 
 
 def render_login_page(
@@ -120,10 +124,14 @@ def render_login_page(
     )
 
     email_factor_form = f"""
-      <input type="hidden" name="redirect_on_failure" value="{
-        base_path}/ui/signin" />
-      <input type="hidden" name="redirect_to" value="{
-          redirect_to_on_signup or redirect_to}" />
+      <input
+        type="hidden"
+        name="redirect_on_failure"
+        value="{base_path}/ui/signin" />
+      <input
+        type="hidden"
+        name="redirect_to"
+        value="{redirect_to_on_signup or redirect_to}" />
       <input type="hidden" name="challenge" value="{challenge}" />
 
       <label for="email">Email</label>
@@ -194,23 +202,18 @@ def render_login_page(
            if app_name else '<span>Sign in</span>'}</h1>
 
       {_render_oauth_buttons(oauth_providers, oauth_params, oauth_label)}
-      {
-        """
-        <div class="divider">
-          <span>or</span>
-        </div>"""
-        if has_email_factor is not None
-          and len(oauth_providers) > 0
-        else ''
-      }
+      {"""
+      <div class="divider">
+        <span>or</span>
+      </div>""" if has_email_factor and oauth_providers else ''}
       {email_factor_form if has_email_factor else ''}
       </form>
       {forgot_link_script}
-      {
-        """
-        <script type="module" src="_static/webauthn-authenticate.js"></script>"""
-        if webauthn_provider is not None else ''
-      }
+      {"""
+      <script
+        type="module"
+        src="_static/webauthn-authenticate.js"
+      ></script>""" if webauthn_provider else ''}
       ''',
     )
 

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -284,8 +284,17 @@ filter .email = <str>$email;""",
             cached_globally=True,
         )
         result_json = json.loads(result.decode())
+        if len(result_json) == 0:
+            raise errors.WebAuthnAuthenticationFailed(
+                "No WebAuthn credentials found for the email."
+            )
+
         user_handles: set[str] = {x["user_handle"] for x in result_json}
-        assert len(user_handles) == 1
+        if len(user_handles) > 1:
+            raise errors.WebAuthnAuthenticationFailed(
+                "Multiple user handles found for the email."
+            )
+
         user_handle = base64.b64decode(result_json[0]["user_handle"])
 
         credential_ids = [

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -286,14 +286,13 @@ filter .email = <str>$email;""",
         result_json = json.loads(result.decode())
         if len(result_json) == 0:
             raise errors.WebAuthnAuthenticationFailed(
-                "No WebAuthn credentials found for the email."
+                "No WebAuthn credentials found for this email."
             )
 
         user_handles: set[str] = {x["user_handle"] for x in result_json}
-        if len(user_handles) > 1:
-            raise errors.WebAuthnAuthenticationFailed(
-                "Multiple user handles found for the email."
-            )
+        assert (
+            len(user_handles) == 1
+        ), "Found WebAuthn multiple user handles for the same email."
 
         user_handle = base64.b64decode(result_json[0]["user_handle"])
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3575,6 +3575,85 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
+    async def test_http_auth_ext_webauthn_authenticate_options(self):
+        with self.http_con() as http_con:
+            email = "test@example.com"
+            user_handle = uuid.uuid4().bytes
+            credential_id = uuid.uuid4().bytes
+            public_key = uuid.uuid4().bytes
+
+            await self.con.query_single(
+                """
+                with identity := (insert ext::auth::LocalIdentity {
+                    issuer := "local",
+                    subject := "",
+                })
+                INSERT ext::auth::WebAuthnFactor {
+                    email := <str>$email,
+                    user_handle := <bytes>$user_handle,
+                    credential_id := <bytes>$credential_id,
+                    public_key := <bytes>$public_key,
+                    identity := identity,
+                };
+                """,
+                email=email,
+                user_handle=user_handle,
+                credential_id=credential_id,
+                public_key=public_key,
+            )
+
+            body, _, status = self.http_con_request(
+                http_con,
+                path=f"webauthn/authenticate/options?email={email}",
+            )
+
+            self.assertEqual(status, 200)
+
+            body_json = json.loads(body)
+            self.assertIn("challenge", body_json)
+            self.assertIsInstance(body_json["challenge"], str)
+            self.assertIn("rpId", body_json)
+            self.assertIsInstance(body_json["rpId"], str)
+            self.assertIn("timeout", body_json)
+            self.assertIsInstance(body_json["timeout"], int)
+            self.assertIn("allowCredentials", body_json)
+            self.assertIsInstance(body_json["allowCredentials"], list)
+            allow_credentials = body_json["allowCredentials"]
+            self.assertTrue(
+                all(
+                    "type" in cred and "id" in cred
+                    for cred in allow_credentials
+                ),
+                "Each credential should have 'type' and 'id' keys",
+            )
+            self.assertIn(
+                base64.urlsafe_b64encode(credential_id).rstrip(b"=").decode(),
+                [cred["id"] for cred in allow_credentials],
+                (
+                    "The generated credential_id should be in the "
+                    "'allowCredentials' list"
+                ),
+            )
+
+            challenge_bytes = base64.urlsafe_b64decode(
+                f'{body_json["challenge"]}==='
+            )
+            self.assertTrue(
+                await self.con.query_single(
+                    '''
+                    SELECT EXISTS (
+                        SELECT ext::auth::WebAuthnAuthenticationChallenge
+                        filter .challenge = <bytes>$challenge
+                        AND .factor.email = <str>$email
+                        AND .factor.user_handle = <bytes>$user_handle
+                    )
+                    ''',
+                    challenge=challenge_bytes,
+                    email=email,
+                    user_handle=user_handle,
+                )
+            )
+
     async def test_client_token_identity_card(self):
         await self.con.query_single(
             '''

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -729,10 +729,13 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 self.fail("Failed to parse JSON from response body")
 
             self.assertEqual(status, 400)
-            self.assertEqual(body_json.get("error"), {
-                "type": "InvalidData",
-                "message": "Invalid state token",
-            })
+            self.assertEqual(
+                body_json.get("error"),
+                {
+                    "type": "InvalidData",
+                    "message": "Invalid state token",
+                },
+            )
 
     async def test_http_auth_ext_github_callback_01(self):
         with MockAuthProvider() as mock_provider, self.http_con() as http_con:
@@ -3574,6 +3577,67 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     user_handle=user_handle,
                 )
             )
+
+    async def test_http_auth_ext_webauthn_register_options_existing_user(self):
+        email = "existing@example.com"
+        existing_user_handle = uuid.uuid4().bytes
+
+        # Insert two existing WebAuthnFactors for the email
+        await self.con.query_single(
+            """
+            with
+                email := <str>$email,
+                user_handle := <bytes>$user_handle,
+                credential_one := <bytes>$credential_one,
+                public_key_one := <bytes>$public_key_one,
+                credential_two := <bytes>$credential_two,
+                public_key_two := <bytes>$public_key_two,
+                factor_one := (insert ext::auth::WebAuthnFactor {
+                    email := email,
+                    user_handle := user_handle,
+                    credential_id := credential_one,
+                    public_key := public_key_one,
+                    identity := (insert ext::auth::LocalIdentity {
+                        issuer := "local",
+                        subject := "",
+                    }),
+                }),
+                factor_two := (insert ext::auth::WebAuthnFactor {
+                    email := email,
+                    user_handle := user_handle,
+                    credential_id := credential_two,
+                    public_key := public_key_two,
+                    identity := (insert ext::auth::LocalIdentity {
+                        issuer := "local",
+                        subject := "",
+                    }),
+                }),
+            select true;
+            """,
+            email=email,
+            user_handle=existing_user_handle,
+            credential_one=uuid.uuid4().bytes,
+            public_key_one=uuid.uuid4().bytes,
+            credential_two=uuid.uuid4().bytes,
+            public_key_two=uuid.uuid4().bytes,
+        )
+
+        with self.http_con() as http_con:
+            body, _, status = self.http_con_request(
+                http_con,
+                path=f"webauthn/register/options?email={email}",
+            )
+
+            self.assertEqual(status, 200)
+
+            body_json = json.loads(body)
+            self.assertIn("user", body_json)
+            self.assertIn("id", body_json["user"])
+            user_id_decoded = base64.urlsafe_b64decode(
+                f'{body_json["user"]["id"]}==='
+            )
+
+            self.assertEqual(user_id_decoded, existing_user_handle)
 
     async def test_http_auth_ext_webauthn_authenticate_options(self):
         with self.http_con() as http_con:


### PR DESCRIPTION
- Spec: https://w3c.github.io/webauthn
- WebAuthn Primers
  - https://webauthn.guide/#authentication
  - https://webauthn.me/introduction

Builds on #6791 

Authentication is almost the same as registration:
1. Fetch the "options" from the server which include a `challenge` and `allowCredentials` that identifies the user based on the provided `email` + `user_handle`
2. The authenticator will sign with the stored private key and generate an `assertion` which includes the signed challenge, and other information about the authenticator.
3. The server verifies the signature and some other metadata, and if it passes considers the session authenticated.

Like the registration flow, it uses PKCE to do the final exchange of the actual token.