### PR TITLE
Support session and backend extension configs

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_02_01_00_00
+EDGEDB_CATALOG_VERSION = 2024_02_09_00_00
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -372,14 +372,6 @@ def _validate_op(
     ptr = None
 
     if isinstance(expr, (qlast.ConfigSet, qlast.ConfigReset)):
-        # TODO: Fix this. The problem is that it gets lost when serializing it
-        if is_ext_config and expr.scope == qltypes.ConfigScope.SESSION:
-            raise errors.UnsupportedFeatureError(
-                'SESSION configuration of extension-defined config variables '
-                'is not yet implemented'
-            )
-
-        # This error is legit, though
         if is_ext_config and expr.scope == qltypes.ConfigScope.INSTANCE:
             raise errors.ConfigurationError(
                 'INSTANCE configuration of extension-defined config variables '

--- a/edb/lib/ext/pg_trgm.edgeql
+++ b/edb/lib/ext/pg_trgm.edgeql
@@ -23,10 +23,10 @@ create extension package pg_trgm version '1.6' {
 
     create module ext::pg_trgm;
 
-    create type ext::pg_trgm::Config extending cfg::ConfigObject {
+    create type ext::pg_trgm::Config extending cfg::ExtensionConfig {
         create required property similarity_threshold: std::float32 {
             create annotation cfg::backend_setting :=
-                "pg_trgm.similarity_threshold";
+                '"pg_trgm.similarity_threshold"';
             create annotation std::description :=
                 "The current similarity threshold that is used by the "
                 ++ "pg_trgm::similar() function, the pg_trgm::gin and "
@@ -38,7 +38,7 @@ create extension package pg_trgm version '1.6' {
         };
         create required property word_similarity_threshold: std::float32 {
             create annotation cfg::backend_setting :=
-                "pg_trgm.word_similarity_threshold";
+                '"pg_trgm.word_similarity_threshold"';
             create annotation std::description :=
                 "The current word similarity threshold that is used by the "
                 ++ "pg_trgrm::word_similar() function. The threshold must be "
@@ -50,7 +50,7 @@ create extension package pg_trgm version '1.6' {
         create required property strict_word_similarity_threshold: std::float32
         {
             create annotation cfg::backend_setting :=
-                "pg_trgm.strict_word_similarity_threshold";
+                '"pg_trgm.strict_word_similarity_threshold"';
             create annotation std::description :=
                 "The current strict word similarity threshold that is used by "
                 ++ "the pg_trgrm::strict_word_similar() function. The "

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3879,7 +3879,12 @@ class ObjectTypeMetaCommand(AliasCapableMetaCommand,
 
         from edb.pgsql import metaschema
 
-        new_local_spec = config.load_spec_from_schema(schema, only_exts=True)
+        new_local_spec = config.load_spec_from_schema(
+            schema,
+            only_exts=True,
+            # suppress validation because we might be in an intermediate state
+            validate=False,
+        )
         spec_json = config.spec_to_json(new_local_spec)
         self.pgops.add(dbops.Query(textwrap.dedent(f'''\
             UPDATE

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -317,6 +317,8 @@ def spec_to_json(spec: spec.Spec):
             typeid = s_obj.get_known_type_id('std::bool')
         elif _issubclass(setting.type, int):
             typeid = s_obj.get_known_type_id('std::int64')
+        elif _issubclass(setting.type, float):
+            typeid = s_obj.get_known_type_id('std::float32')
         elif _issubclass(setting.type, types.ConfigType):
             typeid = setting.type.get_edgeql_typeid()
         elif _issubclass(setting.type, statypes.Duration):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16564,22 +16564,19 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                         "session!";
                 ''')
 
-        # TODO: This should all work, instead!
-        async with self.assertRaisesRegexTx(
-                edgedb.UnsupportedFeatureError, ""):
-            await self.con.execute('''
-                configure session set ext::_conf::Config::config_name :=
-                    "session!";
-            ''')
+        await self.con.execute('''
+            configure session set ext::_conf::Config::config_name :=
+                "session!";
+        ''')
 
-            await _check(
-                config_name='session!',
-                objs=[],
-            )
+        await _check(
+            config_name='session!',
+            objs=[],
+        )
 
-            await self.con.execute('''
-                configure session reset ext::_conf::Config::config_name;
-            ''')
+        await self.con.execute('''
+            configure session reset ext::_conf::Config::config_name;
+        ''')
 
         await _check(
             config_name='test',


### PR DESCRIPTION
This requires:
 * Some special handling for reflection, since extension settings
   don't show up in the views we look at normally
 * Updating _apply_session_config to work for extension configs
 * Making StateSerializerFactory able to include extension configs.

To test this, I fixed pg_trgm's configs. pg_trgm attempted to have
some backend configs, but the config object didn't extend
ExtensionConfig and also the backend_setting wasn't json.  I added
some checks to the extension path to prevent this sort of mistake.

Database configs work too, and I tested it manually, but currently the
only reliable way to make database configs with backend settings take
effect is to restart the server, so no tests for that yet.

The other big motivation for this is pgvector probes, which I'll leave
for @vpetrovykh to follow up on.