### PR TITLE
Remove use of `Wandalen/wretry.action`

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -311,12 +311,10 @@
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -350,12 +350,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -381,12 +381,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |
@@ -596,12 +594,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |
@@ -859,12 +855,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |
@@ -1088,12 +1082,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |
@@ -1305,12 +1297,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -350,12 +350,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -369,12 +369,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -418,12 +418,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |
@@ -564,12 +562,10 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c  # v1.3.0
+      uses: actions/download-artifact@v4
       with:
-        action: actions/download-artifact@v4
-        with: |
-          name: shared-artifacts
-          path: .tmp
+        name: shared-artifacts
+        path: .tmp
 
     - name: Set environment variables
       run: |


### PR DESCRIPTION
This reverts d5fcce58f08, as `download-artifact@v4` ostensibly no longer
has the problem that required the workaround.
