### PR TITLE
Use patched Stolon in CI

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -263,7 +263,7 @@
     - uses: actions/checkout@v4
       if: steps.stolon-cache.outputs.cache-hit != 'true'
       with:
-        repository: sorintlab/stolon
+        repository: edgedb/stolon
         path: build/stolon
         ref: ${{ env.STOLON_GIT_REV }}
         fetch-depth: 0
@@ -312,7 +312,7 @@
     python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
     python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
     python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-    echo 'v0.17.0' >.tmp/stolon_git_rev.txt
+    echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
     python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
     echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
     echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -90,7 +90,7 @@ jobs:
         python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
         python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
         python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'v0.17.0' >.tmp/stolon_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
         python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
         echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
         echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
@@ -304,7 +304,7 @@ jobs:
     - uses: actions/checkout@v4
       if: steps.stolon-cache.outputs.cache-hit != 'true'
       with:
-        repository: sorintlab/stolon
+        repository: edgedb/stolon
         path: build/stolon
         ref: ${{ env.STOLON_GIT_REV }}
         fetch-depth: 0

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -75,7 +75,7 @@ jobs:
         python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
         python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
         python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'v0.17.0' >.tmp/stolon_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
         python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
         echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
         echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
@@ -289,7 +289,7 @@ jobs:
     - uses: actions/checkout@v4
       if: steps.stolon-cache.outputs.cache-hit != 'true'
       with:
-        repository: sorintlab/stolon
+        repository: edgedb/stolon
         path: build/stolon
         ref: ${{ env.STOLON_GIT_REV }}
         fetch-depth: 0

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -77,7 +77,7 @@ jobs:
         python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
         python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
         python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'v0.17.0' >.tmp/stolon_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
         python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
         echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
         echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
@@ -291,7 +291,7 @@ jobs:
     - uses: actions/checkout@v4
       if: steps.stolon-cache.outputs.cache-hit != 'true'
       with:
-        repository: sorintlab/stolon
+        repository: edgedb/stolon
         path: build/stolon
         ref: ${{ env.STOLON_GIT_REV }}
         fetch-depth: 0

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -75,7 +75,7 @@ jobs:
         python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
         python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
         python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'v0.17.0' >.tmp/stolon_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
         python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
         echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
         echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
@@ -289,7 +289,7 @@ jobs:
     - uses: actions/checkout@v4
       if: steps.stolon-cache.outputs.cache-hit != 'true'
       with:
-        repository: sorintlab/stolon
+        repository: edgedb/stolon
         path: build/stolon
         ref: ${{ env.STOLON_GIT_REV }}
         fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
         python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
         python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
         python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'v0.17.0' >.tmp/stolon_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
         python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
         echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
         echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
@@ -301,7 +301,7 @@ jobs:
     - uses: actions/checkout@v4
       if: steps.stolon-cache.outputs.cache-hit != 'true'
       with:
-        repository: sorintlab/stolon
+        repository: edgedb/stolon
         path: build/stolon
         ref: ${{ env.STOLON_GIT_REV }}
         fetch-depth: 0


### PR DESCRIPTION
https://github.com/edgedb/stolon/commit/f8cd94309eaccbfba5dea7835b88c78377608a37 fixes the HA test where `stolon-keeper` failed to start within 60 seconds waiting for a checkpoint under the default `--checkpoint=spread` of `pg_basebackup`:

```
2024-03-15T15:31:09.930-0400	INFO	postgresql/postgresql.go:964	running pg_basebackup
2024-03-15T15:31:09.930-0400	DEBUG	postgresql/postgresql.go:973	execing cmd	{"cmd": "pg_basebackup -R -v -P -Xs -D /tmp/tmpyc1gcke4/postgres -d application_name=stolon_d888bfe0 host=127.0.0.1 options=-c\\ synchronous_commit=off port=35429 sslmode=prefer user=repluser --slot stolon_d888bfe0"}
pg_basebackup: initiating base backup, waiting for checkpoint to complete
```

after 60s, it timed out:

```
2024-03-15T15:32:09.786-0400	DEBUG	cmd/keeper.go:1894	got signal	{"signal": "terminated"}
2024-03-15T15:32:09.786-0400	DEBUG	cmd/keeper.go:841	stopping stolon keeper
2024-03-15 15:32:09.829 EDT [1070513] FATAL:  terminating connection due to administrator command
2024-03-15 15:32:09.829 EDT [1070513] STATEMENT:  BASE_BACKUP ( LABEL 'pg_basebackup base backup',  PROGRESS,  WAIT 0,  MANIFEST 'yes',  TARGET 'client')
 done
server stopped
```

[Sample run](https://github.com/edgedb/edgedb/actions/runs/8303079337)