### PR TITLE
Simplify compilation of TypeIntrospection

### DIFF
--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -350,14 +350,6 @@ def _inline_array_slicing(
     )
 
 
-@dispatch.compile.register(irast.TypeIntrospection)
-def compile_TypeIntrospection(
-        expr: irast.TypeIntrospection, *,
-        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
-    raise errors.UnsupportedFeatureError(
-        'type introspection not supported in simple expressions')
-
-
 def _compile_call_args(
     expr: irast.Call, *,
     ctx: context.CompilerContextLevel
@@ -649,6 +641,13 @@ def compile_TypeRef(
         expr: irast.TypeRef, *,
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
     return astutils.compile_typeref(expr)
+
+
+@dispatch.compile.register(irast.TypeIntrospection)
+def compile_TypeIntrospection(
+        expr: irast.TypeIntrospection, *,
+        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+    return astutils.compile_typeref(expr.output_typeref)
 
 
 @dispatch.compile.register(irast.FunctionCall)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2132,31 +2132,6 @@ def process_set_as_type_cast(
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
 
-@register_get_rvar(irast.TypeIntrospection)
-def process_set_as_type_introspection(
-    ir_set: irast.SetE[irast.TypeIntrospection],
-    *, ctx: context.CompilerContextLevel
-) -> SetRVars:
-    typeref = ir_set.expr.output_typeref
-    type_rvar = relctx.range_for_typeref(
-        ir_set.typeref, ir_set.path_id, ctx=ctx)
-    pathctx.put_rvar_path_bond(type_rvar, ir_set.path_id)
-    clsname = pgast.StringConstant(val=str(typeref.id))
-    nameref = pathctx.get_rvar_path_identity_var(
-        type_rvar, ir_set.path_id, env=ctx.env)
-    condition = astutils.new_binop(nameref, clsname, op='=')
-
-    with ctx.subrel() as subctx:
-        relctx.include_rvar(subctx.rel, type_rvar, ir_set.path_id, ctx=subctx)
-        subctx.rel.where_clause = astutils.extend_binop(
-            subctx.rel.where_clause, condition
-        )
-
-    return new_stmt_set_rvar(
-        ir_set, subctx.rel, aspects=['value', 'source'], ctx=ctx
-    )
-
-
 @register_get_rvar(irast.ConstantSet)
 def process_set_as_const_set(
     ir_set: irast.SetE[irast.ConstantSet], *, ctx: context.CompilerContextLevel


### PR DESCRIPTION
The currently implementation is needlessly verbose, since it provides
the source aspect for schema::Type. We can avoid all that work and
just directly output the id value from a `compile` function, and we'll
automatically join it against a source aspect if needed.