### PR TITLE
Fallback to PKCE RFC parameter names

### DIFF
--- a/docs/guides/auth/built_in_ui.rst
+++ b/docs/guides/auth/built_in_ui.rst
@@ -55,6 +55,20 @@ end of the flow. Take this ``verifier`` string, hash it with SHA256, and then
 base64url encode the resulting string. This new string is called the
 ``challenge``.
 
+.. note::
+
+   If you are familiar with PKCE, you will notice some differences from how RFC
+   7636 defines PKCE. Our authentication flow is not an OAuth flow, but rather a
+   strict server-to-server flow with Proof Key of Code Exchange added for
+   additional security to avoid leaking the authentication token. Here are some
+   differences between PKCE as defined in RFC 7636 and our implementation:
+
+   - We do not support the ``plain`` value for ``code_challenge_method``, and
+     therefore do not read that value if provided in requests.
+   - Our parameters omit the ``code_`` prefix, however we do support
+     ``code_challenge`` and ``code_verifier`` as aliases, preferring
+     ``challenge`` and ``verifier`` if present.
+
 .. code-block:: javascript
 
    import http from "node:http";

--- a/docs/guides/auth/email_password.rst
+++ b/docs/guides/auth/email_password.rst
@@ -58,6 +58,20 @@ end of the flow. Take this ``verifier`` string, hash it with SHA256, and then
 base64url encode the resulting string. This new string is called the
 ``challenge``.
 
+.. note::
+
+   If you are familiar with PKCE, you will notice some differences from how RFC
+   7636 defines PKCE. Our authentication flow is not an OAuth flow, but rather a
+   strict server-to-server flow with Proof Key of Code Exchange added for
+   additional security to avoid leaking the authentication token. Here are some
+   differences between PKCE as defined in RFC 7636 and our implementation:
+
+   - We do not support the ``plain`` value for ``code_challenge_method``, and
+     therefore do not read that value if provided in requests.
+   - Our parameters omit the ``code_`` prefix, however we do support
+     ``code_challenge`` and ``code_verifier`` as aliases, preferring
+     ``challenge`` and ``verifier`` if present.
+
 .. lint-off
 
 .. code-block:: javascript

--- a/docs/guides/auth/oauth.rst
+++ b/docs/guides/auth/oauth.rst
@@ -58,6 +58,20 @@ end of the flow. Take this ``verifier`` string, hash it with SHA256, and then
 base64url encode the resulting string. This new string is called the
 ``challenge``.
 
+.. note::
+
+   If you are familiar with PKCE, you will notice some differences from how RFC
+   7636 defines PKCE. Our authentication flow is not an OAuth flow, but rather a
+   strict server-to-server flow with Proof Key of Code Exchange added for
+   additional security to avoid leaking the authentication token. Here are some
+   differences between PKCE as defined in RFC 7636 and our implementation:
+
+   - We do not support the ``plain`` value for ``code_challenge_method``, and
+     therefore do not read that value if provided in requests.
+   - Our parameters omit the ``code_`` prefix, however we do support
+     ``code_challenge`` and ``code_verifier`` as aliases, preferring
+     ``challenge`` and ``verifier`` if present.
+
 .. code-block:: javascript
 
    import http from "node:http";

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -388,8 +388,8 @@ class Router:
             request.url.query.decode("ascii") if request.url.query else ""
         )
         code = _get_search_param(query, "code")
-        verifier = _get_search_param(query, "verifier") or _get_search_param(
-            query, "code_verifier"
+        verifier = _get_search_param(
+            query, "verifier", fallback_keys=["code_verifier"]
         )
 
         verifier_size = len(verifier)

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -253,7 +253,9 @@ class Router:
             raise errors.InvalidData(
                 "Redirect URL does not match any allowed URLs.",
             )
-        challenge = _get_search_param(query, "challenge")
+        challenge = _get_search_param(
+            query, "challenge", fallback_keys=["code_challenge"]
+        )
         oauth_client = oauth.Client(
             db=self.db, provider_name=provider_name, base_url=self.test_url
         )
@@ -386,7 +388,9 @@ class Router:
             request.url.query.decode("ascii") if request.url.query else ""
         )
         code = _get_search_param(query, "code")
-        verifier = _get_search_param(query, "verifier")
+        verifier = _get_search_param(query, "verifier") or _get_search_param(
+            query, "code_verifier"
+        )
 
         verifier_size = len(verifier)
 
@@ -1338,7 +1342,9 @@ class Router:
             query = urllib.parse.parse_qs(
                 request.url.query.decode("ascii") if request.url.query else ""
             )
-            challenge = _get_search_param(query, "challenge")
+            challenge = _get_search_param(
+                query, "challenge", fallback_keys=["code_challenge"]
+            )
             app_details_config = self._get_app_details_config()
 
             response.status = http.HTTPStatus.OK
@@ -1660,9 +1666,7 @@ class Router:
             claims=claims,
         )
         session_token.make_signed_token(signing_key)
-        metrics.auth_successful_logins.inc(
-            1.0, self.tenant.get_instance_name()
-        )
+        metrics.auth_successful_logins.inc(1.0, self.tenant.get_instance_name())
         return session_token.serialize()
 
     def _get_from_claims(self, state: str, key: str) -> str:
@@ -1987,8 +1991,18 @@ def _maybe_get_search_param(
     return params[0] if params else None
 
 
-def _get_search_param(query_dict: dict[str, list[str]], key: str) -> str:
+def _get_search_param(
+    query_dict: dict[str, list[str]],
+    key: str,
+    *,
+    fallback_keys: Optional[list[str]] = None,
+) -> str:
     val = _maybe_get_search_param(query_dict, key)
+    if val is None and fallback_keys is not None:
+        for fallback_key in fallback_keys:
+            val = _maybe_get_search_param(query_dict, fallback_key)
+            if val is not None:
+                break
     if val is None:
         raise errors.InvalidData(f"Missing query parameter: {key}")
     return val
@@ -2010,7 +2024,9 @@ def _get_pkce_challenge(
     query_dict: dict[str, list[str]],
 ) -> str | None:
     cookie_name = 'edgedb-pkce-challenge'
-    challenge: str | None = _maybe_get_search_param(query_dict, 'challenge')
+    challenge: str | None = _maybe_get_search_param(
+        query_dict, 'challenge'
+    ) or _maybe_get_search_param(query_dict, "code_challenge")
     if challenge is not None:
         _set_cookie(response, cookie_name, challenge)
     else:

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3042,7 +3042,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 http_con,
                 {
                     "code": pkce.id,
-                    "verifier": base64.urlsafe_b64encode(os.urandom(43))
+                    "code_verifier": base64.urlsafe_b64encode(os.urandom(43))
                     .rstrip(b"=")
                     .decode(),
                 },

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -1071,7 +1071,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             query = {
                 "provider": provider_name,
                 "redirect_to": redirect_to,
-                "challenge": challenge,
+                "code_challenge": challenge,
             }
 
             _, headers, status = self.http_con_request(


### PR DESCRIPTION
I played it a little fast-and-loose when implementing our PKCE implementation since we are not an OAuth authorization flow and therefore are not building an _actual_ PKCE flow, just something inspired by it. However, there are some existing tools that can take advantage of the code exchange if we align with the same parameter names outlined in [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636#section-6.1).

Added a note in the docs for anyone who might be familiar with how RFC 7636 defines PKCE to highlight the differences.

Closes #7026 

---

Special note here about omitting support for `code_challenge_method`: 

>   If the client is capable of using "S256", it MUST use "S256", as
>   "S256" is Mandatory To Implement (MTI) on the server.  Clients are
>   permitted to use "plain" only if they cannot support "S256" for some
>   technical reason and know via out-of-band configuration that the
>   server supports "plain".

[RFC 7636 Section 4.2](https://datatracker.ietf.org/doc/html/rfc7636#section-4.2)

Since our PKCE flow is _always_ a server-to-server flow, we _require_ that clients provide a SHA256 hashed challenge, and do not accept `plain` as a `code_challenge_method` since it negates the added security of PKCE. The RFC specifies that if the `code_challenge_method` is omitted that the server treat the challenge as `plain`, but we do not support `plain`. I considered conforming here but always requiring implementors to provide the constant `S256` value, but that seemed low value and an unnecessary hurdle. In the future we could chose to require it and return a failure status of 400 if you do not provide it if we want to add additional compatibility with RFC 7636.