### PR TITLE
Add a cfg::BranchConfig alias for cfg::DatabaseConfig

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_02_28_00_00
+EDGEDB_CATALOG_VERSION = 2024_03_04_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -242,6 +242,7 @@ def derive_view(
                 mark_derived=True,
                 transient=True,
                 attrs=attrs,
+                stdmode=ctx.env.options.bootstrap_mode,
             )
 
         if (

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -264,6 +264,7 @@ ALTER TYPE cfg::AbstractConfig {
 CREATE TYPE cfg::Config EXTENDING cfg::AbstractConfig;
 CREATE TYPE cfg::InstanceConfig EXTENDING cfg::AbstractConfig;
 CREATE TYPE cfg::DatabaseConfig EXTENDING cfg::AbstractConfig;
+CREATE ALIAS cfg::BranchConfig := cfg::DatabaseConfig;
 
 
 CREATE FUNCTION

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -463,6 +463,7 @@ def compile_alias_expr(
             modaliases=context.modaliases,
             schema_view_mode=True,
             in_ddl_context_name='alias definition',
+            bootstrap_mode=context.stdmode,
         ),
     )
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -173,6 +173,7 @@ class Type(
         inheritance_merge: bool = True,
         transient: bool = False,
         inheritance_refdicts: Optional[AbstractSet[str]] = None,
+        stdmode: bool = False,
         **kwargs: Any,
     ) -> typing.Tuple[s_schema.Schema, TypeT]:
 
@@ -202,6 +203,7 @@ class Type(
         context = sd.CommandContext(
             modaliases={},
             schema=schema,
+            stdmode=stdmode,
         )
 
         delta = sd.DeltaRoot()

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -854,7 +854,7 @@ class TestServerConfig(tb.QueryTestCase):
 
         await self.assert_query_result(
             '''
-            SELECT cfg::DatabaseConfig.__internal_sess_testvalue
+            SELECT cfg::BranchConfig.__internal_sess_testvalue
             ''',
             [
                 3


### PR DESCRIPTION
If I had remembered this *before* the 5.0 branch cut, I'd have made
DatabaseConfig abstract and made BranchConfig a concrete subtype,
which would have been generally more satisfying (actual type is
BranchConfig, `IS` works with either), but this version is much safer
to patch in.

Some fixes were needed to make creating a standard library alias work.