### PR TITLE
Allow `/branch/{dbname}` in extension routes

### DIFF
--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -510,7 +510,7 @@ cdef class HttpProtocol:
                     b'The server is closing.',
                 )
 
-        if route == 'db':
+        if route == 'db' or route == 'branch':
             if path_parts_len < 2:
                 return self._not_found(request, response)
 
@@ -631,7 +631,7 @@ cdef class HttpProtocol:
                             else request_url.host.decode()
                     )
                     extension_base_path = f"{request_url.schema.decode()}://" \
-                                          f"{netloc}/db/{dbname}/ext/auth"
+                                          f"{netloc}/{route}/{dbname}/ext/auth"
                     handler = auth_ext.http.Router(
                         db=db,
                         base_path=extension_base_path,
@@ -734,7 +734,7 @@ cdef class HttpProtocol:
         bint allow_credentials = False
     ):
         db = self.tenant.maybe_get_db(dbname=dbname) if dbname else None
-        
+
         config = None
         if db is not None:
             if db.db_config is None:
@@ -770,7 +770,7 @@ cdef class HttpProtocol:
                 if allow_credentials:
                     response.custom_headers['Access-Control-Allow-Credentials'] = (
                         'true')
-                
+
             return True
 
         return False

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -496,7 +496,7 @@ cdef class HttpProtocol:
         path_parts_len = len(path_parts)
         route = path_parts[0]
 
-        if self.tenant is None and route in ['db', 'auth']:
+        if self.tenant is None and route in ['db', 'auth', 'branch']:
             self.tenant = self.server.get_default_tenant()
             self.check_readiness()
             if self.tenant.is_accepting_connections():
@@ -510,7 +510,7 @@ cdef class HttpProtocol:
                     b'The server is closing.',
                 )
 
-        if route == 'db' or route == 'branch':
+        if route in ['db', 'branch']:
             if path_parts_len < 2:
                 return self._not_found(request, response)
 

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -44,7 +44,7 @@ class BaseHttpExtensionTest(server.QueryTestCase):
     def get_api_prefix(cls):
         extpath = cls.get_extension_path()
         dbname = cls.get_database_name()
-        return f'/db/{dbname}/{extpath}'
+        return f'/branch/{dbname}/{extpath}'
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Allows `/branch` as the base route for our extensions while keeping support for `/db`. We do not currently plan on deprecating the `/db` route, but will be promoting `/branch` in our documentation.

I'll update the documentation as a separate step since we will probably want to align that with release, right?