### PR TITLE
Add Magic Links passwordless provider

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -67,6 +67,12 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property password_hash: std::str;
     };
 
+    create type ext::auth::MagicLinkFactor extending ext::auth::EmailFactor {
+        alter property email {
+            create constraint exclusive;
+        };
+    };
+
     create type ext::auth::WebAuthnFactor extending ext::auth::EmailFactor {
         create required property user_handle: std::bytes;
         create required property credential_id: std::bytes {
@@ -261,6 +267,20 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
         create required property require_verification: std::bool {
             set default := true;
+        };
+    };
+
+    create type ext::auth::MagicLinkProviderConfig
+        extending ext::auth::ProviderConfig {
+        alter property name {
+            set default := 'builtin::local_magic_link';
+            set protected := true;
+        };
+
+        create required property token_time_to_live: std::duration {
+            set default := <std::duration>'10 minutes';
+            create annotation std::description :=
+                "The time after which a magic link token expires.";
         };
     };
 

--- a/edb/server/protocol/auth_ext/_static/magic-link.js
+++ b/edb/server/protocol/auth_ext/_static/magic-link.js
@@ -1,0 +1,126 @@
+import { parseResponseAsJSON } from "./utils.js";
+
+const MAGIC_LINK_REGISTER_URL = new URL(
+  "../magic-link/register",
+  window.location.href
+);
+const MAGIC_LINK_EMAIL_URL = new URL(
+  "../magic-link/email",
+  window.location.href
+);
+const MAGIC_LINK_SENT_URL = new URL("./magic-link-sent", window.location.href);
+
+document.addEventListener("DOMContentLoaded", function () {
+  const emailFactorForm = document.getElementById("email-factor");
+
+  if (emailFactorForm === null) {
+    return;
+  }
+
+  emailFactorForm.addEventListener("submit", async (event) => {
+    switch (event.submitter?.id) {
+      case "magic-link-signup":
+      case "magic-link-signin": {
+        event.preventDefault();
+
+        const formData = new FormData(emailFactorForm);
+        const email = formData.get("email");
+        const provider = "builtin::local_magic_link";
+        const callbackUrl = formData.get("redirect_to");
+        const challenge = formData.get("challenge");
+
+        const missingFields = [email, provider, callbackUrl, challenge].filter(
+          (v) => !v
+        );
+        if (missingFields.length > 0) {
+          throw new Error(
+            "Missing required parameters: " + missingFields.join(", ")
+          );
+        }
+
+        try {
+          if (event.submitter.id === "magic-link-signup") {
+            await registerMagicLink({
+              email,
+              provider,
+              callbackUrl,
+              challenge,
+            });
+          } else if (event.submitter.id === "magic-link-signin") {
+            await sendMagicLink({
+              email,
+              provider,
+              callbackUrl,
+              challenge,
+            });
+          }
+          window.location = MAGIC_LINK_SENT_URL.href;
+        } catch (err) {
+          console.error("Magic link failed: ", err);
+          const url = new URL(window.location.href);
+          url.searchParams.append("error", err.message);
+          window.location = url.href;
+        }
+      }
+      default:
+        return;
+    }
+  });
+});
+
+async function registerMagicLink({ email, provider, callbackUrl, challenge }) {
+  const response = await fetch(MAGIC_LINK_REGISTER_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      provider,
+      callback_url: callbackUrl,
+      challenge,
+    }),
+  });
+
+  return await parseResponseAsJSON(response, [
+    (response, error) => {
+      if (response.status === 409 && error.type === "UserAlreadyRegistered") {
+        throw new Error("User already registered, please sign in.");
+      }
+    },
+    (response, error) => {
+      console.error(
+        "Failed to register: ",
+        response.statusText,
+        JSON.stringify(error)
+      );
+      throw new Error("Failed to register email.");
+    },
+  ]);
+}
+
+async function sendMagicLink({ email, provider, callbackUrl, challenge }) {
+  const response = await fetch(MAGIC_LINK_EMAIL_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      provider,
+      callback_url: callbackUrl,
+      challenge,
+    }),
+  });
+
+  return await parseResponseAsJSON(response, [
+    (response, error) => {
+      console.error(
+        "Failed to send magic link: ",
+        response.statusText,
+        JSON.stringify(error)
+      );
+      throw new Error("Failed to send magic link");
+    },
+  ]);
+}

--- a/edb/server/protocol/auth_ext/_static/utils.js
+++ b/edb/server/protocol/auth_ext/_static/utils.js
@@ -51,5 +51,5 @@ export async function parseResponseAsJSON(response, handlers = []) {
     );
   }
 
-  return response.json();
+  return JSON.parse(bodyText);
 }

--- a/edb/server/protocol/auth_ext/_static/webauthn.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn.js
@@ -1,0 +1,21 @@
+import { onRegisterSubmit } from "./webauthn-register.js";
+import { onAuthenticateSubmit } from "./webauthn-authenticate.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  // Check if WebAuthn is supported
+  if (!window.PublicKeyCredential) {
+    console.error("WebAuthn is not supported in this browser.");
+    return;
+  }
+
+  const emailFactorForm = document.getElementById("email-factor");
+
+  if (emailFactorForm === null) {
+    return;
+  }
+
+  emailFactorForm.addEventListener("submit", (event) => {
+    onRegisterSubmit(event, emailFactorForm);
+    onAuthenticateSubmit(event, emailFactorForm);
+  });
+});

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -17,9 +17,12 @@
 #
 
 
-from typing import Optional
+from typing import Literal, Optional
 from dataclasses import dataclass
 import urllib.parse
+
+
+from edb.ir import statypes
 
 
 class UIConfig:
@@ -66,3 +69,9 @@ class WebAuthnProvider:
                 "Invalid relying_party_origin, hostname cannot be None"
             )
         self.relying_party_id = parsed_url.hostname
+
+
+@dataclass
+class MagicLinkProviderConfig(ProviderConfig):
+    name: Literal["builtin::local_magic_link"]
+    token_time_to_live: statypes.Duration

--- a/edb/server/protocol/auth_ext/email.py
+++ b/edb/server/protocol/auth_ext/email.py
@@ -86,9 +86,44 @@ async def send_verification_email(
     await _protected_send(coro, tenant)
 
 
+async def send_magic_link_email(
+    db: Any,
+    tenant: tenant.Tenant,
+    to_addr: str,
+    link: str,
+    test_mode: bool,
+):
+    from_addr = util.get_config(db, "ext::auth::SMTPConfig::sender")
+    app_details_config = util.get_app_details_config(db)
+    if app_details_config is None:
+        email_args = {}
+    else:
+        email_args = dict(
+            app_name=app_details_config.app_name,
+            logo_url=app_details_config.logo_url,
+            dark_logo_url=app_details_config.dark_logo_url,
+            brand_color=app_details_config.brand_color,
+        )
+    msg = ui.render_magic_link_email(
+        from_addr=from_addr,
+        to_addr=to_addr,
+        link=link,
+        **email_args,
+    )
+    coro = smtp.send_email(
+        db,
+        msg,
+        sender=from_addr,
+        recipients=to_addr,
+        test_mode=test_mode,
+    )
+    await _protected_send(coro, tenant)
+
+
 async def send_fake_email(tenant: tenant.Tenant):
     async def noop_coroutine():
         pass
+
     coro = noop_coroutine()
     await _protected_send(coro, tenant)
 

--- a/edb/server/protocol/auth_ext/local.py
+++ b/edb/server/protocol/auth_ext/local.py
@@ -19,14 +19,26 @@
 
 import datetime
 import json
+import base64
 
+from jwcrypto import jwk
 from typing import Any
 from edb.server.protocol import execute
+
+from . import util
 
 
 class Client:
     def __init__(self, db: Any):
         self.db = db
+
+    def _get_signing_key(self) -> jwk.JWK:
+        auth_signing_key = util.get_config(
+            self.db, "ext::auth::AuthConfig::auth_signing_key"
+        )
+        key_bytes = base64.b64encode(auth_signing_key.encode())
+
+        return jwk.JWK(kty="oct", k=key_bytes.decode())
 
     async def verify_email(
         self, identity_id: str, verified_at: datetime.datetime
@@ -89,3 +101,26 @@ select ext::auth::EmailFactor {
         assert len(result_json) == 1
 
         return result_json[0]["verified_at"]
+
+    async def get_identity_id_by_email(self, email: str) -> str | None:
+        r = await execute.parse_execute_json(
+            self.db,
+            """
+with
+    email := <str>$email,
+    identity := (
+        select ext::auth::LocalIdentity
+        filter .<identity[is ext::auth::EmailFactor].email = email
+    ),
+select identity.id;""",
+            variables={"email": email},
+            cached_globally=True,
+        )
+
+        result_json = json.loads(r.decode())
+        if len(result_json) == 0:
+            return None
+
+        assert len(result_json) == 1
+
+        return result_json[0]

--- a/edb/server/protocol/auth_ext/local.py
+++ b/edb/server/protocol/auth_ext/local.py
@@ -102,15 +102,20 @@ select ext::auth::EmailFactor {
 
         return result_json[0]["verified_at"]
 
-    async def get_identity_id_by_email(self, email: str) -> str | None:
+    async def get_identity_id_by_email(
+        self,
+        email: str,
+        *,
+        factor_type: str = 'EmailFactor'
+    ) -> str | None:
         r = await execute.parse_execute_json(
             self.db,
-            """
+            f"""
 with
     email := <str>$email,
     identity := (
         select ext::auth::LocalIdentity
-        filter .<identity[is ext::auth::EmailFactor].email = email
+        filter .<identity[is ext::auth::{factor_type}].email = email
     ),
 select identity.id;""",
             variables={"email": email},

--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -97,7 +97,12 @@ select identity { * };""",
         return data.LocalIdentity(**result_json[0])
 
     async def send_magic_link(
-        self, email: str, callback_url: str, link_url: str, challenge: str
+        self,
+        email: str,
+        callback_url: str,
+        link_url: str,
+        challenge: str,
+        redirect_on_failure: str,
     ):
         signing_key = self._get_signing_key()
         identity_id = await self.get_identity_id_by_email(email)
@@ -122,6 +127,7 @@ select identity { * };""",
             link_url,
             {
                 "token": token,
+                "redirect_on_failure": redirect_on_failure,
             },
         )
 

--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -1,0 +1,143 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2024-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import logging
+import datetime
+import aiosmtplib
+import json
+
+from typing import Any, cast
+
+from edb import errors as edb_errors
+from edb.common import debug
+from edb.server.protocol import execute
+
+from . import config, data, errors, util, local, email as auth_emails
+
+
+logger = logging.getLogger('edb.server')
+
+
+class Client(local.Client):
+    def __init__(self, db: Any, tenant: Any, test_mode: bool, issuer: str):
+        super().__init__(db)
+        self.tenant = tenant
+        self.test_mode = test_mode
+        self.issuer = issuer
+        self.provider = self._get_provider()
+
+    def _get_provider(self) -> config.MagicLinkProviderConfig:
+        provider_name = "builtin::local_magic_link"
+        provider_client_config = cast(
+            list[config.ProviderConfig],
+            util.get_config(
+                self.db, "ext::auth::AuthConfig::providers", frozenset
+            ),
+        )
+        for cfg in provider_client_config:
+            if cfg.name == provider_name:
+                cfg = cast(config.MagicLinkProviderConfig, cfg)
+                return config.MagicLinkProviderConfig(
+                    name=cfg.name,
+                    token_time_to_live=cfg.token_time_to_live,
+                )
+
+        raise errors.MissingConfiguration(
+            provider_name, f"Provider is not configured"
+        )
+
+    async def register(self, email: str):
+        try:
+            result = await execute.parse_execute_json(
+                self.db,
+                """
+with
+    email := <str>$email,
+    identity := (insert ext::auth::LocalIdentity {
+        issuer := "local",
+        subject := "",
+    }),
+    email_factor := (insert ext::auth::MagicLinkFactor {
+        email := email,
+        identity := identity,
+    })
+select identity { * };""",
+                variables={
+                    "email": email,
+                },
+                cached_globally=True,
+            )
+
+        except Exception as e:
+            exc = await execute.interpret_error(e, self.db)
+            if isinstance(exc, edb_errors.ConstraintViolationError):
+                raise errors.UserAlreadyRegistered()
+            else:
+                raise exc
+
+        result_json = json.loads(result.decode())
+        assert len(result_json) == 1
+
+        return data.LocalIdentity(**result_json[0])
+
+    async def send_magic_link(
+        self, email: str, callback_url: str, link_url: str, challenge: str
+    ):
+        signing_key = self._get_signing_key()
+        identity_id = await self.get_identity_id_by_email(email)
+
+        if identity_id is None:
+            await auth_emails.send_fake_email(self.tenant)
+            return
+
+        token = util.make_token(
+            signing_key=signing_key,
+            issuer=self.issuer,
+            subject=identity_id,
+            additional_claims={
+                "challenge": challenge,
+                "callback_url": callback_url,
+            },
+            include_issued_at=True,
+            expires_in=datetime.timedelta(minutes=10),
+        )
+
+        link = util.join_url_params(
+            link_url,
+            {
+                "token": token,
+            },
+        )
+
+        try:
+            await auth_emails.send_magic_link_email(
+                db=self.db,
+                tenant=self.tenant,
+                to_addr=email,
+                link=link,
+                test_mode=self.test_mode,
+            )
+        except aiosmtplib.SMTPException as ex:
+            if not debug.flags.server:
+                logger.warning(
+                    "Failed to send magic link via SMTP", exc_info=True
+                )
+            raise edb_errors.InternalServerError(
+                "Failed to send magic link email, please try again later."
+            ) from ex

--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -18,7 +18,6 @@
 
 
 import logging
-import datetime
 import aiosmtplib
 import json
 
@@ -105,7 +104,8 @@ select identity { * };""",
         redirect_on_failure: str,
     ):
         signing_key = self._get_signing_key()
-        identity_id = await self.get_identity_id_by_email(email)
+        identity_id = await self.get_identity_id_by_email(
+            email, factor_type='MagicLinkFactor')
 
         if identity_id is None:
             await auth_emails.send_fake_email(self.tenant)
@@ -120,7 +120,7 @@ select identity { * };""",
                 "callback_url": callback_url,
             },
             include_issued_at=True,
-            expires_in=datetime.timedelta(minutes=10),
+            expires_in=self.provider.token_time_to_live.to_timedelta(),
         )
 
         link = util.join_url_params(

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -376,13 +376,10 @@ def render_signup_page(
       {_render_error_message(error_message)}
 
       {_render_oauth_buttons(oauth_providers, oauth_params, oauth_label)}
-      {
-        """
-        <div class="divider">
-          <span>or</span>
-        </div>
-        """ if has_email_factor and oauth_providers else ''
-      }
+      {"""
+      <div class="divider">
+        <span>or</span>
+      </div>""" if has_email_factor and oauth_providers else ''}
       {email_factor_form if has_email_factor else ''}
     </form>
     {email_factor_script}

--- a/edb/server/protocol/auth_ext/ui.py
+++ b/edb/server/protocol/auth_ext/ui.py
@@ -69,7 +69,7 @@ def _render_oauth_buttons(
     )
 
 
-def render_login_page(
+def render_signin_page(
     *,
     base_path: str,
     providers: frozenset,
@@ -86,12 +86,15 @@ def render_login_page(
 ):
     password_provider = None
     webauthn_provider = None
+    magic_link_provider = None
     oauth_providers = []
     for p in providers:
         if p.name == 'builtin::local_emailpassword':
             password_provider = p
         elif p.name == 'builtin::local_webauthn':
             webauthn_provider = p
+        elif p.name == 'builtin::local_magic_link':
+            magic_link_provider = p
         elif p.name.startswith('builtin::oauth_'):
             oauth_providers.append(p)
 
@@ -138,8 +141,8 @@ def render_login_page(
       <input id="email" name="email" type="email" value="{email or ''}" />
     """
 
-    has_email_factor = (
-        password_provider is not None or webauthn_provider is not None
+    has_email_factor = any(
+        [password_provider, webauthn_provider, magic_link_provider]
     )
 
     email_factor_form += (
@@ -160,21 +163,41 @@ def render_login_page(
         if password_provider is not None
         else ""
     )
-    match (password_provider, webauthn_provider):
-        case (None, None):
+    match (password_provider, webauthn_provider, magic_link_provider):
+        case (None, None, None):
             email_factor_form += ""
-        case (None, _):
+        case (None, None, _):
+            email_factor_form += f"""
+            {_render_button('Sign In with Magic Link', id='magic-link-signin')}
+            """
+        case (None, _, None):
             email_factor_form += f"""
             {_render_button('Sign In', id='webauthn-signin')}
             """
-        case (_, None):
+        case (_, None, None):
             email_factor_form += f"""
             {_render_button("Sign In", id="password-signin")}
             """
-        case (_, _):
+        case (_, _, None):
             email_factor_form += f"""
             {_render_button('Sign In', id='webauthn-signin')}
             {_render_button("Sign in with password", id="password-signin")}
+            """
+        case (None, _, _):
+            email_factor_form += f"""
+            {_render_button('Sign In', id='webauthn-signin')}
+            {_render_button("Sign in with Magic Link", id="magic-link-signin")}
+            """
+        case (_, None, _):
+            email_factor_form += f"""
+            {_render_button("Sign In", id="password-signin")}
+            {_render_button("Sign in with Magic Link", id="magic-link-signin")}
+            """
+        case (_, _, _):
+            email_factor_form += f"""
+            {_render_button('Sign In', id='webauthn-signin')}
+            {_render_button("Sign in with password", id="password-signin")}
+            {_render_button("Sign in with Magic Link", id="magic-link-signin")}
             """
 
     email_factor_form += f"""
@@ -183,6 +206,14 @@ def render_login_page(
           <a href="signup" tabindex="3">Sign up</a>
         </div>
         """
+
+    email_factor_script = ""
+    if webauthn_provider:
+        email_factor_script += f"""
+        <script type="module" src="_static/webauthn.js"></script>"""
+    if magic_link_provider:
+        email_factor_script += f"""
+        <script type="module" src="_static/magic-link.js"></script>"""
 
     return _render_base_page(
         title=f'Sign in{f" to {app_name}" if app_name else ""}',
@@ -209,11 +240,7 @@ def render_login_page(
       {email_factor_form if has_email_factor else ''}
       </form>
       {forgot_link_script}
-      {"""
-      <script
-        type="module"
-        src="_static/webauthn-authenticate.js"
-      ></script>""" if webauthn_provider else ''}
+      {email_factor_script}
       ''',
     )
 
@@ -235,12 +262,15 @@ def render_signup_page(
 ):
     password_provider = None
     webauthn_provider = None
+    magic_link_provider = None
     oauth_providers = []
     for p in providers:
         if p.name == 'builtin::local_emailpassword':
             password_provider = p
         elif p.name == 'builtin::local_webauthn':
             webauthn_provider = p
+        elif p.name == 'builtin::local_magic_link':
+            magic_link_provider = p
         elif p.name.startswith('builtin::oauth_'):
             oauth_providers.append(p)
 
@@ -261,13 +291,14 @@ def render_signup_page(
              value="{redirect_to_on_signup or redirect_to}" />
       <input type="hidden" name="challenge" value="{challenge}" />
       <input type="hidden" name="verify_url" value="{base_path}/ui/verify" />
+      <input type="hidden" name="callback_url" value="{base_path}/ui/callba" />
 
       <label for="email">Email</label>
       <input id="email" name="email" type="email" value="{email or ''}" />
     """
 
-    has_email_factor = (
-        password_provider is not None or webauthn_provider is not None
+    has_email_factor = any(
+        [password_provider, webauthn_provider, magic_link_provider]
     )
 
     email_factor_form += (
@@ -279,21 +310,42 @@ def render_signup_page(
         if password_provider is not None
         else ""
     )
-    match (password_provider, webauthn_provider):
-        case (None, None):
+
+    match (password_provider, webauthn_provider, magic_link_provider):
+        case (None, None, None):
             email_factor_form += ""
-        case (None, _):
+        case (None, None, _):
+            email_factor_form += f"""
+            {_render_button('Sign Up with Magic Link', id='magic-link-signup')}
+            """
+        case (None, _, None):
             email_factor_form += f"""
             {_render_button('Sign Up', id='webauthn-signup')}
             """
-        case (_, None):
+        case (_, None, None):
             email_factor_form += f"""
             {_render_button("Sign Up", id="password-signup")}
             """
-        case (_, _):
+        case (_, _, None):
             email_factor_form += f"""
             {_render_button('Sign Up', id='webauthn-signup')}
             {_render_button("Sign up with password", id="password-signup")}
+            """
+        case (None, _, _):
+            email_factor_form += f"""
+            {_render_button('Sign Up', id='webauthn-signup')}
+            {_render_button('Sign Up with Magic Link', id='magic-link-signup')}
+            """
+        case (_, None, _):
+            email_factor_form += f"""
+            {_render_button("Sign Up", id="password-signup")}
+            {_render_button('Sign Up with Magic Link', id='magic-link-signup')}
+            """
+        case (_, _, _):
+            email_factor_form += f"""
+            {_render_button('Sign Up', id='webauthn-signup')}
+            {_render_button("Sign up with password", id="password-signup")}
+            {_render_button('Sign Up with Magic Link', id='magic-link-signup')}
             """
 
     email_factor_form += f"""
@@ -303,29 +355,37 @@ def render_signup_page(
         </div>
         """
 
+    email_factor_script = ""
+    if webauthn_provider:
+        email_factor_script += f"""
+        <script type="module" src="_static/webauthn.js"></script>"""
+    if magic_link_provider:
+        email_factor_script += f"""
+        <script type="module" src="_static/magic-link.js"></script>"""
+
     content = f'''
-        <form
+    <form
         class="container"
         id="email-factor"
         method="POST"
         action="../register" novalidate
-        >
-        <h1>{f'<span>Sign up to</span> {html.escape(app_name)}'
-             if app_name else '<span>Sign up</span>'}</h1>
+    >
+      <h1>{f'<span>Sign up to</span> {html.escape(app_name)}'
+           if app_name else '<span>Sign up</span>'}</h1>
 
-        {_render_error_message(error_message)}
+      {_render_error_message(error_message)}
 
-        {_render_oauth_buttons(oauth_providers, oauth_params, oauth_label)}
-        {"""
-         <div class="divider">
-           <span>or</span>
-         </div>
-         """ if has_email_factor and oauth_providers else ''}
-        {email_factor_form if has_email_factor else ''}
-        </form>
-        {"""
-         <script type="module" src="_static/webauthn-register.js"></script>"""
-         if webauthn_provider is not None else ''}
+      {_render_oauth_buttons(oauth_providers, oauth_params, oauth_label)}
+      {
+        """
+        <div class="divider">
+          <span>or</span>
+        </div>
+        """ if has_email_factor and oauth_providers else ''
+      }
+      {email_factor_form if has_email_factor else ''}
+    </form>
+    {email_factor_script}
     '''
 
     return _render_base_page(
@@ -586,6 +646,32 @@ def render_resend_verification_done_page(
     )
 
 
+def render_magic_link_sent_page(
+    *,
+    app_name: Optional[str] = None,
+    logo_url: Optional[str] = None,
+    dark_logo_url: Optional[str] = None,
+    brand_color: Optional[str] = None,
+):
+    content = _render_success_message(
+        "A sign in link has been sent to your email. Please check your email."
+    )
+    return _render_base_page(
+        title=(f'Sign in link sent{f" for {app_name}" if app_name else ""}'),
+        logo_url=logo_url,
+        dark_logo_url=dark_logo_url,
+        brand_color=brand_color,
+        cleanup_search_params=['error'],
+        content=f'''
+    <div class="container">
+      <h1>{f'<span>Sign in link sent for</span> {html.escape(app_name)}'
+           if app_name else '<span>Sign in link sent</span>'}</h1>
+
+        {content}
+    </div>''',
+    )
+
+
 hex_color_regexp = re.compile(r'[0-9a-fA-F]{6}')
 
 
@@ -794,6 +880,46 @@ def render_verification_email(
     <a href="{verify_url}">Verify your email</a>
   </body>
 </html>
+        """,
+        "html",
+        "utf-8",
+    )
+    alternative.attach(html_msg)
+    msg.attach(alternative)
+    return msg
+
+
+def render_magic_link_email(
+    *,
+    from_addr: str,
+    to_addr: str,
+    link: str,
+    app_name: Optional[str] = None,
+    logo_url: Optional[str] = None,
+    dark_logo_url: Optional[str] = None,
+    brand_color: Optional[str] = None,
+) -> multipart.MIMEMultipart:
+    msg = multipart.MIMEMultipart()
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg["Subject"] = "Sign in link"
+    alternative = multipart.MIMEMultipart('alternative')
+    plain_text_msg = mime_text.MIMEText(
+        f"""
+        {link}
+        """,
+        "plain",
+        "utf-8",
+    )
+    alternative.attach(plain_text_msg)
+    html_msg = mime_text.MIMEText(
+        f"""
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <a href="{link}">Sign in</a>
+          </body>
+        </html>
         """,
         "html",
         "utf-8",

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3775,9 +3775,10 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         email = "test@example.com"
         challenge = "test_challenge"
         callback_url = "https://example.com/auth/callback"
+        redirect_on_failure = "https://example.com/auth/magic-link-failure"
 
         with self.http_con() as http_con:
-            body, _, status = self.http_con_request(
+            _, _, status = self.http_con_request(
                 http_con,
                 method="POST",
                 path="magic-link/register",
@@ -3787,6 +3788,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                         "email": email,
                         "challenge": challenge,
                         "callback_url": callback_url,
+                        "redirect_on_failure": redirect_on_failure,
                     }
                 ).encode(),
                 headers={"Content-Type": "application/json"},


### PR DESCRIPTION
Adds another passwordless authentication option that sends an expiring token to an email address. This is similar in spirit to a reset password flow. This is commonly called "Magic Link", so that's what I've adopted here at least as an internal feature name. For users, we plan on calling it "Email a sign in link".