### PR TITLE
Fix DML coalesce inside of IF/ELSE

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -180,7 +180,7 @@ def compile_ForQuery(
             if ectx.expr_exposed:
                 ectx.expr_exposed = context.Exposure.BINDING
             iterator_view = stmtctx.declare_view(
-                iterator,
+                astutils.ensure_ql_select(iterator),
                 s_name.UnqualName(qlstmt.iterator_alias),
                 factoring_fence=contains_dml,
                 path_id_namespace=sctx.path_id_namespace,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -232,6 +232,7 @@ def get_set_rvar(
 
         # Actually compile the set
         rvars = _get_set_rvar(ir_set, ctx=subctx)
+        relctx.update_scope_masks(ir_set, rvars.main.rvar, ctx=subctx)
 
         if ctx.env.expand_inhviews:
             for srvar in rvars.new:
@@ -242,6 +243,7 @@ def get_set_rvar(
         if optional_wrapping:
             rvars = finalize_optional_rel(ir_set, optrel=optrel,
                                           rvars=rvars, ctx=subctx)
+            relctx.update_scope_masks(ir_set, rvars.main.rvar, ctx=subctx)
         elif not is_optional and is_empty_set:
             # In most cases it is totally fine for us to represent an
             # empty set as an empty relation.
@@ -251,7 +253,6 @@ def get_set_rvar(
                 null_query, (pgast.SelectStmt, pgast.NullRelation))
             null_query.where_clause = pgast.BooleanConstant(val=False)
 
-        relctx.update_scope_masks(ir_set, rvars.main.rvar, ctx=subctx)
         result_rvar = _include_rvars(rvars, scope_stmt=scope_stmt, ctx=subctx)
         for aspect in rvars.main.aspects:
             pathctx.put_path_rvar_if_not_exists(

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -1238,3 +1238,15 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [{}],
         )
+
+    async def test_edgeql_for_optional_03(self):
+        Q = '''
+        for dummy in "1"
+        for optional x in (delete Card filter .name = 'Yolanda Swaggins')
+        select x.cost ?? 420;
+        '''
+
+        await self.assert_query_result(
+            Q,
+            [420],
+        )


### PR DESCRIPTION
The core thing here is that when we move a compiled IR expression into
a FOR loop, we need to adjust the scope tree so that it is inside the
loop's scope.

Also fix DML appearing directly as a FOR iterator, which I ran into
while testing a minimized bug (that turned out to not be the full
issue). I was nervous my change there might mess up the GROUP
optimizations, so I added another codegen test.

Fixes main part of #6794.