### PR TITLE
Fix changing index expressions in migrations

### DIFF
--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -215,7 +215,7 @@ class Index(
         s_expr.Expression,
         default=None,
         coerce=True,
-        compcoef=0.909,
+        compcoef=0.0,
         ddl_identity=True,
     )
 
@@ -223,7 +223,7 @@ class Index(
         s_expr.Expression,
         default=None,
         coerce=True,
-        compcoef=0.909,
+        compcoef=0.0,
         ddl_identity=True,
     )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6480,6 +6480,21 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+    def test_schema_migrations_equivalence_index_06(self):
+        self._assert_migration_equivalence([r"""
+            type Base {
+                required property name -> str;
+                required property year -> int64;
+                index on ((.name, .year));
+            }
+        """, r"""
+            type Base {
+                required property name -> str;
+                required property year -> int64;
+                index on ((.year, .name));
+            }
+        """])
+
     def test_schema_migrations_equivalence_constraint_01(self):
         self._assert_migration_equivalence([r"""
             type Base {


### PR DESCRIPTION
They should always be a DROP/CREATE, but the migration system was
trying to generate ALTERs.