### PR TITLE
Add note comparing `limit 1` to `assert_single`

### DIFF
--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -569,6 +569,12 @@ Sets
         db> select assert_single((select User), message := "too many users!")
         ERROR: CardinalityViolationError: too many users!
 
+    .. note::
+
+        ``assert_single`` can be useful in many of the same contexts as ``limit
+        1`` with the key difference being that ``limit 1`` doesn't produce an
+        error if more than a single element exists in the set.
+
 ----------
 
 


### PR DESCRIPTION
Inspired by a Slack discussion around [a user question about `assert_single`](https://github.com/edgedb/edgedb/issues/6920).