### PR TITLE
Fix CI test failure by cleaning up in test_edgeql_ddl_reindex

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2461,8 +2461,8 @@ def get_cases_by_shard(cases, selected_shard, total_shards, verbosity, stats):
     # Prepare the source heaps
     setup_count = 0
     for case, tests in cases.items():
-        setup_script = getattr(case, 'get_setup_script', lambda: None)()
-        if setup_script and tests:
+        setup_script_getter = getattr(case, 'get_setup_script', None)
+        if setup_script_getter and tests:
             tests_per_setup = []
             est_per_setup = setup_est = stats.get(
                 'setup::' + case.get_database_name(), (new_setup_est, 0),

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -17171,27 +17171,35 @@ class TestDDLExtensions(tb.DDLTestCase):
             create module test;
             create type test::Bar extending Foo;
         ''')
-        await self.con.execute('''
-            administer reindex(Foo)
-        ''')
-        await self.con.execute('''
-            administer reindex(Foo.foo)
-        ''')
-        await self.con.execute('''
-            administer reindex(Foo.bar)
-        ''')
-        await self.con.execute('''
-            administer reindex(Foo.tgt)
-        ''')
-        await self.con.execute('''
-            administer reindex(Foo.tgts)
-        ''')
-        await self.con.execute('''
-            administer reindex(test::Bar)
-        ''')
-        await self.con.execute('''
-            administer reindex(Object)
-        ''')
+        try:
+            await self.con.execute('''
+                administer reindex(Foo)
+            ''')
+            await self.con.execute('''
+                administer reindex(Foo.foo)
+            ''')
+            await self.con.execute('''
+                administer reindex(Foo.bar)
+            ''')
+            await self.con.execute('''
+                administer reindex(Foo.tgt)
+            ''')
+            await self.con.execute('''
+                administer reindex(Foo.tgts)
+            ''')
+            await self.con.execute('''
+                administer reindex(test::Bar)
+            ''')
+            await self.con.execute('''
+                administer reindex(Object)
+            ''')
+        finally:
+            await self.con.execute('''
+                drop type test::Bar;
+                drop type Foo;
+                drop type Tgt;
+                drop module test;
+            ''')
 
     async def _deadlock_tester(self, setup, teardown, modification, query):
         """Deadlock test helper.


### PR DESCRIPTION
I'm not totally sure what happened to cause test_edgeql_ddl_reindex
to get sorted earlier than test_edgeql_ddl_extensions_01, though...