### PR TITLE
IDEA: Introduce a WITH based syntax for FOR-style iteration

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -155,6 +155,7 @@ class SortExpr(Base):
 class AliasedExpr(Base):
     alias: str
     expr: Expr
+    monadic: bool = False
 
 
 class ModuleAliasDecl(Base):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -195,7 +195,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_AliasedExpr(self, node: qlast.AliasedExpr) -> None:
         self.write(ident_to_str(node.alias))
-        self.write(' := ')
+        if node.monadic:
+            self.write(' <- ')
+        else:
+            self.write(' := ')
         self._block_ws(1)
 
         self.visit(node.expr)

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -90,6 +90,12 @@ class AliasedExpr(Nonterm):
         self.val = qlast.AliasedExpr(alias=kids[0].val, expr=kids[2].val)
 
 
+class MonadicExpr(Nonterm):
+    def reduce_Identifier_LANGBRACKET_MINUS_Expr(self, *kids):
+        self.val = qlast.AliasedExpr(
+            alias=kids[0].val, expr=kids[3].val, monadic=True)
+
+
 class OptionallyAliasedExpr(Nonterm):
     def reduce_AliasedExpr(self, *kids):
         val = kids[0].val
@@ -387,6 +393,10 @@ class AliasDecl(Nonterm):
 
     @parsing.inline(0)
     def reduce_AliasedExpr(self, *kids):
+        pass
+
+    @parsing.inline(0)
+    def reduce_MonadicExpr(self, *kids):
         pass
 
 

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -340,17 +340,13 @@ class TestEdgeQLFor(tb.QueryTestCase):
                 SELECT User {
                     select_deck := ((
                         WITH cards := (
-                            FOR letter IN {'I', 'B'}
-                            UNION (
-                                FOR copy IN {'1', '2'}
-                                UNION (
-                                    SELECT User.deck {
-                                        name,
-                                        letter := letter ++ copy
-                                    }
-                                    FILTER User.deck.name[0] = letter
-                                )
-                            )
+                            WITH letter <- {'I', 'B'},
+                                 copy <- {'1', '2'},
+                            SELECT User.deck {
+                                name,
+                                letter := letter ++ copy
+                            }
+                            FILTER User.deck.name[0] = letter
                         )
                         SELECT cards ORDER BY .name THEN .letter
                     ),)

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1272,19 +1272,19 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_01(self):
         await self.con.execute(r'''
-            FOR x IN {3, 5, 7, 2}
-            UNION (INSERT InsertTest {
+            WITH x <- {3, 5, 7, 2}
+            INSERT InsertTest {
                 name := 'insert for 1',
                 l2 := x,
-            });
+            };
 
-            FOR Q IN (SELECT InsertTest{foo := 'foo' ++ <str> InsertTest.l2}
-                      FILTER .name = 'insert for 1')
-            UNION (INSERT InsertTest {
+            WITH Q <- (SELECT InsertTest{foo := 'foo' ++ <str> InsertTest.l2}
+                       FILTER .name = 'insert for 1')
+            INSERT InsertTest {
                 name := 'insert for 1',
                 l2 := 35 % Q.l2,
                 l3 := Q.foo,
-            });
+            };
         ''')
 
         await self.assert_query_result(
@@ -1383,13 +1383,11 @@ class TestInsert(tb.QueryTestCase):
                 name := 'nested-insert-for',
                 l2 := 999,
                 subordinates := (
-                    FOR x IN {('sub1', 'first'), ('sub2', 'second')}
-                    UNION (
-                        INSERT Subordinate {
-                            name := x.0,
-                            @comment := x.1,
-                        }
-                    )
+                    WITH x <- {('sub1', 'first'), ('sub2', 'second')}
+                    INSERT Subordinate {
+                        name := x.0,
+                        @comment := x.1,
+                    }
                 )
             };
         ''')
@@ -1417,9 +1415,9 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_06(self):
         res = await self.con.query(r'''
-            FOR a in {"a", "b"} UNION (
-                FOR b in {"c", "d"} UNION (
-                    INSERT Note {name := b}));
+            WITH a <- {"a", "b"},
+                 b <- {"c", "d"},
+            INSERT Note {name := b};
         ''')
         self.assertEqual(len(res), 4)
 
@@ -1433,9 +1431,9 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_07(self):
         res = await self.con.query(r'''
-            FOR a in {"a", "b"} UNION (
-                FOR b in {a++"c", a++"d"} UNION (
-                    INSERT Note {name := b}));
+            WITH a <- {"a", "b"},
+                 b <- {a++"c", a++"d"},
+            INSERT Note {name := b};
         ''')
         self.assertEqual(len(res), 4)
 
@@ -1449,10 +1447,10 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_08(self):
         res = await self.con.query(r'''
-            FOR a in {"a", "b"} UNION (
-                FOR b in {"a", "b"} UNION (
-                    FOR c in {a++b++"a", a++b++"b"} UNION (
-                        INSERT Note {name := c})));
+            WITH a <- {"a", "b"},
+                 b <- {"a", "b"},
+                 c <- {a++b++"a", a++b++"b"},
+            INSERT Note {name := c};
         ''')
         self.assertEqual(len(res), 8)
 


### PR DESCRIPTION
I dislike how `for` looks and feels so much "heavier" than `with`, due
to the `union` keyword and the need to parenthesize the body if it is
a query, and especially if you need to have *nested* `for`s.

So my idea is to introduce `<-` binding, which behaves like a `for`
binding.

So then you can do something like
```
with name <- {'Sully', 'Zhibo', 'Aljaž'}
insert Person { name := name }
```
I modified some tests you can look at to compare.

Is this a bad idea, and I'm just sleep-deprived?
Does anybody but me like this?
(Does anybody have any other ideas about lighter-weight `for`?)