### PR TITLE
refactor shells

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2633,7 +2633,9 @@ class AlterScalarType(ScalarTypeMetaCommand, adapts=s_scalars.AlterScalarType):
                 prop:
                 s_utils.type_shell_multi_substitute(
                     type_substs,
-                    not_none(prop.get_target(schema)).as_shell(schema))
+                    not_none(prop.get_target(schema)).as_shell(schema),
+                    schema,
+                )
                 for prop in seen_props
             }
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -69,20 +69,15 @@ class AliasCommandContext(
 
 
 def _is_view_from_alias(
-    our_name: sn.QualName,
+    alias_name: sn.QualName,
     obj: s_types.Type,
     schema: s_schema.Schema,
 ) -> bool:
     name = obj.get_name(schema)
-    if our_name == name:
-        return True
-    name_prefix = f'__{our_name.name}__'
-
-    name = obj.get_name(schema)
-    return (
+    return alias_name == name or (
         isinstance(name, sn.QualName)
-        and name.module == our_name.module
-        and name.name.startswith(name_prefix)
+        and name.module == alias_name.module
+        and name.name.startswith(f'__{alias_name.name}__')
     )
 
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2193,17 +2193,15 @@ class ObjectShell(Shell, Generic[Object_T_co]):
                 'cannot resolve anonymous ObjectShell'
             )
 
-        if (
-            self.schemaclass is Object
-            or issubclass(self.schemaclass, QualifiedObject)
-        ):
+        name = self.get_name(schema)
+        if isinstance(name, sn.QualName):
             return schema.get(
-                self.name,
-                type=self.schemaclass,
-                sourcectx=self.sourcectx,
+                name, type=self.schemaclass, sourcectx=self.sourcectx,
             )
         else:
-            return schema.get_global(self.schemaclass, self.name)
+            return schema.get_global(
+                self.schemaclass, name
+            )
 
     def get_refname(self, schema: s_schema.Schema) -> sn.Name:
         if self.origname is not None:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -605,13 +605,6 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         self.expr = expr
         self.extra_args = extra_args
 
-    def resolve(self, schema: s_schema.Schema) -> TypeT_co:
-        return schema.get(
-            self.get_name(schema),
-            type=self.schemaclass,
-            sourcectx=self.sourcectx,
-        )
-
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return self.resolve(schema).is_polymorphic(schema)
 
@@ -1512,13 +1505,6 @@ class ArrayTypeShell(CollectionTypeShell[Array_T_co]):
     def get_displayname(self, schema: s_schema.Schema) -> str:
         return f'array<{self.subtype.get_displayname(schema)}>'
 
-    def resolve(self, schema: s_schema.Schema) -> Array_T_co:
-        if isinstance(self.name, s_name.QualName):
-            arr = schema.get(self.name, type=Array)
-        else:
-            arr = schema.get_global(Array, self.get_name(schema))
-        return arr  # type: ignore
-
     def as_create_delta(
         self,
         schema: s_schema.Schema,
@@ -2077,13 +2063,6 @@ class TupleTypeShell(CollectionTypeShell[Tuple_T_co]):
     def is_named(self) -> bool:
         return self.typemods is not None and self.typemods.get('named', False)
 
-    def resolve(self, schema: s_schema.Schema) -> Tuple_T_co:
-        if isinstance(self.name, s_name.QualName):
-            tup = schema.get(self.name, type=Tuple)
-        else:
-            tup = schema.get_global(Tuple, self.get_name(schema))
-        return tup  # type: ignore
-
     def as_create_delta(
         self,
         schema: s_schema.Schema,
@@ -2473,13 +2452,6 @@ class RangeTypeShell(CollectionTypeShell[Range_T_co]):
     def get_displayname(self, schema: s_schema.Schema) -> str:
         return f'range<{self.subtype.get_displayname(schema)}>'
 
-    def resolve(self, schema: s_schema.Schema) -> Range_T_co:
-        if isinstance(self.name, s_name.QualName):
-            rng = schema.get(self.name, type=Range)
-        else:
-            rng = schema.get_global(Range, self.get_name(schema))
-        return rng  # type: ignore
-
     def as_create_delta(
         self,
         schema: s_schema.Schema,
@@ -2819,13 +2791,6 @@ class MultiRangeTypeShell(CollectionTypeShell[MultiRange_T_co]):
 
     def get_displayname(self, schema: s_schema.Schema) -> str:
         return f'multirange<{self.subtype.get_displayname(schema)}>'
-
-    def resolve(self, schema: s_schema.Schema) -> MultiRange_T_co:
-        if isinstance(self.name, s_name.QualName):
-            rng = schema.get(self.name, type=MultiRange)
-        else:
-            rng = schema.get_global(MultiRange, self.get_name(schema))
-        return rng  # type: ignore
 
     def as_create_delta(
         self,

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -411,12 +411,14 @@ def type_op_ast_to_type_shell(
                 components=left.components + right.components,
                 module=module,
                 schemaclass=metaclass,
+                schema=schema
             )
         else:
             return s_types.UnionTypeShell(
                 components=left.components + (right,),
                 module=module,
                 schemaclass=metaclass,
+                schema=schema,
             )
     else:
         if isinstance(right, s_types.UnionTypeShell):
@@ -424,12 +426,14 @@ def type_op_ast_to_type_shell(
                 components=(left,) + right.components,
                 schemaclass=metaclass,
                 module=module,
+                schema=schema,
             )
         else:
             return s_types.UnionTypeShell(
                 components=(left, right),
                 module=module,
                 schemaclass=metaclass,
+                schema=schema,
             )
 
 
@@ -1291,9 +1295,10 @@ def get_config_type_shape(
 def type_shell_multi_substitute(
     mapping: Dict[sn.Name, s_types.TypeShell[s_types.TypeT_co]],
     typ: s_types.TypeShell[s_types.TypeT_co],
+    schema: s_schema.Schema,
 ) -> s_types.TypeShell[s_types.TypeT_co]:
     for name, new in mapping.items():
-        typ = type_shell_substitute(name, new, typ)
+        typ = type_shell_substitute(name, new, typ, schema)
     return typ
 
 
@@ -1301,6 +1306,7 @@ def type_shell_substitute(
     name: sn.Name,
     new: s_types.TypeShell[s_types.TypeT_co],
     typ: s_types.TypeShell[s_types.TypeT_co],
+    schema: s_schema.Schema,
 ) -> s_types.TypeShell[s_types.TypeT_co]:
     from . import types as s_types
 
@@ -1309,48 +1315,55 @@ def type_shell_substitute(
         return new
 
     if isinstance(typ, s_types.UnionTypeShell):
+        assert isinstance(typ.name, sn.QualName)
         return s_types.UnionTypeShell(
-            module=typ.module,
+            module=typ.name.module,
             schemaclass=typ.schemaclass,
             opaque=typ.opaque,
             components=[
-                type_shell_substitute(name, new, c)
+                type_shell_substitute(name, new, c, schema)
                 for c in typ.components
-            ]
+            ],
+            schema=schema,
         )
     elif isinstance(typ, s_types.IntersectionTypeShell):
+        assert isinstance(typ.name, sn.QualName)
         return s_types.IntersectionTypeShell(
-            module=typ.module,
+            module=typ.name.module,
             schemaclass=typ.schemaclass,
             components=[
-                type_shell_substitute(name, new, c)
+                type_shell_substitute(name, new, c, schema)
                 for c in typ.components
-            ]
+            ],
+            schema=schema,
         )
     elif isinstance(typ, s_types.ArrayTypeShell):
         return s_types.ArrayTypeShell(
-            name=sn.UnqualName('__unresolved__'),
+            name=None,
             expr=typ.expr,
             typemods=typ.typemods,
             schemaclass=typ.schemaclass,
-            subtype=type_shell_substitute(name, new, typ.subtype),
+            subtype=type_shell_substitute(name, new, typ.subtype, schema),
+            schema=schema,
         )
     elif isinstance(typ, s_types.TupleTypeShell):
         return s_types.TupleTypeShell(
-            name=sn.UnqualName('__unresolved__'),
+            name=None,
             typemods=typ.typemods,
             schemaclass=typ.schemaclass,
             subtypes={
-                k: type_shell_substitute(name, new, v)
+                k: type_shell_substitute(name, new, v, schema)
                 for k, v in typ.subtypes.items()
-            }
+            },
+            schema=schema,
         )
     elif isinstance(typ, s_types.RangeTypeShell):
         return s_types.RangeTypeShell(
-            name=sn.UnqualName('__unresolved__'),
+            name=None,
             typemods=typ.typemods,
             schemaclass=typ.schemaclass,
-            subtype=type_shell_substitute(name, new, typ.subtype),
+            subtype=type_shell_substitute(name, new, typ.subtype, schema),
+            schema=schema,
         )
     else:
         return typ


### PR DESCRIPTION
- refactor: _is_view_from_alias
- refactor: remove a few TypeShell.resolve functions
- refactor: make shell name generation eager instead of lazy
