### PR TITLE
Refactor alias and global delta operations

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -359,7 +359,7 @@ def compile_ast_fragment_to_ir(
         view_shapes_metadata={},
         schema_refs=frozenset(),
         schema_ref_exprs=None,
-        new_coll_types=frozenset(),
+        created_schema_types=frozenset(),
         scope_tree=ctx.path_scope,
         type_rewrites={},
         singletons=[],

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -284,9 +284,9 @@ def fini_expression(
         schema_refs=frozenset(
             ctx.env.schema_refs - ctx.env.created_schema_objects),
         schema_ref_exprs=ctx.env.schema_ref_exprs,
-        new_coll_types=frozenset(
+        created_schema_types=frozenset(
             t for t in ctx.env.created_schema_objects
-            if isinstance(t, s_types.Collection) and t != expr_type
+            if isinstance(t, s_types.Type)
         ),
         type_rewrites={
             (typ.id, not skip_subtypes): s

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -285,7 +285,7 @@ def fini_expression(
             ctx.env.schema_refs - ctx.env.created_schema_objects),
         schema_ref_exprs=ctx.env.schema_ref_exprs,
         new_coll_types=frozenset(
-            t for t in (ctx.env.schema_refs | ctx.env.created_schema_objects)
+            t for t in ctx.env.created_schema_objects
             if isinstance(t, s_types.Collection) and t != expr_type
         ),
         type_rewrites={

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1609,13 +1609,7 @@ def _normalize_view_ptr_expr(
         ptr_cardinality = None
         ptr_required = False
 
-        if (
-            isinstance(ptr_target, s_types.Collection)
-            and not ctx.env.orig_schema.get_by_id(ptr_target.id, default=None)
-        ):
-            # Record references to implicitly defined collection types,
-            # so that the alias delta machinery can pick them up.
-            ctx.env.created_schema_objects.add(ptr_target)
+        _record_created_collection_types(ptr_target, ctx)
 
         generic_type = ptr_target.find_generic(ctx.env.schema)
         if generic_type is not None:
@@ -2505,3 +2499,22 @@ def _late_compile_view_shapes_in_array(
         ctx: context.ContextLevel) -> None:
     for element in expr.elements:
         late_compile_view_shapes(element, ctx=ctx)
+
+
+def _record_created_collection_types(
+    type: s_types.Type,
+    ctx: context.ContextLevel
+) -> None:
+    """
+    Record references to implicitly defined collection types,
+    so that the alias delta machinery can pick them up.
+    """
+
+    if (
+        isinstance(type, s_types.Collection)
+        and not ctx.env.orig_schema.get_by_id(type.id, default=None)
+    ):
+        ctx.env.created_schema_objects.add(type)
+
+        for sub_type in type.get_subtypes(ctx.env.schema):
+            _record_created_collection_types(sub_type, ctx)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2502,18 +2502,16 @@ def _late_compile_view_shapes_in_array(
 
 
 def _record_created_collection_types(
-    type: s_types.Type,
-    ctx: context.ContextLevel
+    type: s_types.Type, ctx: context.ContextLevel
 ) -> None:
     """
     Record references to implicitly defined collection types,
     so that the alias delta machinery can pick them up.
     """
 
-    if (
-        isinstance(type, s_types.Collection)
-        and not ctx.env.orig_schema.get_by_id(type.id, default=None)
-    ):
+    if isinstance(
+        type, s_types.Collection
+    ) and not ctx.env.orig_schema.get_by_id(type.id, default=None):
         ctx.env.created_schema_objects.add(type)
 
         for sub_type in type.get_subtypes(ctx.env.schema):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -722,7 +722,7 @@ class Statement(Command):
     schema_refs: typing.FrozenSet[so.Object]
     schema_ref_exprs: typing.Optional[
         typing.Dict[so.Object, typing.Set[qlast.Base]]]
-    new_coll_types: typing.FrozenSet[s_types.Collection]
+    created_schema_types: typing.FrozenSet[s_types.Type]
     scope_tree: ScopeTreeNode
     dml_exprs: typing.List[qlast.Base]
     type_rewrites: typing.Dict[typing.Tuple[uuid.UUID, bool], Set]

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Optional, Tuple, Dict, List, TYPE_CHECKING, Set
+from typing import Any, Optional, Tuple, List, TYPE_CHECKING, Set
 
 from edb import errors
 from edb.common import parsing
@@ -472,7 +472,7 @@ def define_alias(
 ) -> Tuple[
     sd.Command,
     s_types.TypeShell[s_types.Type],
-    Set[so.ObjectShell[s_types.Type]]
+    Set[so.ObjectShell[s_types.Type]],
 ]:
     from . import ordering as s_ordering
 
@@ -485,10 +485,9 @@ def define_alias(
 
     for ty in ir.created_schema_types:
         name = ty.get_name(new_schema)
-        if (
-            not isinstance(ty, s_types.Collection)
-            and not _has_alias_name_prefix(classname, name)
-        ):
+        if not isinstance(
+            ty, s_types.Collection
+        ) and not _has_alias_name_prefix(classname, name):
             # not all created types are visible from the root, so they don't
             # need to be created in the schema
             continue
@@ -557,4 +556,3 @@ def _has_alias_name_prefix(
         and name.module == alias_name.module
         and name.name.startswith(f'__{alias_name.name}__')
     )
-

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -218,7 +218,7 @@ class AliasLikeCommand(
             parser_context=parser_context,
         )
 
-        expr = s_expr.Expression.from_ir(expr, ir, schema=schema)            
+        expr = s_expr.Expression.from_ir(expr, ir, schema=schema)
 
         is_global = (self.get_schema_metaclass().
                      get_schema_class_displayname() == 'global')
@@ -501,32 +501,25 @@ def _create_alias_types(
 
     for ty in ir.created_schema_types:
         name = ty.get_name(new_schema)
-        if not isinstance(
-            ty, s_types.Collection
-        ) and not _has_alias_name_prefix(classname, name):
+        if (
+            not isinstance(ty, s_types.Collection)
+            and not _has_alias_name_prefix(classname, name)
+        ):
             # not all created types are visible from the root, so they don't
             # need to be created in the schema
             continue
 
-        new_schema = ty.set_field_value(
-            new_schema, 'alias_is_persistent', True
+        new_schema = ty.update(
+            new_schema,
+            dict(
+                alias_is_persistent=True,
+                expr_type=s_types.ExprType.Select,
+                from_alias=True,
+                from_global=is_global,
+                internal=False,
+                builtin=False,
+            ),
         )
-        new_schema = ty.set_field_value(
-            new_schema, 'expr_type', s_types.ExprType.Select
-        )
-        new_schema = ty.set_field_value(
-            new_schema, 'from_alias', True
-        )
-        new_schema = ty.set_field_value(
-            new_schema, 'from_global', is_global
-        )
-        new_schema = ty.set_field_value(
-            new_schema, 'internal', False
-        )
-        new_schema = ty.set_field_value(
-            new_schema, 'builtin', False
-        )
-
         if isinstance(ty, s_types.Collection):
             new_schema = ty.set_field_value(new_schema, 'is_persistent', True)
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Optional, Tuple, Dict, List, TYPE_CHECKING
+from typing import Any, Optional, Tuple, Dict, List, TYPE_CHECKING, Set
 
 from edb import errors
 from edb.common import parsing
@@ -193,16 +193,22 @@ class AliasLikeCommand(
         context: sd.CommandContext,
         is_alter: bool = False,
         parser_context: Optional[parsing.ParserContext] = None,
-    ) -> Tuple[sd.Command, s_types.TypeShell[s_types.Type], s_expr.Expression]:
+    ) -> Tuple[
+        sd.Command,
+        s_types.TypeShell[s_types.Type],
+        s_expr.Expression,
+        Set[so.ObjectShell[s_types.Type]],
+    ]:
         pschema = schema
 
-        # On alters, remove all the existing objects from the schema before
-        # trying to compile again.
+        # For alters, drop the alias first, use the schema without the alias
+        # for compilation of the new alias expr
+        drop_old_types_cmd: Optional[sd.Command] = None
         if is_alter:
-            drop_cmd = self._delete_alias_type(
+            drop_old_types_cmd = self._delete_alias_type(
                 self.scls, schema, context)
             with context.suspend_dep_verification():
-                pschema = drop_cmd.apply(pschema, context)
+                pschema = drop_old_types_cmd.apply(pschema, context)
 
         ir = compile_alias_expr(
             expr.qlast,
@@ -212,36 +218,28 @@ class AliasLikeCommand(
             parser_context=parser_context,
         )
 
-        expr = s_expr.Expression.from_ir(expr, ir, schema=schema)
-
-        if not is_alter:
-            prev_expr = None
-        else:
-            prev = schema.get(classname, type=s_types.Type)
-            prev_expr_ = prev.get_expr(schema)
-            assert prev_expr_ is not None
-            prev_ir = compile_alias_expr(
-                prev_expr_.qlast,
-                classname,
-                pschema,
-                context,
-                parser_context=parser_context,
-            )
-            prev_expr = s_expr.Expression.from_ir(
-                prev_expr_, prev_ir, schema=schema)
+        expr = s_expr.Expression.from_ir(expr, ir, schema=schema)            
 
         is_global = (self.get_schema_metaclass().
                      get_schema_class_displayname() == 'global')
         cmd, type_shell = define_alias(
             expr=expr,
-            prev_expr=prev_expr,
             classname=classname,
             schema=schema,
             is_global=is_global,
             parser_context=parser_context,
         )
+        if drop_old_types_cmd:
+            cmd.prepend(drop_old_types_cmd)
 
-        return cmd, type_shell, expr
+        created_types: Set[so.ObjectShell[s_types.Type]] = {
+            so.ObjectShell(
+                name=ty.get_name(expr.ir_statement.schema),
+                schemaclass=type(ty),
+            )
+            for ty in expr.ir_statement.created_schema_types
+        }
+        return cmd, type_shell, expr, created_types
 
 
 class AliasCommand(
@@ -303,7 +301,7 @@ class CreateAliasLike(
     ) -> s_schema.Schema:
         if not context.canonical and self.get_attribute_value('expr'):
             alias_name = self._get_alias_name(self.classname)
-            type_cmd, type_shell, expr = self._handle_alias_op(
+            type_cmd, type_shell, expr, created_types = self._handle_alias_op(
                 expr=self.get_attribute_value('expr'),
                 classname=alias_name,
                 schema=schema,
@@ -314,18 +312,6 @@ class CreateAliasLike(
             self.set_attribute_value('expr', expr)
             self.set_attribute_value(
                 self.TYPE_FIELD_NAME, type_shell, computed=True)
-
-            created_types = {
-                so.ObjectShell(
-                    name=cmd.classname,
-                    schemaclass=cmd.get_schema_metaclass(),
-                )
-                for cmd in type_cmd.get_subcommands()
-                if (
-                    isinstance(cmd, sd.CreateObject)
-                    and issubclass(cmd.get_schema_metaclass(), s_types.Type)
-                )
-            }
             self.set_attribute_value('created_types', created_types)
 
         return super()._create_begin(schema, context)
@@ -387,7 +373,7 @@ class AlterAliasLike(
             is_alias = self._is_alias(self.scls, schema)
             if expr:
                 alias_name = self._get_alias_name(self.classname)
-                type_cmd, type_shell, expr = self._handle_alias_op(
+                type_cmd, type_shell, expr, created_tys = self._handle_alias_op(
                     expr=expr,
                     classname=alias_name,
                     schema=schema,
@@ -396,46 +382,13 @@ class AlterAliasLike(
                     parser_context=self.get_attribute_source_context('expr'),
                 )
 
-                # clear created_types, so type_cmd will be able to drop unneeded
-                # types
-                wipe_created = self.scls.init_delta_command(
-                    schema, sd.AlterObject
-                )
-                wipe_created.canonical = True
-                wipe_created.set_attribute_value('created_types', set())
-                self.add_prerequisite(wipe_created)
-
                 self.add_prerequisite(type_cmd)
 
                 self.set_attribute_value('expr', expr)
                 self.set_attribute_value(
                     self.TYPE_FIELD_NAME, type_shell, computed=True)
 
-                # TODO: this code chunk is a bit dodgy and inefficient,
-                # but it is fine since we are changing how alias types are saved
-                # soon.
-                from . import globals as s_globals
-                from . import objtypes as s_objtypes
-                assert isinstance(self.scls, (Alias, s_globals.Global))
-                created_types: Dict[sn.Name, Any] = {
-                    t.get_name(schema): t
-                    for t in self.scls.get_created_types(schema).objects(schema)
-                }
-                for cmd in type_cmd.get_subcommands():
-                    if isinstance(
-                        cmd, (sd.CreateObject, s_objtypes.CreateObjectType)
-                    ) and issubclass(cmd.get_schema_metaclass(), s_types.Type):
-                        created_types[cmd.classname] = so.ObjectShell(
-                            name=cmd.classname,
-                            schemaclass=cmd.get_schema_metaclass(),
-                        )
-                    if isinstance(
-                        cmd, (sd.DeleteObject, s_objtypes.DeleteObjectType)
-                    ) and issubclass(cmd.get_schema_metaclass(), s_types.Type):
-                        del created_types[cmd.classname]
-                self.set_attribute_value(
-                    'created_types', set(created_types.values())
-                )
+                self.set_attribute_value('created_types', created_tys)
 
                 # Clear out the type field in the schema *now*,
                 # before we call the parent _alter_begin, which will
@@ -529,7 +482,6 @@ def compile_alias_expr(
 def define_alias(
     *,
     expr: s_expr.CompiledExpression,
-    prev_expr: Optional[s_expr.CompiledExpression] = None,
     classname: sn.QualName,
     schema: s_schema.Schema,
     is_global: bool,
@@ -540,127 +492,52 @@ def define_alias(
     ir = expr.irast
     new_schema = ir.schema
 
-    coll_expr_aliases: List[s_types.Collection] = []
-    prev_coll_expr_aliases: List[s_types.Collection] = []
-    expr_aliases: List[s_types.Type] = []
-    prev_expr_aliases: List[s_types.Type] = []
-    prev_ir: Optional[irast.Statement] = None
-    old_schema: Optional[s_schema.Schema] = None
-
-    for vt in ir.views.values():
-        if not _is_view_from_alias(classname, vt, new_schema):
-            continue
-        if isinstance(vt, s_types.Collection):
-            coll_expr_aliases.append(vt)
-        elif prev_expr is not None or not schema.has_object(vt.id):
-            new_schema = vt.set_field_value(
-                new_schema, 'alias_is_persistent', True)
-            new_schema = vt.set_field_value(
-                new_schema, 'from_global', is_global)
-
-            expr_aliases.append(vt)
-
-    if prev_expr is not None:
-        prev_ir = prev_expr.irast
-        old_schema = prev_ir.schema
-        for vt in prev_ir.views.values():
-            if not _is_view_from_alias(classname, vt, old_schema):
-                continue
-            if isinstance(vt, s_types.Collection):
-                prev_coll_expr_aliases.append(vt)
-            else:
-                prev_expr_aliases.append(vt)
-
     derived_delta = sd.DeltaRoot()
 
-    for ref in ir.new_coll_types:
-        colltype_shell = ref.as_shell(new_schema)
-        # not "new_schema", because that already contains this
-        # collection type.
-        derived_delta.add(colltype_shell.as_create_delta(new_schema))
-
-    if prev_expr is not None:
-        assert old_schema is not None
+    for ty in ir.created_schema_types:            
+        new_schema = ty.set_field_value(
+            new_schema, 'alias_is_persistent', True
+        )
+        new_schema = ty.set_field_value(
+            new_schema, 'expr_type', s_types.ExprType.Select
+        )
+        new_schema = ty.set_field_value(
+            new_schema, 'from_alias', True
+        )
+        new_schema = ty.set_field_value(
+            new_schema, 'from_global', is_global
+        )
+        new_schema = ty.set_field_value(
+            new_schema, 'internal', False
+        )
+        new_schema = ty.set_field_value(
+            new_schema, 'builtin', False
+        )
+        
         derived_delta.add(
-            sd.delta_objects(
-                prev_expr_aliases,
-                expr_aliases,
-                sclass=s_types.Type,
-                old_schema=old_schema,
-                new_schema=new_schema,
-                context=so.ComparisonContext(),
+            ty.as_create_delta(
+                schema=new_schema,
+                context=so.ComparisonContext()
             )
         )
-    else:
-        for expr_alias in expr_aliases:
-            derived_delta.add(
-                expr_alias.as_create_delta(
-                    schema=new_schema,
-                    context=so.ComparisonContext(),
-                )
-            )
-
-    if prev_ir is not None:
-        assert old_schema
-        for vt in prev_coll_expr_aliases:
-            if dt := vt.as_type_delete_if_unused(old_schema):
-                derived_delta.prepend(dt)
-        for vt in prev_ir.new_coll_types:
-            if dt := vt.as_type_delete_if_unused(old_schema):
-                derived_delta.prepend(dt)
-
-    for vt in coll_expr_aliases:
-        new_schema = vt.set_field_value(new_schema, 'expr', expr)
-        new_schema = vt.set_field_value(
-            new_schema, 'alias_is_persistent', True)
-        ct = vt.as_shell(new_schema).as_create_delta(
-            # not "new_schema", to ensure the nested collection types
-            # are picked up properly.
-            new_schema,
-            view_name=classname,
-            attrs={
-                'expr': expr,
-                'alias_is_persistent': True,
-                'expr_type': s_types.ExprType.Select,
-                'from_alias': True,
-            },
-        )
-        derived_delta.add(ct)
 
     derived_delta = s_ordering.linearize_delta(
-        derived_delta, old_schema=schema, new_schema=new_schema)
+        derived_delta, old_schema=schema, new_schema=new_schema
+    )
 
-    existing_type_cmd = None
+    type_cmd = None
     for op in derived_delta.get_subcommands():
         assert isinstance(op, sd.ObjectCommand)
-        if (
-            op.classname == classname
-            and not isinstance(op, sd.DeleteObject)
-        ):
-            existing_type_cmd = op
+        if op.classname == classname:
+            type_cmd = op
             break
-
-    if existing_type_cmd is not None:
-        type_cmd = existing_type_cmd
-    else:
-        assert prev_expr is not None
-        for expr_alias in expr_aliases:
-            if expr_alias.get_name(new_schema) == classname:
-                type_cmd = expr_alias.init_delta_command(
-                    new_schema,
-                    sd.AlterObject,
-                )
-                derived_delta.add(type_cmd)
-                break
-        else:
-            raise RuntimeError(
-                'view delta does not contain the expected '
-                'view Create/Alter command')
+    assert type_cmd
 
     type_cmd.set_attribute_value('expr', expr)
 
     result = sd.CommandGroup()
     result.update(derived_delta.get_subcommands())
+
     type_shell = s_types.TypeShell(
         name=classname,
         origname=classname,

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -129,7 +129,8 @@ class AliasLikeCommand(
         alter_alias = scls.init_delta_command(schema, sd.AlterObject)
         alter_alias.canonical = True
         alter_alias.set_attribute_value('created_types', set())
-        alter_alias.set_attribute_value(self.TYPE_FIELD_NAME, None)
+        if isinstance(self, AliasCommand):
+            alter_alias.set_attribute_value('type', None)
         cmd.add(alter_alias)
 
         for dep_type in created:
@@ -384,9 +385,9 @@ class AlterAliasLike(
                     self.scls, self.TYPE_FIELD_NAME)
             else:
                 # there is no expr
-                # if this is a global that just had its expr unset,
-                # remove the types
+
                 if is_computable and self.has_attribute_value('expr'):
+                    # this is a global that just had its expr unset
                     self.add(
                         self._delete_alias_types(self.scls, schema, context)
                     )

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -126,10 +126,14 @@ class AliasLikeCommand(
 
         cmd = sd.CommandGroup()
 
+        # Unset created_types and type, so the types can be dropped
         alter_alias = scls.init_delta_command(schema, sd.AlterObject)
         alter_alias.canonical = True
         alter_alias.set_attribute_value('created_types', set())
         if isinstance(self, AliasCommand):
+            # HACK: this should be applied to both globals and aliases,
+            # but globals have code in SetGlobalType command that should not be
+            # executing in this case.
             alter_alias.set_attribute_value('type', None)
         cmd.add(alter_alias)
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -356,7 +356,12 @@ class AlterAliasLike(
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        if not context.canonical:
+        if (
+            not context.canonical
+            # FIXME: This is not really correct, but alias altering is
+            # currently too broken to accept expr propagations.
+            and not self.from_expr_propagation
+        ):
             expr = self.get_attribute_value('expr')
             is_computable = self._is_computable(self.scls, schema)
             if expr:

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -145,8 +145,10 @@ class AliasLikeCommand(
         cmd.add(wipe_created_types)
 
         for dep_type in created:
+            if_unused = isinstance(dep_type, s_types.Collection)
+
             drop_dep = dep_type.init_delta_command(
-                schema, sd.DeleteObject, if_exists=True
+                schema, sd.DeleteObject, if_exists=True, if_unused=if_unused
             )
             subcmds = drop_dep._canonicalize(schema, context, dep_type)
             drop_dep.update(subcmds)
@@ -514,10 +516,14 @@ def define_alias(
             new_schema, 'builtin', False
         )
         
+        # if isinstance(ty, s_types.Collection):
+        #     derived_delta.add(
+                # ty.as_shell(schema).as_create_delta(schema=new_schema)
+        #     )
+        # else:
         derived_delta.add(
             ty.as_create_delta(
-                schema=new_schema,
-                context=so.ComparisonContext()
+                schema=new_schema, context=so.ComparisonContext()
             )
         )
 

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -123,7 +123,7 @@ class GlobalCommand(
         return cls._mangle_name(type_name)
 
     @classmethod
-    def _is_alias(cls, obj: Global, schema: s_schema.Schema) -> bool:
+    def _is_computable(cls, obj: Global, schema: s_schema.Schema) -> bool:
         return obj.is_computable(schema)
 
     def _check_expr(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -576,9 +576,11 @@ class RebaseObjectType(
     pass
 
 
-class AlterObjectType(ObjectTypeCommand,
-                      s_types.AlterType[ObjectType],
-                      inheriting.AlterInheritingObject[ObjectType]):
+class AlterObjectType(
+    ObjectTypeCommand,
+    s_types.AlterType[ObjectType],
+    inheriting.AlterInheritingObject[ObjectType],
+):
     astnode = qlast.AlterObjectType
 
     def _alter_begin(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -577,6 +577,7 @@ class RebaseObjectType(
 
 
 class AlterObjectType(ObjectTypeCommand,
+                      s_types.AlterType[ObjectType],
                       inheriting.AlterInheritingObject[ObjectType]):
     astnode = qlast.AlterObjectType
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -803,6 +803,7 @@ def _prettyprint_enum(elements: Iterable[str]) -> str:
 
 class AlterScalarType(
     ScalarTypeCommand,
+    s_types.AlterType[ScalarType],
     inheriting.AlterInheritingObject[ScalarType],
 ):
     astnode = qlast.AlterScalarType

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -706,7 +706,7 @@ class AlterType(sd.AlterObject[TypeT]):
         *,
         parent_node: Optional[qlast.DDLOperation] = None,
     ) -> Optional[qlast.DDLOperation]:
-        if self.scls.get_from_alias(schema):
+        if hasattr(self, 'scls') and self.scls.get_from_alias(schema):
             # This is a nested view type, e.g
             # __FooAlias_bar produced by  FooAlias := (SELECT Foo { bar: ... })
             # and should obviously not appear as a top level definition.

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -614,7 +614,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         attrs: Optional[Dict[str, Any]] = None,
     ) -> sd.Command:
         raise errors.UnsupportedFeatureError(
-            f'unsupported type intersection in schema {str(view_name)} -- {str(self.schemaclass)}',
+            f'unsupported type intersection in schema {str(view_name)}',
             hint=f'Type intersections are currently '
                  f'unsupported as valid link targets.',
             context=self.sourcectx,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -614,7 +614,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         attrs: Optional[Dict[str, Any]] = None,
     ) -> sd.Command:
         raise errors.UnsupportedFeatureError(
-            f'unsupported type intersection in schema',
+            f'unsupported type intersection in schema {str(view_name)} -- {str(self.schemaclass)}',
             hint=f'Type intersections are currently '
                  f'unsupported as valid link targets.',
             context=self.sourcectx,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13899,7 +13899,7 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
 
         self.assertEqual(
             await self.con.query_single(count_query),
-            orig_count + 2,
+            orig_count + 1,
         )
 
         await self.con.execute(r"""
@@ -13908,7 +13908,7 @@ CREATE MIGRATION m14i24uhm6przo3bpl2lqndphuomfrtq3qdjaqdg6fza7h6m7tlbra
 
         self.assertEqual(
             await self.con.query_single(count_query),
-            orig_count + 2,
+            orig_count + 1,
         )
 
         await self.con.execute(r"""


### PR DESCRIPTION
Followup for #6866

Findings:
- linearize_delta will:
  - silently drop all declarations that have a namespace (`default::__FooAlias__x@w1`)
  - break when delta contains an un-setting alter property i.e. (`alter_alias.set_attribute_value('type', None)`),

I have a hard time differentiating between the initial and the canonicalized version of the delta tree. Could we completely separate these two passes? So we have one full pass of the tree for canonicalization and then a separate apply pass.

