### PR TITLE
Bump `docker/setup-buildx-action` to v3

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -417,7 +417,7 @@
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345  # v3
 
     - name: Publish Docker Image (docker.io)
       uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2593,7 +2593,7 @@ jobs:
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345  # v3
 
     - name: Publish Docker Image (docker.io)
       uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2168,7 +2168,7 @@ jobs:
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345  # v3
 
     - name: Publish Docker Image (docker.io)
       uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2254,7 +2254,7 @@ jobs:
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345  # v3
 
     - name: Publish Docker Image (docker.io)
       uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5


### PR DESCRIPTION
Looks like the last action version in the build workflow that uses
Node 16.  Bump it also.
