### PR TITLE
Switch to using Github's runners for macOS builds

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -132,18 +132,29 @@
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "<< tgt.arch >>-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -158,6 +169,7 @@
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PKG_PLATFORM_ARCH: "<< tgt.arch if tgt.arch else '' >>"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         <%- if tgt.family == "generic" %>
         BUILD_GENERIC: true

--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -142,10 +142,10 @@ targets:
           platform: macos
           platform_version: x86_64
           family: generic
-          runs_on: [self-hosted, macOS, X64]
+          runs_on: [macos-14]
         - name: macos-aarch64
           arch: aarch64
           platform: macos
           platform_version: aarch64
           family: generic
-          runs_on: [self-hosted, macOS, ARM64]
+          runs_on: [macos-14]

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -888,7 +888,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
     needs: prep
 
     if: needs.prep.outputs.if_macos_x86_64 == 'true'
@@ -902,18 +902,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "x86_64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -923,6 +934,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"
         PKG_PLATFORM_ARCH: "x86_64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -934,7 +946,7 @@ jobs:
         path: artifacts/macos-x86_64
 
   build-macos-aarch64:
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
     needs: prep
 
     if: needs.prep.outputs.if_macos_aarch64 == 'true'
@@ -948,18 +960,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "aarch64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -969,6 +992,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "aarch64"
         PKG_PLATFORM_ARCH: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -1422,7 +1446,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4
@@ -1446,7 +1470,7 @@ jobs:
 
   test-macos-aarch64:
     needs: [build-macos-aarch64]
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -893,7 +893,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
     needs: prep
 
     if: needs.prep.outputs.if_macos_x86_64 == 'true'
@@ -907,18 +907,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "x86_64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -928,6 +939,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"
         PKG_PLATFORM_ARCH: "x86_64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -939,7 +951,7 @@ jobs:
         path: artifacts/macos-x86_64
 
   build-macos-aarch64:
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
     needs: prep
 
     if: needs.prep.outputs.if_macos_aarch64 == 'true'
@@ -953,18 +965,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "aarch64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -974,6 +997,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "aarch64"
         PKG_PLATFORM_ARCH: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -1427,7 +1451,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4
@@ -1451,7 +1475,7 @@ jobs:
 
   test-macos-aarch64:
     needs: [build-macos-aarch64]
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,7 +491,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
     needs: prep
 
 
@@ -503,18 +503,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "x86_64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -524,6 +535,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"
         PKG_PLATFORM_ARCH: "x86_64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -535,7 +547,7 @@ jobs:
         path: artifacts/macos-x86_64
 
   build-macos-aarch64:
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
     needs: prep
 
 
@@ -547,18 +559,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "aarch64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -568,6 +591,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "aarch64"
         PKG_PLATFORM_ARCH: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -1000,7 +1024,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4
@@ -1023,7 +1047,7 @@ jobs:
 
   test-macos-aarch64:
     needs: [build-macos-aarch64]
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -512,7 +512,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
     needs: prep
 
 
@@ -524,18 +524,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "x86_64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -546,6 +557,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"
         PKG_PLATFORM_ARCH: "x86_64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -557,7 +569,7 @@ jobs:
         path: artifacts/macos-x86_64
 
   build-macos-aarch64:
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
     needs: prep
 
 
@@ -569,18 +581,29 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "aarch64-apple-darwin"
 
     - name: Set up Python
       uses: actions/setup-python@v5
-      if: false
+      if: true
       with:
         python-version: "3.x"
+
+    - name: Set up NodeJS
+      uses: actions/setup-node@v4
+      if: true
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -591,6 +614,7 @@ jobs:
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "aarch64"
         PKG_PLATFORM_ARCH: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
@@ -1044,7 +1068,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['self-hosted', 'macOS', 'X64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4
@@ -1068,7 +1092,7 @@ jobs:
 
   test-macos-aarch64:
     needs: [build-macos-aarch64]
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Those are now available, and though a tad slower than our current hosted
runners, allow us to avoid having to maintain hosted macOS runners.
