### PR TITLE
Add error when parsing shape applied to type cast

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1372,6 +1372,16 @@ class Expr(Nonterm):
         )
 
     @parsing.precedence(precedence.P_TYPECAST)
+    def reduce_TypeCast_with_shape(
+            self, *kids):
+        r"%reduce LANGBRACKET FullTypeExpr \
+                  RANGBRACKET ParameterOptType Shape"
+
+        raise errors.EdgeQLSyntaxError(
+            f"cannot apply a shape to the parameter",
+            context=kids[-2].context)
+
+    @parsing.precedence(precedence.P_TYPECAST)
     def reduce_LANGBRACKET_OPTIONAL_FullTypeExpr_RANGBRACKET_Expr(
             self, *kids):
         self.val = qlast.TypeCast(
@@ -1390,6 +1400,16 @@ class Expr(Nonterm):
         )
 
     @parsing.precedence(precedence.P_TYPECAST)
+    def reduce_Optional_TypeCast_with_shape(
+            self, *kids):
+        r"%reduce LANGBRACKET OPTIONAL FullTypeExpr \
+                  RANGBRACKET ParameterOptType Shape"
+
+        raise errors.EdgeQLSyntaxError(
+            f"cannot apply a shape to the parameter",
+            context=kids[-2].context)
+
+    @parsing.precedence(precedence.P_TYPECAST)
     def reduce_LANGBRACKET_REQUIRED_FullTypeExpr_RANGBRACKET_Expr(
             self, *kids):
         self.val = qlast.TypeCast(
@@ -1406,6 +1426,16 @@ class Expr(Nonterm):
             type=kids[2].val,
             cardinality_mod=qlast.CardinalityModifier.Required,
         )
+
+    @parsing.precedence(precedence.P_TYPECAST)
+    def reduce_Required_TypeCast_with_shape(
+            self, *kids):
+        r"%reduce LANGBRACKET REQUIRED FullTypeExpr \
+                  RANGBRACKET ParameterOptType Shape"
+
+        raise errors.EdgeQLSyntaxError(
+            f"cannot apply a shape to the parameter",
+            context=kids[-2].context)
 
     def reduce_Expr_IF_Expr_ELSE_Expr(self, *kids):
         if_expr, _, condition, _, else_expr = kids

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -207,15 +207,6 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
         SELECT FALSE;
         """
 
-    def test_edgeql_syntax_constants_06(self):
-        """
-        SELECT $1;
-        SELECT $123;
-        SELECT $somevar;
-        SELECT $select;
-        SELECT (($SELECT + $TRUE) + $WITH);
-        """
-
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   "leading zeros are not allowed in numbers",
                   line=2, col=16)
@@ -480,11 +471,6 @@ aa';
     def test_edgeql_syntax_constants_41(self):
         r"""
         SELECT 'aaa \(aaa) bbb';
-        """
-
-    def test_edgeql_syntax_constants_42(self):
-        """
-        SELECT $select;
         """
 
     def test_edgeql_syntax_constants_43(self):
@@ -1386,16 +1372,6 @@ aa';
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Missing ':='", line=4, col=23)
-    def test_edgeql_syntax_shape_29(self):
-        """
-        SELECT Issue{
-            name,
-            related_to *$var,
-        };
-        """
-
     def test_edgeql_syntax_shape_30(self):
         """
         SELECT Named {
@@ -2259,26 +2235,6 @@ aa';
         SELECT TUP.1.1;
         """
 
-    def test_edgeql_syntax_path_29(self):
-        # legal when `$0`, `$1`, `$a` and `$abc` are tuples
-        """
-        SELECT $0.0;
-        SELECT $0.0.name;
-        SELECT $0.0.1.name;
-        SELECT $0.0.1.n;
-        SELECT $abc.0;
-        SELECT $abc.0.name;
-        SELECT $abc.0.1.name;
-        SELECT $abc.0.1.n;
-        """
-
-    def test_edgeql_syntax_path_30(self):
-        # legal when `$0`, `$1`, `$a` and `$abc` are tuples
-        """
-        SELECT $1.1.1;
-        SELECT $a.1.1;
-        """
-
     @tb.must_fail(errors.EdgeQLSyntaxError, r"bare \$ is not allowed",
                   line=2, col=16)
     def test_edgeql_syntax_path_31(self):
@@ -2548,6 +2504,13 @@ aa';
         SELECT <tuple<>>$1;
         """
 
+    def test_edgeql_syntax_cast_11(self):
+        """
+        SELECT <int64>$var;
+        SELECT <std::str>$var;
+        SELECT <std::array<std::str>>$var;
+        """
+
     def test_edgeql_syntax_with_01(self):
         """
         WITH
@@ -2799,13 +2762,6 @@ aa';
         """
         SELECT Issue {name} ORDER BY Issue.priority.name ASC EMPTY FIRST;
         SELECT Issue {name} ORDER BY Issue.priority.name DESC EMPTY LAST;
-        """
-
-    def test_edgeql_syntax_select_10(self):
-        """
-        SELECT User.name OFFSET $1;
-        SELECT User.name LIMIT $2;
-        SELECT User.name OFFSET $1 LIMIT $2;
         """
 
     def test_edgeql_syntax_select_11(self):
@@ -4587,7 +4543,7 @@ aa';
             EXTENDING std::constraint
         {
             SET errmessage := '{subject} must be one of: {p}.';
-            USING (contains($p, __subject__));
+            USING (contains(p, __subject__));
         };
         """
 
@@ -4595,7 +4551,7 @@ aa';
         """
         CREATE ABSTRACT CONSTRAINT std::enum(VARIADIC p: anytype) {
             SET errmessage := '{subject} must be one of: {$p}.';
-            USING (contains($p, __subject__));
+            USING (contains(p, __subject__));
         };
         """
 
@@ -4603,7 +4559,7 @@ aa';
         """
         CREATE ABSTRACT CONSTRAINT std::enum {
             SET errmessage := '{subject} must be one of: {param}.';
-            USING (contains($param, __subject__));
+            USING (contains(param, __subject__));
         };
         """
 
@@ -4611,14 +4567,14 @@ aa';
         """
         CREATE ABSTRACT CONSTRAINT std::enum() {
             SET errmessage := '{subject} must be one of: {param}.';
-            USING (contains($param, __subject__));
+            USING (contains(param, __subject__));
         };
 
 % OK %
 
         CREATE ABSTRACT CONSTRAINT std::enum {
             SET errmessage := '{subject} must be one of: {param}.';
-            USING (contains($param, __subject__));
+            USING (contains(param, __subject__));
         };
         """
 
@@ -6449,7 +6405,7 @@ class TestEdgeQLNormalization(EdgeQLSyntaxTest):
     ) -> None:
         pass
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=25)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=26)
     def test_edgeql_normalization_01(self):
         '''
         select count(foo 1);

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2511,6 +2511,14 @@ aa';
         SELECT <std::array<std::str>>$var;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  "cannot apply a shape to the parameter",
+                  line=2, col=22)
+    def test_edgeql_syntax_cast_12(self):
+        """
+        SELECT <uuid>$var { id };
+        """
+
     def test_edgeql_syntax_with_01(self):
         """
         WITH


### PR DESCRIPTION
When passing the query from #6605, the error has been changed to:

```
select User filter .id = <uuid>$userId { id };
error: EdgeQLSyntaxError: cannot apply a shape to the parameter
  ┌─ <query>:1:32
  │
1 │ select User filter .id = <uuid>$userId { id };
  │                                ^^^^^^^ error
```