### PR TITLE
Serialize tokenized/normalized Source

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -202,9 +202,9 @@
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
         restore-keys: |
-          edb-parsers-v2-
+          edb-parsers-v3-
 
     - name: Build parsers
       env:
@@ -358,7 +358,7 @@
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -238,9 +238,9 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
         restore-keys: |
-          edb-parsers-v2-
+          edb-parsers-v3-
 
     - name: Build parsers
       env:
@@ -401,7 +401,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -223,9 +223,9 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
         restore-keys: |
-          edb-parsers-v2-
+          edb-parsers-v3-
 
     - name: Build parsers
       env:
@@ -432,7 +432,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3
@@ -638,7 +638,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3
@@ -892,7 +892,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3
@@ -1112,7 +1112,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3
@@ -1320,7 +1320,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -225,9 +225,9 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
         restore-keys: |
-          edb-parsers-v2-
+          edb-parsers-v3-
 
     - name: Build parsers
       env:
@@ -401,7 +401,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -223,9 +223,9 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
         restore-keys: |
-          edb-parsers-v2-
+          edb-parsers-v3-
 
     - name: Build parsers
       env:
@@ -420,7 +420,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,9 +235,9 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
         restore-keys: |
-          edb-parsers-v2-
+          edb-parsers-v3-
 
     - name: Build parsers
       env:
@@ -469,7 +469,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3
@@ -606,7 +606,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,28 +39,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcode"
-version = "0.4.0"
+name = "bincode"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab8eb922a99ab601facde7ae07200e811cdc2ae1df604ffd6c2b7c976dd3fff"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "bitcode_derive",
- "bytemuck",
- "from_bytes_or_zeroed",
- "residua-zigzag",
  "serde",
-]
-
-[[package]]
-name = "bitcode_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ab471e684e2f6f3c3071361e2c30e41d7543f505658daae3ceb89c202d933e"
-dependencies = [
- "packagemerge",
- "proc-macro2",
- "quote",
- "syn 2.0.16",
 ]
 
 [[package]]
@@ -92,12 +76,6 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
-name = "bytemuck"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -253,7 +231,7 @@ name = "edgeql-parser-python"
 version = "0.1.0"
 dependencies = [
  "bigdecimal",
- "bitcode",
+ "bincode",
  "blake2",
  "bytes",
  "edgedb-protocol",
@@ -271,12 +249,6 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "from_bytes_or_zeroed"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d25934a78435889223e575c7b0fc36a290c5a312e7a7ae901f10587792e142a"
 
 [[package]]
 name = "generic-array"
@@ -328,12 +300,6 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
-
-[[package]]
-name = "itertools"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"
 
 [[package]]
 name = "itoa"
@@ -447,15 +413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "packagemerge"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efcf6ee55f8f7a24333bc8d1dd0e541a6cedf903dbc07ae6479d7f8ff32ed08"
-dependencies = [
- "itertools",
 ]
 
 [[package]]
@@ -590,7 +547,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -602,14 +559,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -639,12 +596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "residua-zigzag"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b37805477eee599a61753230f511ae94d737f69b536e468e294723ad5f1b75f"
-
-[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,22 +609,22 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -752,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,7 +735,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -861,7 +812,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -883,7 +834,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
+++ b/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 indexmap = "1.9.3"
 once_cell = "1.18.0"
 pyo3 = { version = "0.20.2", features = ["extension-module"] }
-bitcode = { version = "0.4.0", features = ["serde"] }
+bincode = { version = "1.3.3" }
 
 [dependencies.edgedb-protocol]
 git = "https://github.com/edgedb/edgedb-rust"

--- a/edb/edgeql-parser/edgeql-parser-python/src/errors.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/errors.rs
@@ -1,6 +1,7 @@
 use edgeql_parser::tokenizer::Error;
 use pyo3::prelude::*;
 use pyo3::{create_exception, exceptions};
+use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyBytes, PyList};
 
 use crate::tokenizer::OpaqueToken;
@@ -26,7 +27,8 @@ impl ParserResult {
             rv.push(token.borrow().inner.clone());
         }
         let mut buf = vec![0u8];  // type and version
-        bincode::serialize_into(&mut buf, &rv).expect("serialize");
+        bincode::serialize_into(&mut buf, &rv)
+            .map_err(|e| PyValueError::new_err(format!("Failed to pack: {e}")))?;
         Ok(PyBytes::new(py, buf.as_slice()).into())
     }
 }

--- a/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
@@ -6,6 +6,7 @@ mod parser;
 mod position;
 mod pynormalize;
 mod tokenizer;
+mod unpack;
 
 use pyo3::prelude::*;
 
@@ -38,6 +39,9 @@ fn _edgeql_parser(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<tokenizer::OpaqueToken>()?;
     m.add_function(wrap_pyfunction!(tokenizer::tokenize, m)?)?;
     m.add_function(wrap_pyfunction!(tokenizer::unpickle_token, m)?)?;
+
+    m.add_function(wrap_pyfunction!(unpack::unpack, m)?)?;
+
     tokenizer::fini_module(py, m);
 
     Ok(())

--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -6,7 +6,7 @@ use edgeql_parser::tokenizer::{Kind, Token, Tokenizer, Value};
 
 use blake2::{Blake2b512, Digest};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Variable {
     pub value: Value,
 }
@@ -18,6 +18,40 @@ pub struct Entry {
     pub variables: Vec<Vec<Variable>>,
     pub named_args: bool,
     pub first_arg: Option<usize>,
+}
+
+/// EntryPack is a compact Entry for serialization purposes
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct EntryPack {
+    pub tokens: Vec<Token<'static>>,
+    pub variables: Vec<Vec<Variable>>,
+    pub named_args: bool,
+    pub first_arg: Option<usize>,
+}
+
+impl Into<EntryPack> for Entry {
+    fn into(self) -> EntryPack {
+        EntryPack {
+            tokens: self.tokens,
+            variables: self.variables,
+            named_args: self.named_args,
+            first_arg: self.first_arg,
+        }
+    }
+}
+
+impl Into<Entry> for EntryPack {
+    fn into(self) -> Entry {
+        let processed_source = serialize_tokens(&self.tokens[..]);
+        Entry {
+            hash: hash(&processed_source),
+            processed_source,
+            tokens: self.tokens,
+            variables: self.variables,
+            named_args: self.named_args,
+            first_arg: self.first_arg,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -20,18 +20,18 @@ pub struct Entry {
     pub first_arg: Option<usize>,
 }
 
-/// EntryPack is a compact Entry for serialization purposes
+/// PackedEntry is a compact Entry for serialization purposes
 #[derive(serde::Serialize, serde::Deserialize)]
-pub struct EntryPack {
+pub struct PackedEntry {
     pub tokens: Vec<Token<'static>>,
     pub variables: Vec<Vec<Variable>>,
     pub named_args: bool,
     pub first_arg: Option<usize>,
 }
 
-impl Into<EntryPack> for Entry {
-    fn into(self) -> EntryPack {
-        EntryPack {
+impl Into<PackedEntry> for Entry {
+    fn into(self) -> PackedEntry {
+        PackedEntry {
             tokens: self.tokens,
             variables: self.variables,
             named_args: self.named_args,
@@ -40,7 +40,7 @@ impl Into<EntryPack> for Entry {
     }
 }
 
-impl Into<Entry> for EntryPack {
+impl Into<Entry> for PackedEntry {
     fn into(self) -> Entry {
         let processed_source = serialize_tokens(&self.tokens[..]);
         Entry {

--- a/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::OnceCell;
 
 use edgeql_parser::parser;
-use pyo3::exceptions::PyAssertionError;
+use pyo3::exceptions::{PyAssertionError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple};
 
@@ -115,7 +115,7 @@ pub fn preload_spec(py: Python, spec_filepath: &PyString) -> PyResult<()> {
         .unwrap_or_else(|e| panic!("Cannot read grammar spec from {spec_filepath} ({e})"));
 
     let spec: parser::Spec = bincode::deserialize::<parser::SpecSerializable>(&bytes)
-        .unwrap()
+        .map_err(|e| PyValueError::new_err(format!("Bad spec: {e}")))?
         .into();
     let productions = load_productions(py, &spec)?;
 
@@ -129,8 +129,10 @@ pub fn preload_spec(py: Python, spec_filepath: &PyString) -> PyResult<()> {
 #[pyfunction]
 pub fn save_spec(spec_json: &PyString, dst: &PyString) -> PyResult<()> {
     let spec_json = spec_json.to_string();
-    let spec: parser::SpecSerializable = serde_json::from_str(&spec_json).unwrap();
-    let spec_bitcode = bincode::serialize(&spec).unwrap();
+    let spec: parser::SpecSerializable = serde_json::from_str(&spec_json)
+        .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {e}")))?;
+    let spec_bitcode = bincode::serialize(&spec)
+        .map_err(|e| PyValueError::new_err(format!("Failed to pack spec: {e}")))?;
 
     let dst = dst.to_string();
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
@@ -114,7 +114,7 @@ pub fn preload_spec(py: Python, spec_filepath: &PyString) -> PyResult<()> {
     let bytes = std::fs::read(&spec_filepath)
         .unwrap_or_else(|e| panic!("Cannot read grammar spec from {spec_filepath} ({e})"));
 
-    let spec: parser::Spec = bitcode::deserialize::<parser::SpecSerializable>(&bytes)
+    let spec: parser::Spec = bincode::deserialize::<parser::SpecSerializable>(&bytes)
         .unwrap()
         .into();
     let productions = load_productions(py, &spec)?;
@@ -130,7 +130,7 @@ pub fn preload_spec(py: Python, spec_filepath: &PyString) -> PyResult<()> {
 pub fn save_spec(spec_json: &PyString, dst: &PyString) -> PyResult<()> {
     let spec_json = spec_json.to_string();
     let spec: parser::SpecSerializable = serde_json::from_str(&spec_json).unwrap();
-    let spec_bitcode = bitcode::serialize(&spec).unwrap();
+    let spec_bitcode = bincode::serialize(&spec).unwrap();
 
     let dst = dst.to_string();
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/pynormalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/pynormalize.rs
@@ -11,32 +11,14 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyFloat, PyList, PyLong, PyString};
 
 use crate::errors::SyntaxError;
-use crate::normalize::{normalize as _normalize, Error, Variable};
+use crate::normalize::{normalize as _normalize, Error, Variable, EntryPack};
 use crate::tokenizer::tokens_to_py;
 
 #[pyfunction]
 pub fn normalize(py: Python<'_>, text: &PyString) -> PyResult<Entry> {
     let text = text.to_string();
     match _normalize(&text) {
-        Ok(entry) => {
-            let blobs =
-                serialize_all(py, &entry.variables).map_err(PyAssertionError::new_err)?;
-            let counts: Vec<_> = entry
-                .variables
-                .iter()
-                .map(|x| x.len().into_py(py))
-                .collect();
-
-            Ok(Entry {
-                key: PyBytes::new(py, &entry.hash[..]).into(),
-                tokens: tokens_to_py(py, entry.tokens)?,
-                extra_blobs: blobs.into(),
-                extra_named: entry.named_args,
-                first_extra: entry.first_arg,
-                extra_counts: PyList::new(py, &counts[..]).into(),
-                variables: entry.variables,
-            })
-        }
+        Ok(entry) => Entry::new(py, entry),
         Err(Error::Tokenizer(msg, pos)) => {
             Err(SyntaxError::new_err((
                 msg,
@@ -70,7 +52,29 @@ pub struct Entry {
     #[pyo3(get)]
     extra_counts: PyObject,
 
-    variables: Vec<Vec<Variable>>,
+    entry_pack: EntryPack,
+}
+
+impl Entry {
+    pub fn new(py: Python, entry: crate::normalize::Entry) -> PyResult<Self> {
+        let blobs =
+            serialize_all(py, &entry.variables).map_err(PyAssertionError::new_err)?;
+        let counts: Vec<_> = entry
+            .variables
+            .iter()
+            .map(|x| x.len().into_py(py))
+            .collect();
+
+        Ok(Entry {
+            key: PyBytes::new(py, &entry.hash[..]).into(),
+            tokens: tokens_to_py(py, entry.tokens.clone())?,
+            extra_blobs: blobs.into(),
+            extra_named: entry.named_args,
+            first_extra: entry.first_arg,
+            extra_counts: PyList::new(py, &counts[..]).into(),
+            entry_pack: entry.into(),
+        })
+    }
 }
 
 #[pymethods]
@@ -81,7 +85,7 @@ impl Entry {
             Some(first) => first,
             None => return Ok(vars.to_object(py)),
         };
-        for (idx, var) in self.variables.iter().flatten().enumerate() {
+        for (idx, var) in self.entry_pack.variables.iter().flatten().enumerate() {
             let s = if self.extra_named {
                 format!("__edb_arg_{}", first + idx)
             } else {
@@ -91,6 +95,12 @@ impl Entry {
         }
 
         Ok(vars.to_object(py))
+    }
+
+    fn pack(&self, py: Python) -> PyResult<PyObject> {
+        let mut buf = vec![1u8];  // type and version
+        bincode::serialize_into(&mut buf, &self.entry_pack).expect("serialize");
+        Ok(PyBytes::new(py, buf.as_slice()).into())
     }
 }
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/pynormalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/pynormalize.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyFloat, PyList, PyLong, PyString};
 
 use crate::errors::SyntaxError;
-use crate::normalize::{normalize as _normalize, Error, Variable, EntryPack};
+use crate::normalize::{normalize as _normalize, Error, Variable, PackedEntry};
 use crate::tokenizer::tokens_to_py;
 
 #[pyfunction]
@@ -52,7 +52,7 @@ pub struct Entry {
     #[pyo3(get)]
     extra_counts: PyObject,
 
-    entry_pack: EntryPack,
+    entry_pack: PackedEntry,
 }
 
 impl Entry {

--- a/edb/edgeql-parser/edgeql-parser-python/src/pynormalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/pynormalize.rs
@@ -6,7 +6,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use edgedb_protocol::codec;
 use edgedb_protocol::model::{BigInt, Decimal};
 use edgeql_parser::tokenizer::Value;
-use pyo3::exceptions::PyAssertionError;
+use pyo3::exceptions::{PyAssertionError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyFloat, PyList, PyLong, PyString};
 
@@ -99,7 +99,8 @@ impl Entry {
 
     fn pack(&self, py: Python) -> PyResult<PyObject> {
         let mut buf = vec![1u8];  // type and version
-        bincode::serialize_into(&mut buf, &self.entry_pack).expect("serialize");
+        bincode::serialize_into(&mut buf, &self.entry_pack)
+            .map_err(|e| PyValueError::new_err(format!("Failed to pack: {e}")))?;
         Ok(PyBytes::new(py, buf.as_slice()).into())
     }
 }

--- a/edb/edgeql-parser/edgeql-parser-python/src/tokenizer.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/tokenizer.rs
@@ -1,5 +1,6 @@
 use edgeql_parser::tokenizer::{Token, Tokenizer};
 use once_cell::sync::OnceCell;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList, PyString};
 
@@ -49,7 +50,8 @@ impl OpaqueToken {
         Ok(self.inner.to_string())
     }
     fn __reduce__(&self, py: Python) -> PyResult<(PyObject, (PyObject,))> {
-        let data = bincode::serialize(&self.inner).unwrap();
+        let data = bincode::serialize(&self.inner)
+            .map_err(|e| PyValueError::new_err(format!("Failed to reduce: {e}")))?;
 
         let tok = get_unpickle_token_fn(py);
         Ok((tok, (PyBytes::new(py, &data).to_object(py),)))
@@ -86,7 +88,8 @@ pub fn fini_module(py: Python, m: &PyModule) {
 
 #[pyfunction]
 pub fn unpickle_token(bytes: &PyBytes) -> PyResult<OpaqueToken> {
-    let token = bincode::deserialize(bytes.as_bytes()).unwrap();
+    let token = bincode::deserialize(bytes.as_bytes())
+        .map_err(|e| PyValueError::new_err(format!("Failed to read token: {e}")))?;
     Ok(OpaqueToken { inner: token })
 }
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/tokenizer.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/tokenizer.rs
@@ -49,7 +49,7 @@ impl OpaqueToken {
         Ok(self.inner.to_string())
     }
     fn __reduce__(&self, py: Python) -> PyResult<(PyObject, (PyObject,))> {
-        let data = bitcode::serialize(&self.inner).unwrap();
+        let data = bincode::serialize(&self.inner).unwrap();
 
         let tok = get_unpickle_token_fn(py);
         Ok((tok, (PyBytes::new(py, &data).to_object(py),)))
@@ -86,7 +86,7 @@ pub fn fini_module(py: Python, m: &PyModule) {
 
 #[pyfunction]
 pub fn unpickle_token(bytes: &PyBytes) -> PyResult<OpaqueToken> {
-    let token = bitcode::deserialize(bytes.as_bytes()).unwrap();
+    let token = bincode::deserialize(bytes.as_bytes()).unwrap();
     Ok(OpaqueToken { inner: token })
 }
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use edgeql_parser::tokenizer::Token;
 
-use crate::normalize::EntryPack;
+use crate::normalize::PackedEntry;
 use crate::pynormalize::Entry;
 use crate::tokenizer::tokens_to_py;
 
@@ -17,7 +17,7 @@ pub fn unpack(py: Python<'_>, serialized: &PyBytes) -> PyResult<PyObject> {
             tokens_to_py(py, tokens)
         }
         1u8 => {
-            let pack: EntryPack = bincode::deserialize(&buf[1..])
+            let pack: PackedEntry = bincode::deserialize(&buf[1..])
                 .map_err(|e| PyValueError::new_err(format!("{e}")))?;
             let entry = Entry::new(py, pack.into())?;
             Ok(entry.into_py(py))

--- a/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
@@ -18,7 +18,7 @@ pub fn unpack(py: Python<'_>, serialized: &PyBytes) -> PyResult<PyObject> {
         }
         1u8 => {
             let pack: PackedEntry = bincode::deserialize(&buf[1..])
-                .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+                .map_err(|e| PyValueError::new_err(format!("Failed to unpack: {e}")))?;
             let entry = Entry::new(py, pack.into())?;
             Ok(entry.into_py(py))
         }

--- a/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
@@ -1,0 +1,27 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use edgeql_parser::tokenizer::Token;
+
+use crate::normalize::EntryPack;
+use crate::pynormalize::Entry;
+use crate::tokenizer::tokens_to_py;
+
+#[pyfunction]
+pub fn unpack(py: Python<'_>, serialized: &PyBytes) -> PyResult<PyObject> {
+    let buf = serialized.as_bytes();
+    match buf[0] {
+        0u8 => {
+            let tokens: Vec<Token> = bincode::deserialize(&buf[1..])
+                .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+            tokens_to_py(py, tokens)
+        }
+        1u8 => {
+            let pack: EntryPack = bincode::deserialize(&buf[1..])
+                .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+            let entry = Entry::new(py, pack.into())?;
+            Ok(entry.into_py(py))
+        }
+        _ => Err(PyValueError::new_err(format!("Invalid type/version byte: {}", buf[0]))),
+    }
+}

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -6339,3 +6339,28 @@ class TestEdgeQLNormalization(EdgeQLSyntaxTest):
         '''
         select count 1;
         '''
+
+
+class TestEdgeQLTokenSerialization(unittest.TestCase):
+    def test_edgeql_token_serialization(self):
+        query = "SELECT (12345678, <str>$0)"
+        src1 = tokenizer.Source.from_string(query)
+        src2 = tokenizer.deserialize(src1.serialize(), query)
+        self.assertSourceEqual(src1, src2)
+
+    def test_edgeql_normalized_token_serialization(self):
+        query = "SELECT (12345678, <str>$0)"
+        src1 = tokenizer.NormalizedSource.from_string(query)
+        src2 = tokenizer.deserialize(src1.serialize(), query)
+        self.assertSourceEqual(src1, src2)
+
+    def assertSourceEqual(self, src1, src2):
+        self.assertIs(type(src1), type(src2))
+        self.assertEqual(src1.text(), src2.text())
+        self.assertEqual(src1.cache_key(), src2.cache_key())
+        self.assertEqual(src1.variables(), src2.variables())
+        self.assertEqual(str(src1.tokens()), str(src2.tokens()))
+        self.assertEqual(src1.first_extra(), src2.first_extra())
+        self.assertEqual(src1.extra_counts(), src2.extra_counts())
+        self.assertEqual(src1.extra_blobs(), src2.extra_blobs())
+        self.assertIs(src1.serialize(), src2.serialize())


### PR DESCRIPTION
Per persistent cache, we have a scenario to re-compile cached queries. Due to security concerns, the original query string with potentially sensitive literals is unsuitable for database storage. So, to be able to recompile, we shall store the serialized `Source` (only tokens) and `NormalizedSource` (tokens + variables + named_args + first_arg) in the db cache.

On re-compile, we don't really need the spans in tokens, because the cache shall be dropped on compile errors. An alternative way is to store a normalized query string, which requires a hack to replace the internal expr, e.g., `<lit int64>$3` with legal EdgeQL like `<int64>$3`. In this case, we still need to serialize other necessary info like `first_extra` for the compiler to work properly. So as for now, I'm just serializing the tokens + necessary fields as a first implementation.

Size wise, a query like `select (12345678, <str>$0);` is serialized into:

 * 464 bytes with normalization, or
 * 425 bytes without

The serialization is done using `bincode`, which is friendly for long-term storage. At the same time, the current `bitcode` is also replaced with `bincode` for less dependency / smaller binary build.