### PR TITLE
Explicitly pass WebAuthn credential properties

### DIFF
--- a/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
@@ -150,10 +150,12 @@ async function authenticateAssertion(props) {
   // Assertion includes raw bytes, so need to be encoded as base64url
   // for transmission
   const encodedAssertion = {
-    ...props.assertion,
+    type: props.assertion.type,
+    id: props.assertion.id,
+    authenticatorAttachments: props.assertion.authenticatorAttachment,
+    clientExtensionResults: props.assertion.getClientExtensionResults(),
     rawId: encodeBase64Url(new Uint8Array(props.assertion.rawId)),
     response: {
-      ...props.assertion.response,
       authenticatorData: encodeBase64Url(
         new Uint8Array(props.assertion.response.authenticatorData)
       ),

--- a/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn-authenticate.js
@@ -152,7 +152,7 @@ async function authenticateAssertion(props) {
   const encodedAssertion = {
     type: props.assertion.type,
     id: props.assertion.id,
-    authenticatorAttachments: props.assertion.authenticatorAttachment,
+    authenticatorAttachment: props.assertion.authenticatorAttachment,
     clientExtensionResults: props.assertion.getClientExtensionResults(),
     rawId: encodeBase64Url(new Uint8Array(props.assertion.rawId)),
     response: {

--- a/edb/server/protocol/auth_ext/_static/webauthn-register.js
+++ b/edb/server/protocol/auth_ext/_static/webauthn-register.js
@@ -164,10 +164,12 @@ async function registerCredentials(props) {
   // Credentials include raw bytes, so need to be encoded as base64url
   // for transmission
   const encodedCredentials = {
-    ...props.credentials,
+    type: props.credentials.type,
+    authenticatorAttachment: props.credentials.authenticatorAttachment,
+    clientExtensionResults: props.credentials.getClientExtensionResults(),
+    id: props.credentials.id,
     rawId: encodeBase64Url(new Uint8Array(props.credentials.rawId)),
     response: {
-      ...props.credentials.response,
       attestationObject: encodeBase64Url(
         new Uint8Array(props.credentials.response.attestationObject)
       ),


### PR DESCRIPTION
Not sure if this was working before due to some idiosyncratic behavior of Bitwarden's passkey implementation, but when I tried this with the built-in Chrome passkey functionality, I was getting errors about missing properties.