### PR TITLE
Fix edb server development mode logging

### DIFF
--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -19,6 +19,10 @@
 
 from __future__ import annotations
 
+from edb.common.log import early_setup
+# ruff: noqa: E402
+early_setup()
+
 import os
 import sys
 


### PR DESCRIPTION
This should be the only missing entry point that logs stuff:

```
[project.scripts]
edgedb-server = "edb.server.main:main"
edb = "edb.tools.edb:edbcommands"
edgedb = "edb.cli:rustcli"
```

The packaging CI is running `python -m edb.tools` which then imports `edb.tools.edb` for testing.

Depends on #7033 