### PR TITLE
Add styled default email templates

### DIFF
--- a/edb/server/protocol/auth_ext/ui/__init__.py
+++ b/edb/server/protocol/auth_ext/ui/__init__.py
@@ -665,6 +665,7 @@ def render_password_reset_email(
     reset_url: str,
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
+    dark_logo_url: Optional[str] = None,
     brand_color: Optional[str] = "#007bff",
 ) -> multipart.MIMEMultipart:
     msg = multipart.MIMEMultipart()
@@ -919,6 +920,7 @@ def render_verification_email(
     verify_url: str,
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
+    dark_logo_url: Optional[str] = None,
     brand_color: Optional[str] = "#007bff",
 ) -> multipart.MIMEMultipart:
     msg = multipart.MIMEMultipart()
@@ -1094,6 +1096,7 @@ def render_magic_link_email(
     link: str,
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
+    dark_logo_url: Optional[str] = None,
     brand_color: Optional[str] = "#007bff",
 ) -> multipart.MIMEMultipart:
     msg = multipart.MIMEMultipart()

--- a/edb/server/protocol/auth_ext/ui/__init__.py
+++ b/edb/server/protocol/auth_ext/ui/__init__.py
@@ -897,7 +897,7 @@ email address:
     </div>
   </td>
 </tr>
-    """
+    """ # noqa: E501
     html_msg = mime_text.MIMEText(
         render.base_default_email(
             app_name=app_name,
@@ -924,7 +924,9 @@ def render_verification_email(
     msg = multipart.MIMEMultipart()
     msg["From"] = from_addr
     msg["To"] = to_addr
-    msg["Subject"] = f"Verify your email{f' for {app_name}' if app_name else ''}"
+    msg["Subject"] = (
+        f"Verify your email{f' for {app_name}' if app_name else ''}"
+    )
     alternative = multipart.MIMEMultipart('alternative')
     plain_text_msg = mime_text.MIMEText(
         f"""

--- a/edb/server/protocol/auth_ext/ui/__init__.py
+++ b/edb/server/protocol/auth_ext/ui/__init__.py
@@ -665,8 +665,7 @@ def render_password_reset_email(
     reset_url: str,
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
-    dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None,
+    brand_color: Optional[str] = "#007bff",
 ) -> multipart.MIMEMultipart:
     msg = multipart.MIMEMultipart()
     msg["From"] = from_addr
@@ -675,21 +674,236 @@ def render_password_reset_email(
     alternative = multipart.MIMEMultipart('alternative')
     plain_text_msg = mime_text.MIMEText(
         f"""
-        {reset_url}
+Somebody requested a new password for the {app_name or ''} account associated
+with {to_addr}.
+
+Please paste the following URL into your browser address bar to verify your
+email address:
+
+{reset_url}
         """,
         "plain",
         "utf-8",
     )
     alternative.attach(plain_text_msg)
+
+    content = f"""
+<tr>
+  <td
+    style="
+      direction: ltr;
+      font-size: 0px;
+      padding: 20px 0;
+      padding-bottom: 20px;
+      padding-top: 20px;
+      text-align: center;
+    "
+  >
+    <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
+    <div
+      class="mj-column-per-100 mj-outlook-group-fix"
+      style="
+        font-size: 0px;
+        text-align: left;
+        direction: ltr;
+        display: inline-block;
+        vertical-align: middle;
+        width: 100%;
+      "
+    >
+      <table
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+        style="vertical-align: middle"
+        width="100%"
+      >
+        <tbody>
+          <tr>
+            <td
+              align="left"
+              style="
+                font-size: 0px;
+                padding: 10px 25px;
+                padding-top: 50px;
+                word-break: break-word;
+              "
+            >
+              <div
+                style="
+                  font-family: open Sans Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  text-align: left;
+                  color: #000000;
+                "
+              >
+                Somebody requested a new password for the {app_name or ''}
+                account associated with {to_addr}.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td
+              align="left"
+              style="
+                font-size: 0px;
+                padding: 10px 25px;
+                word-break: break-word;
+              "
+            >
+              <div
+                style="
+                  font-family: open Sans Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  text-align: left;
+                  color: #000000;
+                "
+              >
+                No changes have been made to your account yet.
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td
+              align="left"
+              style="
+                font-size: 0px;
+                padding: 10px 25px;
+                word-break: break-word;
+              "
+            >
+              <div
+                style="
+                  font-family: open Sans Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  text-align: left;
+                  color: #000000;
+                "
+              >
+                You can reset your password by clicking the button below:
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td
+              align="center"
+              vertical-align="middle"
+              style="
+                font-size: 0px;
+                padding: 10px 25px;
+                word-break: break-word;
+              "
+            >
+              <table
+                border="0"
+                cellpadding="0"
+                cellspacing="0"
+                role="presentation"
+                style="border-collapse: separate; line-height: 100%"
+              >
+                <tr>
+                  <td
+                    align="center"
+                    bgcolor="{brand_color}"
+                    role="presentation"
+                    style="
+                      border: none;
+                      border-radius: 4px;
+                      cursor: auto;
+                      mso-padding-alt: 10px 25px;
+                      background: {brand_color};
+                    "
+                    valign="middle"
+                  >
+                    <a
+                      href="{reset_url}"
+                      style="
+                        display: inline-block;
+                        background: {brand_color};
+                        color: #ffffff;
+                        font-family: open Sans Helvetica, Arial, sans-serif;
+                        font-size: 18px;
+                        font-weight: bold;
+                        line-height: 120%;
+                        margin: 0;
+                        text-decoration: none;
+                        text-transform: none;
+                        padding: 10px 25px;
+                        mso-padding-alt: 0px;
+                        border-radius: 4px;
+                      "
+                      target="_blank"
+                    >
+                      Reset your password
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td
+              align="left"
+              style="
+                font-size: 0px;
+                padding: 10px 25px;
+                word-break: break-word;
+              "
+            >
+              <div
+                style="
+                  font-family: open Sans Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  text-align: left;
+                  color: #000000;
+                "
+              >
+                In case the button didn't work, please paste the following URL
+                into your browser address bar:
+                <p style="word-break: break-all">{reset_url}</p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td
+              align="left"
+              style="
+                font-size: 0px;
+                padding: 10px 25px;
+                word-break: break-word;
+              "
+            >
+              <div
+                style="
+                  font-family: open Sans Helvetica, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1;
+                  text-align: left;
+                  color: #000000;
+                "
+              >
+                If you did not request a new password, please let us know
+                immediately by replying to this email.
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </td>
+</tr>
+    """
     html_msg = mime_text.MIMEText(
-        f"""
-<!DOCTYPE html>
-<html>
-  <body>
-    <a href="{reset_url}">Reset password</a>
-  </body>
-</html>
-        """,
+        render.base_default_email(
+            app_name=app_name,
+            logo_url=logo_url,
+            content=content,
+        ),
         "html",
         "utf-8",
     )
@@ -705,31 +919,164 @@ def render_verification_email(
     verify_url: str,
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
-    dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None,
+    brand_color: Optional[str] = "#007bff",
 ) -> multipart.MIMEMultipart:
     msg = multipart.MIMEMultipart()
     msg["From"] = from_addr
     msg["To"] = to_addr
-    msg["Subject"] = "Verify your email"
+    msg["Subject"] = f"Verify your email{f' for {app_name}' if app_name else ''}"
     alternative = multipart.MIMEMultipart('alternative')
     plain_text_msg = mime_text.MIMEText(
         f"""
-        {verify_url}
+Congratulations, you're registered{f' at {app_name}' if app_name else ''}!
+
+Please paste the following URL into your browser address bar to verify your
+email address:
+
+{verify_url}
         """,
         "plain",
         "utf-8",
     )
     alternative.attach(plain_text_msg)
+
+    content = f"""
+<tr>
+  <td
+    align="left"
+    style="
+      font-size: 0px;
+      padding: 10px 25px;
+      padding-top: 50px;
+      word-break: break-word;
+    "
+  >
+    <div
+      style="
+        font-family:
+          open Sans Helvetica,
+          Arial,
+          sans-serif;
+        font-size: 16px;
+        line-height: 1;
+        text-align: left;
+        color: #000000;
+      "
+    >
+      Congratulations, you're registered
+      {f'at {app_name}' if app_name else ''}!
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    style="font-size: 0px; padding: 10px 25px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family:
+          open Sans Helvetica,
+          Arial,
+          sans-serif;
+        font-size: 16px;
+        line-height: 1;
+        text-align: left;
+        color: #000000;
+      "
+    >
+      Please press the button below to verify your email address:
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="center"
+    vertical-align="middle"
+    style="font-size: 0px; padding: 10px 25px; word-break: break-word"
+  >
+    <table
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="border-collapse: separate; line-height: 100%"
+    >
+      <tr>
+        <td
+          align="center"
+          bgcolor="{brand_color}"
+          role="presentation"
+          style="
+            border: none;
+            border-radius: 4px;
+            cursor: auto;
+            mso-padding-alt: 10px 25px;
+            background: {brand_color};
+          "
+          valign="middle"
+        >
+          <a
+            href="{verify_url}"
+            style="
+              display: inline-block;
+              background: {brand_color};
+              color: #ffffff;
+              font-family:
+                open Sans Helvetica,
+                Arial,
+                sans-serif;
+              font-size: 18px;
+              font-weight: bold;
+              line-height: 120%;
+              margin: 0;
+              text-decoration: none;
+              text-transform: none;
+              padding: 10px 25px;
+              mso-padding-alt: 0px;
+              border-radius: 4px;
+            "
+            target="_blank"
+          >
+            Verify email address
+          </a>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    style="font-size: 0px; padding: 10px 25px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family:
+          open Sans Helvetica,
+          Arial,
+          sans-serif;
+        font-size: 16px;
+        line-height: 1;
+        text-align: left;
+        color: #000000;
+      "
+    >
+      In case the button didn't work, please paste the following URL into
+      your browser address bar:
+      <p style="word-break: break-all">{verify_url}</p>
+    </div>
+  </td>
+</tr>
+
+"""
+
     html_msg = mime_text.MIMEText(
-        f"""
-<!DOCTYPE html>
-<html>
-  <body>
-    <a href="{verify_url}">Verify your email</a>
-  </body>
-</html>
-        """,
+        render.base_default_email(
+            app_name=app_name,
+            logo_url=logo_url,
+            content=content,
+        ),
         "html",
         "utf-8",
     )
@@ -745,8 +1092,7 @@ def render_magic_link_email(
     link: str,
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
-    dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None,
+    brand_color: Optional[str] = "#007bff",
 ) -> multipart.MIMEMultipart:
     msg = multipart.MIMEMultipart()
     msg["From"] = from_addr
@@ -755,21 +1101,114 @@ def render_magic_link_email(
     alternative = multipart.MIMEMultipart('alternative')
     plain_text_msg = mime_text.MIMEText(
         f"""
-        {link}
+Please paste the following URL into your browser address bar to be signed into
+your account:
+
+{link}
         """,
         "plain",
         "utf-8",
     )
     alternative.attach(plain_text_msg)
+    content = f"""
+<tr>
+  <td
+    align="left"
+    style="font-size: 0px; padding: 10px 25px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: open Sans Helvetica, Arial, sans-serif;
+        font-size: 16px;
+        line-height: 1;
+        text-align: left;
+        color: #000000;
+      "
+    >
+      Sign into your {app_name or ""} account by clicking the button below:
+    </div>
+  </td>
+</tr>
+<tr>
+  <td
+    align="center"
+    vertical-align="middle"
+    style="font-size: 0px; padding: 10px 25px; word-break: break-word"
+  >
+    <table
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="border-collapse: separate; line-height: 100%"
+    >
+      <tr>
+        <td
+          align="center"
+          bgcolor="{brand_color}"
+          role="presentation"
+          style="
+            border: none;
+            border-radius: 4px;
+            cursor: auto;
+            mso-padding-alt: 10px 25px;
+            background: {brand_color};
+          "
+          valign="middle"
+        >
+          <a
+            href="{link}"
+            style="
+              display: inline-block;
+              background: {brand_color};
+              color: #ffffff;
+              font-family: open Sans Helvetica, Arial, sans-serif;
+              font-size: 18px;
+              font-weight: bold;
+              line-height: 120%;
+              margin: 0;
+              text-decoration: none;
+              text-transform: none;
+              padding: 10px 25px;
+              mso-padding-alt: 0px;
+              border-radius: 4px;
+            "
+            target="_blank"
+          >
+            Sign in
+          </a>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td
+    align="left"
+    style="font-size: 0px; padding: 10px 25px; word-break: break-word"
+  >
+    <div
+      style="
+        font-family: open Sans Helvetica, Arial, sans-serif;
+        font-size: 16px;
+        line-height: 1;
+        text-align: left;
+        color: #000000;
+      "
+    >
+      In case the button didn't work, please paste the following URL into your
+      browser address bar:
+      <p style="word-break: break-all">{link}</p>
+    </div>
+  </td>
+</tr>
+    """
     html_msg = mime_text.MIMEText(
-        f"""
-        <!DOCTYPE html>
-        <html>
-          <body>
-            <a href="{link}">Sign in</a>
-          </body>
-        </html>
-        """,
+        render.base_default_email(
+            app_name=app_name,
+            logo_url=logo_url,
+            content=content,
+        ),
         "html",
         "utf-8",
     )

--- a/edb/server/protocol/auth_ext/ui/components.py
+++ b/edb/server/protocol/auth_ext/ui/components.py
@@ -169,7 +169,7 @@ def _oauth_button(
 
 
 def button(
-    text: str,
+    text: Optional[str],
     *,
     id: Optional[str] = None,
     secondary: Optional[bool] = False,
@@ -189,7 +189,7 @@ def button(
 
     return f'''
       <button {attrs}>
-        {f'<span>{text}</span>' if text is not None else ''}
+        {f'<span>{text}</span>' if text else ''}
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="24"
@@ -412,7 +412,9 @@ def base_default_email(
                               <tr>
                                 <td style="width: 150px">
                                   <img
-                                    alt="{f'{app_name} logo' if app_name else ''}"
+                                    alt="
+                                      {f'{app_name} logo' if app_name else ''}
+                                    "
                                     height="150"
                                     src="{logo_url}"
                                     style="
@@ -442,7 +444,7 @@ def base_default_email(
         </table>
       </div>
       <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-""" if logo_url else ""
+""" if logo_url else "" # noqa: E501
 
     return f"""
 <!doctype html>
@@ -599,4 +601,4 @@ def base_default_email(
     </div>
   </body>
 </html>
-"""
+""" # noqa: E501

--- a/edb/server/protocol/auth_ext/ui/components.py
+++ b/edb/server/protocol/auth_ext/ui/components.py
@@ -336,3 +336,267 @@ def success_message(message: str) -> str:
         <span>{message}</span>
         </div>
     '''
+
+
+def base_default_email(
+    *,
+    content: str,
+    app_name: Optional[str],
+    logo_url: Optional[str],
+) -> str:
+    logo_html = f"""
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <div style="margin: 0px auto; max-width: 600px">
+        <table
+          align="center"
+          border="0"
+          cellpadding="0"
+          cellspacing="0"
+          role="presentation"
+          style="width: 100%"
+        >
+          <tbody>
+            <tr>
+              <td
+                style="
+                  direction: ltr;
+                  font-size: 0px;
+                  padding: 20px 0;
+                  padding-bottom: 0px;
+                  padding-top: 20px;
+                  text-align: center;
+                "
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                <div
+                  class="mj-column-per-100 mj-outlook-group-fix"
+                  style="
+                    font-size: 0px;
+                    text-align: left;
+                    direction: ltr;
+                    display: inline-block;
+                    vertical-align: top;
+                    width: 100%;
+                  "
+                >
+                  <table
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="vertical-align: top"
+                    width="100%"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          align="center"
+                          style="
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            padding-top: 0;
+                            padding-right: 0px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            word-break: break-word;
+                          "
+                        >
+                          <table
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="border-collapse: collapse; border-spacing: 0px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td style="width: 150px">
+                                  <img
+                                    alt="{f'{app_name} logo' if app_name else ''}"
+                                    height="150"
+                                    src="{logo_url}"
+                                    style="
+                                      border: none;
+                                      display: block;
+                                      outline: none;
+                                      text-decoration: none;
+                                      height: 150px;
+                                      width: 100%;
+                                      font-size: 13px;
+                                    "
+                                    width="150"
+                                  />
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+""" if logo_url else ""
+
+    return f"""
+<!doctype html>
+<html
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:o="urn:schemas-microsoft-com:office:office"
+>
+<head>
+  <title>
+  </title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {{
+      padding: 0;
+    }}
+
+    body {{
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }}
+
+    table,
+    td {{
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }}
+
+    img {{
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }}
+
+    p {{
+      display: block;
+      margin: 13px 0;
+    }}
+  </style>
+  <!--[if mso]>
+        <noscript>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        </noscript>
+        <![endif]-->
+  <!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix {{ width:100% !important; }}
+        </style>
+        <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700);
+  </style>
+  <!--<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {{
+      .mj-column-per-100 {{
+        width: 100% !important;
+        max-width: 100%;
+      }}
+    }}
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {{
+      width: 100% !important;
+      max-width: 100%;
+    }}
+  </style>
+  <style type="text/css">
+    @media only screen and (max-width:480px) {{
+      table.mj-full-width-mobile {{
+        width: 100% !important;
+      }}
+
+      td.mj-full-width-mobile {{
+        width: auto !important;
+      }}
+    }}
+  </style>
+</head>
+
+  <body style="word-spacing: normal; background-color: #ffffff">
+    <div style="background-color: #ffffff">
+{logo_html}
+      <div style="margin: 0px auto; max-width: 600px">
+        <table
+          align="center"
+          border="0"
+          cellpadding="0"
+          cellspacing="0"
+          role="presentation"
+          style="width: 100%"
+        >
+          <tbody>
+            <tr>
+              <td
+                style="
+                  direction: ltr;
+                  font-size: 0px;
+                  padding: 20px 0;
+                  padding-bottom: 20px;
+                  padding-top: 20px;
+                  text-align: center;
+                "
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
+                <div
+                  class="mj-column-per-100 mj-outlook-group-fix"
+                  style="
+                    font-size: 0px;
+                    text-align: left;
+                    direction: ltr;
+                    display: inline-block;
+                    vertical-align: middle;
+                    width: 100%;
+                  "
+                >
+                  <table
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="vertical-align: middle"
+                    width="100%"
+                  >
+                    <tbody>
+{content}
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    </div>
+  </body>
+</html>
+"""

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -2919,7 +2919,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(email_args["recipients"], form_data["email"])
             html_msg = email_args["message"].get_payload(0).get_payload(1)
             html_email = html_msg.get_payload(decode=True).decode("utf-8")
-            match = re.search(r'<a href=[\'"]?([^\'" >]+)', html_email)
+            match = re.search(
+                r'<p style="word-break: break-all">([^<]+)', html_email
+            )
             assert match is not None
             verify_url = urllib.parse.urlparse(match.group(1))
             search_params = urllib.parse.parse_qs(verify_url.query)
@@ -3162,8 +3164,10 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(email_args["recipients"], form_data["email"])
             html_msg = email_args["message"].get_payload(0).get_payload(1)
             html_email = html_msg.get_payload(decode=True).decode("utf-8")
-            match = re.search(r'<a href=[\'"]?([^\'" >]+)', html_email)
-            self.assertIsNotNone(match)
+            match = re.search(
+                r'<p style="word-break: break-all">([^<]+)', html_email
+            )
+            assert match is not None
             reset_url = match.group(1)
             self.assertTrue(
                 reset_url.startswith(form_data['reset_url'] + '?reset_token=')
@@ -3340,8 +3344,10 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(email_args["recipients"], form_data["email"])
             html_msg = email_args["message"].get_payload(0).get_payload(1)
             html_email = html_msg.get_payload(decode=True).decode("utf-8")
-            match = re.search(r'<a href=[\'"]?([^\'" >]+)', html_email)
-            self.assertIsNotNone(match)
+            match = re.search(
+                r'<p style="word-break: break-all">([^<]+)', html_email
+            )
+            assert match is not None
             reset_url = match.group(1)
             self.assertTrue(
                 reset_url.startswith(form_data['reset_url'] + '?reset_token=')
@@ -3805,7 +3811,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(email_args["recipients"], email)
             html_msg = email_args["message"].get_payload(0).get_payload(1)
             html_email = html_msg.get_payload(decode=True).decode("utf-8")
-            match = re.search(r'<a href=[\'"]?([^\'" >]+)', html_email)
+            match = re.search(
+                r'<p style="word-break: break-all">([^<]+)', html_email
+            )
             assert match is not None
             verify_url = urllib.parse.urlparse(match.group(1))
             search_params = urllib.parse.parse_qs(verify_url.query)


### PR DESCRIPTION
Used [MJML](https://mjml.io/) to produce some reasonable email templates based on some designs provided by Roman. I considered basically translating MJML into "components" but there are some tricky ways they wrap certain kinds of elements. Probably still doable, but I ran out of patience.

Here is the general shape (showing the magic link email)

![image](https://github.com/edgedb/edgedb/assets/1682194/74bb1e13-ade2-449a-a702-829e72763ea7)
