### PR TITLE
Make CREATE EXTENSION ... VERSION more flexible

### DIFF
--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -196,7 +196,10 @@ def get_package(
     ]
     if version is not None:
         filters.append(
-            lambda schema, pkg: pkg.get_version(schema) == version,
+            lambda schema, pkg: (
+                pkg.get_version(schema) >= version
+                and pkg.get_version(schema).major == version.major
+            )
         )
 
     pkgs = list(schema.get_objects(


### PR DESCRIPTION
It will now select something >= the specified version while still
matching the major version.

In the future we can start adding qualifiers to the string to be more
or less specific.

Doing something like this is desired because existing migrations have
pgvector 0.4.0 written in them, which we'd prefer to not have exist in
edgedb 5.0.