### PR TITLE
Disable query-cache-changes message sending for now

### DIFF
--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -642,13 +642,23 @@ def signal_side_effects(dbv, side_effects):
 
 
 def signal_query_cache_changes(dbv):
-    dbv.tenant.create_task(
-        dbv.tenant.signal_sysevent(
-            'query-cache-changes',
-            dbname=dbv.dbname,
-        ),
-        interruptable=False,
-    )
+    # FIXME: This is disabled because the increased sysevent traffic
+    # caused by doing this was causing test failures on aarch64 when
+    # sometimes the signals failed due to a failure to look up
+    # transactions. We need to figure out what is going on with that
+    # and restore it. We also probably want to rate limit
+    # query-cache-changes, or include a more detailed payload, since
+    # it can force pretty aggressive amounts of cache reloading work
+    # on the targets.
+
+    # dbv.tenant.create_task(
+    #     dbv.tenant.signal_sysevent(
+    #         'query-cache-changes',
+    #         dbname=dbv.dbname,
+    #     ),
+    #     interruptable=False,
+    # )
+    pass
 
 
 async def parse_execute_json(


### PR DESCRIPTION
This is blocking a beta release, since the query-cache-changes traffic
is sometimes failing with bizarre failures to lookup transactions.
We do need to get to the bottom of this, though.