### PR TITLE
Fix authentication-related nightly test failure

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2026,7 +2026,7 @@ class _EdgeDBServer:
         runstate_dir: Optional[str] = None,
         reset_auth: Optional[bool] = None,
         tenant_id: Optional[str] = None,
-        security: Optional[edgedb_args.ServerSecurityMode] = None,
+        security: edgedb_args.ServerSecurityMode,
         default_auth_method: Optional[edgedb_args.ServerAuthMethod] = None,
         binary_endpoint_security: Optional[
             edgedb_args.ServerEndpointSecurityMode] = None,
@@ -2354,7 +2354,8 @@ def start_edgedb_server(
     data_dir: Optional[str] = None,
     reset_auth: Optional[bool] = None,
     tenant_id: Optional[str] = None,
-    security: Optional[edgedb_args.ServerSecurityMode] = None,
+    security: edgedb_args.ServerSecurityMode = (
+        edgedb_args.ServerSecurityMode.Strict),
     default_auth_method: Optional[edgedb_args.ServerAuthMethod] = None,
     binary_endpoint_security: Optional[
         edgedb_args.ServerEndpointSecurityMode] = None,

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1631,6 +1631,7 @@ class TestSeparateCluster(tb.BaseHTTPTestCase):
         DBNAME = 'asdf'
         async with tb.start_edgedb_server(
             http_endpoint_security=args.ServerEndpointSecurityMode.Optional,
+            security=args.ServerSecurityMode.InsecureDevMode,
             default_branch=DBNAME,
         ) as sd:
             def check(mode, name, current, ok=True):


### PR DESCRIPTION
A new test in #6996 relied on start_edgedb_server starting a server
using insecure_dev_mode, which was only true when the tests were run
from a dev-mode build.

Specify insecure_dev_mode explicitly in that test, and change the
default in start_edgedb_server to avoid this kind of problem in the
future.

(I actually don't know how to produce and run something locally that
works in non dev-mode.)