### PR TITLE
Remove Nonterm metaclasses

### DIFF
--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -42,6 +42,7 @@ class ParserSpecIncompatibleError(Exception):
 
 class Token(parsing.Token):
     token_map: Dict[Any, Any] = {}
+    _token: str = ""
 
     def __init_subclass__(
             cls, token=None, lextoken=None, precedence_class=None,

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -37,11 +37,11 @@ from .precedence import *  # NOQA
 from .tokens import *  # NOQA
 
 
-class Nonterm(parsing.Nonterm):
+class Nonterm(parsing.Nonterm, is_internal=True):
     pass
 
 
-class ListNonterm(parsing.ListNonterm, element=None):
+class ListNonterm(parsing.ListNonterm, element=None, is_internal=True):
     pass
 
 
@@ -2219,9 +2219,13 @@ class AnyNodeName(Nonterm):
             name=kids[0].val)
 
 
-class KeywordMeta(parsing.NontermMeta):
-    def __new__(mcls, name, bases, dct, *, type):
-        result = super().__new__(mcls, name, bases, dct)
+class Keyword(parsing.Nonterm):
+    def __init_subclass__(
+            cls, type, is_internal=False, **kwargs):
+        super().__init_subclass__(is_internal=is_internal, **kwargs)
+
+        if is_internal:
+            return
 
         assert type in keywords.keyword_types
 
@@ -2231,25 +2235,20 @@ class KeywordMeta(parsing.NontermMeta):
             method = context.has_context(method)
             method.__doc__ = "%%reduce %s" % token
             method.__name__ = 'reduce_%s' % token
-            setattr(result, method.__name__, method)
-
-        return result
-
-    def __init__(cls, name, bases, dct, *, type):
-        super().__init__(name, bases, dct)
+            setattr(cls, method.__name__, method)
 
 
-class UnreservedKeyword(Nonterm, metaclass=KeywordMeta,
+class UnreservedKeyword(Keyword,
                         type=keywords.UNRESERVED_KEYWORD):
     pass
 
 
-class PartialReservedKeyword(Nonterm, metaclass=KeywordMeta,
+class PartialReservedKeyword(Keyword,
                              type=keywords.PARTIAL_RESERVED_KEYWORD):
     pass
 
 
-class ReservedKeyword(Nonterm, metaclass=KeywordMeta,
+class ReservedKeyword(Keyword,
                       type=keywords.RESERVED_KEYWORD):
     pass
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -2221,7 +2221,7 @@ class AnyNodeName(Nonterm):
 
 class Keyword(parsing.Nonterm):
     def __init_subclass__(
-            cls, type, is_internal=False, **kwargs):
+            cls, *, type, is_internal=False, **kwargs):
         super().__init_subclass__(is_internal=is_internal, **kwargs)
 
         if is_internal:

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 import sys
 import types
+import typing
 
 from edb.common import parsing
 
@@ -284,6 +285,9 @@ class T_SUBSTITUTION(Token):
 class T_EOF(Token):
     pass
 
+
+# explicitly define tokens which are referenced elsewhere
+T_THEN: typing.Optional[Token] = None
 
 def _gen_keyword_tokens():
     # Define keyword tokens


### PR DESCRIPTION
Removed the following `Nonterm` related metaclasses:

- `NontermMeta`
- `ListNontermMeta`
- `KeywordMeta`

Replaced functionality with `__init_subclass__`.