### PR TITLE
Disable a failing CORS test

### DIFF
--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -28,6 +28,7 @@ from edb import protocol
 from edb.server import defines as edbdef
 from edb.testbase import server as tb_server
 from edb.testbase import http as tb_http
+from edb.tools import test
 
 
 class BaseTestHttpAuth(
@@ -202,6 +203,7 @@ class TestHttpAuth(BaseTestHttpAuth):
     def test_http_auth_scram_no_user(self):
         self._scram_auth_expect_failure("scram_no_user", "bad-password")
 
+    @test.xfail('FIXME: scotttrinh, jaclarke')
     async def test_http_auth_scram_cors(self):
         conn_args = self.get_connect_args()
         url = f'https://{conn_args["host"]}:{conn_args["port"]}/auth/token'

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -203,7 +203,7 @@ class TestHttpAuth(BaseTestHttpAuth):
     def test_http_auth_scram_no_user(self):
         self._scram_auth_expect_failure("scram_no_user", "bad-password")
 
-    @test.xfail('FIXME: scotttrinh, jaclarke')
+    @test.skip('FIXME: uses configure instance unsafely')
     async def test_http_auth_scram_cors(self):
         conn_args = self.get_connect_args()
         url = f'https://{conn_args["host"]}:{conn_args["port"]}/auth/token'

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -25,6 +25,7 @@ import decimal
 import edgedb
 
 from edb.testbase import http as tb
+from edb.tools import test
 
 
 class TestHttpEdgeQL(tb.EdgeQLTestCase):
@@ -409,6 +410,7 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
             ]
         })
 
+    @test.skip('FIXME: uses configure instance unsafely')
     async def test_http_edgeql_cors(self):
         req = urllib.request.Request(self.http_addr, method='OPTIONS')
         req.add_header('Origin', 'https://example.edgedb.com')


### PR DESCRIPTION
I'm not sure what caused it to slip in; a bad merge or something?