### PR TITLE
Add `instance_config` to `server-info` endpoint output when in multi-tenant mode + fix tests wait for config

### DIFF
--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1433,6 +1433,8 @@ class Tenant(ha_base.ClusterProtocol):
                 suggested_client_pool_size=self._suggested_client_pool_size,
                 tenant_id=self._tenant_id,
             ),
+            instance_config=config.debug_serialize_config(
+                self.get_sys_config()),
             user_roles=self._roles,
             pg_addr={
                 k: v for k, v in self.get_pgaddr().items() if k not in ["ssl"]

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -76,12 +76,12 @@ class BaseHttpExtensionTest(server.QueryTestCase):
                         path="server-info",
                     )
                     data = json.loads(rdata)
+                    if 'databases' not in data:
+                        # multi-tenant instance - use the first tenant
+                        data = next(iter(data['tenants'].values()))
                     if instance_config:
                         config = data['instance_config']
                     else:
-                        if 'databases' not in data:
-                            # multi-tenant instance - use the first tenant
-                            data = next(iter(data['tenants'].values()))
                         config = data['databases'][dbname]['config']
                     if config_key not in config:
                         raise AssertionError('database config not ready')


### PR DESCRIPTION
Should fix cors test failures in multi tenant mode (https://github.com/edgedb/edgedb/actions/runs/7967907312/job/21751374662).