### PR TITLE
Fix hash integer length

### DIFF
--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -59,7 +59,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         object _startup_msg_waiter
 
         dbview.CompiledQuery _last_anon_compiled
-        int _last_anon_compiled_hash
+        int64_t _last_anon_compiled_hash
 
         bint query_cache_enabled
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -511,7 +511,7 @@ class TestProtocol(ProtocolTestCase):
             await con2.aclose()
 
     async def _parse_execute(self, query, args):
-        output_format=protocol.OutputFormat.BINARY
+        output_format = protocol.OutputFormat.BINARY
         await self._parse(query, output_format=output_format)
         res = await self.con.recv()
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -404,14 +404,14 @@ class TestProtocol(ProtocolTestCase):
 
         self.assertNotEqual(cdd1.output_typedesc_id, cdd2.output_typedesc_id)
 
-    async def _parse(self, query):
+    async def _parse(self, query, output_format=protocol.OutputFormat.BINARY):
         await self.con.send(
             protocol.Parse(
                 annotations=[],
                 allowed_capabilities=protocol.Capability.ALL,
                 compilation_flags=protocol.CompilationFlag(0),
                 implicit_limit=0,
-                output_format=protocol.OutputFormat.BINARY,
+                output_format=output_format,
                 expected_cardinality=compiler.Cardinality.MANY,
                 command_text=query,
                 state_typedesc_id=b'\0' * 16,
@@ -511,9 +511,8 @@ class TestProtocol(ProtocolTestCase):
             await con2.aclose()
 
     async def _parse_execute(self, query, args):
-        await self.con.connect()
-
-        await self._parse(query)
+        output_format=protocol.OutputFormat.BINARY
+        await self._parse(query, output_format=output_format)
         res = await self.con.recv()
 
         await self.con.send(
@@ -523,7 +522,7 @@ class TestProtocol(ProtocolTestCase):
                 compilation_flags=protocol.CompilationFlag(0),
                 implicit_limit=0,
                 command_text=query,
-                output_format=protocol.OutputFormat.NONE,
+                output_format=output_format,
                 expected_cardinality=protocol.Cardinality.MANY,
                 input_typedesc_id=res.input_typedesc_id,
                 output_typedesc_id=res.output_typedesc_id,
@@ -533,7 +532,6 @@ class TestProtocol(ProtocolTestCase):
             ),
             protocol.Sync(),
         )
-        await self.con.recv()
 
     async def test_proto_execute_bad_array_01(self):
         q = "SELECT <array<int32>>$0"
@@ -558,6 +556,7 @@ class TestProtocol(ProtocolTestCase):
             len(array),   # len
         ) + array
 
+        await self.con.connect()
         await self._parse_execute(q, args)
         await self.con.recv_match(
             protocol.ErrorResponse,
@@ -586,6 +585,7 @@ class TestProtocol(ProtocolTestCase):
             len(array),   # len
         ) + array
 
+        await self.con.connect()
         await self._parse_execute(q, args)
         await self.con.recv_match(
             protocol.ErrorResponse,
@@ -614,6 +614,7 @@ class TestProtocol(ProtocolTestCase):
             len(array),   # len
         ) + array
 
+        await self.con.connect()
         await self._parse_execute(q, args)
         await self.con.recv_match(
             protocol.ErrorResponse,
@@ -655,6 +656,27 @@ class TestProtocol(ProtocolTestCase):
         await self.con.recv_match(
             protocol.ErrorResponse,
             message='invalid NULL'
+        )
+
+    async def test_proto_parse_execute_transaction_id(self):
+        await self.con.connect()
+        await self._parse_execute("start transaction", b"")
+        await self.con.recv_match(
+            protocol.CommandComplete,
+            status='START TRANSACTION'
+        )
+        await self.con.recv_match(
+            protocol.ReadyForCommand,
+            transaction_state=protocol.TransactionState.IN_TRANSACTION,
+        )
+        await self._parse_execute("commit", b"")
+        await self.con.recv_match(
+            protocol.CommandComplete,
+            status='COMMIT'
+        )
+        await self.con.recv_match(
+            protocol.ReadyForCommand,
+            transaction_state=protocol.TransactionState.NOT_IN_TRANSACTION,
         )
 
 


### PR DESCRIPTION
This fixes the CI failure in the CLI repo. It only failed in the CLI repo because it's still using the Parse + Execute flow (instead of single Execute) in migration and other places. Since we merged the new compilation request serialization, the Python `hash` of a UUID has higher chance to be greater than 32-bit integer, and reveal this issue.

- [x] Add a test