### PR TITLE
Fix parser at unrecoverable errors

### DIFF
--- a/edb/edgeql-parser/src/parser.rs
+++ b/edb/edgeql-parser/src/parser.rs
@@ -55,6 +55,7 @@ pub fn parse<'a>(input: &'a [Terminal], ctx: &'a Context) -> (Option<&'a CSTNode
     let mut new_parsers = Vec::with_capacity(parsers.len() + 5);
 
     for token in input {
+        // println!("token {:?}", token);
         while let Some(mut parser) = parsers.pop() {
             let res = parser.act(ctx, token);
 
@@ -75,22 +76,24 @@ pub fn parse<'a>(input: &'a [Terminal], ctx: &'a Context) -> (Option<&'a CSTNode
                 };
 
                 // option 1: inject a token
-                let possible_actions = &ctx.spec.actions[parser.stack_top.state];
-                for token_kind in possible_actions.keys() {
-                    let mut inject = parser.clone();
+                if parser.error_cost <= ERROR_COST_INJECT_MAX {
+                    let possible_actions = &ctx.spec.actions[parser.stack_top.state];
+                    for token_kind in possible_actions.keys() {
+                        let mut inject = parser.clone();
 
-                    let injection = new_token_for_injection(*token_kind, ctx);
+                        let injection = new_token_for_injection(*token_kind, ctx);
 
-                    let cost = injection_cost(token_kind);
-                    let error = Error::new(format!("Missing {injection}")).with_span(gap_span);
-                    inject.push_error(error, cost);
+                        let cost = injection_cost(token_kind);
+                        let error = Error::new(format!("Missing {injection}")).with_span(gap_span);
+                        inject.push_error(error, cost);
 
-                    if inject.error_cost <= ERROR_COST_INJECT_MAX {
-                        // println!("   --> [inject {injection}]");
+                        if inject.error_cost <= ERROR_COST_INJECT_MAX {
+                            if inject.act(ctx, injection).is_ok() {
+                                // println!("   --> [inject {injection}]");
 
-                        if inject.act(ctx, injection).is_ok() {
-                            // insert into parsers, to retry the original token
-                            parsers.push(inject);
+                                // insert into parsers, to retry the original token
+                                parsers.push(inject);
+                            }
                         }
                     }
                 }
@@ -104,12 +107,14 @@ pub fn parse<'a>(input: &'a [Terminal], ctx: &'a Context) -> (Option<&'a CSTNode
                             .push_error(error.default_span_to(token.span), ERROR_COST_CUSTOM_ERROR);
                         parser.has_custom_error = true;
 
+                        // println!("   --> [custom error]");
                         new_parsers.push(parser);
                         continue;
                     }
                 } else if parser.has_custom_error {
                     // when there is a custom error, just skip the tokens until
                     // the parser recovers
+                    // println!("   --> [skip because of custom error]");
                     new_parsers.push(parser);
                     continue;
                 }
@@ -124,9 +129,8 @@ pub fn parse<'a>(input: &'a [Terminal], ctx: &'a Context) -> (Option<&'a CSTNode
                     skip.can_recover = false;
                 }
 
-                // println!("   --> [skip]");
-
                 // insert into new_parsers, so the token is skipped
+                // println!("   --> [skip] {}", skip.error_cost);
                 new_parsers.push(skip);
             }
         }
@@ -150,6 +154,11 @@ pub fn parse<'a>(input: &'a [Terminal], ctx: &'a Context) -> (Option<&'a CSTNode
                     new_parsers.push(recovered);
                 }
             }
+        }
+
+        // prune: pick only 1 best parsers that has cost > ERROR_COST_INJECT_MAX
+        if new_parsers[0].error_cost > ERROR_COST_INJECT_MAX {
+            new_parsers.drain(1..);
         }
 
         // prune: pick only X best parsers
@@ -245,8 +254,7 @@ pub struct Reduce {
 /// Any types that do allocation with global allocator (such as String or Vec),
 /// must manually drop. This is why Terminal has a special vec arena that does
 /// Drop.
-#[derive(Debug, Clone, Copy)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum CSTNode<'a> {
     #[default]
     Empty,
@@ -566,8 +574,6 @@ impl std::fmt::Display for Terminal {
         }
     }
 }
-
-
 
 impl Terminal {
     pub fn from_token(token: Token) -> Self {

--- a/edb/tools/parser_demo.py
+++ b/edb/tools/parser_demo.py
@@ -31,7 +31,7 @@ from edb.tools.edb import edbcommands
 def main():
     qlparser.preload_spec()
 
-    for q in QUERIES[-10:]:
+    for q in QUERIES[-1:]:
         sdl = q.startswith('sdl')
         if sdl:
             q = q[3:]
@@ -328,4 +328,18 @@ QUERIES = [
     '''
     INSERT Foo FILTER Foo.bar = 42;
     ''',
+    '''
+    start migration to {
+      module default {
+        type Hello extending MetaHello {
+          property platform_fee_percentage: int16 {
+            constrant exclusive {
+              errmessage := "asxasx";
+            }
+          }
+          required property blah := .bleh - .bloh - .blih;
+        }
+      }
+    }
+    '''
 ]

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -6429,6 +6429,27 @@ aa';
         crEAte something;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  "Unexpected 'exclusive'", line=6, col=27)
+    def test_edgeql_syntax_ddl_01(self):
+        """
+        start migration to {
+          module default {
+            type Hello extending MetaHello {
+              property platform_fee_percentage: int16 {
+                constrant exclusive {
+                  errmessage := "asxasx";
+                }
+              }
+              required property blah := .bleh - .bloh - .blih;
+            }
+          }
+        }
+        """
+        # TODO: this actually returns a bunch of errors, but we throw all away
+        # and pick only first.
+        # When returning multiple errors is supported, we should still return
+        # just the first one.
 
 class TestEdgeQLNormalization(EdgeQLSyntaxTest):
 


### PR DESCRIPTION
In some cases, our parser will not be able to recover from an error.
What we want in this case is to skip all tokens until EOF.
This was working correctly, but:

1. It could be skiping tokens for up to 10 different recovery paths.
   (i.e. each token would processed 10 times).
   This maked parsing of such cases ~10x slower than it could be.
   We do have a mechanism that prevents injecting new tokens after
   error recovery cost gets too large, so I've made it so that when that
   happens, we discard all but the best recovery path.

2. Each time a parser would skip a token, it would first check all
   possible tokens to inject. It would then figure out it is not
   allowed to inject token in this case, so loop was done completely
   unnecessarily.

The pathological case from BeatGig now parses in ~400ms on my machine.

Another thing that we should probably look into, is not reporting
15000 errors of unexpected tokens, but a single error saying\
"cannot parse from here on".
