### PR TITLE
Cross-link FTS to pg_trgm

### DIFF
--- a/docs/stdlib/fts.rst
+++ b/docs/stdlib/fts.rst
@@ -9,6 +9,12 @@ Full-text Search
 The ``fts`` built-in module contains various tools that enable full-text
 search functionality in EdgeDB.
 
+.. note::
+
+    Since full-text search is a natural language search, it may not be ideal
+    for your use case, particularly if you want to find partial matches. In
+    that case, you may want to look instead at :ref:`ref_ext_pgtrgm`.
+
 .. list-table::
     :class: funcoptable
 


### PR DESCRIPTION
to make it more discoverable, since the use case is similar. Users may find FTS thinking it fits their use case when they actually want fuzzy matching. pg_trgm is less discoverable since a user would have to already know that is what they need. This alleviates the problem somewhat by suggesting pg_trgm as an alternative from the FTS documentation.

Inspired by a discussion on Discord: https://discord.com/channels/841451783728529451/1203490908939616298