### PR TITLE
Add annotation on internal config that affects compilation

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_02_14_00_00
+EDGEDB_CATALOG_VERSION = 2024_02_16_00_00
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -83,6 +83,7 @@ ALTER TYPE cfg::AbstractConfig {
     # reflection queries.
     CREATE PROPERTY __internal_no_apply_query_rewrites -> std::bool {
         CREATE ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
         SET default := false;
     };
 
@@ -91,6 +92,7 @@ ALTER TYPE cfg::AbstractConfig {
     # that are hidden in the public introspection schema.
     CREATE PROPERTY __internal_query_reflschema -> std::bool {
         CREATE ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
         SET default := false;
     };
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -75,6 +75,7 @@ ALTER TYPE cfg::AbstractConfig {
 
     CREATE PROPERTY __internal_testmode -> std::bool {
         CREATE ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
         SET default := false;
     };
 


### PR DESCRIPTION
We will honor `affects_compilation` for including (session) config values in the compile request, so `__internal_testmode` should be included by then.