### PR TITLE
Fix empty array literals in SQL adapter

### DIFF
--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -77,7 +77,7 @@ def _list(
     builder: Builder,
     mapper: Callable[[T], U] = _ident,
 ) -> List[U]:
-    return [mapper(builder(n, ctx)) for n in node[name]]
+    return [mapper(builder(n, ctx)) for n in node.get(name, [])]
 
 
 def _maybe_list(

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -503,6 +503,13 @@ class TestSQL(tb.SQLQueryTestCase):
 
         res = await self.scon.fetch(
             '''
+            SELECT unnest(ARRAY[]::int8[]) a
+            '''
+        )
+        self.assertEqual(len(res), 0)
+
+        res = await self.scon.fetch(
+            '''
             SELECT *, unnested_b + 1 computed
             FROM
                 (SELECT ARRAY[1, 2, 3] a, ARRAY[4, 5, 6] b) t,


### PR DESCRIPTION
Apparently the `elements` field gets omitted from pg_query's output
when there aren't elements.