### PR TITLE
Document drop branch force

### DIFF
--- a/docs/changelog/5_x.rst
+++ b/docs/changelog/5_x.rst
@@ -324,7 +324,7 @@ EdgeQL
       {b'\x01\xff\x02\xff\x03'}
 
 * Support closing all connections to a database on ``drop database``.
-  (:eql:gh:`#6780`)
+  (:eql:gh:`#6780`, :eql:gh:`#6862`)
 
 
 Bug fixes

--- a/docs/reference/admin/databases.rst
+++ b/docs/reference/admin/databases.rst
@@ -50,6 +50,16 @@ Remove a database.
 
     drop database <name> ;
 
+.. versionadded:: 5.0
+
+    You may now drop a branch, even if it has active connections by adding
+    ``force``:
+
+    .. eql:synopsis::
+
+        drop branch <name> [force] ;
+
+
 Description
 -----------
 


### PR DESCRIPTION
Added this to the Reference > Administration > Database page since I think it needs to be there. Its canonical home should be on a new Reference > Administration > Branch page. As part of a future PR, I will comb through the docs to update "database" to "branch" wherever appropriate, and I will also add the aforementioned page with a note on the Administration > Database page that "databases" were renamed "branches" in v5.