### PR TITLE
Skip creating @source/@target on derived views

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -241,6 +241,10 @@ def derive_view(
                 inheritance_refdicts={'pointers'},
                 mark_derived=True,
                 transient=True,
+                # When compiling aliases, we can't elide
+                # @source/@target pointers, which normally we would
+                # when creating a view.
+                preserve_endpoint_ptrs=ctx.env.options.schema_view_mode,
                 attrs=attrs,
                 stdmode=ctx.env.options.bootstrap_mode,
             )
@@ -335,7 +339,12 @@ def derive_ptr(
         inheritance_refdicts={'pointers'},
         mark_derived=True,
         transient=True,
-        attrs=attrs)
+        # When compiling aliases, we can't elide
+        # @source/@target pointers, which normally we would
+        # when creating a view.
+        preserve_endpoint_ptrs=ctx.env.options.schema_view_mode,
+        attrs=attrs,
+    )
 
     if not ptr.is_non_concrete(ctx.env.schema):
         if isinstance(derived, s_sources.Source):
@@ -587,7 +596,6 @@ def derive_dummy_ptr(
             },
             name=derived_name,
             mark_derived=True,
-            transient=True,
         )
         ctx.env.created_schema_objects.add(derived)
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1226,6 +1226,13 @@ class CommandContextToken(Generic[Command_T_co]):
     mark_derived: Optional[bool]
     enable_recursion: Optional[bool]
     transient_derivation: Optional[bool]
+    # Whether to skip creating @source/@target properties on links.
+    # Typically this is set whenever transient_derivation is,
+    # (so that it doesn't get set on transiet views, etc),
+    # except when compiling aliases where we need to produce
+    # fully populated links.
+    # This is a surprisingly valuable optimization (25% on a big schema).
+    slim_links: Optional[bool]
 
     def __init__(
         self,
@@ -1246,6 +1253,7 @@ class CommandContextToken(Generic[Command_T_co]):
         self.mark_derived = None
         self.enable_recursion = None
         self.transient_derivation = None
+        self.slim_links = None
 
 
 class CommandContextWrapper(Generic[Command_T_co]):
@@ -1369,6 +1377,10 @@ class CommandContext:
                 return ctx.transient_derivation
 
         return False
+
+    @property
+    def slim_links(self) -> bool:
+        return any(ctx.slim_links for ctx in self.stack)
 
     @property
     def canonical(self) -> bool:

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -298,6 +298,7 @@ class ReferencedInheritingObject(
         inheritance_merge: bool = True,
         inheritance_refdicts: Optional[AbstractSet[str]] = None,
         transient: bool = False,
+        preserve_endpoint_ptrs: bool = False,
         name: Optional[sn.QualName] = None,
         **kwargs: Any,
     ) -> Tuple[s_schema.Schema, ReferencedInheritingObjectT]:
@@ -388,6 +389,8 @@ class ReferencedInheritingObject(
 
             if transient:
                 context.current().transient_derivation = True
+                if not preserve_endpoint_ptrs:
+                    context.current().slim_links = True
 
             parent_cmd.add(cmd)
             schema = delta.apply(schema, context)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -175,6 +175,7 @@ class Type(
         attrs: Optional[Mapping[str, Any]] = None,
         inheritance_merge: bool = True,
         transient: bool = False,
+        preserve_endpoint_ptrs: bool = False,
         inheritance_refdicts: Optional[AbstractSet[str]] = None,
         stdmode: bool = False,
         **kwargs: Any,
@@ -223,6 +224,8 @@ class Type(
 
             if transient:
                 context.current().transient_derivation = True
+                if not preserve_endpoint_ptrs:
+                    context.current().slim_links = True
 
             delta.add(cmd)
             schema = delta.apply(schema, context)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -743,6 +743,20 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ]
         )
 
+        # Make sure @source/@target are correct in created alias
+        await self.assert_query_result(
+            r"""
+                SELECT schema::Link {
+                    pnames := .properties.name
+                } FILTER .name = {"connected", '__type__'}
+                  AND .source.name = 'default::Alias2'
+            """,
+            [
+                {"pnames": {'source', 'target'}},
+                {"pnames": {'source', 'target'}},
+            ]
+        )
+
     async def test_edgeql_ddl_20(self):
         await self.con.execute("""
 


### PR DESCRIPTION
This gave a 20-25% speedup on loading a big production schema.

In general I think that hugely slimming down how we create transient
types during compilation is the biggest opportunity for a big
performance improvement, and there are promising approaches that will
require some big changes. This gets a bunch done for very little.