### PR TITLE
Add error when a constant set is used in singleton mode

### DIFF
--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -600,6 +600,15 @@ def compile_TypeCheckOp(
     return result
 
 
+@dispatch.compile.register(irast.ConstantSet)
+def compile_ConstantSet(
+        expr: irast.ConstantSet, *,
+        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+    raise errors.UnsupportedFeatureError(
+        "Constant sets not allowed in singleton mode",
+        hint="Are you passing a set into a variadic function?")
+
+
 @dispatch.compile.register(irast.Array)
 def compile_Array(
         expr: irast.Array, *,

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1769,6 +1769,19 @@ class TestConstraintsDDL(tb.DDLTestCase):
                 };
             """)
 
+    async def test_constraints_ddl_error_07(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            r'Constant sets not allowed in singleton mode'
+        ):
+            await self.con.execute(r"""
+                CREATE TYPE ConstraintOnTest_err_07 {
+                    CREATE PROPERTY less_than_three -> std::int64 {
+                        CREATE CONSTRAINT std::one_of({1,2,3});
+                    };
+                };
+            """)
+
     async def test_constraints_tuple(self):
         await self.con.execute(r"""
             CREATE TYPE Transaction {


### PR DESCRIPTION
When using the migration in #6213, the following error is produced:

```
edgedb error: UnsupportedFeatureError: Constant sets not allowed in singleton mode
  Hint: Are you passing a set into a variadic function?
edgedb error: error in one of the migrations
```

Not the most descriptive, but better than the wall of errors before.