### PR TITLE
Handle in-transaction query cache properly

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -176,7 +176,7 @@ class flags(metaclass=FlagsMeta):
 
     zombodb = Flag(doc="Enabled zombodb and disables postgres FTS")
 
-    persistent_cache = Flag(doc="Use persistent cache")
+    disable_persistent_cache = Flag(doc="Don't use persistent cache")
 
     # Function cache is an experimental feature that may not fully work
     func_cache = Flag(doc="Use stored functions for persistent cache")

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -870,7 +870,7 @@ class Compiler:
             request.protocol_version,
             request.inline_objectids,
             request.json_parameters,
-            persistent_cache=bool(debug.flags.persistent_cache),
+            persistent_cache=not debug.flags.disable_persistent_cache,
             cache_key=request.get_cache_key(),
         )
         return units, cstate
@@ -976,7 +976,7 @@ class Compiler:
             request.inline_objectids,
             request.json_parameters,
             expect_rollback=expect_rollback,
-            persistent_cache=bool(debug.flags.persistent_cache),
+            persistent_cache=not debug.flags.disable_persistent_cache,
             cache_key=request.get_cache_key(),
         )
         return units, cstate

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -184,7 +184,7 @@ async def execute(
     # This flag indicates both features are in use, and we actually have
     # recompiled the query cache to persist.
     persist_recompiled_query_cache = bool(
-        debug.flags.persistent_cache and compiled.recompiled_cache)
+        not debug.flags.disable_persistent_cache and compiled.recompiled_cache)
 
     data = None
 


### PR DESCRIPTION
- [x] Disable in-tx cache while persistent_cache is on ([dry run](https://github.com/edgedb/edgedb/actions/runs/8205312820))
- [ ] Properly fix in-tx cache by tracking in dbview and writeback after transaction commits
