### PR TITLE
Remove explicit `target-version` from Ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,5 +224,4 @@ lint.ignore = [
 ]
 line-length = 80
 indent-width = 4
-target-version = "py310"
 exclude = ["postgres", ".github"]


### PR DESCRIPTION
Rely on `requires-python` instead.
