### PR TITLE
Improve error when applying a shape to a parameter

### DIFF
--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -21,6 +21,7 @@
 
 
 from __future__ import annotations
+from dataclasses import dataclass
 from typing import Optional, Tuple, Dict, List
 
 from edb.common import ast
@@ -121,6 +122,12 @@ def extend_path(expr: qlast.Expr, field: str) -> qlast.Path:
         return qlast.Path(steps=[expr, step])
 
 
+@dataclass
+class Params:
+    params: List[
+        Tuple[qlast.TypeCast, Dict[Optional[str], str]]] = []
+    loose_params: List[qlast.Parameter] = []
+
 class FindParams(ast.NodeVisitor):
     """Visitor to find all the parameters.
 
@@ -128,9 +135,7 @@ class FindParams(ast.NodeVisitor):
     """
     def __init__(self, modaliases: Dict[Optional[str], str]) -> None:
         super().__init__()
-        self.params: List[
-            Tuple[qlast.TypeCast, Dict[Optional[str], str]]] = []
-        self.loose_params: List[qlast.Parameter] = []
+        self.params: Params = []
         self.modaliases = modaliases
 
     def visit_Command(self, n: qlast.Command) -> None:
@@ -154,12 +159,12 @@ class FindParams(ast.NodeVisitor):
 
     def visit_TypeCast(self, n: qlast.TypeCast) -> None:
         if isinstance(n.expr, qlast.Parameter):
-            self.params.append((n, self.modaliases))
+            self.params.params.append((n, self.modaliases))
         else:
             self.generic_visit(n)
 
     def visit_Parameter(self, n: qlast.Parameter) -> None:
-        self.loose_params.append(n)
+        self.params.loose_params.append(n)
 
     def visit_CreateFunction(self, n: qlast.CreateFunction) -> None:
         pass
@@ -170,13 +175,11 @@ class FindParams(ast.NodeVisitor):
 
 def find_parameters(
     ql: qlast.Base, modaliases: Dict[Optional[str], str]
-) -> Tuple[
-        List[Tuple[qlast.TypeCast, Dict[Optional[str], str]]],
-        List[qlast.Parameter]]:
+) -> Params:
     """Get all query parameters"""
     v = FindParams(modaliases)
     v.visit(ql)
-    return v.params, v.loose_params
+    return v.params
 
 
 class alias_view(

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -127,7 +127,9 @@ class Params:
     cast_params: List[
         Tuple[qlast.TypeCast, Dict[Optional[str], str]]
     ] = field(default_factory=list)
-    shaped_params: List[qlast.Parameter] = field(default_factory=list)
+    shaped_params: List[
+        Tuple[qlast.Parameter, qlast.Shape]
+    ] = field(default_factory=list)
     loose_params: List[qlast.Parameter] = field(default_factory=list)
 
 class FindParams(ast.NodeVisitor):
@@ -164,7 +166,7 @@ class FindParams(ast.NodeVisitor):
             self.params.cast_params.append((n, self.modaliases))
         elif isinstance(n.expr, qlast.Shape):
             if isinstance(n.expr.expr, qlast.Parameter):
-                self.params.shaped_params.append(n.expr.expr)
+                self.params.shaped_params.append((n.expr.expr, n.expr))
             else:
                 self.generic_visit(n)
         else:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -820,11 +820,13 @@ def check_params(params: Dict[str, irast.Param]) -> None:
 
 def throw_on_shaped_param(
     param: qlast.Parameter,
+    shape: qlast.Shape,
     ctx: context.ContextLevel
 ) -> None:
     raise errors.QueryError(
         f'cannot apply a shape to the parameter',
-        context=param.context)
+        hint='Consider adding parentheses around the parameter and type cast',
+        context=shape.context)
 
 
 def throw_on_loose_param(
@@ -860,17 +862,17 @@ def preprocess_script(
         for stmt in stmts
     ]
 
-    if shaped_params := [
-        shaped for params in params_lists
-        for shaped in params.shaped_params
-    ]:
-        throw_on_shaped_param(shaped_params[0], ctx)
-
     if loose_params := [
         loose for params in params_lists
         for loose in params.loose_params
     ]:
         throw_on_loose_param(loose_params[0], ctx)
+
+    if shaped_params := [
+        shaped for params in params_lists
+        for shaped in params.shaped_params
+    ]:
+        throw_on_shaped_param(shaped_params[0][0], shaped_params[0][1], ctx)
 
     casts = [
         cast for params in params_lists for cast in params.cast_params

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -846,19 +846,19 @@ def preprocess_script(
     Doing this in advance makes it easy to check that they have
     consistent types.
     """
-    param_lists = [
+    params_lists = [
         astutils.find_parameters(stmt, ctx.modaliases)
         for stmt in stmts
     ]
 
     if loose_params := [
-        loose for _, loose_list in param_lists
-        for loose in loose_list
+        loose for params in params_lists
+        for loose in params.loose_list
     ]:
         throw_on_loose_param(loose_params[0], ctx)
 
     casts = [
-        cast for cast_lists, _ in param_lists for cast in cast_lists
+        cast for cast_lists, _ in params_lists for cast in cast_lists
     ]
     params = {}
     for cast, modaliases in casts:

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -8212,6 +8212,12 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(edgedb.QueryError, "missing a type cast"):
             await self.con.query("select ($0, <std::int64>$0)")
 
+    async def test_edgeql_select_params_04(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    "cannot apply a shape to the parameter"):
+            await self.con.query("select <std::int64>$0 { id }")
+
+
     async def test_edgeql_type_pointer_inlining_01(self):
         await self.con._fetchall(
             r'''

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -796,6 +796,13 @@ class TestServerProto(tb.QueryTestCase):
             await self.con.query_single(
                 'select schema::Object {name} filter .id=$id', id='asd')
 
+    async def test_server_proto_args_07_1(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    "cannot apply a shape to the parameter"):
+            await self.con.query_single(
+                'select schema::Object filter .id=<uuid>$id {name}', id='asd')
+
+
     async def test_server_proto_args_08(self):
         async with self._run_and_rollback():
             await self.con.execute(


### PR DESCRIPTION
When passing the query from #6605, the error has been changed to:

```
select User filter .id = <uuid>$userId { id };
error: QueryError: cannot apply a shape to the parameter
  ┌─ <query>:1:32
  │
1 │ select User filter .id = <uuid>$userId { id };
  │                                ^^^^^^^^^^^^ Consider adding parentheses around the parameter and type cast
```

When parentheses are added:
```
error: QueryError: shapes cannot be applied to scalar type 'std::uuid'
  ┌─ <query>:1:27
  │
1 │ select User filter .id = (<uuid>$userId) { id };
  │                           ^^^^^^^^^^^^^^^^^^^ error
```
