### PR TITLE
Properly report errors involving newly created types

### DIFF
--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -182,6 +182,11 @@ async def execute(
                 await dbv.apply_config_ops(be_conn, config_ops)
 
     except Exception as ex:
+        # If we made schema changes, include the new schema in the
+        # exception so that it can be used when interpreting.
+        if query_unit.user_schema:
+            ex._user_schema = query_unit.user_schema
+
         dbv.on_error()
 
         if query_unit.tx_commit and not be_conn.in_tx() and dbv.in_tx():
@@ -358,6 +363,10 @@ async def execute_script(
 
     except Exception as e:
         dbv.on_error()
+
+        # Include the new schema in the exception so that it can be
+        # used when interpreting.
+        e._user_schema = dbv.get_user_schema_pickle()
 
         if not in_tx and dbv.in_tx():
             # Abort the implicit transaction
@@ -684,8 +693,12 @@ async def interpret_error(
 
             # only use the backend if schema is required
             if static_exc is errormech.SchemaRequired:
+                # Grab the schema from the exception first, if it is present.
                 user_schema_pickle = (
-                    user_schema_pickle or db.user_schema_pickle)
+                    getattr(exc, '_user_schema', None)
+                    or user_schema_pickle
+                    or db.user_schema_pickle
+                )
                 global_schema_pickle = (
                     global_schema_pickle or db._index._global_schema_pickle
                 )

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -185,7 +185,8 @@ async def execute(
         # If we made schema changes, include the new schema in the
         # exception so that it can be used when interpreting.
         if query_unit.user_schema:
-            ex._user_schema = query_unit.user_schema
+            if isinstance(ex, pgerror.BackendError):
+                ex._user_schema = query_unit.user_schema
 
         dbv.on_error()
 
@@ -366,7 +367,8 @@ async def execute_script(
 
         # Include the new schema in the exception so that it can be
         # used when interpreting.
-        e._user_schema = dbv.get_user_schema_pickle()
+        if isinstance(e, pgerror.BackendError):
+            e._user_schema = dbv.get_user_schema_pickle()
 
         if not in_tx and dbv.in_tx():
             # Abort the implicit transaction


### PR DESCRIPTION
Currently, if we run a DDL command that errors, and we are not in a
transaction, we will ISE instead of interpreting the error correctly.
This is because the updated user schema doesn't get stored anywhere,
because we weren't in a transaction. When inside a transaction, it
would be stored in the dbview.

I originally fixed this by using implicit transactions to keep track
of the new user schema, but this required keeping implicit
transactions open on failures, and in opening up an implicit
transaction even in single statement execution of DDL, and that all
seemed questionable.

I wound up fixing it by stashing the schema in the exception object
and extracting it in interpret_error.

Fixes #6845.