### PR TITLE
Make constraint error details contain useful information for developers

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -198,19 +198,6 @@ class Constraint(
         # if there no origin, return self
         return [self] if not origins else list(origins)
 
-    def get_ancestor_from_std(
-        self, schema: s_schema.Schema
-    ) -> Optional[Constraint]:
-        name: sn.QualName = self.get_name(schema)
-        if name.module == 'std':
-            return self
-
-        for base in self.get_bases(schema).objects(schema):
-            std_ancestor = base.get_ancestor_from_std(schema)
-            if std_ancestor:
-                return std_ancestor
-        return None
-
     def is_independent(self, schema: s_schema.Schema) -> bool:
         return (
             not self.descendants(schema)

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -218,21 +218,6 @@ class Constraint(
             self.get_field_value(schema, 'subject'),
         )
 
-    def format_error(
-        self,
-        schema: s_schema.Schema,
-    ) -> str:
-        subject = self.get_subject(schema)
-        titleattr = subject.get_annotation(schema, sn.QualName('std', 'title'))
-
-        if not titleattr:
-            subjname = subject.get_shortname(schema)
-            subjtitle = subjname.name
-        else:
-            subjtitle = titleattr
-
-        return self.format_error_message(schema, subjtitle)
-
     def format_error_message(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -261,6 +261,7 @@ class Constraint(
         subject_name: str,
     ) -> str:
         text = self.get_errmessage(schema)
+        assert text
         args = self.get_args(schema)
         if args:
             args_ql: List[qlast.Base] = [

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -218,6 +218,21 @@ class Constraint(
             self.get_field_value(schema, 'subject'),
         )
 
+    def format_error(
+        self,
+        schema: s_schema.Schema,
+    ) -> str:
+        subject = self.get_subject(schema)
+        titleattr = subject.get_annotation(schema, sn.QualName('std', 'title'))
+
+        if not titleattr:
+            subjname = subject.get_shortname(schema)
+            subjtitle = subjname.name
+        else:
+            subjtitle = titleattr
+
+        return self.format_error_message(schema, subjtitle)
+
     def format_error_message(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -198,6 +198,19 @@ class Constraint(
         # if there no origin, return self
         return [self] if not origins else list(origins)
 
+    def get_ancestor_from_std(
+        self, schema: s_schema.Schema
+    ) -> Optional[Constraint]:
+        name: sn.QualName = self.get_name(schema)
+        if name.module == 'std':
+            return self
+
+        for base in self.get_bases(schema).objects(schema):
+            std_ancestor = base.get_ancestor_from_std(schema)
+            if std_ancestor:
+                return std_ancestor
+        return None
+
     def is_independent(self, schema: s_schema.Schema) -> bool:
         return (
             not self.descendants(schema)
@@ -227,31 +240,31 @@ class Constraint(
             self.get_field_value(schema, 'subject'),
         )
 
-    def format_error(
+    def format_error_message(
         self,
         schema: s_schema.Schema,
     ) -> str:
         subject = self.get_subject(schema)
-        titleattr = subject.get_annotation(schema, sn.QualName('std', 'title'))
 
-        if not titleattr:
-            subjname = subject.get_shortname(schema)
-            subjtitle = subjname.name
+        title_ann = subject.get_annotation(schema, sn.QualName('std', 'title'))
+        if title_ann:
+            subject_name = title_ann
         else:
-            subjtitle = titleattr
+            short_name = subject.get_shortname(schema)
+            subject_name = short_name.name
 
-        return self.format_error_message(schema, subjtitle)
+        return self.format_error_text(schema, subject_name)
 
-    def format_error_message(
+    def format_error_text(
         self,
         schema: s_schema.Schema,
-        subjtitle: str,
+        subject_name: str,
     ) -> str:
-        errmsg: Optional[str] = self.get_errmessage(schema)
+        text = self.get_errmessage(schema)
         args = self.get_args(schema)
         if args:
             args_ql: List[qlast.Base] = [
-                qlast.Path(steps=[qlast.ObjectRef(name=subjtitle)]),
+                qlast.Path(steps=[qlast.ObjectRef(name=subject_name)]),
             ]
 
             args_ql.extend(arg.qlast for arg in args)
@@ -273,10 +286,9 @@ class Constraint(
             args_map = {name: edgeql.generate_source(val, pretty=False)
                         for name, val in index_parameters.items()}
         else:
-            args_map = {'__subject__': subjtitle}
+            args_map = {'__subject__': subject_name}
 
-        assert errmsg is not None
-        return interpolate_errmessage(errmsg, args_map)
+        return interpolate_error_text(text, args_map)
 
     def as_alter_delta(
         self,
@@ -1587,7 +1599,7 @@ class RebaseConstraint(
         return ()
 
 
-def interpolate_errmessage(message: str, args: Dict[str, str]) -> str:
+def interpolate_error_text(text: str, args: Dict[str, str]) -> str:
     """
     Converts message template "hello {world}! {nope}{{world}}" and
     arguments {"world": "Alice", "hell": "Eve"}
@@ -1598,8 +1610,8 @@ def interpolate_errmessage(message: str, args: Dict[str, str]) -> str:
 
     formatted = ""
     last_start = 0
-    for match in re.finditer(regex, message, flags=0):
-        formatted += message[last_start : match.start()]
+    for match in re.finditer(regex, text, flags=0):
+        formatted += text[last_start : match.start()]
         last_start = match.end()
 
         if match[1] is None:
@@ -1612,5 +1624,5 @@ def interpolate_errmessage(message: str, args: Dict[str, str]) -> str:
             # arg not found
             formatted += match[0]
 
-    formatted += message[last_start:]
+    formatted += text[last_start:]
     return formatted

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -176,27 +176,18 @@ class Constraint(
             return [self.get_nearest_generic_parent(schema)]
 
     def get_constraint_origins(
-        self, schema: s_schema.Schema
-    ) -> List[Constraint]:
-        """
-        Find the transitive closure of all constraints that apply.
-        Return parents of these constraints.
-        """
-        # I'm not sure that this explanation is clear (or even entirely correct)
-
-        origins: Set[Constraint] = set()
+            self, schema: s_schema.Schema) -> List[Constraint]:
+        origins: List[Constraint] = []
         for base in self.get_bases(schema).objects(schema):
+            if not base.is_non_concrete(schema) and not base.get_delegated(
+                schema
+            ):
+                origins.extend(
+                    x for x in base.get_constraint_origins(schema)
+                    if x not in origins
+                )
 
-            # if this base applies
-            is_concrete = not base.is_non_concrete(schema)
-            if is_concrete and not base.get_delegated(schema):
-
-                # add all of its origins
-                for x in base.get_constraint_origins(schema):
-                    origins.add(x)
-
-        # if there no origin, return self
-        return [self] if not origins else list(origins)
+        return [self] if not origins else origins
 
     def is_independent(self, schema: s_schema.Schema) -> bool:
         return (

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -280,7 +280,7 @@ class ScalarType(
     ) -> Optional[str]:
         type, scheme = self.resolve_sql_type_scheme(schema)
         if scheme:
-            return constraints.interpolate_errmessage(
+            return constraints.interpolate_error_text(
                 scheme,
                 {
                     f'__arg_{i}__': v

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -625,7 +625,7 @@ def _interpret_constraint_errors(
         # msg is for the "end user" that should not mention pointers and object
         # type it is also affected by setting `errmessage` in user schema.
         msg = constraint.format_error_message(schema)
-        
+
         # details is for the "developer" that must explain what's going on
         # under the hood. It should be picked up from the errmessage on the
         # first ancestor constraint that's in std module.

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -627,8 +627,7 @@ def _interpret_constraint_errors(
         msg = constraint.format_error_message(schema)
 
         # details is for the "developer" that must explain what's going on
-        # under the hood. It should be picked up from the errmessage on the
-        # first ancestor constraint that's in std module.
+        # under the hood. It contains verbose descriptions of object involved.
         subject = constraint.get_subject(schema)
         subject_description = subject.get_verbosename(schema, with_parent=True)
         constraint_description = constraint.get_verbosename(schema)

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -599,6 +599,8 @@ def _interpret_constraint_errors(
     # no need for else clause since it would have been handled by
     # the static version
 
+    print(error_type)
+
     if error_type == 'constraint' or error_type == 'idconstraint':
         assert err_details.constraint_name
 
@@ -628,13 +630,9 @@ def _interpret_constraint_errors(
         # under the hood. It should be picked up from the errmessage on the
         # first ancestor constraint that's in std module.
         subject = constraint.get_subject(schema)
-        verbose_name = subject.get_verbosename(schema, with_parent=True)
-        if std_ancestor := constraint.get_ancestor_from_std(schema):
-            details = std_ancestor.format_error_text(schema, verbose_name)
-        else:
-            # this constrain does not have ancestor from std module
-            constraint_name = constraint.get_verbosename(schema)
-            details = f'constraint {constraint_name} violated'
+        subject_description = subject.get_verbosename(schema, with_parent=True)
+        constraint_description = constraint.get_verbosename(schema)
+        details = f'violated {constraint_description} on {subject_description}'
 
         if from_graphql:
             msg = gql_replace_type_names_in_text(msg)

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -599,8 +599,6 @@ def _interpret_constraint_errors(
     # no need for else clause since it would have been handled by
     # the static version
 
-    print(error_type)
-
     if error_type == 'constraint' or error_type == 'idconstraint':
         assert err_details.constraint_name
 

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -620,10 +620,9 @@ def _interpret_constraint_errors(
             obj_ptr = obj_type.getptr(schema, sn.UnqualName('id'))
             constraint = obj_ptr.get_exclusive_constraints(schema)[0]
 
-        msg = constraint.format_error(schema)
         subject = constraint.get_subject(schema)
         vname = subject.get_verbosename(schema, with_parent=True)
-        details = constraint.format_error_message(schema, vname)
+        msg = constraint.format_error_message(schema, vname)
 
         if from_graphql:
             msg = gql_replace_type_names_in_text(msg)

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -620,9 +620,10 @@ def _interpret_constraint_errors(
             obj_ptr = obj_type.getptr(schema, sn.UnqualName('id'))
             constraint = obj_ptr.get_exclusive_constraints(schema)[0]
 
+        msg = constraint.format_error(schema)
         subject = constraint.get_subject(schema)
         vname = subject.get_verbosename(schema, with_parent=True)
-        msg = constraint.format_error_message(schema, vname)
+        details = constraint.format_error_message(schema, vname)
 
         if from_graphql:
             msg = gql_replace_type_names_in_text(msg)

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -764,21 +764,11 @@ class ClusterTestCase(BaseHTTPTestCase):
         """A version of assertRaisesRegex with automatic transaction recovery
         """
 
-        with super().assertRaisesRegex(exception, regex, msg=msg):
+        with super().assertRaisesRegex(exception, regex, msg=msg, **kwargs):
             try:
                 tx = self.con.transaction()
                 await tx.start()
                 yield
-            except BaseException as e:
-                if isinstance(e, exception):
-                    for attr_name, expected_val in kwargs.items():
-                        val = getattr(e, attr_name)
-                        if val != expected_val:
-                            raise self.failureException(
-                                f'{exception.__name__} context attribute '
-                                f'{attr_name!r} is {val} (expected '
-                                f'{expected_val!r})') from e
-                raise
             finally:
                 await tx.rollback()
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1132,8 +1132,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
         qry = r"""
             CREATE ABSTRACT CONSTRAINT mymax3(max: std::int64) {
                 SET errmessage :=
-                    '{__subject__} must be no longer ' ++
-                    'than {max} characters.';
+                    'My custom ' ++ 'message.';
                 USING (__subject__ <= max);
             };
 
@@ -1149,13 +1148,25 @@ class TestConstraintsDDL(tb.DDLTestCase):
         # making sure the constraint was applied successfully
         async with self.assertRaisesRegexTx(
             edgedb.ConstraintViolationError,
-            'foo must be no longer than 3 characters.',
+            'My custom message.'
         ):
-            await self.con.execute("""
-                INSERT ConstraintOnTest3 {
-                    foo := 'Test'
-                };
-            """)
+            try:
+                await self.con.execute("""
+                    INSERT ConstraintOnTest3 {
+                        foo := 'Test'
+                    };
+                """)
+            except edgedb.ConstraintViolationError as e:
+                # edgedb-python does not expose a nicer access to details field
+                details = e._attrs[2].decode("utf-8")
+                self.assertEqual(
+                    details,
+                    "violated constraint 'default::mymax3' on "
+                    "property 'foo' of "
+                    "object type 'default::ConstraintOnTest3'"
+                )
+                raise
+
 
         # testing interpolation
         await self.con.execute(r"""
@@ -1169,11 +1180,22 @@ class TestConstraintsDDL(tb.DDLTestCase):
         """)
         async with self.assertRaisesRegexTx(
             edgedb.ConstraintViolationError,
-            '{"json": "{nope} {min} 4"}',
+            '{"json": "{nope} {min} 4"}'
         ):
-            await self.con.execute("""
-                INSERT ConstraintOnTest4_2 { email := '' };
-            """)
+            try:
+                await self.con.execute("""
+                    INSERT ConstraintOnTest4_2 { email := '' };
+                """)
+            except edgedb.ConstraintViolationError as e:
+                # edgedb-python does not expose a nicer access to details field
+                details = e._attrs[2].decode("utf-8")
+                self.assertEqual(
+                    details,
+                    "violated constraint 'std::min_len_value' on "
+                    "property 'email' of "
+                    "object type 'default::ConstraintOnTest4_2'"
+                )
+                raise
 
     async def test_constraints_ddl_05(self):
         # Test that constraint expression returns a boolean.

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1147,15 +1147,16 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         # making sure the constraint was applied successfully
         async with self.assertRaisesRegexTx(
-            edgedb.ConstraintViolationError,
-            'My custom message.'
+            edgedb.ConstraintViolationError, 'My custom message.'
         ):
             try:
-                await self.con.execute("""
+                await self.con.execute(
+                    """
                     INSERT ConstraintOnTest3 {
                         foo := 'Test'
                     };
-                """)
+                    """
+                )
             except edgedb.ConstraintViolationError as e:
                 # edgedb-python does not expose a nicer access to details field
                 details = e._attrs[2].decode("utf-8")
@@ -1163,10 +1164,9 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     details,
                     "violated constraint 'default::mymax3' on "
                     "property 'foo' of "
-                    "object type 'default::ConstraintOnTest3'"
+                    "object type 'default::ConstraintOnTest3'",
                 )
                 raise
-
 
         # testing interpolation
         await self.con.execute(r"""
@@ -1179,13 +1179,14 @@ class TestConstraintsDDL(tb.DDLTestCase):
             };
         """)
         async with self.assertRaisesRegexTx(
-            edgedb.ConstraintViolationError,
-            '{"json": "{nope} {min} 4"}'
+            edgedb.ConstraintViolationError, '{"json": "{nope} {min} 4"}'
         ):
             try:
-                await self.con.execute("""
+                await self.con.execute(
+                    """
                     INSERT ConstraintOnTest4_2 { email := '' };
-                """)
+                    """
+                )
             except edgedb.ConstraintViolationError as e:
                 # edgedb-python does not expose a nicer access to details field
                 details = e._attrs[2].decode("utf-8")
@@ -1193,7 +1194,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     details,
                     "violated constraint 'std::min_len_value' on "
                     "property 'email' of "
-                    "object type 'default::ConstraintOnTest4_2'"
+                    "object type 'default::ConstraintOnTest4_2'",
                 )
                 raise
 


### PR DESCRIPTION
Closes #6768

Changes error details of constraint violations to:

```
f'violated {constraint_description} on {subject_description}'
```
... where `x_description` is the `x.get_verbosename()`