### PR TITLE
Cleanup of pgvector.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_02_09_00_00
+EDGEDB_CATALOG_VERSION = 2024_02_14_00_00
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -359,6 +359,15 @@ std::_datetime_range_buckets(
     $$;
 };
 
+
+CREATE FUNCTION
+std::_current_settings(sqlname: str) -> OPTIONAL std::int64 {
+    USING SQL $$
+      SELECT nullif(current_setting(sqlname, true), '')::int8
+    $$;
+};
+
+
 CREATE MODULE std::_test;
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -361,9 +361,9 @@ std::_datetime_range_buckets(
 
 
 CREATE FUNCTION
-std::_current_settings(sqlname: str) -> OPTIONAL std::int64 {
+std::_current_setting(sqlname: str) -> OPTIONAL std::str {
     USING SQL $$
-      SELECT nullif(current_setting(sqlname, true), '')::int8
+      SELECT current_setting(sqlname, true)
     $$;
 };
 

--- a/edb/lib/ext/pgvector.edgeql
+++ b/edb/lib/ext/pgvector.edgeql
@@ -147,6 +147,17 @@ create extension package pgvector version '0.5.0' {
         set force_return_cast := true;
     };
 
+    create function ext::pgvector::set_probes(num: std::int64) -> std::int64 {
+        using sql $$
+            select num from (
+                select set_config('ivfflat.probes', num::text, true)
+            ) as dummy;
+        $$;
+        CREATE ANNOTATION std::deprecated :=
+            'This function is deprecated. ' ++
+            'Configure ext::pgvector::Config::probes instead';
+    };
+
     create abstract index ext::pgvector::ivfflat_euclidean(
         named only lists: int64
     ) {

--- a/edb/lib/ext/pgvector.edgeql
+++ b/edb/lib/ext/pgvector.edgeql
@@ -23,6 +23,31 @@ create extension package pgvector version '0.5.0' {
 
     create module ext::pgvector;
 
+    create type ext::pgvector::Config extending cfg::ExtensionConfig {
+        create required property probes: std::int64 {
+            create annotation cfg::backend_setting :=
+                '"ivfflat.probes"';
+            create annotation std::description :=
+                "The number of probes (1 by default) used by IVFFlat "
+                ++ "index. A higher value provides better recall at the "
+                ++ "cost of speed, and it can be set to the number of "
+                ++ "lists for exact nearest neighbor search (at which point "
+                ++ "the planner won’t use the index)";
+            set default := 1;
+            create constraint std::min_value(1);
+        };
+        create required property ef_search: std::int64 {
+            create annotation cfg::backend_setting :=
+                '"hnsw.ef_search"';
+            create annotation std::description :=
+                "The size of the dynamic candidate list for search (40 "
+                ++ "by default) used by HNSW index. A higher value "
+                ++ "provides better recall at the  cost of speed.";
+            set default := 40;
+            create constraint std::min_value(1);
+        };
+    };
+
     create scalar type ext::pgvector::vector extending std::anyscalar {
         set id := <uuid>"9565dd88-04f5-11ee-a691-0b6ebe179825";
         set sql_type := "vector";
@@ -120,20 +145,6 @@ create extension package pgvector version '0.5.0' {
         using sql function 'vector_norm';
         set volatility := 'Immutable';
         set force_return_cast := true;
-    };
-
-    create function ext::pgvector::set_probes(num: std::int64) -> std::int64 {
-	using sql $$
-            select num from (
-	        select set_config('ivfflat.probes', num::text, true)
-            ) as dummy;
-	$$;
-    };
-
-    create function ext::pgvector::_get_probes() -> optional std::int64 {
-        using sql $$
-          select nullif(current_setting('ivfflat.probes'), '')::int8
-        $$;
     };
 
     create abstract index ext::pgvector::ivfflat_euclidean(

--- a/tests/test_edgeql_vector.py
+++ b/tests/test_edgeql_vector.py
@@ -803,9 +803,16 @@ class TestEdgeQLVector(tb.QueryTestCase):
         # We can't test the effects of config parameters easily, but we can
         # at least verify that they are updated as expected.
 
+        # The pgvector configs don't seem to show up in
+        # current_setting unless we've done something involving vector
+        # on the connection...
+        await self.con.query('''
+            select <ext::pgvector::vector>[3, 4];
+        ''')
+
         # probes
         await self.assert_query_result(
-            'select _current_settings("ivfflat.probes")',
+            'select <int64>_current_setting("ivfflat.probes")',
             [1],
         )
 
@@ -815,7 +822,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
         ''')
 
         await self.assert_query_result(
-            'select _current_settings("ivfflat.probes")',
+            'select <int64>_current_setting("ivfflat.probes")',
             [23],
         )
 
@@ -825,13 +832,13 @@ class TestEdgeQLVector(tb.QueryTestCase):
         ''')
 
         await self.assert_query_result(
-            'select _current_settings("ivfflat.probes")',
+            'select <int64>_current_setting("ivfflat.probes")',
             [1],
         )
 
         # ef_search
         await self.assert_query_result(
-            'select _current_settings("hnsw.ef_search")',
+            'select <int64>_current_setting("hnsw.ef_search")',
             [40],
         )
 
@@ -841,7 +848,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
         ''')
 
         await self.assert_query_result(
-            'select _current_settings("hnsw.ef_search")',
+            'select <int64>_current_setting("hnsw.ef_search")',
             [23],
         )
 
@@ -851,6 +858,6 @@ class TestEdgeQLVector(tb.QueryTestCase):
         ''')
 
         await self.assert_query_result(
-            'select _current_settings("hnsw.ef_search")',
+            'select <int64>_current_setting("hnsw.ef_search")',
             [40],
         )

--- a/tests/test_edgeql_vector.py
+++ b/tests/test_edgeql_vector.py
@@ -798,3 +798,59 @@ class TestEdgeQLVector(tb.QueryTestCase):
     async def test_edgeql_vector_index_06(self):
         await self._check_index(
             'HNSW_IP', 'neg_inner_product', 'hnsw', 'ip')
+
+    async def test_edgeql_vector_config(self):
+        # We can't test the effects of config parameters easily, but we can
+        # at least verify that they are updated as expected.
+
+        # probes
+        await self.assert_query_result(
+            'select _current_settings("ivfflat.probes")',
+            [1],
+        )
+
+        await self.con.execute('''
+            configure session
+            set ext::pgvector::Config::probes := 23
+        ''')
+
+        await self.assert_query_result(
+            'select _current_settings("ivfflat.probes")',
+            [23],
+        )
+
+        await self.con.execute('''
+            configure session
+            reset ext::pgvector::Config::probes
+        ''')
+
+        await self.assert_query_result(
+            'select _current_settings("ivfflat.probes")',
+            [1],
+        )
+
+        # ef_search
+        await self.assert_query_result(
+            'select _current_settings("hnsw.ef_search")',
+            [40],
+        )
+
+        await self.con.execute('''
+            configure session
+            set ext::pgvector::Config::ef_search := 23
+        ''')
+
+        await self.assert_query_result(
+            'select _current_settings("hnsw.ef_search")',
+            [23],
+        )
+
+        await self.con.execute('''
+            configure session
+            reset ext::pgvector::Config::ef_search
+        ''')
+
+        await self.assert_query_result(
+            'select _current_settings("hnsw.ef_search")',
+            [40],
+        )


### PR DESCRIPTION
Drop undocumented `set_probes` and `_get_probes` in favor of actual configarion parameters.

We now have `probes` and `ef_search` config parameters that effectively expose the corresponding parameters from the postgres extension.

Add tests for the exposed config parameters.