### PR TITLE
Remove CentOS 7 from list of build targets

### DIFF
--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -79,12 +79,6 @@ targets:
           platform_version: jammy
           family: debian
           runs_on: [self-hosted, linux, arm64]
-        - name: centos-7-x86_64
-          arch: x86_64
-          platform: centos
-          platform_version: 7
-          family: redhat
-          runs_on: [self-hosted, linux, x64]
         - name: centos-8-x86_64
           arch: x86_64
           platform: centos

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -35,8 +35,6 @@ jobs:
 
       if_ubuntu_jammy_aarch64: ${{ steps.scm.outputs.if_ubuntu_jammy_aarch64 }}
 
-      if_centos_7_x86_64: ${{ steps.scm.outputs.if_centos_7_x86_64 }}
-
       if_centos_8_x86_64: ${{ steps.scm.outputs.if_centos_8_x86_64 }}
 
       if_centos_8_aarch64: ${{ steps.scm.outputs.if_centos_8_aarch64 }}
@@ -243,20 +241,6 @@ jobs:
         fi
 
         echo if_ubuntu_jammy_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el7.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
-        fi
-        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing centos-7-x86_64'
-          val=false
-        fi
-
-        echo if_centos_7_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
@@ -664,30 +648,6 @@ jobs:
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
-
-  build-centos-7-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_centos_7_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
 
   build-centos-8-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -1255,27 +1215,6 @@ jobs:
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-centos-7-x86_64:
-    needs: [build-centos-7-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
   test-centos-8-x86_64:
     needs: [build-centos-8-x86_64]
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -1522,8 +1461,6 @@ jobs:
       - test-ubuntu-jammy-x86_64
       - build-ubuntu-jammy-aarch64
       - test-ubuntu-jammy-aarch64
-      - build-centos-7-x86_64
-      - test-centos-7-x86_64
       - build-centos-8-x86_64
       - test-centos-8-x86_64
       - build-centos-8-aarch64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,8 +40,6 @@ jobs:
 
       if_ubuntu_jammy_aarch64: ${{ steps.scm.outputs.if_ubuntu_jammy_aarch64 }}
 
-      if_centos_7_x86_64: ${{ steps.scm.outputs.if_centos_7_x86_64 }}
-
       if_centos_8_x86_64: ${{ steps.scm.outputs.if_centos_8_x86_64 }}
 
       if_centos_8_aarch64: ${{ steps.scm.outputs.if_centos_8_aarch64 }}
@@ -248,20 +246,6 @@ jobs:
         fi
 
         echo if_ubuntu_jammy_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el7.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
-        fi
-        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing centos-7-x86_64'
-          val=false
-        fi
-
-        echo if_centos_7_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
@@ -669,30 +653,6 @@ jobs:
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
-
-  build-centos-7-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_centos_7_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
 
   build-centos-8-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -1255,27 +1215,6 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-7-x86_64:
-    needs: [build-centos-7-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
         PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
@@ -2121,58 +2060,6 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-centos-7-x86_64:
-    needs: [test-centos-7-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-7-x86_64:
-    needs: [publish-centos-7-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-7
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-7@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
   publish-centos-8-x86_64:
     needs: [test-centos-8-x86_64]
     runs-on: ubuntu-latest
@@ -2785,10 +2672,6 @@ jobs:
       - test-ubuntu-jammy-aarch64
       - publish-ubuntu-jammy-aarch64
       - check-published-ubuntu-jammy-aarch64
-      - build-centos-7-x86_64
-      - test-centos-7-x86_64
-      - publish-centos-7-x86_64
-      - check-published-centos-7-x86_64
       - build-centos-8-x86_64
       - test-centos-8-x86_64
       - publish-centos-8-x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,28 +286,6 @@ jobs:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
 
-  build-centos-7-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
   build-centos-8-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
@@ -842,26 +820,6 @@ jobs:
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-centos-7-x86_64:
-    needs: [build-centos-7-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
-      env:
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
   test-centos-8-x86_64:
     needs: [build-centos-8-x86_64]
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -1081,7 +1039,6 @@ jobs:
     - test-ubuntu-focal-aarch64
     - test-ubuntu-jammy-x86_64
     - test-ubuntu-jammy-aarch64
-    - test-centos-7-x86_64
     - test-centos-8-x86_64
     - test-centos-8-aarch64
     - test-rockylinux-9-x86_64
@@ -1696,56 +1653,6 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-centos-7-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-7-x86_64:
-    needs: [publish-centos-7-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-7
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-7@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
   publish-centos-8-x86_64:
     needs: [collect]
     runs-on: ubuntu-latest
@@ -2341,10 +2248,6 @@ jobs:
       - test-ubuntu-jammy-aarch64
       - publish-ubuntu-jammy-aarch64
       - check-published-ubuntu-jammy-aarch64
-      - build-centos-7-x86_64
-      - test-centos-7-x86_64
-      - publish-centos-7-x86_64
-      - check-published-centos-7-x86_64
       - build-centos-8-x86_64
       - test-centos-8-x86_64
       - publish-centos-8-x86_64

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -298,29 +298,6 @@ jobs:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
 
-  build-centos-7-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
-      env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
   build-centos-8-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
@@ -877,27 +854,6 @@ jobs:
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-centos-7-x86_64:
-    needs: [build-centos-7-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
   test-centos-8-x86_64:
     needs: [build-centos-8-x86_64]
     runs-on: ['self-hosted', 'linux', 'x64']
@@ -1127,7 +1083,6 @@ jobs:
     - test-ubuntu-focal-aarch64
     - test-ubuntu-jammy-x86_64
     - test-ubuntu-jammy-aarch64
-    - test-centos-7-x86_64
     - test-centos-8-x86_64
     - test-centos-8-aarch64
     - test-rockylinux-9-x86_64
@@ -1766,58 +1721,6 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-centos-7-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-7-x86_64:
-    needs: [publish-centos-7-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: builds-centos-7-x86_64
-        path: artifacts/centos-7
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-7
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-7@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
   publish-centos-8-x86_64:
     needs: [collect]
     runs-on: ubuntu-latest
@@ -2431,10 +2334,6 @@ jobs:
       - test-ubuntu-jammy-aarch64
       - publish-ubuntu-jammy-aarch64
       - check-published-ubuntu-jammy-aarch64
-      - build-centos-7-x86_64
-      - test-centos-7-x86_64
-      - publish-centos-7-x86_64
-      - check-published-centos-7-x86_64
       - build-centos-8-x86_64
       - test-centos-8-x86_64
       - publish-centos-8-x86_64


### PR DESCRIPTION
We can no longer build a native CentOS 7 RPM (at least not with the
default toolchain), and it seems like making it work would be harder and
harder.  If you're still running CentOS 7, switch to the generic
portable build instead, which can still run on CentOS 7 and is
supported.
