### PR TITLE
Drop dead code of in-transaction cache after DDL

### DIFF
--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -138,9 +138,6 @@ cdef class DatabaseConnectionView:
         tuple _session_state_db_cache
         tuple _session_state_cache
 
-
-        object _eql_to_compiled
-
         object _txid
         object _in_tx_db_config
         object _in_tx_savepoints
@@ -163,7 +160,6 @@ cdef class DatabaseConnectionView:
 
         object __weakref__
 
-    cdef _invalidate_local_cache(self)
     cdef _reset_tx_state(self)
 
     cdef clear_tx_error(self)


### PR DESCRIPTION
The dropped dead code path was never used since:

https://github.com/edgedb/edgedb/pull/641/files#diff-1503bde887dee692dada5bf2b3a8e924233fabc6df2ca972baffe86c2581cf3cR177-R179

After the persistent cache lands, we should add this back.