### PR TITLE
Allow passing WebAuthn user_handle in request body

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -947,9 +947,8 @@ class Router:
                     "Error redirect URL does not match any allowed URLs.",
                 )
 
-            if (
-                maybe_redirect_to and
-                not self._is_url_allowed(maybe_redirect_to)
+            if maybe_redirect_to and not self._is_url_allowed(
+                maybe_redirect_to
             ):
                 raise errors.InvalidData(
                     "Redirect URL does not match any allowed URLs.",
@@ -1090,17 +1089,22 @@ class Router:
 
         user_handle_cookie = request.cookies.get(
             "edgedb-webauthn-registration-user-handle"
-        ).value or data.get("user_handle")
-        if user_handle_cookie is None:
+        )
+        user_handle_base64url: Optional[str] = (
+            user_handle_cookie.value
+            if user_handle_cookie
+            else data.get("user_handle")
+        )
+        if user_handle_base64url is None:
             raise errors.InvalidData(
                 "Missing user_handle from cookie or request body"
             )
         try:
-            user_handle = base64.urlsafe_b64decode(user_handle_cookie)
+            user_handle = base64.urlsafe_b64decode(
+                f"{user_handle_base64url}==="
+            )
         except Exception as e:
-            raise errors.InvalidData(
-                "Failed to decode user_handle"
-            ) from e
+            raise errors.InvalidData("Failed to decode user_handle") from e
 
         require_verification = webauthn_client.provider.require_verification
         pkce_code: Optional[str] = None
@@ -1162,18 +1166,12 @@ class Router:
             )
         webauthn_client = webauthn.Client(self.db)
 
-        (user_handle, registration_options) = (
+        (_, registration_options) = (
             await webauthn_client.create_authentication_options_for_email(
                 email=email, webauthn_provider=webauthn_provider
             )
         )
 
-        _set_cookie(
-            response,
-            "edgedb-webauthn-authentication-user-handle",
-            user_handle,
-            path="/",
-        )
         response.status = http.HTTPStatus.OK
         response.content_type = b"application/json"
         response.body = registration_options
@@ -1191,24 +1189,9 @@ class Router:
         assertion: str = data["assertion"]
         pkce_challenge: str = data["challenge"]
 
-        user_handle_cookie = request.cookies.get(
-            "edgedb-webauthn-authentication-user-handle"
-        ).value or data.get("user_handle")
-        if user_handle_cookie is None:
-            raise errors.InvalidData(
-                "Missing user_handle from cookie or request body"
-            )
-        try:
-            user_handle = base64.urlsafe_b64decode(user_handle_cookie)
-        except Exception as e:
-            raise errors.InvalidData(
-                "Failed to decode user_handle"
-            ) from e
-
         identity = await webauthn_client.authenticate(
             assertion=assertion,
             email=email,
-            user_handle=user_handle,
         )
 
         require_verification = webauthn_client.provider.require_verification
@@ -1224,12 +1207,6 @@ class Router:
             self.db, identity.id, pkce_challenge
         )
 
-        _set_cookie(
-            response,
-            "edgedb-webauthn-authentication-user-handle",
-            "",
-            path="/",
-        )
         response.status = http.HTTPStatus.OK
         response.content_type = b"application/json"
         response.body = json.dumps(

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1090,17 +1090,16 @@ class Router:
 
         user_handle_cookie = request.cookies.get(
             "edgedb-webauthn-registration-user-handle"
-        ).value
+        ).value or data.get("user_handle")
         if user_handle_cookie is None:
             raise errors.InvalidData(
-                "Missing 'edgedb-webauthn-registration-user-handle' cookie"
+                "Missing user_handle from cookie or request body"
             )
         try:
             user_handle = base64.urlsafe_b64decode(user_handle_cookie)
         except Exception as e:
             raise errors.InvalidData(
-                "Failed to decode 'edgedb-webauthn-registration-user-handle'"
-                " cookie"
+                "Failed to decode user_handle"
             ) from e
 
         require_verification = webauthn_client.provider.require_verification
@@ -1194,17 +1193,16 @@ class Router:
 
         user_handle_cookie = request.cookies.get(
             "edgedb-webauthn-authentication-user-handle"
-        ).value
+        ).value or data.get("user_handle")
         if user_handle_cookie is None:
             raise errors.InvalidData(
-                "Missing 'edgedb-webauthn-authentication-user-handle' cookie"
+                "Missing user_handle from cookie or request body"
             )
         try:
             user_handle = base64.urlsafe_b64decode(user_handle_cookie)
         except Exception as e:
             raise errors.InvalidData(
-                "Failed to decode 'edgedb-webauthn-authentication-user-handle'"
-                " cookie"
+                "Failed to decode user_handle"
             ) from e
 
         identity = await webauthn_client.authenticate(

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3801,15 +3801,6 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             challenge_bytes = base64.urlsafe_b64decode(
                 f'{body_json["challenge"]}==='
             )
-            user_handle_cookie = self.maybe_get_cookie_value(
-                headers, "edgedb-webauthn-authentication-user-handle"
-            )
-            user_handle_cookie_value = base64.urlsafe_b64decode(
-                f'{user_handle_cookie}==='
-            )
-            self.assertEqual(
-                user_handle_cookie_value, user_handle
-            )
             self.assertTrue(
                 await self.con.query_single(
                     '''

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -31,7 +31,7 @@ import pickle
 import re
 import hashlib
 
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 from jwcrypto import jwt, jwk
 
 from edgedb import QueryAssertionError
@@ -567,14 +567,19 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
         claims = json.loads(jwt_token.claims)
         return claims
 
-    def maybe_get_auth_token(self, headers: dict[str, str]) -> str | None:
+    def maybe_get_cookie_value(
+        self, headers: dict[str, str], name: str
+    ) -> Optional[str]:
         set_cookie = headers.get("set-cookie")
         if set_cookie is not None:
-            (k, v) = set_cookie.split(";")[0].split("=")
-            if k == "edgedb-session":
+            (k, v) = set_cookie.split(";", 1)[0].split("=", 1)
+            if k == name:
                 return v
 
         return None
+
+    def maybe_get_auth_token(self, headers: dict[str, str]) -> Optional[str]:
+        return self.maybe_get_cookie_value(headers, "edgedb-session")
 
     async def extract_session_claims(self, headers: dict[str, str]):
         maybe_token = self.maybe_get_auth_token(headers)
@@ -3548,7 +3553,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             email = f"{uuid.uuid4()}@example.com"
             query_params = urllib.parse.urlencode({"email": email})
 
-            body, _, status = self.http_con_request(
+            body, headers, status = self.http_con_request(
                 http_con,
                 path=f"webauthn/register/options?{query_params}",
             )
@@ -3599,6 +3604,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             user_handle = base64.urlsafe_b64decode(
                 f'{body_json["user"]["id"]}==='
             )
+            user_handle_cookie = self.maybe_get_cookie_value(
+                headers, "edgedb-webauthn-registration-user-handle"
+            )
+            user_handle_cookie_value = base64.urlsafe_b64decode(
+                f'{user_handle_cookie}==='
+            )
+            self.assertEqual(user_handle_cookie_value, user_handle)
+
             self.assertTrue(
                 await self.con.query_single(
                     '''
@@ -3752,7 +3765,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 public_key=public_key,
             )
 
-            body, _, status = self.http_con_request(
+            body, headers, status = self.http_con_request(
                 http_con,
                 path=f"webauthn/authenticate/options?email={email}",
             )
@@ -3787,6 +3800,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             challenge_bytes = base64.urlsafe_b64decode(
                 f'{body_json["challenge"]}==='
+            )
+            user_handle_cookie = self.maybe_get_cookie_value(
+                headers, "edgedb-webauthn-authentication-user-handle"
+            )
+            user_handle_cookie_value = base64.urlsafe_b64decode(
+                f'{user_handle_cookie}==='
+            )
+            self.assertEqual(
+                user_handle_cookie_value, user_handle
             )
             self.assertTrue(
                 await self.con.query_single(


### PR DESCRIPTION
When I originally tested this code with the built-in UI, all of the browser interaction was happening directly with the EdgeDB server, so setting a cookie works great for ensuring that the original `user_handle` would be present across the whole session. However, for the custom UI, you'll actually be interacting with your own application's server to let that server handle the PKCE session creation. Since it's not ergonomic to have server-to-server communication with cookies, we should allow the client to specify the `user_handle` as part of the request body. I cannot picture any issue with allowing the client to specify the `user_handle` since if they try to specify one that is different than the original, we'll fail to find the challenge we created for their `(email,user_handle)` pair during option creation.

The application can get the user handle like this:
1. For *registration*, the user handle is the [`options.user.id`](https://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-id).
2. ~For *authentication*, the user handle is returned from the authenticator at [`assertion.userHandle`](https://w3c.github.io/webauthn/#dom-authenticatorassertionresponse-userhandle)~. Turns out this is purely optional in the case where the application sends a non-empty `allowCredentials` list, which we always do.

So, the client will just need to reference that already-in-scope value when making the `register` ~or `authenticate`~ requests to their own application server, and that server will need to pass it along to the EdgeDB server in the body as `user_handle`.

---

w.r.t. testing here:

I will spend some effort to generate authentic mock data that a _real_ authenticator would use so we can tests both flows end-to-end, but it doesn't seem like that should block getting this merged.

---

Edit: update to not require user handle in the authentication flow: use `(email, credential_id)` pair.