### PR TITLE
Fix tokenized Source cache key

### DIFF
--- a/edb/edgeql/tokenizer.py
+++ b/edb/edgeql/tokenizer.py
@@ -51,7 +51,7 @@ class Source:
         tokens: List[ql_parser.Token],
         serialized: bytes,
     ) -> None:
-        self._cache_key = hashlib.blake2b(text.encode('utf-8')).digest()
+        self._cache_key = hashlib.blake2b(serialized).digest()
         self._text = text
         self._tokens = tokens
         self._serialized = serialized

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -252,11 +252,11 @@ cdef class CompilationRequest:
         assert buf.read_byte() == 0  # version
 
         flags = buf.read_byte()
-        self.json_parameters = flags & MASK_JSON_PARAMETERS
-        self.expect_one = flags & MASK_EXPECT_ONE
-        self.inline_typeids = flags & MASK_INLINE_TYPEIDS
-        self.inline_typenames = flags & MASK_INLINE_TYPENAMES
-        self.inline_objectids = flags & MASK_INLINE_OBJECTIDS
+        self.json_parameters = flags & MASK_JSON_PARAMETERS > 0
+        self.expect_one = flags & MASK_EXPECT_ONE > 0
+        self.inline_typeids = flags & MASK_INLINE_TYPEIDS > 0
+        self.inline_typenames = flags & MASK_INLINE_TYPENAMES > 0
+        self.inline_objectids = flags & MASK_INLINE_OBJECTIDS > 0
 
         self.protocol_version = buf.read_int16(), buf.read_int16()
         self.output_format = deserialize_output_format(buf.read_byte())

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -459,3 +459,25 @@ class TestCompilerPool(tbs.TestCase):
 
     async def test_server_compiler_pool_disconnect_queue_adaptive(self):
         await self._test_pool_disconnect_queue(pool.SimpleAdaptivePool)
+
+    def test_server_compiler_rpc_hash_eq(self):
+        compiler = edbcompiler.new_compiler(
+            std_schema=self._std_schema,
+            reflection_schema=self._refl_schema,
+            schema_class_layout=self._schema_class_layout,
+        )
+
+        def test(source: edgeql.Source):
+            request1 = rpc.CompilationRequest(
+                compiler.state.compilation_config_serializer
+            ).update(
+                source=source,
+                protocol_version=(1, 0),
+            )
+            request2 = rpc.CompilationRequest(
+                compiler.state.compilation_config_serializer
+            ).deserialize(request1.serialize(), "<unknown>")
+            self.assertEqual(hash(request1), hash(request2))
+            self.assertEqual(request1, request2)
+
+        test(edgeql.NormalizedSource.from_string("SELECT 42"))

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -480,4 +480,5 @@ class TestCompilerPool(tbs.TestCase):
             self.assertEqual(hash(request1), hash(request2))
             self.assertEqual(request1, request2)
 
+        test(edgeql.Source.from_string("SELECT 42"))
         test(edgeql.NormalizedSource.from_string("SELECT 42"))


### PR DESCRIPTION
`bint` can actually store an integer instead of just 0/1. Fix to use 0/1 only.
