### PR TITLE
Start refactoring irast.Set

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -566,7 +566,9 @@ def compile_GlobalExpr(
             # card_inference_override so that we use the real cardinality
             # instead of assuming it is MANY.
             assert isinstance(rewrite_target, irast.Set)
-            target = setgen.new_set_from_set(target, expr=None, ctx=ctx)
+            target = setgen.new_set_from_set(
+                target, expr=irast.TypeRoot(typeref=target.typeref), ctx=ctx
+            )
             wrap = irast.SelectStmt(
                 result=target,
                 card_inference_override=rewrite_target,

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -331,7 +331,7 @@ def _move_fenced_anchor(ir: irast.Set, *, ctx: context.ContextLevel) -> None:
     scope tree there.
     """
     match ir.expr:
-        case irast.SelectStmt(result=irast.Set(path_scope_id=int(id))):
+        case irast.SelectStmt(result=irast.SetE(path_scope_id=int(id))):
             node = next(iter(
                 x for x in ctx.path_scope.root.descendants
                 if x.unique_id == id

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -332,6 +332,19 @@ def __infer_type_introspection(
     return ONE
 
 
+@_infer_cardinality.register
+def __infer_type_root(
+    ir: irast.TypeRoot,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Cardinality:
+    if typeutils.is_exactly_free_object(ir.typeref):
+        return ONE
+    else:
+        return MANY
+
+
 def _infer_pointer_cardinality(
     *,
     ptrcls: s_pointers.Pointer,
@@ -656,9 +669,12 @@ def _infer_set_inner(
         card = AT_MOST_ONE
     elif ir.expr is not None:
         card = expr_card
-    elif typeutils.is_free_object(ir.typeref) and not ir.is_binding:
-        card = ONE
     else:
+        # The only things that should be here without an expression or
+        # an rptr are certain visible_binding_refs (typically from
+        # GROUP). We report them as MANY, but that might be refined
+        # based on the scope tree in the enclosing context.
+        assert ir.is_visible_binding_ref
         card = MANY
 
     # If this node is an optional argument bound at this location,

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -175,6 +175,16 @@ def __infer_type_introspection(
     return UNIQUE
 
 
+@_infer_multiplicity.register
+def __infer_type_root(
+    ir: irast.TypeRoot,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    return UNIQUE
+
+
 def _infer_shape(
     ir: irast.Set,
     *,
@@ -304,7 +314,7 @@ def _infer_set_inner(
         path_mult = dataclasses.replace(path_mult, disjoint_union=True)
 
     # Mark free object roots
-    if irtyputils.is_free_object(ir.typeref) and not ir.expr:
+    if irutils.is_trivial_free_object(ir):
         path_mult = dataclasses.replace(path_mult, fresh_free_object=True)
 
     # Remove free object freshness when we see them through a binding

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -137,6 +137,14 @@ def __infer_type_introspection(
 
 
 @_infer_volatility_inner.register
+def __infer_type_root(
+    ir: irast.TypeRoot,
+    env: context.Environment,
+) -> InferredVolatility:
+    return STABLE
+
+
+@_infer_volatility_inner.register
 def __infer_set(
     ir: irast.Set,
     env: context.Environment,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -417,21 +417,20 @@ def _find_visible_binding_refs(
 
 def _try_namespace_fix(
     scope: irast.ScopeTreeNode,
-    obj: Union[irast.ScopeTreeNode, irast.Set],
-) -> None:
-    if obj.path_id is None:
-        return
-    for prefix in obj.path_id.iter_prefixes():
+    path_id: irast.PathId,
+) -> irast.PathId:
+    for prefix in path_id.iter_prefixes():
         replacement = scope.find_visible(prefix, allow_group=True)
         if (
             replacement and replacement.path_id
             and prefix != replacement.path_id
         ):
             new = irtyputils.replace_pathid_prefix(
-                obj.path_id, prefix, replacement.path_id)
+                path_id, prefix, replacement.path_id)
 
-            obj.path_id = new
-            break
+            return new
+
+    return path_id
 
 
 def _rewrite_weak_namespaces(
@@ -454,7 +453,8 @@ def _rewrite_weak_namespaces(
     tree = ctx.path_scope
 
     for node in tree.strict_descendants:
-        _try_namespace_fix(node, node)
+        if node.path_id:
+            node.path_id = _try_namespace_fix(node, node.path_id)
 
     scopes = irutils.find_path_scopes(irs)
 
@@ -464,7 +464,10 @@ def _rewrite_weak_namespaces(
             # Some entries in set_types are from compiling views
             # in temporary scopes, so we need to just skip those.
             if scope := ctx.env.scope_tree_nodes.get(path_scope_id):
-                _try_namespace_fix(scope, ir_set)
+                ir_set.path_id = _try_namespace_fix(scope, ir_set.path_id)
+                if ir_set.rptr:
+                    ir_set.rptr.target_path_id = (
+                        _try_namespace_fix(scope, ir_set.rptr.target_path_id))
 
 
 def _fixup_schema_view(

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -465,9 +465,6 @@ def _rewrite_weak_namespaces(
             # in temporary scopes, so we need to just skip those.
             if scope := ctx.env.scope_tree_nodes.get(path_scope_id):
                 ir_set.path_id = _try_namespace_fix(scope, ir_set.path_id)
-                if ir_set.rptr:
-                    ir_set.rptr.target_path_id = (
-                        _try_namespace_fix(scope, ir_set.rptr.target_path_id))
 
 
 def _fixup_schema_view(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1193,7 +1193,7 @@ def prepare_rewrite_anchors(
         schema, stype, typename=subject_name, namespace=ctx.path_id_namespace,
         env=ctx.env,
     )
-    subject_set = setgen.new_set(
+    subject_set = setgen.class_set(
         stype=stype, path_id=subject_path_id, ctx=ctx
     )
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -537,7 +537,6 @@ def _process_view(
             )
             ptr_set.rptr = irast.Pointer(
                 source=ir_set,
-                target_path_id=ptr_set.path_id,
                 direction=s_pointers.PointerDirection.Outbound,
                 ptrref=not_none(ptr_set.path_id.rptr()),
                 is_definition=True,
@@ -825,7 +824,8 @@ def _gen_pointers_from_defaults(
         assert irset
         dep_pointers = ast.find_children(irset, irast.Pointer)
         dep_rptrs = (
-            pointer.target_path_id.rptr() for pointer in dep_pointers
+            # pointer.target_path_id.rptr() for pointer in dep_pointers
+            pointer.ptrref for pointer in dep_pointers
             if pointer.source.typeref.id == stype.id
         )
         deps = {
@@ -970,7 +970,6 @@ def _compile_rewrites(
             # construct a new set with correct path_id
             ptr_set.rptr = irast.Pointer(
                 source=ir_set,
-                target_path_id=path_id,
                 direction=s_pointers.PointerDirection.Outbound,
                 ptrref=actual_ptrref,
                 is_definition=True,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -537,7 +537,7 @@ def _process_view(
             )
             ptr_set.rptr = irast.Pointer(
                 source=ir_set,
-                target=ptr_set,
+                target_path_id=ptr_set.path_id,
                 direction=s_pointers.PointerDirection.Outbound,
                 ptrref=not_none(ptr_set.path_id.rptr()),
                 is_definition=True,
@@ -825,7 +825,7 @@ def _gen_pointers_from_defaults(
         assert irset
         dep_pointers = ast.find_children(irset, irast.Pointer)
         dep_rptrs = (
-            pointer.target.path_id.rptr() for pointer in dep_pointers
+            pointer.target_path_id.rptr() for pointer in dep_pointers
             if pointer.source.typeref.id == stype.id
         )
         deps = {
@@ -970,7 +970,7 @@ def _compile_rewrites(
             # construct a new set with correct path_id
             ptr_set.rptr = irast.Pointer(
                 source=ir_set,
-                target=ptr_set,
+                target_path_id=path_id,
                 direction=s_pointers.PointerDirection.Outbound,
                 ptrref=actual_ptrref,
                 is_definition=True,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -452,7 +452,7 @@ class TypeIntersectionPointerRef(BasePointerRef):
 class Pointer(Base):
 
     source: Set
-    target: Set
+    target_path_id: PathId
     ptrref: BasePointerRef
     direction: s_pointers.PointerDirection
     is_definition: bool

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -452,7 +452,6 @@ class TypeIntersectionPointerRef(BasePointerRef):
 class Pointer(Base):
 
     source: Set
-    target_path_id: PathId
     ptrref: BasePointerRef
     direction: s_pointers.PointerDirection
     is_definition: bool

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -508,6 +508,14 @@ class BindingKind(s_enum.StrEnum):
     Select = 'Select'
 
 
+class TypeRoot(Expr):
+    # This will be replicated in the enclosing set.
+    typeref: TypeRef
+
+    # Whether to force this to not select subtypes
+    skip_subtypes: bool = False
+
+
 T_co = typing.TypeVar('T_co', covariant=True)
 
 
@@ -518,7 +526,12 @@ T_co = typing.TypeVar('T_co', covariant=True)
 class SetE(Base, typing.Generic[T_co]):
     '''A somewhat overloaded metadata container for expressions.
 
+    Its primary notional purpose is to be the holder for expression metadata
+    such as path_id.
 
+    It *also*, when rptr is set, represents pointer dereferences.
+
+    Also also, it contains shape applications.
     '''
 
     __ast_frozen_fields__ = frozenset({'typeref'})
@@ -547,11 +560,13 @@ class SetE(Base, typing.Generic[T_co]):
     # card/multi inference.
     is_visible_binding_ref: bool = False
 
-    # Whether to force this to not select subtypes
-    skip_subtypes: bool = False
     # Whether to force this to ignore rewrites. Very dangerous!
-    # Currently only used for preventing duplicate explicit .id
-    # insertions to BaseObject.
+    # Currently for preventing duplicate explicit .id
+    # insertions to BaseObject and for ignoring other access policies
+    # inside access policy expressions.
+    #
+    # N.B: This is defined on Set and not on TypeRoot because we use the Set
+    # to join against target types on links, and to ensure rvars.
     ignore_rewrites: bool = False
 
     def __repr__(self) -> str:

--- a/edb/ir/astmatch.py
+++ b/edb/ir/astmatch.py
@@ -29,6 +29,8 @@ from . import ast as irast
 
 for name, cls in irast.__dict__.items():
     if isinstance(cls, type) and issubclass(cls, ast.AST):
+        if name == 'SetE':
+            continue
         adapter = astmatch.MatchASTMeta(
             name, (astmatch.MatchASTNode,),
             {'__module__': __name__}, adapts=cls)

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -77,10 +77,9 @@ def get_parameters(ir: irast.Base) -> Set[irast.Parameter]:
 
 def is_const(ir: irast.Base) -> bool:
     """Return True if the given *ir* expression is constant."""
-    flt = lambda n: n.expr is None and n is not ir
-    ir_sets = ast.find_children(ir, irast.Set, flt)
+    roots = ast.find_children(ir, irast.TypeRoot)
     variables = get_parameters(ir)
-    return not ir_sets and not variables
+    return not roots and not variables
 
 
 def is_union_expr(ir: irast.Base) -> bool:
@@ -227,7 +226,10 @@ def is_type_intersection_reference(ir_expr: irast.Base) -> bool:
 
 def is_trivial_free_object(ir: irast.Set) -> bool:
     ir = unwrap_set(ir)
-    return not ir.expr and typeutils.is_exactly_free_object(ir.typeref)
+    return (
+        isinstance(ir.expr, irast.TypeRoot)
+        and typeutils.is_exactly_free_object(ir.typeref)
+    )
 
 
 def collapse_type_intersection(

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -25,6 +25,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TypeVar,
     AbstractSet,
     Mapping,
     Sequence,
@@ -480,6 +481,12 @@ def as_const(ir: irast.Base) -> Optional[irast.BaseConstant]:
             return ir
         case irast.TypeCast():
             return as_const(ir.expr)
-        case irast.Set() if ir.expr:
+        case irast.SetE() if ir.expr:
             return as_const(ir.expr)
     return None
+
+
+T = TypeVar('T')
+
+def is_set_instance(ir: irast.Set, typ: Type[T]) -> TypeGuard[irast.SetE[T]]:
+    return isinstance(ir.expr, typ)

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -965,7 +965,7 @@ def process_insert_rewrites(
         handled.add(ext_ir.rptr.ptrref.shortname.name)
         with ctx.subrel() as ectx:
             ext_rvar = relctx.new_pointer_rvar(
-                ext_ir.rptr, link_bias=True, src_rvar=iterator_rvar, ctx=ectx)
+                ext_ir, link_bias=True, src_rvar=iterator_rvar, ctx=ectx)
             relctx.include_rvar(ectx.rel, ext_rvar, ext_ir.path_id, ctx=ectx)
             # Make the subquery output the target
             pathctx.get_path_value_output(
@@ -1946,7 +1946,7 @@ def process_update_rewrites(
                 typeref, ext_ir.rptr.ptrref)
             with rctx.subrel() as ectx:
                 ext_rvar = relctx.new_pointer_rvar(
-                    ext_ir.rptr, link_bias=True, src_rvar=contents_rvar,
+                    ext_ir, link_bias=True, src_rvar=contents_rvar,
                     ctx=ectx)
                 relctx.include_rvar(
                     ectx.rel, ext_rvar, ext_ir.path_id, ctx=ectx)

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -24,6 +24,7 @@ from typing import Optional, AbstractSet, List
 from edb.edgeql import ast as qlast
 from edb.edgeql import desugar_group
 from edb.ir import ast as irast
+from edb.ir import utils as irutils
 from edb.pgsql import ast as pgast
 
 from . import astutils
@@ -232,6 +233,7 @@ def _compile_group(
             with groupctx.subrel() as hoistctx:
                 hoistctx.skippable_sources |= skippable
 
+                assert irutils.is_set_instance(group_use, irast.FunctionCall)
                 relgen.process_set_as_agg_expr_inner(
                     group_use,
                     aspect='value', wrapper=None, for_group_by=True,

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -40,6 +40,8 @@ import immutables as immu
 
 from edb import errors
 
+from edb.common.typeutils import not_none
+
 from edb.edgeql import qltypes
 from edb.edgeql import ast as qlast
 
@@ -578,11 +580,11 @@ def new_root_rvar(
 
 
 def new_pointer_rvar(
-        ir_ptr: irast.Pointer, *,
+        ir_set: irast.Set, *,
         link_bias: bool=False,
         src_rvar: pgast.PathRangeVar,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
-
+    ir_ptr = not_none(ir_set.rptr)
     ptrref = ir_ptr.ptrref
 
     ptr_info = pg_types.get_ptrref_storage_info(
@@ -591,28 +593,30 @@ def new_pointer_rvar(
     if ptr_info and ptr_info.table_type == 'ObjectType':
         # Inline link
         return _new_inline_pointer_rvar(
-            ir_ptr, ptr_info=ptr_info,
+            ir_set, ptr_info=ptr_info,
             src_rvar=src_rvar, ctx=ctx)
     else:
-        return _new_mapped_pointer_rvar(ir_ptr, ctx=ctx)
+        return _new_mapped_pointer_rvar(ir_set, ctx=ctx)
 
 
 def _new_inline_pointer_rvar(
-        ir_ptr: irast.Pointer, *,
+        ir_set: irast.Set, *,
         lateral: bool=True,
         ptr_info: pg_types.PointerStorageInfo,
         src_rvar: pgast.PathRangeVar,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
+    ir_ptr = not_none(ir_set.rptr)
+
     ptr_rel = pgast.SelectStmt()
     ptr_rvar = rvar_for_rel(ptr_rel, lateral=lateral, ctx=ctx)
-    ptr_rvar.query.path_id = ir_ptr.target_path_id.ptr_path()
+    ptr_rvar.query.path_id = ir_set.path_id.ptr_path()
 
     is_inbound = ir_ptr.direction == s_pointers.PointerDirection.Inbound
 
     if is_inbound:
         far_pid = ir_ptr.source.path_id
     else:
-        far_pid = ir_ptr.target_path_id
+        far_pid = ir_set.path_id
 
     far_ref = pathctx.get_rvar_path_identity_var(
         src_rvar, far_pid, env=ctx.env)
@@ -624,11 +628,13 @@ def _new_inline_pointer_rvar(
 
 
 def _new_mapped_pointer_rvar(
-        ir_ptr: irast.Pointer, *,
+        ir_set: irast.Set, *,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
+    ir_ptr = not_none(ir_set.rptr)
+
     ptrref = ir_ptr.ptrref
     dml_source = irutils.get_dml_sources(ir_ptr.source)
-    ptr_rvar = range_for_pointer(ir_ptr, dml_source=dml_source, ctx=ctx)
+    ptr_rvar = range_for_pointer(ir_set, dml_source=dml_source, ctx=ctx)
 
     src_col = 'source'
     source_ref = pgast.ColumnRef(name=[src_col], nullable=False)
@@ -649,7 +655,7 @@ def _new_mapped_pointer_rvar(
         far_ref = target_ref
 
     src_pid = ir_ptr.source.path_id
-    tgt_pid = ir_ptr.target_path_id
+    tgt_pid = ir_set.path_id
     ptr_pid = tgt_pid.ptr_path()
 
     ptr_rvar.query.path_id = ptr_pid
@@ -712,7 +718,7 @@ def semi_join(
     else:
         far_pid = ir_set.path_id
         # Link range.
-        map_rvar = new_pointer_rvar(rptr, src_rvar=src_rvar, ctx=ctx)
+        map_rvar = new_pointer_rvar(ir_set, src_rvar=src_rvar, ctx=ctx)
         include_rvar(
             ctx.rel, map_rvar,
             path_id=ir_set.path_id.ptr_path(), ctx=ctx)
@@ -2080,13 +2086,14 @@ def range_for_ptrref(
 
 
 def range_for_pointer(
-    pointer: irast.Pointer,
+    ir_set: irast.Set,
     *,
     dml_source: Sequence[irast.MutatingLikeStmt]=(),
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
+    pointer = not_none(ir_set.rptr)
 
-    path_id = pointer.target_path_id.ptr_path()
+    path_id = ir_set.path_id.ptr_path()
     external_rvar = ctx.env.external_rvars.get((path_id, 'source'))
     if external_rvar is not None:
         return external_rvar

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -605,14 +605,14 @@ def _new_inline_pointer_rvar(
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
     ptr_rel = pgast.SelectStmt()
     ptr_rvar = rvar_for_rel(ptr_rel, lateral=lateral, ctx=ctx)
-    ptr_rvar.query.path_id = ir_ptr.target.path_id.ptr_path()
+    ptr_rvar.query.path_id = ir_ptr.target_path_id.ptr_path()
 
     is_inbound = ir_ptr.direction == s_pointers.PointerDirection.Inbound
 
     if is_inbound:
         far_pid = ir_ptr.source.path_id
     else:
-        far_pid = ir_ptr.target.path_id
+        far_pid = ir_ptr.target_path_id
 
     far_ref = pathctx.get_rvar_path_identity_var(
         src_rvar, far_pid, env=ctx.env)
@@ -649,7 +649,7 @@ def _new_mapped_pointer_rvar(
         far_ref = target_ref
 
     src_pid = ir_ptr.source.path_id
-    tgt_pid = ir_ptr.target.path_id
+    tgt_pid = ir_ptr.target_path_id
     ptr_pid = tgt_pid.ptr_path()
 
     ptr_rvar.query.path_id = ptr_pid
@@ -2086,7 +2086,7 @@ def range_for_pointer(
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
 
-    path_id = pointer.target.path_id.ptr_path()
+    path_id = pointer.target_path_id.ptr_path()
     external_rvar = ctx.env.external_rvars.get((path_id, 'source'))
     if external_rvar is not None:
         return external_rvar

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -884,7 +884,7 @@ def process_set_as_link_property_ref(
             # (FIXME: Would it be better to pass this in to new_pointer_rvar?)
             pathctx.put_path_bond(link_rvar.query, link_path_id.tgt_path())
             var = pathctx.get_rvar_path_identity_var(
-                link_rvar, link_prefix.rptr.target.path_id, env=ctx.env)
+                link_rvar, link_prefix.rptr.target_path_id, env=ctx.env)
             pathctx.put_rvar_path_output(
                 link_rvar, link_path_id.tgt_path(), 'identity', var)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -430,6 +430,10 @@ def _get_set_rvar(
         if irutils.is_set_instance(ir_set, irast.TriggerAnchor):
             return process_set_as_trigger_anchor(ir_set, ctx=ctx)
 
+        # Regular non-computable path start.
+        if irutils.is_set_instance(ir_set, irast.TypeRoot):
+            return process_set_as_root(ir_set, ctx=ctx)
+
         # All other expressions.
         return process_set_as_expr(ir_set, ctx=ctx)
 
@@ -445,11 +449,7 @@ def _get_set_rvar(
         # {}
         return process_set_as_empty(ir_set, ctx=ctx)
 
-    if ir_set.path_id in ctx.external_rels:
-        return process_external_rel(ir_set, ctx=ctx)
-
-    # Regular non-computable path start.
-    return process_set_as_root(ir_set, ctx=ctx)
+    raise AssertionError(f'invalid Set! {ir_set}')
 
 
 def _get_source_rvar(
@@ -795,6 +795,10 @@ def get_set_rel_alias(ir_set: irast.Set, *,
 def process_set_as_root(
     ir_set: irast.Set, *, ctx: context.CompilerContextLevel
 ) -> SetRVars:
+
+    # TODO(ir): Represent these as something other than TypeRoot?
+    if ir_set.path_id in ctx.external_rels:
+        return process_external_rel(ir_set, ctx=ctx)
 
     assert not ir_set.is_visible_binding_ref, (
         f"Can't compile ref to visible binding {ir_set.path_id}"

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -878,13 +878,13 @@ def process_set_as_link_property_ref(
             src_rvar = get_set_rvar(ir_source, ctx=newctx)
             assert link_prefix.rptr is not None
             link_rvar = relctx.new_pointer_rvar(
-                link_prefix.rptr, src_rvar=src_rvar,
+                link_prefix, src_rvar=src_rvar,
                 link_bias=True, ctx=newctx)
             # Make sure the link rvar understands the path_id we are using.
             # (FIXME: Would it be better to pass this in to new_pointer_rvar?)
             pathctx.put_path_bond(link_rvar.query, link_path_id.tgt_path())
             var = pathctx.get_rvar_path_identity_var(
-                link_rvar, link_prefix.rptr.target_path_id, env=ctx.env)
+                link_rvar, link_prefix.path_id, env=ctx.env)
             pathctx.put_rvar_path_output(
                 link_rvar, link_path_id.tgt_path(), 'identity', var)
 
@@ -1224,7 +1224,7 @@ def process_set_as_path(
 
         assert ir_set.rptr is not None
         map_rvar = SetRVar(
-            relctx.new_pointer_rvar(ir_set.rptr, src_rvar=src_rvar, ctx=ctx),
+            relctx.new_pointer_rvar(ir_set, src_rvar=src_rvar, ctx=ctx),
             path_id=ir_set.path_id.ptr_path(),
             aspects=aspects
         )

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4980,6 +4980,7 @@ class PointerMetaCommand(
                             path_scope_id=iter_uid,
                             path_id=src_path_id,
                             typeref=src_path_id.target,
+                            expr=irast.TypeRoot(typeref=src_path_id.target),
                         )
                     )
                 ),


### PR DESCRIPTION
Here is a series of refactors for irast.Set, with the general eventual
goal of making irast.Set *just* a metadata holder, and not also
responsible for a bunch of other operations directly.

Probably review the commits individually.

An eventual goal is to also eliminate the `rptr` field by making
`Pointer` an `Expr` (and putting computed expressions inside `Pointer`
in the cases where currently both `expr` and `rptr` are set), and I am
making good progress on that, but that one is a bigger project.