### PR TITLE
Switch _get_set_rvar to use a dispatch based system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,8 @@ warn_redundant_casts = true
 warn_unused_configs = true
 show_column_numbers = true
 show_error_codes = true
+# This being an error seems super confused to me.
+disable_error_code = "type-abstract"
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
Eventually, when my in-flight refactors are finished and all Sets have
an expr, we'll be able to drop _get_set_rvar and have it be purely
dispatched.