### PR TITLE
Fix query cache dbver issue with concurrent DDL

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2337,6 +2337,9 @@ def _try_compile(
     source: edgeql.Source,
 ) -> dbstate.QueryUnitGroup:
     if _get_config_val(ctx, '__internal_testmode'):
+        # This is a bad but simple way to emulate a slow compilation for tests.
+        # Ideally, we should have a testmode function that is hooked to sleep
+        # as `simple_special_case`, or wait for a notification from the test.
         sentinel = "# EDGEDB_TEST_COMPILER_SLEEP = "
         text = source.text()
         if text.startswith(sentinel):

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -26,6 +26,7 @@ import json
 import hashlib
 import pickle
 import textwrap
+import time
 import uuid
 
 import immutables
@@ -2335,6 +2336,11 @@ def _try_compile(
     ctx: CompileContext,
     source: edgeql.Source,
 ) -> dbstate.QueryUnitGroup:
+    if _get_config_val(ctx, '__internal_testmode'):
+        sentinel = "# EDGEDB_TEST_COMPILER_SLEEP = "
+        text = source.text()
+        if text.startswith(sentinel):
+            time.sleep(float(text[len(sentinel):text.index("\n")]))
 
     default_cardinality = enums.Cardinality.NO_RESULT
     statements = edgeql.parse_block(source)

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -94,7 +94,7 @@ cdef class Database:
     cdef schedule_config_update(self)
 
     cdef _invalidate_caches(self)
-    cdef _cache_compiled_query(self, key, query_unit)
+    cdef _cache_compiled_query(self, key, compiled, int dbver)
     cdef _new_view(self, query_cache, protocol_version)
     cdef _remove_view(self, view)
     cdef _update_backend_ids(self, new_types)
@@ -171,7 +171,9 @@ cdef class DatabaseConnectionView:
     cpdef in_tx(self)
     cpdef in_tx_error(self)
 
-    cdef cache_compiled_query(self, object key, object query_unit)
+    cdef cache_compiled_query(
+        self, object key, object query_unit_group, int dbver
+    )
     cdef lookup_compiled_query(self, object key)
 
     cdef tx_error(self)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -233,6 +233,7 @@ cdef class Database:
     cdef _cache_compiled_query(
         self, key, compiled: dbstate.QueryUnitGroup, int dbver
     ):
+        # `dbver` must be the schema version `compiled` was compiled upon
         assert compiled.cacheable
 
         existing, existing_dbver = self._eql_to_compiled.get(key, DICTDEFAULT)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -230,15 +230,17 @@ cdef class Database:
         self._sql_to_compiled.clear()
         self._index.invalidate_caches()
 
-    cdef _cache_compiled_query(self, key, compiled: dbstate.QueryUnitGroup):
+    cdef _cache_compiled_query(
+        self, key, compiled: dbstate.QueryUnitGroup, int dbver
+    ):
         assert compiled.cacheable
 
-        existing, dbver = self._eql_to_compiled.get(key, DICTDEFAULT)
-        if existing is not None and dbver == self.dbver:
+        existing, existing_dbver = self._eql_to_compiled.get(key, DICTDEFAULT)
+        if existing is not None and existing_dbver == self.dbver:
             # We already have a cached query for a more recent DB version.
             return
 
-        self._eql_to_compiled[key] = compiled, self.dbver
+        self._eql_to_compiled[key] = compiled, dbver
 
     def cache_compiled_sql(self, key, compiled: list[str]):
         existing, dbver = self._sql_to_compiled.get(key, DICTDEFAULT)
@@ -714,12 +716,14 @@ cdef class DatabaseConnectionView:
     cpdef in_tx_error(self):
         return self._tx_error
 
-    cdef cache_compiled_query(self, object key, object query_unit_group):
+    cdef cache_compiled_query(
+        self, object key, object query_unit_group, int dbver
+    ):
         assert query_unit_group.cacheable
 
         if not self._in_tx_with_ddl:
             key = (key, self.get_modaliases(), self.get_session_config())
-            self._db._cache_compiled_query(key, query_unit_group)
+            self._db._cache_compiled_query(key, query_unit_group, dbver)
 
     cdef lookup_compiled_query(self, object key):
         if (self._tx_error or
@@ -975,6 +979,7 @@ cdef class DatabaseConnectionView:
         if query_unit_group is None:
             # Cache miss; need to compile this query.
             cached = False
+            dbver = self._db.dbver
 
             try:
                 query_unit_group = await self._compile(query_req)
@@ -1016,7 +1021,7 @@ cdef class DatabaseConnectionView:
             if cached_globally:
                 self.server.system_compile_cache[query_req] = query_unit_group
             else:
-                self.cache_compiled_query(query_req, query_unit_group)
+                self.cache_compiled_query(query_req, query_unit_group, dbver)
 
         if use_metrics:
             metrics.edgeql_query_compilations.inc(

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2871,6 +2871,8 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 self.skipTest("The host is too slow for this test.")
                 # If this happens too much, consider increasing the sleep time
 
+            # ISE is NOT the right expected result - a proper EdgeDB error is.
+            # FIXME in https://github.com/edgedb/edgedb/issues/6820
             with self.assertRaisesRegex(
                 edgedb.errors.InternalServerError,
                 "column .* does not exist",

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -20,6 +20,7 @@ import asyncio
 import decimal
 import http
 import json
+import time
 import uuid
 import unittest
 
@@ -2826,6 +2827,63 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
         finally:
             await self.con.query('ROLLBACK')
+
+    async def test_server_proto_query_cache_invalidate_10(self):
+        typename = 'CacheInv_10'
+
+        con1 = self.con
+        con2 = await self.connect(database=con1.dbname)
+        try:
+            await con2.execute(f'''
+                CREATE TYPE {typename} {{
+                    CREATE REQUIRED PROPERTY prop1 -> std::str;
+                }};
+
+                INSERT {typename} {{
+                    prop1 := 'aaa'
+                }};
+            ''')
+
+            sleep = 3
+            query = (
+                f"# EDGEDB_TEST_COMPILER_SLEEP = {sleep}\n"
+                f"SELECT {typename}.prop1"
+            )
+            task = self.loop.create_task(con1.query(query))
+
+            start = time.monotonic()
+            await con2.execute(f'''
+                DELETE (SELECT {typename});
+
+                ALTER TYPE {typename} {{
+                    DROP PROPERTY prop1;
+                }};
+
+                ALTER TYPE {typename} {{
+                    CREATE REQUIRED PROPERTY prop1 -> std::int64;
+                }};
+
+                INSERT {typename} {{
+                    prop1 := 123
+                }};
+            ''')
+            if time.monotonic() - start > sleep:
+                self.skipTest("The host is too slow for this test.")
+                # If this happens too much, consider increasing the sleep time
+
+            with self.assertRaisesRegex(
+                edgedb.errors.InternalServerError,
+                "column .* does not exist",
+            ):
+                await task
+
+            self.assertEqual(
+                await con1.query(query),
+                edgedb.Set([123]),
+            )
+
+        finally:
+            await con2.aclose()
 
     async def test_server_proto_backend_tid_propagation_01(self):
         async with self._run_and_rollback():


### PR DESCRIPTION
During a query compilation, if the schema is changed, the server was caching the compiled query under a wrong dbver, causing future queries to fail. See the test for issue reproduction.

@msullivan, I think you mentioned adding a similar compiler sleep hook for testing, but I can't find it. Please let me know if there's a better way than the sleep sentinel I added here in the query string.