### PR TITLE
Fix amsg Server.stop() for Python 3.12

### DIFF
--- a/edb/server/compiler_pool/amsg.py
+++ b/edb/server/compiler_pool/amsg.py
@@ -235,9 +235,9 @@ class Server:
 
     async def stop(self):
         self._srv.close()
-        await self._srv.wait_closed()
         for con in self._pids.values():
             con.abort()
+        await self._srv.wait_closed()
 
     def kill_outdated_worker(self, current_version):
         for conn in self._pids.values():


### PR DESCRIPTION
asyncio.Server.wait_closed() will now wait for client connections to disconnect, so we should abort them before waiting for a server close.