### PR TITLE
Use official pgvector Docker images in CI

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -49,7 +49,7 @@ jobs:
             multi-tenant-mode: 'multi-tenant'
     services:
       postgres:
-        image: fantix/pgvector:${{ matrix.postgres-version }}
+        image: pgvector/pgvector:pg${{ matrix.postgres-version }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -338,7 +338,7 @@ jobs:
             multi-tenant-mode: 'multi-tenant'
     services:
       postgres:
-        image: fantix/pgvector:${{ matrix.postgres-version }}
+        image: pgvector/pgvector:pg${{ matrix.postgres-version }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
Upstream [started](https://github.com/pgvector/pgvector/commit/8a6c52f649827ed490ad01b70e515b3aa0c9f5e1) to pack pgvector for different PG versions, so we can use them now after [upgrading](https://github.com/edgedb/edgedb/pull/6773) to pgvector 0.5.0+.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/7817478729)