### PR TITLE
Add ADMINISTER command to vacuum.

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1689,6 +1689,8 @@ def _compile_ql_administer(
         return ddl.administer_repair_schema(ctx, ql)
     elif ql.expr.func == 'reindex':
         return ddl.administer_reindex(ctx, ql)
+    elif ql.expr.func == 'vacuum':
+        return ddl.administer_vacuum(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',


### PR DESCRIPTION
Calling `administer vacuum(SomeType, OtherType.ptr, full := true)` will vacuum the table for `SomeType` and all its descendants, as well as the link table associated with the `ptr` (assuming that `ptr` is multi) and all its descendants. The named only argument `full` being set to `true` indicates the `FULL` option.

All of these arguments can be omitted. Not specifying any types or pointers to vacuum will result in vacuuming everything that is accessible to the user.

Co-authored-by: Michael J. Sullivan <sully@msully.net>

Fixes #6663