### PR TITLE
Fall back to `ui_config` for getting app details

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -270,22 +270,32 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             create annotation std::description :=
                 "The name of your application to be shown on the login \
                 screen.";
+            create annotation std::deprecated :=
+                "Use the app_name property in ext::auth::AuthConfig instead.";
         };
 
         create property logo_url: std::str {
             create annotation std::description :=
                 "A url to an image of your application's logo.";
+            create annotation std::deprecated :=
+                "Use the logo_url property in ext::auth::AuthConfig instead.";
         };
 
         create property dark_logo_url: std::str {
             create annotation std::description :=
                 "A url to an image of your application's logo to be used \
                 with the dark theme.";
+            create annotation std::deprecated :=
+                "Use the dark_logo_url property in ext::auth::AuthConfig \
+                instead.";
         };
 
         create property brand_color: std::str {
             create annotation std::description :=
                 "The brand color of your application as a hex string.";
+            create annotation std::deprecated :=
+                "Use the brand_color property in ext::auth::AuthConfig \
+                instead.";
         };
     };
 

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -23,6 +23,10 @@ import urllib.parse
 
 
 class UIConfig:
+    app_name: Optional[str]
+    logo_url: Optional[str]
+    dark_logo_url: Optional[str]
+    brand_color: Optional[str]
     redirect_to: str
     redirect_to_on_signup: Optional[str]
 

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -17,18 +17,17 @@
 #
 
 
-from typing import TypeVar, Type, overload, Any
+from typing import TypeVar, Type, overload, Any, cast
 
-from edb.server import config
+from edb.server import config as edb_config
 
-from . import errors
-from .config import AppDetailsConfig
+from . import errors, config
 
 T = TypeVar("T")
 
 
 def maybe_get_config_unchecked(db: Any, key: str) -> Any:
-    return config.lookup(key, db.db_config, spec=db.user_config_spec)
+    return edb_config.lookup(key, db.db_config, spec=db.user_config_spec)
 
 
 @overload
@@ -88,16 +87,33 @@ def get_config_unchecked(db: Any, key: str) -> Any:
     return value
 
 
-def get_config_typename(config_value: config.SettingValue) -> str:
+def get_config_typename(config_value: edb_config.SettingValue) -> str:
     return config_value._tspec.name  # type: ignore
 
 
-def get_app_details_config(db: Any) -> AppDetailsConfig:
-    return AppDetailsConfig(
-        app_name=maybe_get_config(db, "ext::auth::AuthConfig::app_name"),
-        logo_url=maybe_get_config(db, "ext::auth::AuthConfig::logo_url"),
-        dark_logo_url=maybe_get_config(
-            db, "ext::auth::AuthConfig::dark_logo_url"
-        ),
-        brand_color=maybe_get_config(db, "ext::auth::AuthConfig::brand_color"),
+def get_app_details_config(db: Any) -> config.AppDetailsConfig:
+    ui_config = cast(
+        config.UIConfig,
+        maybe_get_config(db, "ext::auth::AuthConfig::ui"),
     )
+
+
+    return config.AppDetailsConfig(
+        app_name=(
+            maybe_get_config(db, "ext::auth::AuthConfig::app_name")
+            or ui_config.app_name
+        ),
+        logo_url=(
+            maybe_get_config(db, "ext::auth::AuthConfig::logo_url")
+            or ui_config.logo_url
+        ),
+        dark_logo_url=(
+            maybe_get_config(db, "ext::auth::AuthConfig::dark_logo_url")
+            or ui_config.dark_logo_url
+        ),
+        brand_color=(
+            maybe_get_config(db, "ext::auth::AuthConfig::brand_color")
+            or ui_config.brand_color
+        ),
+    )
+

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -20,6 +20,7 @@
 from typing import TypeVar, Type, overload, Any, cast
 
 from edb.server import config as edb_config
+from edb.server.config.types import CompositeConfigType
 
 from . import errors, config
 
@@ -94,7 +95,7 @@ def get_config_typename(config_value: edb_config.SettingValue) -> str:
 def get_app_details_config(db: Any) -> config.AppDetailsConfig:
     ui_config = cast(
         config.UIConfig,
-        maybe_get_config(db, "ext::auth::AuthConfig::ui"),
+        maybe_get_config(db, "ext::auth::AuthConfig::ui", CompositeConfigType),
     )
 
     return config.AppDetailsConfig(

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -17,7 +17,7 @@
 #
 
 
-from typing import TypeVar, Type, overload, Any, cast
+from typing import TypeVar, Type, overload, Any, cast, Optional
 
 from edb.server import config as edb_config
 from edb.server.config.types import CompositeConfigType
@@ -94,25 +94,25 @@ def get_config_typename(config_value: edb_config.SettingValue) -> str:
 
 def get_app_details_config(db: Any) -> config.AppDetailsConfig:
     ui_config = cast(
-        config.UIConfig,
+        Optional[config.UIConfig],
         maybe_get_config(db, "ext::auth::AuthConfig::ui", CompositeConfigType),
     )
 
     return config.AppDetailsConfig(
         app_name=(
             maybe_get_config(db, "ext::auth::AuthConfig::app_name")
-            or ui_config.app_name
+            or (ui_config.app_name if ui_config else None)
         ),
         logo_url=(
             maybe_get_config(db, "ext::auth::AuthConfig::logo_url")
-            or ui_config.logo_url
+            or (ui_config.logo_url if ui_config else None)
         ),
         dark_logo_url=(
             maybe_get_config(db, "ext::auth::AuthConfig::dark_logo_url")
-            or ui_config.dark_logo_url
+            or (ui_config.dark_logo_url if ui_config else None)
         ),
         brand_color=(
             maybe_get_config(db, "ext::auth::AuthConfig::brand_color")
-            or ui_config.brand_color
+            or (ui_config.brand_color if ui_config else None)
         ),
     )

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -97,7 +97,6 @@ def get_app_details_config(db: Any) -> config.AppDetailsConfig:
         maybe_get_config(db, "ext::auth::AuthConfig::ui"),
     )
 
-
     return config.AppDetailsConfig(
         app_name=(
             maybe_get_config(db, "ext::auth::AuthConfig::app_name")
@@ -116,4 +115,3 @@ def get_app_details_config(db: Any) -> config.AppDetailsConfig:
             or ui_config.brand_color
         ),
     )
-


### PR DESCRIPTION
We plan on keeping the `ui_config` around for now, so allow falling back.

See also #6732 