### PR TITLE
Fix another `DROP DATABASE` flake in the tests

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1046,7 +1046,6 @@ class DatabaseTestCase(ConnectedTestCase):
     async def setup_and_connect(cls):
         dbname = cls.get_database_name()
 
-        cls.admin_conn = None
         cls.con = None
 
         class_set_up = os.environ.get('EDGEDB_TEST_CASES_SET_UP', 'run')
@@ -1054,16 +1053,17 @@ class DatabaseTestCase(ConnectedTestCase):
         # Only open an extra admin connection if necessary.
         if class_set_up == 'run':
             script = f'CREATE DATABASE {dbname};'
-            cls.admin_conn = await cls.connect()
-            await cls.admin_conn.execute(script)
+            admin_conn = await cls.connect()
+            await admin_conn.execute(script)
+            await admin_conn.aclose()
 
         elif class_set_up == 'inplace':
             dbname = edgedb_defines.EDGEDB_SUPERUSER_DB
 
         elif cls.uses_database_copies():
-            cls.admin_conn = await cls.connect()
+            admin_conn = await cls.connect()
 
-            orig_testmode = await cls.admin_conn.query(
+            orig_testmode = await admin_conn.query(
                 'SELECT cfg::Config.__internal_testmode',
             )
             if not orig_testmode:
@@ -1073,7 +1073,7 @@ class DatabaseTestCase(ConnectedTestCase):
 
             # Enable testmode to unblock the template database syntax below.
             if not orig_testmode:
-                await cls.admin_conn.execute(
+                await admin_conn.execute(
                     'CONFIGURE SESSION SET __internal_testmode := true;',
                 )
 
@@ -1088,7 +1088,7 @@ class DatabaseTestCase(ConnectedTestCase):
                     timeout=30,
                 ):
                     async with tr:
-                        await cls.admin_conn.execute(
+                        await admin_conn.execute(
                             f'''
                                 CREATE DATABASE {qlquote.quote_ident(dbname)}
                                 FROM {qlquote.quote_ident(base_db_name)}
@@ -1097,9 +1097,11 @@ class DatabaseTestCase(ConnectedTestCase):
             await create_db()
 
             if not orig_testmode:
-                await cls.admin_conn.execute(
+                await admin_conn.execute(
                     'CONFIGURE SESSION SET __internal_testmode := false;',
                 )
+
+            await admin_conn.aclose()
 
         cls.con = await cls.connect(database=dbname)
 
@@ -1127,19 +1129,18 @@ class DatabaseTestCase(ConnectedTestCase):
             if class_set_up == 'inplace':
                 await cls.tearDownSingleDB()
         finally:
-            try:
-                await cls.con.aclose()
+            await cls.con.aclose()
 
-                if class_set_up == 'inplace':
-                    pass
+            if class_set_up == 'inplace':
+                pass
 
-                elif class_set_up == 'run' or cls.uses_database_copies():
-                    dbname = qlquote.quote_ident(cls.get_database_name())
-                    await drop_db(cls.admin_conn, dbname)
-
-            finally:
-                if cls.admin_conn is not None:
-                    await cls.admin_conn.aclose()
+            elif class_set_up == 'run' or cls.uses_database_copies():
+                dbname = qlquote.quote_ident(cls.get_database_name())
+                admin_conn = await cls.connect()
+                try:
+                    await drop_db(admin_conn, dbname)
+                finally:
+                    await admin_conn.aclose()
 
     @classmethod
     def get_database_name(cls):


### PR DESCRIPTION
In #6782, we got rid of test suite retry loops on DROP DATABASE. There
was one cause of retries I missed, which was if the admin connection
got closed for being idle. Fix this by not bothering to hold the admin
connection open for the entire test run.