### PR TITLE
Fix issues with cached global shapes and global cardinality inference

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -511,6 +511,9 @@ class TypeRoot(Expr):
     # This will be replicated in the enclosing set.
     typeref: TypeRef
 
+    # Whether this is a reference to a cached global.
+    is_cached_global: bool = False
+
     # Whether to force this to not select subtypes
     skip_subtypes: bool = False
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -511,7 +511,8 @@ class TypeRoot(Expr):
     # This will be replicated in the enclosing set.
     typeref: TypeRef
 
-    # Whether this is a reference to a cached global.
+    # Whether this is a reference to a global that is cached in a
+    # materialized CTE in the query.
     is_cached_global: bool = False
 
     # Whether to force this to not select subtypes

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -505,7 +505,8 @@ def new_primitive_rvar(
         skip_subtypes = ir_set.expr.skip_subtypes
         is_global = ir_set.expr.is_cached_global
     else:
-        skip_subtypes = is_global = False
+        skip_subtypes = False
+        is_global = False
 
     typeref = ir_set.typeref
     dml_source = irutils.get_dml_sources(ir_set)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -503,15 +503,19 @@ def new_primitive_rvar(
 ) -> pgast.PathRangeVar:
     if isinstance(ir_set.expr, irast.TypeRoot):
         skip_subtypes = ir_set.expr.skip_subtypes
+        is_global = ir_set.expr.is_cached_global
     else:
-        skip_subtypes = False
+        skip_subtypes = is_global = False
 
     typeref = ir_set.typeref
     dml_source = irutils.get_dml_sources(ir_set)
     set_rvar = range_for_typeref(
         typeref, path_id, lateral=lateral, dml_source=dml_source,
         include_descendants=not skip_subtypes,
-        ignore_rewrites=ir_set.ignore_rewrites, ctx=ctx)
+        ignore_rewrites=ir_set.ignore_rewrites,
+        is_global=is_global,
+        ctx=ctx,
+    )
     pathctx.put_rvar_path_bond(set_rvar, path_id)
 
     # FIXME: This feels like it should all not be here.
@@ -1413,20 +1417,15 @@ def range_for_material_objtype(
     include_overlays: bool=True,
     include_descendants: bool=True,
     ignore_rewrites: bool=False,
+    is_global: bool=False,
     dml_source: Sequence[irast.MutatingLikeStmt]=(),
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
 
     env = ctx.env
 
-    # If this is a view type, but it still appears in rewrites, that is
-    # because it is a global that we are caching.
-    if (
-        typeref.material_type is not None
-        and (typeref.id, include_descendants) not in ctx.env.type_rewrites
-    ):
-        typeref = typeref.material_type
-    is_global = typeref.material_type is not None
+    if not is_global:
+        typeref = typeref.real_material_type
 
     if not is_global and not path_id.is_objtype_path():
         raise ValueError('cannot create root rvar for non-object path')
@@ -1562,7 +1561,7 @@ def range_for_material_objtype(
         )
 
     else:
-
+        assert not typeref.is_view, "attempting to generate range from view"
         table_schema_name, table_name = common.get_objtype_backend_name(
             typeref.id,
             typeref.name_hint.module,
@@ -1661,6 +1660,7 @@ def range_for_typeref(
     for_mutation: bool=False,
     include_descendants: bool=True,
     ignore_rewrites: bool=False,
+    is_global: bool=False,
     dml_source: Sequence[irast.MutatingLikeStmt]=(),
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
@@ -1743,6 +1743,7 @@ def range_for_typeref(
             ignore_rewrites=ignore_rewrites,
             include_overlays=not for_mutation,
             for_mutation=for_mutation,
+            is_global=is_global,
             dml_source=dml_source,
             ctx=ctx,
         )

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -157,3 +157,5 @@ abstract type Named2 {
     delegated constraint exclusive on (.name);
 }
 type Named2Sub extending Named2;
+
+global Alice := (select User filter .name = 'Alice');

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7113,6 +7113,38 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             [{'org': {'id': obj.id}}],
         )
 
+    async def test_edgeql_ddl_global_11(self):
+        # Just like 9, but with a shape on current_org
+        await self.con.execute('''
+            create type Org;
+
+            create global current_org_id -> uuid;
+            create global current_org := (
+              select Org { * } filter .id = global current_org_id
+            );
+
+            create type Widget {
+              create required link org -> Org {
+                set default := global current_org;
+              }
+            };
+        ''')
+
+        obj = await self.con.query_single('insert Org')
+        await self.con.execute(
+            '''
+            set global current_org_id := <uuid>$0
+            ''',
+            obj.id,
+        )
+        await self.con.execute('insert Widget')
+        await self.assert_query_result(
+            '''
+                select Widget { org }
+            ''',
+            [{'org': {'id': obj.id}}],
+        )
+
     async def test_edgeql_ddl_global_default(self):
         await self.con.execute('''
             create global foo -> str;

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1308,3 +1308,10 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         AT_MOST_ONE
         """
+
+    def test_edgeql_ir_card_inference_156(self):
+        """
+        select global Alice
+% OK %
+        AT_MOST_ONE
+        """


### PR DESCRIPTION
Having an actual shape on a cached global caused confusion with the
convoluted logic used to determine whether something was a cached
global in range_for_material_objtype.
Instead, track it directly in TypeRoot.

Also, properly compile the type_rewrite for cached globals in a
detached scope so that the cardinality inference for it doesn't
collide with the enclosing scope.

Fixes #7056. Fixes #7061.