### PR TITLE
Handle WebAuthn challenge having multiple factors

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -111,9 +111,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property challenge: std::bytes {
             create constraint exclusive;
         };
-        create required link factor: ext::auth::WebAuthnFactor {
-            create constraint exclusive;
-        };
         create required multi link factors: ext::auth::WebAuthnFactor {
             create constraint exclusive;
         };

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -114,6 +114,9 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required link factor: ext::auth::WebAuthnFactor {
             create constraint exclusive;
         };
+        create required multi link factors: ext::auth::WebAuthnFactor {
+            create constraint exclusive;
+        };
     };
 
     create type ext::auth::PKCEChallenge extending ext::auth::Auditable {

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -190,13 +190,14 @@ class WebAuthnAuthenticationChallenge:
     created_at: datetime.datetime
     modified_at: datetime.datetime
     challenge: bytes
-    factor: WebAuthnFactor
+    factors: list[WebAuthnFactor]
 
-    def __init__(self, *, id, created_at, modified_at, challenge, factor):
+    def __init__(self, *, id, created_at, modified_at, challenge, factors):
         self.id = id
         self.created_at = created_at
         self.modified_at = modified_at
         self.challenge = base64.b64decode(challenge)
-        self.factor = (
+        self.factors = [
             WebAuthnFactor(**factor) if isinstance(factor, dict) else factor
-        )
+            for factor in factors
+        ]

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -390,7 +390,7 @@ select ext::auth::WebAuthnAuthenticationChallenge {
     created_at,
     modified_at,
     challenge,
-    factors: {
+    factors := (distinct (.factors union .factor)) {
         id,
         created_at,
         modified_at,

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -390,7 +390,7 @@ select ext::auth::WebAuthnAuthenticationChallenge {
     created_at,
     modified_at,
     challenge,
-    factors := (distinct (.factors union .factor)) {
+    factors: {
         id,
         created_at,
         modified_at,

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -324,7 +324,6 @@ with
     )
 insert ext::auth::WebAuthnAuthenticationChallenge {
     challenge := challenge,
-    factor := assert_exists(assert_single((select factors limit 1))),
     factors := factors,
 }
 unless conflict on .factors

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -315,18 +315,19 @@ with
     challenge := <bytes>$challenge,
     user_handle := <bytes>$user_handle,
     email := <str>$email,
-    factor := (
-        assert_exists(assert_single((
+    factors := (
+        assert_exists((
             select ext::auth::WebAuthnFactor
             filter .user_handle = user_handle
             and .email = email
-        )))
+        ))
     )
 insert ext::auth::WebAuthnAuthenticationChallenge {
     challenge := challenge,
-    factor := factor,
+    factor := assert_exists(assert_single((select factors limit 1))),
+    factors := factors,
 }
-unless conflict on .factor
+unless conflict on .factors
 else (
     update ext::auth::WebAuthnAuthenticationChallenge
     set {
@@ -389,7 +390,7 @@ select ext::auth::WebAuthnAuthenticationChallenge {
     created_at,
     modified_at,
     challenge,
-    factor: {
+    factors: {
         id,
         created_at,
         modified_at,
@@ -407,7 +408,7 @@ select ext::auth::WebAuthnAuthenticationChallenge {
         }
     },
 }
-filter .factor.email = email and .factor.credential_id = credential_id;""",
+filter .factors.email = email and .factors.credential_id = credential_id;""",
             variables={
                 "email": email,
                 "credential_id": credential_id,
@@ -437,7 +438,7 @@ with
     email := <str>$email,
     credential_id := <bytes>$credential_id,
 delete ext::auth::WebAuthnAuthenticationChallenge
-filter .factor.email = email and .factor.credential_id = credential_id;""",
+filter .factors.email = email and .factors.credential_id = credential_id;""",
             variables={
                 "email": email,
                 "credential_id": credential_id,
@@ -461,13 +462,21 @@ filter .factor.email = email and .factor.credential_id = credential_id;""",
             credential_id=credential.raw_id,
         )
 
+        factor = next(
+            (
+                f
+                for f in authentication_challenge.factors
+                if f.credential_id == credential.raw_id
+            ),
+            None,
+        )
+        assert factor is not None, "Missing factor for the given credential."
+
         try:
             webauthn.verify_authentication_response(
                 credential=credential,
                 expected_challenge=authentication_challenge.challenge,
-                credential_public_key=(
-                    authentication_challenge.factor.public_key
-                ),
+                credential_public_key=factor.public_key,
                 credential_current_sign_count=0,
                 expected_rp_id=self.provider.relying_party_id,
                 expected_origin=self.provider.relying_party_origin,
@@ -477,4 +486,4 @@ filter .factor.email = email and .factor.credential_id = credential_id;""",
                 "Invalid authentication response. Please retry authentication."
             )
 
-        return authentication_challenge.factor.identity
+        return factor.identity

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3807,8 +3807,8 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     SELECT EXISTS (
                         SELECT ext::auth::WebAuthnAuthenticationChallenge
                         filter .challenge = <bytes>$challenge
-                        AND .factor.email = <str>$email
-                        AND .factor.user_handle = <bytes>$user_handle
+                        AND .factors.email = <str>$email
+                        AND .factors.user_handle = <bytes>$user_handle
                     )
                     ''',
                     challenge=challenge_bytes,


### PR DESCRIPTION
We made some big changes late in the game for allowing multiple WebAuthn factors for a given (email, user_handle) pair, but didn't update this in the authentication challenge flow.

Since we cannot remove the old link, this adds an additional link and ignores the old one.