### PR TITLE
Fix computed single scalar globals

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -501,9 +501,6 @@ def new_primitive_rvar(
     lateral: bool,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
-    if not ir_set.path_id.is_objtype_path():
-        raise ValueError('cannot create root rvar for non-object path')
-
     if isinstance(ir_set.expr, irast.TypeRoot):
         skip_subtypes = ir_set.expr.skip_subtypes
     else:
@@ -1430,6 +1427,9 @@ def range_for_material_objtype(
     ):
         typeref = typeref.material_type
     is_global = typeref.material_type is not None
+
+    if not is_global and not path_id.is_objtype_path():
+        raise ValueError('cannot create root rvar for non-object path')
 
     relation: Union[pgast.Relation, pgast.CommonTableExpr]
 

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -40,6 +40,9 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             create required global def_cur_user -> str {
                 set default := 'Alice'
             };
+            create global def_cur_user_excited := (
+                global def_cur_user ++ '!'
+            );
             create global cur_card -> str {
                 set default := 'Dragon'
             };
@@ -119,9 +122,10 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                select (global cur_user, global def_cur_user)
+                select (global cur_user, global def_cur_user,
+                        global def_cur_user_excited)
             ''',
-            [['Bob', 'Dave']],
+            [['Bob', 'Dave', 'Dave!']],
         )
 
     async def test_edgeql_globals_03(self):


### PR DESCRIPTION
They were being cached, but we were rejecting attempts to use the
cache because of an overly zealous assert. Make the assert more
permissive.

Fixes #6988.