### PR TITLE
Schema version in query cache key

### DIFF
--- a/edb/server/compiler/rpc.pxd
+++ b/edb/server/compiler/rpc.pxd
@@ -40,6 +40,7 @@ cdef class CompilationRequest:
         readonly object session_config
         object database_config
         object system_config
+        object schema_version
 
         bytes serialized_cache
         object cache_key

--- a/edb/server/compiler/rpc.pyi
+++ b/edb/server/compiler/rpc.pyi
@@ -80,6 +80,9 @@ class CompilationRequest:
     ) -> CompilationRequest:
         ...
 
+    def set_schema_version(self, version: uuid.UUID) -> CompilationRequest:
+        ...
+
     def serialize(self) -> bytes:
         ...
 

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -131,6 +131,12 @@ cdef class CompilationRequest:
         self.cache_key = None
         return self
 
+    def set_schema_version(self, version: uuid.UUID) -> CompilationRequest:
+        self.schema_version = version
+        self.serialized_cache = None
+        self.cache_key = None
+        return self
+
     def deserialize(self, bytes data, str query_text) -> CompilationRequest:
         if data[0] == 0:
             self._deserialize_v0(data, query_text)
@@ -216,6 +222,10 @@ cdef class CompilationRequest:
             {k: v.value for k, v in comp_config.items()}
         )
         hash_obj.update(serialized_comp_config)
+
+        # Must set_schema_version() before serializing compilation request
+        assert self.schema_version is not None
+        hash_obj.update(self.schema_version.bytes)
 
         cache_key_bytes = hash_obj.digest()
         self.cache_key = uuidgen.from_bytes(cache_key_bytes)

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -83,7 +83,7 @@ cdef class Database:
     cdef schedule_config_update(self)
 
     cdef _invalidate_caches(self)
-    cdef _cache_compiled_query(self, key, compiled, schema_version)
+    cdef _cache_compiled_query(self, key, compiled)
     cdef _new_view(self, query_cache, protocol_version)
     cdef _remove_view(self, view)
     cdef _update_backend_ids(self, new_types)
@@ -163,9 +163,7 @@ cdef class DatabaseConnectionView:
     cpdef in_tx(self)
     cpdef in_tx_error(self)
 
-    cdef cache_compiled_query(
-        self, object key, object query_unit_group, schema_version
-    )
+    cdef cache_compiled_query(self, object key, object query_unit_group)
     cdef lookup_compiled_query(self, object key)
     cdef as_compiled(self, query_req, query_unit_group, bint use_metrics=?)
 

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -152,6 +152,7 @@ cdef class DatabaseConnectionView:
         object __weakref__
 
     cdef _reset_tx_state(self)
+    cdef inline _check_in_tx_error(self, query_unit_group)
 
     cdef clear_tx_error(self)
     cdef rollback_tx_to_savepoint(self, name)
@@ -166,6 +167,7 @@ cdef class DatabaseConnectionView:
         self, object key, object query_unit_group, schema_version
     )
     cdef lookup_compiled_query(self, object key)
+    cdef as_compiled(self, query_req, query_unit_group, bint use_metrics=?)
 
     cdef tx_error(self)
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1081,10 +1081,9 @@ cdef class DatabaseConnectionView:
                     )
                 else:
                     query_unit_group = self.lookup_compiled_query(query_req)
-
-            if query_unit_group is not None:
-                return self.as_compiled(
-                    query_req, query_unit_group, use_metrics)
+                if query_unit_group is not None:
+                    return self.as_compiled(
+                        query_req, query_unit_group, use_metrics)
 
             try:
                 query_unit_group = await self._compile(query_req)

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -758,6 +758,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             object output_format
             bint expect_one = False
             bytes query
+            dbview.DatabaseConnectionView _dbview
 
         allow_capabilities = <uint64_t>self.buffer.read_int64()
         compilation_flags = <uint64_t>self.buffer.read_int64()
@@ -790,10 +791,11 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         if not query:
             raise errors.BinaryProtocolError('empty query')
 
+        _dbview = self.get_dbview()
         state_tid = self.buffer.read_bytes(16)
         state_data = self.buffer.read_len_prefixed_bytes()
         try:
-            self.get_dbview().decode_state(state_tid, state_data)
+            _dbview.decode_state(state_tid, state_data)
         except errors.StateMismatchError:
             self.write(self.make_state_data_description_msg())
             raise
@@ -808,7 +810,11 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             inline_typeids=inline_typeids,
             inline_typenames=inline_typenames,
             inline_objectids=inline_objectids,
-        )
+        ).set_schema_version(_dbview.schema_version)
+        rv.set_modaliases(_dbview.get_modaliases())
+        rv.set_session_config(_dbview.get_session_config())
+        rv.set_database_config(_dbview.get_database_config())
+        rv.set_system_config(_dbview.get_compilation_system_config())
         return rv, allow_capabilities
 
     async def parse(self):
@@ -828,10 +834,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         if _dbview.get_state_serializer() is None:
             await _dbview.reload_state_serializer()
         query_req, allow_capabilities = self.parse_execute_request()
-        query_req.set_modaliases(_dbview.get_modaliases())
-        query_req.set_session_config(_dbview.get_session_config())
-        query_req.set_database_config(_dbview.get_database_config())
-        query_req.set_system_config(_dbview.get_compilation_system_config())
         compiled = await self._parse(query_req, allow_capabilities)
         units = compiled.query_unit_group
         if len(units) == 1 and units[0].cache_sql:
@@ -872,10 +874,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         in_tid = self.buffer.read_bytes(16)
         out_tid = self.buffer.read_bytes(16)
         args = self.buffer.read_len_prefixed_bytes()
-        query_req.set_modaliases(_dbview.get_modaliases())
-        query_req.set_session_config(_dbview.get_session_config())
-        query_req.set_database_config(_dbview.get_database_config())
-        query_req.set_system_config(_dbview.get_compilation_system_config())
         self.buffer.finish_message()
 
         if (
@@ -1430,16 +1428,14 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         self.flush()
 
     async def _execute_utility_stmt(self, eql: str, pgcon):
-        cdef dbview.DatabaseConnectionView _dbview
+        cdef dbview.DatabaseConnectionView _dbview = self.get_dbview()
 
         query_req = rpc.CompilationRequest(
             self.server.compilation_config_serializer
         )
         query_req.update(
             edgeql.Source.from_string(eql), self.protocol_version
-        )
-
-        _dbview = self.get_dbview()
+        ).set_schema_version(_dbview.schema_version)
 
         compiled = await _dbview.parse(query_req)
         query_unit_group = compiled.query_unit_group
@@ -1825,17 +1821,19 @@ async def run_script(
     cdef:
         EdgeConnection conn
         dbview.CompiledQuery compiled
+        dbview.DatabaseConnectionView _dbview
     conn = new_edge_connection(server, tenant)
     await conn._start_connection(database)
     try:
-        compiled = await conn.get_dbview().parse(
+        _dbview = conn.get_dbview()
+        compiled = await _dbview.parse(
             rpc.CompilationRequest(
                 server.compilation_config_serializer
             ).update(
                 edgeql.Source.from_string(script),
                 conn.protocol_version,
                 output_format=FMT_NONE,
-            )
+            ).set_schema_version(_dbview.schema_version)
         )
         if len(compiled.query_unit_group) > 1:
             await conn._execute_script(compiled, b'')

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -375,7 +375,7 @@ async def execute(
             else:
                 recompile_requests = [
                     req
-                    for req, (grp, _) in dbv._db._eql_to_compiled.items()
+                    for req, grp in dbv._db._eql_to_compiled.items()
                     if len(grp) == 1
                 ]
             await dbv.recompile_all(be_conn, recompile_requests)
@@ -579,7 +579,7 @@ async def execute_script(
             else:
                 recompile_requests = [
                     req
-                    for req, (grp, _) in dbv._db._eql_to_compiled.items()
+                    for req, grp in dbv._db._eql_to_compiled.items()
                     if len(grp) == 1
                 ]
 

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -738,7 +738,7 @@ async def parse_execute_json(
         protocol_version=edbdef.CURRENT_PROTOCOL,
         input_format=compiler.InputFormat.JSON,
         output_format=output_format,
-    )
+    ).set_schema_version(dbv.schema_version)
 
     compiled = await dbv.parse(
         query_req,

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -26,6 +26,7 @@ import sys
 import tempfile
 import time
 import unittest.mock
+import uuid
 
 import immutables
 
@@ -442,7 +443,7 @@ class TestCompilerPool(tbs.TestCase):
                     source=edgeql.Source.from_string(orig_query),
                     protocol_version=(1, 0),
                     implicit_limit=101,
-                )
+                ).set_schema_version(uuid.uuid4())
 
                 await asyncio.gather(*(pool_.compile_in_tx(
                     context.state.current_tx().id,
@@ -473,7 +474,7 @@ class TestCompilerPool(tbs.TestCase):
             ).update(
                 source=source,
                 protocol_version=(1, 0),
-            )
+            ).set_schema_version(uuid.uuid4())
             request2 = rpc.CompilationRequest(
                 compiler.state.compilation_config_serializer
             ).deserialize(request1.serialize(), "<unknown>")

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -481,5 +481,12 @@ class TestCompilerPool(tbs.TestCase):
             self.assertEqual(hash(request1), hash(request2))
             self.assertEqual(request1, request2)
 
+            # schema_version affects the cache_key, hence the hash.
+            # But, it's not serialized so the 2 requests are still equal.
+            # This makes request2 a new key as being used in dicts.
+            request2.set_schema_version(uuid.uuid4())
+            self.assertNotEqual(hash(request1), hash(request2))
+            self.assertEqual(request1, request2)
+
         test(edgeql.Source.from_string("SELECT 42"))
         test(edgeql.NormalizedSource.from_string("SELECT 42"))


### PR DESCRIPTION
This PR adds schema_version into the query cache key, so that the cache table can be append-only to avoid concurrent update errors.