### PR TITLE
Some test suite perf tweaks

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1092,7 +1092,8 @@ class DatabaseTestCase(ConnectedTestCase):
             # The retry here allows the test to survive a concurrent testing
             # EdgeDB server (e.g. async with tb.start_edgedb_server()) whose
             # introspection holds a lock on the base_db here
-            create_command = f'CREATE BRANCH {qlquote.quote_ident(dbname)}'
+            create_command = (
+                f'CREATE SCHEMA BRANCH {qlquote.quote_ident(dbname)}')
             if cls.get_setup_script():
                 create_command += f' FROM {qlquote.quote_ident(base_db_name)}'
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1091,7 +1091,7 @@ class DatabaseTestCase(ConnectedTestCase):
 
             if cls.get_setup_script():
                 create_command = (
-                    f'CREATE SCHEMA BRANCH {qlquote.quote_ident(dbname)}'
+                    f'CREATE DATA BRANCH {qlquote.quote_ident(dbname)}'
                     f' FROM {qlquote.quote_ident(base_db_name)}'
                 )
             else:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1841,9 +1841,6 @@ def get_test_cases_setup(
         except unittest.SkipTest:
             continue
 
-        if setup_script is None:
-            continue
-
         dbname = case.get_database_name()
         result.append((case, dbname, setup_script))
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1092,7 +1092,7 @@ class DatabaseTestCase(ConnectedTestCase):
             # The retry here allows the test to survive a concurrent testing
             # EdgeDB server (e.g. async with tb.start_edgedb_server()) whose
             # introspection holds a lock on the base_db here
-            create_command = f'CREATE DATABASE {qlquote.quote_ident(dbname)}'
+            create_command = f'CREATE BRANCH {qlquote.quote_ident(dbname)}'
             if cls.get_setup_script():
                 create_command += f' FROM {qlquote.quote_ident(base_db_name)}'
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1089,14 +1089,18 @@ class DatabaseTestCase(ConnectedTestCase):
 
             base_db_name, _, _ = dbname.rpartition('_')
 
+            if cls.get_setup_script():
+                create_command = (
+                    f'CREATE SCHEMA BRANCH {qlquote.quote_ident(dbname)}'
+                    f' FROM {qlquote.quote_ident(base_db_name)}'
+                )
+            else:
+                create_command = (
+                    f'CREATE EMPTY BRANCH {qlquote.quote_ident(dbname)}')
+
             # The retry here allows the test to survive a concurrent testing
             # EdgeDB server (e.g. async with tb.start_edgedb_server()) whose
             # introspection holds a lock on the base_db here
-            create_command = (
-                f'CREATE SCHEMA BRANCH {qlquote.quote_ident(dbname)}')
-            if cls.get_setup_script():
-                create_command += f' FROM {qlquote.quote_ident(base_db_name)}'
-
             async for tr in cls.try_until_succeeds(
                 ignore=edgedb.ExecutionError,
                 timeout=30,

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -471,10 +471,10 @@ class VerboseRenderer(BaseRenderer):
 class MultiLineRenderer(BaseRenderer):
 
     FT_LABEL = 'First few failed: '
-    FT_MAX_LINES = 3
+    FT_MAX_LINES = 6
 
     R_LABEL = 'Running: '
-    R_MAX_LINES = 3
+    R_MAX_LINES = 6
 
     def __init__(self, *, tests, stream):
         super().__init__(tests=tests, stream=stream)
@@ -627,7 +627,7 @@ class MultiLineRenderer(BaseRenderer):
                 running_tests.append('...')
 
             _render_test_list(
-                self.R_LABEL,
+                self.R_LABEL + f'({len(currently_running)})',
                 self.R_MAX_LINES,
                 running_tests,
                 styles.marker_passed
@@ -726,6 +726,7 @@ class ParallelTextTestResult(unittest.result.TestResult):
     def startTest(self, test):
         super().startTest(test)
         self.currently_running[test] = True
+        self.ren._render(list(self.currently_running))
 
     def addSuccess(self, test):
         super().addSuccess(test)

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -437,6 +437,9 @@ class BaseRenderer:
     def report(self, test, marker, description=None, *, currently_running):
         raise NotImplementedError
 
+    def report_start(self, test, *, currently_running):
+        return
+
 
 class SimpleRenderer(BaseRenderer):
     def report(self, test, marker, description=None, *, currently_running):
@@ -503,6 +506,9 @@ class MultiLineRenderer(BaseRenderer):
 
         self.buffer[test.__class__.__module__] += marker.value
         self.completed_tests += 1
+        self._render(currently_running)
+
+    def report_start(self, test, *, currently_running):
         self._render(currently_running)
 
     def _render_modname(self, name):
@@ -726,7 +732,8 @@ class ParallelTextTestResult(unittest.result.TestResult):
     def startTest(self, test):
         super().startTest(test)
         self.currently_running[test] = True
-        self.ren._render(list(self.currently_running))
+        self.ren.report_start(
+            test, currently_running=list(self.currently_running))
 
     def addSuccess(self, test):
         super().addSuccess(test)

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -24,7 +24,7 @@ from edb.testbase import server as tb
 from edb.tools import test
 
 
-class TestEdgeQLFuncCalls(tb.DDLTestCase):
+class TestEdgeQLFuncCalls(tb.QueryTestCase):
 
     async def test_edgeql_calls_01(self):
         await self.con.execute('''


### PR DESCRIPTION
Because of the new implementation of branches, creating databases from
a template is serialized now, which slows down test suites that rely
on creating database clones. Fortunately most of them don't really
need it, so we can simplify matters by avoiding branches for test
suites with empty databases.

Improve the rendering of tests a bit too by including a count of the
currently running tests and rerendering when a test *starts*, instead
of just when one finishes.