### PR TITLE
Add __setstate__ method to handle Expression consistency when unpickling

### DIFF
--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -98,6 +98,11 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             '_irast': None,
         }
 
+    def __setstate__(self, state: Mapping[str, Any]) -> None:
+        # Since `origin` is omitted from the pickled schema, it needs to be
+        # explicitly set to `None` when loading pickles.
+        super().__setstate__({"origin": None, **state})
+
     def __eq__(self, rhs: object) -> bool:
         if not isinstance(rhs, Expression):
             return NotImplemented


### PR DESCRIPTION
Hello, I'm using the EdgeDB unpickled stdlib into my project, I found an inconsistency in stdschema entries like: 

```
<Expression text='1', refs=None, origin=<edb.common.struct.Field object at 0x70ebd3e29800> at 0x70ebd3852310>
``` 

The `origin` field was introduced in #4731 , but did not modify the `__getstate__()` method, as mentioned by the author in comments, indicating the intention not to store it.

Since the `origin` field is omitted in `__getstate__`, it needs to add `__setstate__` to explicitly set `origin` to `None` when unpickle, ensuring consistent data.

Before:
```
>>> import pickle
>>> from edb.schema import expr
>>> e = expr.Expression(text='1')
<Expression text='1', refs=None, origin=None at 0x701bcfa44f90>
>>> pickle.loads(pickle.dumps(e))
<Expression text='1', refs=None, origin=<edb.common.struct.Field object at 0x701bce8a31f0> at 0x701bcfa56c90>
```

After:
```
>>> import pickle
>>> from edb.schema import expr
>>> e = expr.Expression(text='1')
<Expression text='1', refs=None, origin=None at 0x71a35f95a0d0>
>>> pickle.loads(pickle.dumps(e))
<Expression text='1', refs=None, origin=None at 0x71a35f740390>
```