### PR TITLE
Updated versions of python and rust in contribution guide.

### DIFF
--- a/docs/guides/contributing/code.rst
+++ b/docs/guides/contributing/code.rst
@@ -26,9 +26,9 @@ Linux or macOS.  Windows is not currently supported.
 
 * GNU make version 3.80 or newer;
 * C compiler (GCC or clang);
-* Rust compiler and Cargo 1.65 or later;
+* Rust compiler and Cargo 1.74 or later;
 * autotools;
-* Python 3.10 dev package;
+* Python 3.11 dev package;
 * Bison 1.875 or later;
 * Flex 2.5.31 or later;
 * Perl 5.8.3 or later;


### PR DESCRIPTION
The versions of python and rust required for the contribution guide are out of date and should be updated.

The following guides are not updated but they also explicitly reference python 3.10. They will likely need to be updated in the future:

- `docs/guides/tutorials/graphql_apis_with_strawberry.rst`
- `docs/guides/tutorials/rest_apis_with_fastapi.rst`
- `docs/guides/tutorials/rest_apis_with_flask.rst`