### PR TITLE
bump more actions

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -58,14 +58,14 @@
     # Restore binary cache
 
     - name: Handle cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
@@ -74,21 +74,21 @@
           edb-rust-v3-
 
     - name: Handle cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Handle cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
@@ -120,7 +120,7 @@
     # Build EdgeDB CLI
 
     - name: Handle EdgeDB CLI build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
@@ -142,7 +142,7 @@
     # Build Rust extensions
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
@@ -174,7 +174,7 @@
     # Build extensions
 
     - name: Handle Cython extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
@@ -198,7 +198,7 @@
     # Build parsers
 
     - name: Handle compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
@@ -277,7 +277,7 @@
     # Refresh the bootstrap cache
 
     - name: Handle bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -333,49 +333,49 @@
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache

--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -111,11 +111,10 @@
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     # Build EdgeDB CLI
 

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -74,7 +74,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -87,12 +87,11 @@ jobs:
         toolchain: "stable"
 
     - name: Cargo test
-      uses: actions-rs/cargo@v1
       env:
         CARGO_TARGET_DIR: ${{ env.BUILD_TEMP }}/rust/extensions
         CARGO_HOME: ${{ env.BUILD_TEMP }}/rust/extensions/cargo_home
-      with:
-        command: test
+      run:
+        cargo test
 
   python-test:
     needs: build

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -81,11 +81,10 @@ jobs:
         key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     - name: Cargo test
       uses: actions-rs/cargo@v1

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -94,14 +94,14 @@ jobs:
     # Restore binary cache
 
     - name: Handle cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
@@ -110,21 +110,21 @@ jobs:
           edb-rust-v3-
 
     - name: Handle cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Handle cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
@@ -156,7 +156,7 @@ jobs:
     # Build EdgeDB CLI
 
     - name: Handle EdgeDB CLI build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
@@ -178,7 +178,7 @@ jobs:
     # Build Rust extensions
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
@@ -210,7 +210,7 @@ jobs:
     # Build extensions
 
     - name: Handle Cython extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
@@ -234,7 +234,7 @@ jobs:
     # Build parsers
 
     - name: Handle compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
@@ -313,7 +313,7 @@ jobs:
     # Refresh the bootstrap cache
 
     - name: Handle bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -376,49 +376,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -147,11 +147,10 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     # Build EdgeDB CLI
 

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -79,14 +79,14 @@ jobs:
     # Restore binary cache
 
     - name: Handle cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
@@ -95,21 +95,21 @@ jobs:
           edb-rust-v3-
 
     - name: Handle cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Handle cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
@@ -141,7 +141,7 @@ jobs:
     # Build EdgeDB CLI
 
     - name: Handle EdgeDB CLI build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
@@ -163,7 +163,7 @@ jobs:
     # Build Rust extensions
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
@@ -195,7 +195,7 @@ jobs:
     # Build extensions
 
     - name: Handle Cython extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
@@ -219,7 +219,7 @@ jobs:
     # Build parsers
 
     - name: Handle compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
@@ -298,7 +298,7 @@ jobs:
     # Refresh the bootstrap cache
 
     - name: Handle bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -407,49 +407,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -613,49 +613,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -867,49 +867,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -1087,49 +1087,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -1295,49 +1295,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -132,11 +132,10 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     # Build EdgeDB CLI
 

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -81,14 +81,14 @@ jobs:
     # Restore binary cache
 
     - name: Handle cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
@@ -97,21 +97,21 @@ jobs:
           edb-rust-v3-
 
     - name: Handle cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Handle cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
@@ -143,7 +143,7 @@ jobs:
     # Build EdgeDB CLI
 
     - name: Handle EdgeDB CLI build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
@@ -165,7 +165,7 @@ jobs:
     # Build Rust extensions
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
@@ -197,7 +197,7 @@ jobs:
     # Build extensions
 
     - name: Handle Cython extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
@@ -221,7 +221,7 @@ jobs:
     # Build parsers
 
     - name: Handle compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
@@ -300,7 +300,7 @@ jobs:
     # Refresh the bootstrap cache
 
     - name: Handle bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -376,49 +376,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -134,11 +134,10 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     # Build EdgeDB CLI
 

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -79,14 +79,14 @@ jobs:
     # Restore binary cache
 
     - name: Handle cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
@@ -95,21 +95,21 @@ jobs:
           edb-rust-v3-
 
     - name: Handle cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Handle cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
@@ -141,7 +141,7 @@ jobs:
     # Build EdgeDB CLI
 
     - name: Handle EdgeDB CLI build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
@@ -163,7 +163,7 @@ jobs:
     # Build Rust extensions
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
@@ -195,7 +195,7 @@ jobs:
     # Build extensions
 
     - name: Handle Cython extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
@@ -219,7 +219,7 @@ jobs:
     # Build parsers
 
     - name: Handle compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
@@ -298,7 +298,7 @@ jobs:
     # Refresh the bootstrap cache
 
     - name: Handle bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -395,49 +395,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -132,11 +132,10 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     # Build EdgeDB CLI
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,14 +91,14 @@ jobs:
     # Restore binary cache
 
     - name: Handle cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
@@ -107,21 +107,21 @@ jobs:
           edb-rust-v3-
 
     - name: Handle cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Handle cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
@@ -153,7 +153,7 @@ jobs:
     # Build EdgeDB CLI
 
     - name: Handle EdgeDB CLI build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
@@ -175,7 +175,7 @@ jobs:
     # Build Rust extensions
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
@@ -207,7 +207,7 @@ jobs:
     # Build extensions
 
     - name: Handle Cython extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
@@ -231,7 +231,7 @@ jobs:
     # Build parsers
 
     - name: Handle compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
@@ -310,7 +310,7 @@ jobs:
     # Refresh the bootstrap cache
 
     - name: Handle bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -364,7 +364,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Handle Rust extensions build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
@@ -444,49 +444,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache
@@ -581,49 +581,49 @@ jobs:
     # Restore build cache
 
     - name: Restore cached EdgeDB CLI binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cli-cache
       with:
         path: build/cli
         key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: rust-cache
       with:
         path: build/rust_extensions
         key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
         key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
         key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: postgres-cache
       with:
         path: build/postgres/install
         key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
 
     - name: Restore cached Stolon build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: stolon-cache
       with:
         path: build/stolon/bin
         key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
 
     - name: Restore bootstrap cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bootstrap-cache
       with:
         path: build/cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -376,12 +376,11 @@ jobs:
         toolchain: "stable"
 
     - name: Cargo test
-      uses: actions-rs/cargo@v1
       env:
         CARGO_TARGET_DIR: ${{ env.BUILD_TEMP }}/rust/extensions
         CARGO_HOME: ${{ env.BUILD_TEMP }}/rust/extensions/cargo_home
-      with:
-        command: test
+      run:
+        cargo test
 
   python-test:
     needs: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,11 +144,10 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     # Build EdgeDB CLI
 
@@ -371,11 +370,10 @@ jobs:
         key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       with:
-        profile: minimal
-        toolchain: stable
-        default: true
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
 
     - name: Cargo test
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
- workflows: Bump actions/cache to v4
- Replace unmaintained actions-rs/toolchain with dtolnay/rust-toolchain
- Replace umaintained `actions-rs/cargo` with direct `cargo` invocation
