### PR TITLE
Implement _run_and_rollback_retrying

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -959,12 +959,13 @@ class ConnectedTestCase(ClusterTestCase):
         async def cm(tx):
             try:
                 async with tx:
+                    await tx._ensure_transaction()
                     yield tx
                     raise RollbackException
             except RollbackException:
                 pass
 
-        async for tx in self.con.raw_retrying_transaction():
+        async for tx in self.con.retrying_transaction():
             yield cm(tx)
 
     def assert_data_shape(self, data, shape, message=None):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -359,6 +359,10 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
         }
 
 
+class RollbackException(Exception):
+    pass
+
+
 class RollbackChanges:
     def __init__(self, test):
         self._conn = test.con
@@ -949,6 +953,19 @@ class ConnectedTestCase(ClusterTestCase):
 
     def _run_and_rollback(self):
         return RollbackChanges(self)
+
+    async def _run_and_rollback_retrying(self):
+        @contextlib.asynccontextmanager
+        async def cm(tx):
+            try:
+                async with tx:
+                    yield tx
+                    raise RollbackException
+            except RollbackException:
+                pass
+
+        async for tx in self.con.raw_retrying_transaction():
+            yield cm(tx)
 
     def assert_data_shape(self, data, shape, message=None):
         assert_data_shape.assert_data_shape(

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -27,14 +27,11 @@ from edb.testbase import server as tb
 class DumpTestCaseMixin:
 
     async def ensure_schema_data_integrity(self, include_data=True):
-        tx = self.con.transaction()
-        await tx.start()
-        try:
-            await self._ensure_schema_integrity()
-            if include_data:
-                await self._ensure_data_integrity()
-        finally:
-            await tx.rollback()
+        async for tx in self._run_and_rollback_retrying():
+            async with tx:
+                await self._ensure_schema_integrity()
+                if include_data:
+                    await self._ensure_data_integrity()
 
     async def _ensure_schema_integrity(self):
         # check that all the type annotations are in place

--- a/tests/test_dump02.py
+++ b/tests/test_dump02.py
@@ -25,14 +25,11 @@ from edb.testbase import server as tb
 class DumpTestCaseMixin:
 
     async def ensure_schema_data_integrity(self, include_data=True):
-        tx = self.con.transaction()
-        await tx.start()
-        try:
-            await self._ensure_schema_integrity()
-            if include_data:
-                await self._ensure_data_integrity()
-        finally:
-            await tx.rollback()
+        async for tx in self._run_and_rollback_retrying():
+            async with tx:
+                await self._ensure_schema_integrity()
+                if include_data:
+                    await self._ensure_data_integrity()
 
     async def _ensure_schema_integrity(self):
         # Check that index exists

--- a/tests/test_dump03.py
+++ b/tests/test_dump03.py
@@ -25,12 +25,10 @@ from edb.testbase import server as tb
 class DumpTestCaseMixin:
 
     async def ensure_schema_data_integrity(self):
-        tx = self.con.transaction()
-        await tx.start()
-        try:
+        # We can't use _retrying here, since the sequences won't get reset.
+        # Hopefully this won't be a problem.
+        async with self._run_and_rollback():
             await self._ensure_schema_data_integrity()
-        finally:
-            await tx.rollback()
 
     async def _ensure_schema_data_integrity(self):
         await self.assert_query_result(

--- a/tests/test_dump_v2.py
+++ b/tests/test_dump_v2.py
@@ -27,14 +27,11 @@ from edb.testbase import server as tb
 class DumpTestCaseMixin:
 
     async def ensure_schema_data_integrity(self, include_data=True):
-        tx = self.con.transaction()
-        await tx.start()
-        try:
-            await self._ensure_schema_integrity()
-            if include_data:
-                await self._ensure_data_integrity()
-        finally:
-            await tx.rollback()
+        async for tx in self._run_and_rollback_retrying():
+            async with tx:
+                await self._ensure_schema_integrity()
+                if include_data:
+                    await self._ensure_data_integrity()
 
     async def _ensure_schema_integrity(self):
         # Validate access policies

--- a/tests/test_dump_v3.py
+++ b/tests/test_dump_v3.py
@@ -25,12 +25,9 @@ from edb.testbase import server as tb
 class DumpTestCaseMixin:
 
     async def ensure_schema_data_integrity(self):
-        tx = self.con.transaction()
-        await tx.start()
-        try:
-            await self._ensure_schema_data_integrity()
-        finally:
-            await tx.rollback()
+        async for tx in self._run_and_rollback_retrying():
+            async with tx:
+                await self._ensure_schema_data_integrity()
 
     async def _ensure_schema_data_integrity(self):
         await self.assert_query_result(

--- a/tests/test_dump_v4.py
+++ b/tests/test_dump_v4.py
@@ -25,13 +25,10 @@ from edb.testbase import server as tb
 class DumpTestCaseMixin:
 
     async def ensure_schema_data_integrity(self, include_secrets=False):
-        tx = self.con.transaction()
-        await tx.start()
-        try:
-            await self._ensure_schema_data_integrity(
-                include_secrets=include_secrets)
-        finally:
-            await tx.rollback()
+        async for tx in self._run_and_rollback_retrying():
+            async with tx:
+                await self._ensure_schema_data_integrity(
+                    include_secrets=include_secrets)
 
     async def _ensure_schema_data_integrity(self, include_secrets):
         await self.assert_query_result(

--- a/tests/test_edgeql_extensions.py
+++ b/tests/test_edgeql_extensions.py
@@ -117,8 +117,9 @@ class TestDDLExtensions(tb.DDLTestCase):
         };
         ''')
         try:
-            async with self._run_and_rollback():
-                await self._extension_test_01()
+            async for tx in self._run_and_rollback_retrying():
+                async with tx:
+                    await self._extension_test_01()
         finally:
             await self.con.execute('''
                 drop extension package ltree VERSION '1.0'
@@ -314,10 +315,12 @@ class TestDDLExtensions(tb.DDLTestCase):
         };
         ''')
         try:
-            async with self._run_and_rollback():
-                await self._extension_test_02a()
-            async with self._run_and_rollback():
-                await self._extension_test_02b()
+            async for tx in self._run_and_rollback_retrying():
+                async with tx:
+                    await self._extension_test_02a()
+            async for tx in self._run_and_rollback_retrying():
+                async with tx:
+                    await self._extension_test_02b()
         finally:
             await self.con.execute('''
                 drop extension package varchar VERSION '1.0'
@@ -842,8 +845,9 @@ class TestDDLExtensions(tb.DDLTestCase):
         ''')
 
         try:
-            async with self._run_and_rollback():
-                await self._extension_test_05(in_tx=True)
+            async for tx in self._run_and_rollback_retrying():
+                async with tx:
+                    await self._extension_test_05(in_tx=True)
             try:
                 await self._extension_test_05(in_tx=False)
             finally:
@@ -984,8 +988,9 @@ class TestDDLExtensions(tb.DDLTestCase):
             };
         ''')
         try:
-            async with self._run_and_rollback():
-                await self._extension_test_06b()
+            async for tx in self._run_and_rollback_retrying():
+                async with tx:
+                    await self._extension_test_06b()
         finally:
             await self.con.execute('''
                 drop extension package bar VERSION '1.0';


### PR DESCRIPTION
In general we should be using retrying transactions. Our isolated
tests do retries at the outside, but non-isolated ones don't
necessarily.

Implement _run_and_rollback_retrying and use it some places that
TransactionSerializationError flakes have been seen (in #6954 and
in nightly CI).

Honestly I don't really think that these places ought to be having
TransactionSerializationErrors, but also it really is pretty required
to do retries when using SERIALIZABLE, so we should start moving
towards being more consistent about it.