### PR TITLE
Refactor naming of parser source span

### DIFF
--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -46,7 +46,7 @@ from edb.common import typeutils
 NEW_LINE = re.compile(br'\r\n?|\n')
 
 
-class ParserContext(markup.MarkupExceptionContext):
+class Span(markup.MarkupExceptionContext):
     title = 'Source Context'
 
     def __init__(self, name, buffer, start: int, end: int, document=None, *,
@@ -142,7 +142,7 @@ def _get_context(items, *, reverse=False):
 
 def empty_context():
     """Return a dummy context that points to an empty string."""
-    return ParserContext(
+    return Span(
         name='<empty>',
         buffer='',
         start=0,
@@ -157,7 +157,7 @@ def get_context(*kids):
     if not start_ctx:
         return None
 
-    return ParserContext(
+    return Span(
         name=start_ctx.name,
         buffer=start_ctx.buffer,
         start=start_ctx.start,
@@ -170,7 +170,7 @@ def merge_context(ctxlist):
 
     # assume same name and buffer apply to all
     #
-    return ParserContext(
+    return Span(
         name=ctxlist[0].name,
         buffer=ctxlist[0].buffer,
         start=ctxlist[0].start,

--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -74,11 +74,11 @@ class Token(parsing.Token):
 
             cls.__doc__ = doc
 
-    def __init__(self, val, clean_value, context=None):
+    def __init__(self, val, clean_value, span=None):
         super().__init__()
         self.val = val
         self.clean_value = clean_value
-        self.context = context
+        self.span = span
 
     def __repr__(self):
         return '<Token %s "%s">' % (self.__class__._token, self.val)
@@ -141,7 +141,7 @@ class Nonterm(parsing.Nonterm):
                     attr = lambda self, *args, meth=attr: meth(self, *args)
                     attr.__doc__ = doc
 
-                a = span.has_context(attr)
+                a = span.wrap_function_to_infer_spans(attr)
 
                 a.__doc__ = attr.__doc__
                 a.inline_index = inline_index

--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -32,7 +32,7 @@ import parsing
 
 from edb.common import context as pctx, debug
 
-ParserContext = pctx.ParserContext
+Span = pctx.Span
 
 logger = logging.getLogger('edb.common.parsing')
 

--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -30,7 +30,7 @@ import types
 
 import parsing
 
-from edb.common import debug, span as span
+from edb.common import debug, span
 
 Span = span.Span
 

--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -30,9 +30,9 @@ import types
 
 import parsing
 
-from edb.common import context as pctx, debug
+from edb.common import debug, span as span
 
-Span = pctx.Span
+Span = span.Span
 
 logger = logging.getLogger('edb.common.parsing')
 
@@ -141,7 +141,7 @@ class Nonterm(parsing.Nonterm):
                     attr = lambda self, *args, meth=attr: meth(self, *args)
                     attr.__doc__ = doc
 
-                a = pctx.has_context(attr)
+                a = span.has_context(attr)
 
                 a.__doc__ = attr.__doc__
                 a.inline_index = inline_index

--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -47,7 +47,9 @@ NEW_LINE = re.compile(br'\r\n?|\n')
 
 
 class Span(markup.MarkupExceptionContext):
-    title = 'Source Context'
+    '''
+    Parser Source Context
+    '''
 
     def __init__(self, name, buffer, start: int, end: int, document=None, *,
                  filename=None, context_lines=1):

--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -66,7 +66,7 @@ class Span(markup.MarkupExceptionContext):
         assert end is not None
 
     @classmethod
-    def empty() -> Span:
+    def empty(cls) -> Span:
         return Span(
             name='<empty>',
             buffer='',

--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -42,7 +42,6 @@ import edb._edgeql_parser as ql_parser
 from edb.common import ast
 from edb.common import markup
 from edb.common import typeutils
-from edb.common import span
 
 
 NEW_LINE = re.compile(br'\r\n?|\n')
@@ -65,6 +64,15 @@ class Span(markup.MarkupExceptionContext):
         self._points = None
         assert start is not None
         assert end is not None
+
+    @classmethod
+    def empty() -> Span:
+        return Span(
+            name='<empty>',
+            buffer='',
+            start=0,
+            end=0,
+        )
 
     def __getstate__(self):
         dic = self.__dict__.copy()
@@ -144,16 +152,6 @@ def _get_span(items, *, reverse=False):
     return None
 
 
-def empty_span():
-    """Return a dummy span that points to an empty string."""
-    return Span(
-        name='<empty>',
-        buffer='',
-        start=0,
-        end=0,
-    )
-
-
 def get_span(*kids: List[ast.AST]):
     start_ctx = _get_span(kids)
     end_ctx = _get_span(kids, reverse=True)
@@ -169,7 +167,7 @@ def get_span(*kids: List[ast.AST]):
     )
 
 
-def merge_spans(spans: List[span.Span]) -> span.Span:
+def merge_spans(spans: List[Span]) -> Span:
     spans.sort(key=lambda x: (x.start, x.end))
 
     # assume same name and buffer apply to all
@@ -182,7 +180,7 @@ def merge_spans(spans: List[span.Span]) -> span.Span:
     )
 
 
-def infer_span_from_children(node, span: span.Span):
+def infer_span_from_children(node, span: Span):
     if hasattr(node, 'span'):
         SpanPropagator.run(node, default=span)
         node.span = span

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -88,7 +88,7 @@ class Base(ast.AST):
     __ast_hidden__ = {'context', 'system_comment'}
     __rust_ignore__ = True
 
-    context: typing.Optional[parsing.ParserContext] = None
+    context: typing.Optional[parsing.Span] = None
     # System-generated comment.
     system_comment: typing.Optional[str] = None
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -85,14 +85,13 @@ class DescribeGlobal(s_enum.StrEnum):
 
 class Base(ast.AST):
     __abstract_node__ = True
-    __ast_hidden__ = {'context', 'system_comment'}
+    __ast_hidden__ = {'span', 'system_comment'}
     __rust_ignore__ = True
 
-    context: typing.Optional[parsing.Span] = None
+    span: typing.Optional[parsing.Span] = None
+
     # System-generated comment.
     system_comment: typing.Optional[str] = None
-
-    # parent: typing.Optional[Base]
 
     def dump_edgeql(self) -> None:
         from edb.common.debug import dump_edgeql

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -25,10 +25,11 @@ from __future__ import annotations
 import typing
 
 from edb.common import enum as s_enum
-from edb.common import ast, parsing
+from edb.common import ast, span
 
 from . import qltypes
 
+Span = span.Span
 
 DDLCommand_T = typing.TypeVar(
     'DDLCommand_T',
@@ -88,7 +89,7 @@ class Base(ast.AST):
     __ast_hidden__ = {'span', 'system_comment'}
     __rust_ignore__ = True
 
-    span: typing.Optional[parsing.Span] = None
+    span: typing.Optional[Span] = None
 
     # System-generated comment.
     system_comment: typing.Optional[str] = None

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -90,7 +90,7 @@ def compile_cast(
             stype=new_stype,
             alias=ir_expr.path_id.target_name_hint.name,
             ctx=ctx,
-            span=ir_expr.context)
+            span=ir_expr.span)
 
     if isinstance(new_stype, s_types.Array) and (
         irutils.is_untyped_empty_array_expr(ir_expr)
@@ -136,7 +136,7 @@ def compile_cast(
         return setgen.new_empty_set(
             stype=new_stype,
             ctx=ctx,
-            span=ir_expr.context)
+            span=ir_expr.span)
 
     uuid_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'uuid'))
     if (
@@ -394,7 +394,7 @@ def _compile_cast(
             f'cannot cast '
             f'{orig_stype.get_displayname(ctx.env.schema)!r} to '
             f'{new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx or ir_set.context)
+            context=srcctx or ir_set.span)
 
     return _cast_to_ir(ir_set, cast, orig_stype, new_stype,
                        cardinality_mod, ctx=ctx)

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -81,7 +81,7 @@ def compile_cast(
             f'{new_stype.get_displayname(ctx.env.schema)!r}',
             hint="Please ensure you don't use generic "
                  '"any" types or abstract scalars.',
-            context=span)
+            span=span)
 
     if isinstance(ir_expr, irast.EmptySet):
         # For the common case of casting an empty set, we simply
@@ -111,7 +111,7 @@ def compile_cast(
     if new_stype.is_polymorphic(ctx.env.schema):
         raise errors.QueryError(
             f'expression returns value of indeterminate type',
-            context=span)
+            span=span)
 
     if (orig_stype == new_stype and
             cardinality_mod is not qlast.CardinalityModifier.Required):
@@ -125,7 +125,7 @@ def compile_cast(
             f'{orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}, use '
             f'`...[IS {new_stype.get_displayname(ctx.env.schema)}]` instead',
-            context=span)
+            span=span)
 
     # The only valid object type cast other than <uuid> is from anytype,
     # and thus it must be an empty set.
@@ -394,7 +394,7 @@ def _compile_cast(
             f'cannot cast '
             f'{orig_stype.get_displayname(ctx.env.schema)!r} to '
             f'{new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx or ir_set.span)
+            span=srcctx or ir_set.span)
 
     return _cast_to_ir(ir_set, cast, orig_stype, new_stype,
                        cardinality_mod, ctx=ctx)
@@ -596,7 +596,7 @@ def _find_cast(
             f'cannot unambiguously cast '
             f'{orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx)
+            span=srcctx)
     else:
         return None
 
@@ -712,7 +712,7 @@ def _cast_tuple(
         raise errors.QueryError(
             f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx)
+            span=srcctx)
 
     assert isinstance(new_stype, s_types.Tuple)
     new_subtypes = list(new_stype.iter_subtypes(ctx.env.schema))
@@ -721,7 +721,7 @@ def _cast_tuple(
             f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}: '
             f'the number of elements is not the same',
-            context=srcctx)
+            span=srcctx)
 
     # For tuple-to-tuple casts we generate a new tuple
     # to simplify things on sqlgen side.
@@ -767,7 +767,7 @@ def _cast_range(
         raise errors.QueryError(
             f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx)
+            span=srcctx)
     assert isinstance(new_stype, s_types.Range)
     el_type = new_stype.get_subtypes(ctx.env.schema)[0]
     orig_el_type = orig_stype.get_subtypes(ctx.env.schema)[0]
@@ -778,7 +778,7 @@ def _cast_range(
         raise errors.QueryError(
             f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx)
+            span=srcctx)
 
     with ctx.new() as subctx:
         subctx.anchors = subctx.anchors.copy()
@@ -843,7 +843,7 @@ def _cast_multirange(
         raise errors.QueryError(
             f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx)
+            span=srcctx)
     assert isinstance(new_stype, s_types.MultiRange)
     el_type = new_stype.get_subtypes(ctx.env.schema)[0]
     orig_el_type = orig_stype.get_subtypes(ctx.env.schema)[0]
@@ -853,7 +853,7 @@ def _cast_multirange(
         raise errors.QueryError(
             f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-            context=srcctx)
+            span=srcctx)
 
     ctx.env.schema, new_range_type = s_types.Range.from_subtypes(
         ctx.env.schema, [el_type])
@@ -1066,7 +1066,7 @@ def _cast_array(
             raise errors.QueryError(
                 f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
                 f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-                context=srcctx)
+                span=srcctx)
         assert isinstance(new_stype, s_types.Array)
         el_type = new_stype.get_subtypes(ctx.env.schema)[0]
     elif new_stype.is_json(ctx.env.schema):
@@ -1169,7 +1169,7 @@ def _cast_array_literal(
             raise errors.QueryError(
                 f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
                 f'to {new_stype.get_displayname(ctx.env.schema)!r}',
-                context=srcctx) from None
+                span=srcctx) from None
         assert isinstance(new_stype, s_types.Array)
         el_type = new_stype.get_subtypes(ctx.env.schema)[0]
         intermediate_stype = orig_stype

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
 def compile_cast(
         ir_expr: Union[irast.Set, irast.Expr],
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel,
         cardinality_mod: Optional[qlast.CardinalityModifier]=None
 ) -> irast.Set:
@@ -382,7 +382,7 @@ def _compile_cast(
         ir_expr: Union[irast.Set, irast.Expr],
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel,
         cardinality_mod: Optional[qlast.CardinalityModifier]) -> irast.Set:
 
@@ -560,7 +560,7 @@ class CastCallableWrapper(s_func.CallableLike):
 def _find_cast(
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> Optional[s_casts.Cast]:
 
     # Don't try to pick up casts when there is a direct subtyping
@@ -607,7 +607,7 @@ def _cast_json_to_tuple(
         new_stype: s_types.Tuple,
         cardinality_mod: Optional[qlast.CardinalityModifier],
         *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     with ctx.new() as subctx:
@@ -667,7 +667,7 @@ def _cast_tuple(
         ir_set: irast.Set,
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     assert isinstance(orig_stype, s_types.Tuple)
@@ -752,7 +752,7 @@ def _cast_range(
         ir_set: irast.Set,
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     assert isinstance(orig_stype, s_types.Range)
@@ -828,7 +828,7 @@ def _cast_multirange(
         ir_set: irast.Set,
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     assert isinstance(orig_stype, s_types.MultiRange)
@@ -897,7 +897,7 @@ def _cast_json_to_range(
         new_stype: s_types.Range,
         cardinality_mod: Optional[qlast.CardinalityModifier],
         *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     with ctx.new() as subctx:
@@ -1005,7 +1005,7 @@ def _cast_json_to_multirange(
         new_stype: s_types.MultiRange,
         cardinality_mod: Optional[qlast.CardinalityModifier],
         *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     ctx.env.schema, new_range_type = s_types.Range.from_subtypes(
@@ -1054,7 +1054,7 @@ def _cast_array(
         ir_set: irast.Set,
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     assert isinstance(orig_stype, s_types.Array)
@@ -1155,7 +1155,7 @@ def _cast_array_literal(
         ir_set: irast.Set,
         orig_stype: s_types.Type,
         new_stype: s_types.Type, *,
-        srcctx: Optional[parsing.ParserContext],
+        srcctx: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     assert isinstance(ir_set.expr, irast.Array)

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -90,7 +90,7 @@ def compile_cast(
             stype=new_stype,
             alias=ir_expr.path_id.target_name_hint.name,
             ctx=ctx,
-            srcctx=ir_expr.context)
+            span=ir_expr.context)
 
     if isinstance(new_stype, s_types.Array) and (
         irutils.is_untyped_empty_array_expr(ir_expr)
@@ -136,7 +136,7 @@ def compile_cast(
         return setgen.new_empty_set(
             stype=new_stype,
             ctx=ctx,
-            srcctx=ir_expr.context)
+            span=ir_expr.context)
 
     uuid_t = ctx.env.get_schema_type_and_track(sn.QualName('std', 'uuid'))
     if (

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -80,7 +80,7 @@ def compile_orderby_clause(
                 ir_sortexpr = dispatch.compile(sortexpr.path, ctx=exprctx)
                 ir_sortexpr = setgen.scoped_set(
                     ir_sortexpr, force_reassign=True, ctx=exprctx)
-                ir_sortexpr.context = sortexpr.span
+                ir_sortexpr.span = sortexpr.span
 
                 # Check that the sortexpr type is actually orderable
                 # with either '>' or '<' based on the DESC or ASC sort
@@ -146,6 +146,6 @@ def compile_limit_offset_clause(
                 sn.QualName('std', 'int64'))
             ir_set = setgen.scoped_set(
                 ir_expr, force_reassign=True, typehint=int_t, ctx=subctx)
-            ir_set.context = expr.span
+            ir_set.span = expr.span
 
     return ir_set

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -111,14 +111,14 @@ def compile_orderby_clause(
                             f'type {sort_type_name!r} cannot be used in '
                             f'ORDER BY clause because ordering is not '
                             f'defined for it',
-                            context=sortexpr.span)
+                            span=sortexpr.span)
 
                     elif len(matched) > 1:
                         raise errors.QueryError(
                             f'type {sort_type_name!r} cannot be used in '
                             f'ORDER BY clause because ordering is '
                             f'ambiguous for it',
-                            context=sortexpr.span)
+                            span=sortexpr.span)
 
             result.append(
                 irast.SortExpr(

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -80,7 +80,7 @@ def compile_orderby_clause(
                 ir_sortexpr = dispatch.compile(sortexpr.path, ctx=exprctx)
                 ir_sortexpr = setgen.scoped_set(
                     ir_sortexpr, force_reassign=True, ctx=exprctx)
-                ir_sortexpr.context = sortexpr.context
+                ir_sortexpr.context = sortexpr.span
 
                 # Check that the sortexpr type is actually orderable
                 # with either '>' or '<' based on the DESC or ASC sort
@@ -111,14 +111,14 @@ def compile_orderby_clause(
                             f'type {sort_type_name!r} cannot be used in '
                             f'ORDER BY clause because ordering is not '
                             f'defined for it',
-                            context=sortexpr.context)
+                            context=sortexpr.span)
 
                     elif len(matched) > 1:
                         raise errors.QueryError(
                             f'type {sort_type_name!r} cannot be used in '
                             f'ORDER BY clause because ordering is '
                             f'ambiguous for it',
-                            context=sortexpr.context)
+                            context=sortexpr.span)
 
             result.append(
                 irast.SortExpr(
@@ -146,6 +146,6 @@ def compile_limit_offset_clause(
                 sn.QualName('std', 'int64'))
             ir_set = setgen.scoped_set(
                 ir_expr, force_reassign=True, typehint=int_t, ctx=subctx)
-            ir_set.context = expr.context
+            ir_set.context = expr.span
 
     return ir_set

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -96,7 +96,7 @@ def compile_ConfigSet(
     except ireval.UnsupportedExpressionError as e:
         raise errors.QueryError(
             f'non-constant expression in CONFIGURE {expr.scope} SET',
-            context=expr.expr.context
+            context=expr.expr.span
         ) from e
     else:
         if isinstance(val, statypes.ScalarType) and info.backend_setting:
@@ -119,7 +119,7 @@ def compile_ConfigSet(
         requires_restart=info.requires_restart,
         backend_setting=info.backend_setting,
         is_system_config=info.is_system_config,
-        context=expr.context,
+        context=expr.span,
         expr=param_val,
         backend_expr=backend_expr,
     )
@@ -140,7 +140,7 @@ def compile_ConfigReset(
         raise errors.QueryError(
             'RESET of a primitive configuration parameter '
             'must not have a FILTER clause',
-            context=expr.context,
+            context=expr.span,
         )
 
     elif isinstance(info.param_type, s_objtypes.ObjectType):
@@ -181,7 +181,7 @@ def compile_ConfigReset(
         requires_restart=info.requires_restart,
         backend_setting=info.backend_setting,
         is_system_config=info.is_system_config,
-        context=expr.context,
+        context=expr.span,
         selector=select_ir,
     )
     return setgen.ensure_set(config_reset, ctx=ctx)
@@ -229,7 +229,7 @@ def compile_ConfigInsert(
             backend_setting=info.backend_setting,
             is_system_config=info.is_system_config,
             expr=insert_subject,
-            context=expr.context,
+            context=expr.span,
         ),
         ctx=ctx,
     )
@@ -387,7 +387,7 @@ def _validate_op(
         if isinstance(expr, qlast.ConfigSet):
             raise errors.ConfigurationError(
                 f'unrecognized configuration parameter {name!r}',
-                context=expr.context
+                context=expr.span
             )
 
         cfg_type = ctx.env.get_schema_type_and_track(
@@ -399,7 +399,7 @@ def _validate_op(
         if not cfg_type:
             raise errors.ConfigurationError(
                 f'unrecognized configuration object {name!r}',
-                context=expr.context
+                context=expr.span
             )
 
         assert isinstance(cfg_type, s_objtypes.ObjectType)

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -85,7 +85,7 @@ def compile_ConfigSet(
             )
         else:
             param_val = casts.compile_cast(
-                param_val, param_type, srcctx=None, ctx=ctx)
+                param_val, param_type, span=None, ctx=ctx)
 
     try:
         if expr.scope != qltypes.ConfigScope.GLOBAL:

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -119,7 +119,7 @@ def compile_ConfigSet(
         requires_restart=info.requires_restart,
         backend_setting=info.backend_setting,
         is_system_config=info.is_system_config,
-        context=expr.span,
+        span=expr.span,
         expr=param_val,
         backend_expr=backend_expr,
     )
@@ -181,7 +181,7 @@ def compile_ConfigReset(
         requires_restart=info.requires_restart,
         backend_setting=info.backend_setting,
         is_system_config=info.is_system_config,
-        context=expr.span,
+        span=expr.span,
         selector=select_ir,
     )
     return setgen.ensure_set(config_reset, ctx=ctx)
@@ -229,7 +229,7 @@ def compile_ConfigInsert(
             backend_setting=info.backend_setting,
             is_system_config=info.is_system_config,
             expr=insert_subject,
-            context=expr.span,
+            span=expr.span,
         ),
         ctx=ctx,
     )

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -96,7 +96,7 @@ def compile_ConfigSet(
     except ireval.UnsupportedExpressionError as e:
         raise errors.QueryError(
             f'non-constant expression in CONFIGURE {expr.scope} SET',
-            context=expr.expr.span
+            span=expr.expr.span
         ) from e
     else:
         if isinstance(val, statypes.ScalarType) and info.backend_setting:
@@ -140,7 +140,7 @@ def compile_ConfigReset(
         raise errors.QueryError(
             'RESET of a primitive configuration parameter '
             'must not have a FILTER clause',
-            context=expr.span,
+            span=expr.span,
         )
 
     elif isinstance(info.param_type, s_objtypes.ObjectType):
@@ -387,7 +387,7 @@ def _validate_op(
         if isinstance(expr, qlast.ConfigSet):
             raise errors.ConfigurationError(
                 f'unrecognized configuration parameter {name!r}',
-                context=expr.span
+                span=expr.span
             )
 
         cfg_type = ctx.env.get_schema_type_and_track(
@@ -399,7 +399,7 @@ def _validate_op(
         if not cfg_type:
             raise errors.ConfigurationError(
                 f'unrecognized configuration object {name!r}',
-                context=expr.span
+                span=expr.span
             )
 
         assert isinstance(cfg_type, s_objtypes.ObjectType)

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -505,14 +505,14 @@ def compile_insert_unless_conflict_on(
             raise errors.QueryError(
                 'UNLESS CONFLICT argument must be a property, link, '
                 'or tuple of properties and links',
-                context=constraint_spec.context,
+                context=constraint_spec.span,
             )
 
         if cspec_arg.rptr.source.path_id != stmt.subject.path_id:
             raise errors.QueryError(
                 'UNLESS CONFLICT argument must be a property of the '
                 'type being inserted',
-                context=constraint_spec.context,
+                context=constraint_spec.span,
             )
 
     schema = ctx.env.schema
@@ -527,7 +527,7 @@ def compile_insert_unless_conflict_on(
             raise errors.QueryError(
                 'UNLESS CONFLICT argument must be a property, link, '
                 'or tuple of properties and links',
-                context=constraint_spec.context,
+                context=constraint_spec.span,
             )
 
         ptr = ptr.get_nearest_non_derived_parent(schema)
@@ -546,7 +546,7 @@ def compile_insert_unless_conflict_on(
     if len(all_constrs) != 1:
         raise errors.QueryError(
             'UNLESS CONFLICT property must have a single exclusive constraint',
-            context=constraint_spec.context,
+            context=constraint_spec.span,
         )
 
     ds = {ptr.get_shortname(schema).name: (ptr, field_constrs)
@@ -567,7 +567,7 @@ def compile_insert_unless_conflict_on(
                 details=(
                     f"The existing object can't be exposed in the ELSE clause "
                     f"because it may not have type {typ.get_name(schema)}"),
-                context=constraint_spec.context,
+                context=constraint_spec.span,
             )
 
         with ctx.new() as ectx:

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 from typing import Optional, Tuple, Iterable, Sequence, Dict, List, Set
 
 from edb import errors
-from edb.common import span
 
 from edb.ir import ast as irast
 from edb.ir import typeutils
@@ -88,7 +87,7 @@ def _compile_conflict_select_for_obj_type(
     fake_dml_set: Optional[irast.Set],
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
-    span: Optional[span.Span],
+    span: Optional[irast.Span],
     ctx: context.ContextLevel,
 ) -> tuple[Optional[qlast.Expr], bool]:
     """Synthesize a select of conflicting objects
@@ -375,7 +374,7 @@ def _compile_conflict_select(
     fake_dml_set: Optional[irast.Set]=None,
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: PointerConstraintMap,
-    span: Optional[span.Span],
+    span: Optional[irast.Span],
     ctx: context.ContextLevel,
 ) -> Tuple[irast.Set, bool, bool]:
     """Synthesize a select of conflicting objects

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -471,7 +471,7 @@ def compile_insert_unless_conflict(
         stmt, typ,
         constrs=pointers,
         obj_constrs=obj_constrs,
-        span=stmt.context, ctx=ctx)
+        span=stmt.span, ctx=ctx)
 
     return irast.OnConflictClause(
         constraint=None, select_ir=select_ir, always_check=always_check,
@@ -553,7 +553,7 @@ def compile_insert_unless_conflict_on(
           for ptr in ptrs}
     select_ir, always_check, from_anc = _compile_conflict_select(
         stmt, typ, constrs=ds, obj_constrs=list(obj_constrs),
-        span=stmt.context, ctx=ctx)
+        span=stmt.span, ctx=ctx)
 
     # Compile an else branch
     else_ir = None
@@ -596,7 +596,7 @@ def _has_explicit_id_write(stmt: irast.MutatingStmt) -> bool:
     for elem, _ in stmt.subject.shape:
         assert elem.rptr is not None
         if elem.rptr.ptrref.shortname.name == 'id':
-            return elem.context is not None
+            return elem.span is not None
     return False
 
 
@@ -623,7 +623,7 @@ def _disallow_exclusive_linkprops(
                     'INSERT/UPDATE do not support exclusive constraints on '
                     'link properties when another statement in '
                     'the same query modifies a related type',
-                    context=stmt.context,
+                    context=stmt.span,
                 )
 
 
@@ -708,7 +708,7 @@ def _compile_inheritance_conflict_selects(
             fake_dml_set=fake_dml_set,
             constrs=p,
             obj_constrs=o,
-            span=stmt.context, ctx=ctx)
+            span=stmt.span, ctx=ctx)
         if isinstance(select_ir, irast.EmptySet):
             continue
         cnstr_ref = irast.ConstraintRef(id=cnstr.id)

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -375,7 +375,7 @@ def _compile_conflict_select(
     fake_dml_set: Optional[irast.Set]=None,
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: PointerConstraintMap,
-    parser_context: Optional[span.Span],
+    span: Optional[span.Span],
     ctx: context.ContextLevel,
 ) -> Tuple[irast.Set, bool, bool]:
     """Synthesize a select of conflicting objects
@@ -403,7 +403,7 @@ def _compile_conflict_select(
             stmt, a_obj, obj_constrs=a_obj_constrs, constrs=a_constrs,
             for_inheritance=for_inheritance,
             fake_dml_set=fake_dml_set,
-            span=parser_context, ctx=ctx,
+            span=span, ctx=ctx,
         )
         always_check |= frag_always_check
         if frag:
@@ -471,7 +471,7 @@ def compile_insert_unless_conflict(
         stmt, typ,
         constrs=pointers,
         obj_constrs=obj_constrs,
-        parser_context=stmt.context, ctx=ctx)
+        span=stmt.context, ctx=ctx)
 
     return irast.OnConflictClause(
         constraint=None, select_ir=select_ir, always_check=always_check,
@@ -553,7 +553,7 @@ def compile_insert_unless_conflict_on(
           for ptr in ptrs}
     select_ir, always_check, from_anc = _compile_conflict_select(
         stmt, typ, constrs=ds, obj_constrs=list(obj_constrs),
-        parser_context=stmt.context, ctx=ctx)
+        span=stmt.context, ctx=ctx)
 
     # Compile an else branch
     else_ir = None
@@ -708,7 +708,7 @@ def _compile_inheritance_conflict_selects(
             fake_dml_set=fake_dml_set,
             constrs=p,
             obj_constrs=o,
-            parser_context=stmt.context, ctx=ctx)
+            span=stmt.context, ctx=ctx)
         if isinstance(select_ir, irast.EmptySet):
             continue
         cnstr_ref = irast.ConstraintRef(id=cnstr.id)

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -88,7 +88,7 @@ def _compile_conflict_select_for_obj_type(
     fake_dml_set: Optional[irast.Set],
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
-    parser_context: Optional[pctx.ParserContext],
+    parser_context: Optional[pctx.Span],
     ctx: context.ContextLevel,
 ) -> tuple[Optional[qlast.Expr], bool]:
     """Synthesize a select of conflicting objects
@@ -375,7 +375,7 @@ def _compile_conflict_select(
     fake_dml_set: Optional[irast.Set]=None,
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: PointerConstraintMap,
-    parser_context: Optional[pctx.ParserContext],
+    parser_context: Optional[pctx.Span],
     ctx: context.ContextLevel,
 ) -> Tuple[irast.Set, bool, bool]:
     """Synthesize a select of conflicting objects

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import Optional, Tuple, Iterable, Sequence, Dict, List, Set
 
 from edb import errors
-from edb.common import context as pctx
+from edb.common import span
 
 from edb.ir import ast as irast
 from edb.ir import typeutils
@@ -88,7 +88,7 @@ def _compile_conflict_select_for_obj_type(
     fake_dml_set: Optional[irast.Set],
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
-    parser_context: Optional[pctx.Span],
+    span: Optional[span.Span],
     ctx: context.ContextLevel,
 ) -> tuple[Optional[qlast.Expr], bool]:
     """Synthesize a select of conflicting objects
@@ -119,7 +119,7 @@ def _compile_conflict_select_for_obj_type(
                 raise errors.UnsupportedFeatureError(
                     "INSERT UNLESS CONFLICT cannot be used on properties or "
                     "links that have a rewrite rule specified",
-                    context=parser_context,
+                    context=span,
                 )
 
     ctx.anchors = ctx.anchors.copy()
@@ -161,7 +161,7 @@ def _compile_conflict_select_for_obj_type(
                         'properties'
                     )
                 raise errors.UnsupportedFeatureError(
-                    error, context=parser_context
+                    error, context=span
                 )
 
             # We want to use the same path_scope_id as the original
@@ -188,7 +188,7 @@ def _compile_conflict_select_for_obj_type(
     if not ptr_anchors:
         raise errors.QueryError(
             'INSERT UNLESS CONFLICT property requires matching shape',
-            context=parser_context,
+            context=span,
         )
 
     conds: List[qlast.Expr] = []
@@ -375,7 +375,7 @@ def _compile_conflict_select(
     fake_dml_set: Optional[irast.Set]=None,
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: PointerConstraintMap,
-    parser_context: Optional[pctx.Span],
+    parser_context: Optional[span.Span],
     ctx: context.ContextLevel,
 ) -> Tuple[irast.Set, bool, bool]:
     """Synthesize a select of conflicting objects
@@ -403,7 +403,7 @@ def _compile_conflict_select(
             stmt, a_obj, obj_constrs=a_obj_constrs, constrs=a_constrs,
             for_inheritance=for_inheritance,
             fake_dml_set=fake_dml_set,
-            parser_context=parser_context, ctx=ctx,
+            span=parser_context, ctx=ctx,
         )
         always_check |= frag_always_check
         if frag:

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -118,7 +118,7 @@ def _compile_conflict_select_for_obj_type(
                 raise errors.UnsupportedFeatureError(
                     "INSERT UNLESS CONFLICT cannot be used on properties or "
                     "links that have a rewrite rule specified",
-                    context=span,
+                    span=span,
                 )
 
     ctx.anchors = ctx.anchors.copy()
@@ -160,7 +160,7 @@ def _compile_conflict_select_for_obj_type(
                         'properties'
                     )
                 raise errors.UnsupportedFeatureError(
-                    error, context=span
+                    error, span=span
                 )
 
             # We want to use the same path_scope_id as the original
@@ -187,7 +187,7 @@ def _compile_conflict_select_for_obj_type(
     if not ptr_anchors:
         raise errors.QueryError(
             'INSERT UNLESS CONFLICT property requires matching shape',
-            context=span,
+            span=span,
         )
 
     conds: List[qlast.Expr] = []
@@ -504,14 +504,14 @@ def compile_insert_unless_conflict_on(
             raise errors.QueryError(
                 'UNLESS CONFLICT argument must be a property, link, '
                 'or tuple of properties and links',
-                context=constraint_spec.span,
+                span=constraint_spec.span,
             )
 
         if cspec_arg.rptr.source.path_id != stmt.subject.path_id:
             raise errors.QueryError(
                 'UNLESS CONFLICT argument must be a property of the '
                 'type being inserted',
-                context=constraint_spec.span,
+                span=constraint_spec.span,
             )
 
     schema = ctx.env.schema
@@ -526,7 +526,7 @@ def compile_insert_unless_conflict_on(
             raise errors.QueryError(
                 'UNLESS CONFLICT argument must be a property, link, '
                 'or tuple of properties and links',
-                context=constraint_spec.span,
+                span=constraint_spec.span,
             )
 
         ptr = ptr.get_nearest_non_derived_parent(schema)
@@ -545,7 +545,7 @@ def compile_insert_unless_conflict_on(
     if len(all_constrs) != 1:
         raise errors.QueryError(
             'UNLESS CONFLICT property must have a single exclusive constraint',
-            context=constraint_spec.span,
+            span=constraint_spec.span,
         )
 
     ds = {ptr.get_shortname(schema).name: (ptr, field_constrs)
@@ -566,7 +566,7 @@ def compile_insert_unless_conflict_on(
                 details=(
                     f"The existing object can't be exposed in the ELSE clause "
                     f"because it may not have type {typ.get_name(schema)}"),
-                context=constraint_spec.span,
+                span=constraint_spec.span,
             )
 
         with ctx.new() as ectx:
@@ -622,7 +622,7 @@ def _disallow_exclusive_linkprops(
                     'INSERT/UPDATE do not support exclusive constraints on '
                     'link properties when another statement in '
                     'the same query modifies a related type',
-                    context=stmt.span,
+                    span=stmt.span,
                 )
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -168,7 +168,7 @@ class Environment:
     set_types: Dict[irast.Set, s_types.Type]
     """A dictionary of all Set instances and their schema types."""
 
-    type_origins: Dict[s_types.Type, Optional[parsing.ParserContext]]
+    type_origins: Dict[s_types.Type, Optional[parsing.Span]]
     """A dictionary of notable types and their source origins.
 
     This is used to trace where a particular type instance originated in
@@ -197,7 +197,7 @@ class Environment:
         Tuple[
             Optional[qltypes.SchemaCardinality],
             Optional[bool],
-            Optional[parsing.ParserContext],
+            Optional[parsing.Span],
         ],
     ]
     """Cardinality/source context for pointers with unclear cardinality."""

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -27,7 +27,7 @@ from typing import Callable, Optional, Type, Union, Sequence, List, cast
 from edb import errors
 
 from edb.common import parsing
-from edb.common import span as pspan
+from edb.common import span as edb_span
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
@@ -89,11 +89,11 @@ def _balance(
     ls, rs = elements[:mid], elements[mid:]
     ls_span = rs_span = None
     if len(ls) > 1 and ls[0].span and ls[-1].span:
-        ls_span = pspan.merge_spans([
+        ls_span = edb_span.merge_spans([
             ls[0].span, ls[-1].span
         ])
     if len(rs) > 1 and rs[0].span and rs[-1].span:
-        rs_span = pspan.merge_spans([
+        rs_span = edb_span.merge_spans([
             rs[0].span, rs[-1].span])
 
     return ctor(

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -26,7 +26,7 @@ from typing import Callable, Optional, Type, Union, Sequence, List, cast
 
 from edb import errors
 
-from edb.common import context as ctx_utils
+from edb.common import span as ctx_utils
 from edb.common import parsing
 
 from edb.ir import ast as irast
@@ -690,7 +690,7 @@ def compile_TypeCast(
                     context=expr.expr.context,
                 ),
                 pt,
-                srcctx=expr.expr.context,
+                span=expr.expr.context,
                 ctx=ctx,
             )
 
@@ -750,7 +750,7 @@ def compile_TypeCast(
             target_stype,
             cardinality_mod=expr.cardinality_mod,
             ctx=subctx,
-            srcctx=expr.context,
+            span=expr.context,
         )
 
     return stmt.maybe_add_view(res, ctx=ctx)

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -80,10 +80,10 @@ def compile_Path(
 def _balance(
     elements: Sequence[qlast.Expr],
     ctor: Callable[
-        [qlast.Expr, qlast.Expr, Optional[ctx_utils.ParserContext]],
+        [qlast.Expr, qlast.Expr, Optional[ctx_utils.Span]],
         qlast.Expr
     ],
-    context: Optional[ctx_utils.ParserContext],
+    context: Optional[ctx_utils.Span],
 ) -> qlast.Expr:
     mid = len(elements) // 2
     ls, rs = elements[:mid], elements[mid:]
@@ -759,7 +759,7 @@ def compile_TypeCast(
 def _infer_type_introspection(
     typeref: irast.TypeRef,
     env: context.Environment,
-    srcctx: Optional[parsing.ParserContext]=None,
+    srcctx: Optional[parsing.Span]=None,
 ) -> s_types.Type:
     if irtyputils.is_scalar(typeref):
         return cast(s_objtypes.ObjectType,

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -1003,7 +1003,7 @@ def compile_type_check_op(
     if ltype.is_object_type():
         left = setgen.ptr_step_set(
             left, expr=None, source=ltype, ptr_name='__type__',
-            source_context=expr.span, ctx=ctx
+            span=expr.span, ctx=ctx
         )
         pathctx.register_set_in_scope(left, ctx=ctx)
         result = None

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -270,7 +270,7 @@ def compile_NamedTuple(
         if name in names:
             raise errors.QueryError(
                 f"named tuple has duplicate field '{name}'",
-                context=el.span)
+                span=el.span)
         names.add(name)
 
         element = irast.TupleElement(
@@ -309,7 +309,7 @@ def compile_Array(
         if isinstance(setgen.get_set_type(el, ctx=ctx), s_abc.Array):
             raise errors.QueryError(
                 f'nested arrays are not supported',
-                context=expr_el.span)
+                span=expr_el.span)
 
     return setgen.new_array_set(elements, ctx=ctx, span=expr.span)
 
@@ -604,7 +604,7 @@ def compile_GlobalExpr(
         typname = objctx.get_schema_class_displayname()
         raise errors.SchemaDefinitionError(
             f'global variables cannot be referenced from {typname}',
-            context=expr.span)
+            span=expr.span)
 
     param_set: qlast.Expr | irast.Set
     present_set: qlast.Expr | irast.Set | None
@@ -665,7 +665,7 @@ def compile_TypeCast(
                 f'{target_stype.get_displayname(ctx.env.schema)!r}',
                 hint="Please ensure you don't use generic "
                      '"any" types or abstract scalars.',
-                context=expr.span)
+                span=expr.span)
 
         pt = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
 
@@ -686,7 +686,7 @@ def compile_TypeCast(
                 raise errors.QueryError(
                     'queries compiled to accept JSON parameters do not '
                     'accept positional parameters',
-                    context=expr.expr.span)
+                    span=expr.expr.span)
 
             typeref = typegen.type_to_typeref(
                 ctx.env.get_schema_type_and_track(sn.QualName('std', 'json')),
@@ -727,7 +727,7 @@ def compile_TypeCast(
                     f'{pt.get_displayname(ctx.env.schema)} '
                     f'does not match original type '
                     f'{param_first_type.get_displayname(ctx.env.schema)}',
-                    context=expr.expr.span)
+                    span=expr.expr.span)
 
         if param_name not in ctx.env.query_parameters:
             sub_params = None
@@ -792,7 +792,7 @@ def _infer_type_introspection(
                     env.schema.get('schema::MultiRange'))
     else:
         raise errors.QueryError(
-            'unexpected type in INTROSPECT', context=srcctx)
+            'unexpected type in INTROSPECT', span=srcctx)
 
 
 @dispatch.compile.register(qlast.Introspect)
@@ -814,15 +814,15 @@ def compile_Introspect(
     if irtyputils.is_view(typeref):
         raise errors.QueryError(
             f'cannot introspect transient type variant',
-            context=expr.type.span)
+            span=expr.type.span)
     if irtyputils.is_collection(typeref):
         raise errors.QueryError(
             f'cannot introspect collection types',
-            context=expr.type.span)
+            span=expr.type.span)
     if irtyputils.is_generic(typeref):
         raise errors.QueryError(
             f'cannot introspect generic types',
-            context=expr.type.span)
+            span=expr.type.span)
 
     result_typeref = typegen.type_to_typeref(
         _infer_type_introspection(typeref, ctx.env, expr.span), env=ctx.env
@@ -857,7 +857,7 @@ def _infer_index_type(
                 f'cannot index string by '
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} was expected',
-                context=index.span)
+                span=index.span)
 
         result = str_t
 
@@ -868,7 +868,7 @@ def _infer_index_type(
                 f'cannot index bytes by '
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} was expected',
-                context=index.span)
+                span=index.span)
 
         result = bytes_t
 
@@ -882,7 +882,7 @@ def _infer_index_type(
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} or '
                 f'{str_t.get_displayname(env.schema)} was expected',
-                context=index.span)
+                span=index.span)
 
         result = json_t
 
@@ -893,7 +893,7 @@ def _infer_index_type(
                 f'cannot index array by '
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} was expected',
-                context=index.span)
+                span=index.span)
 
         result = node_type.get_subtypes(env.schema)[0]
 
@@ -908,7 +908,7 @@ def _infer_index_type(
         raise errors.QueryError(
             f'index indirection cannot be applied to '
             f'{node_type.get_verbosename(env.schema)}',
-            context=expr.span)
+            span=expr.span)
 
     return result
 
@@ -941,7 +941,7 @@ def _infer_slice_type(
         # the base type is not valid
         raise errors.QueryError(
             f'{node_type.get_verbosename(env.schema)} cannot be sliced',
-            context=expr.span)
+            span=expr.span)
 
     for index in [start, stop]:
         if index is not None:
@@ -952,7 +952,7 @@ def _infer_slice_type(
                     f'cannot slice {base_name} by '
                     f'{index_type.get_displayname(env.schema)}, '
                     f'{int_t.get_displayname(env.schema)} was expected',
-                    context=index.span)
+                    span=index.span)
 
     return node_type
 

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -689,7 +689,7 @@ def compile_TypeCast(
                     typeref=typeref,
                     name=param_name,
                     required=required,
-                    context=expr.expr.span,
+                    span=expr.expr.span,
                 ),
                 pt,
                 span=expr.expr.span,
@@ -703,7 +703,7 @@ def compile_TypeCast(
                     typeref=typeref,
                     name=param_name,
                     required=required,
-                    context=expr.expr.span,
+                    span=expr.expr.span,
                 ),
                 ctx=ctx,
             )
@@ -848,7 +848,7 @@ def _infer_index_type(
                 f'cannot index string by '
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} was expected',
-                context=index.context)
+                context=index.span)
 
         result = str_t
 
@@ -859,7 +859,7 @@ def _infer_index_type(
                 f'cannot index bytes by '
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} was expected',
-                context=index.context)
+                context=index.span)
 
         result = bytes_t
 
@@ -873,7 +873,7 @@ def _infer_index_type(
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} or '
                 f'{str_t.get_displayname(env.schema)} was expected',
-                context=index.context)
+                context=index.span)
 
         result = json_t
 
@@ -884,7 +884,7 @@ def _infer_index_type(
                 f'cannot index array by '
                 f'{index_type.get_displayname(env.schema)}, '
                 f'{int_t.get_displayname(env.schema)} was expected',
-                context=index.context)
+                context=index.span)
 
         result = node_type.get_subtypes(env.schema)[0]
 
@@ -899,7 +899,7 @@ def _infer_index_type(
         raise errors.QueryError(
             f'index indirection cannot be applied to '
             f'{node_type.get_verbosename(env.schema)}',
-            context=expr.context)
+            context=expr.span)
 
     return result
 
@@ -932,7 +932,7 @@ def _infer_slice_type(
         # the base type is not valid
         raise errors.QueryError(
             f'{node_type.get_verbosename(env.schema)} cannot be sliced',
-            context=expr.context)
+            context=expr.span)
 
     for index in [start, stop]:
         if index is not None:
@@ -943,7 +943,7 @@ def _infer_slice_type(
                     f'cannot slice {base_name} by '
                     f'{index_type.get_displayname(env.schema)}, '
                     f'{int_t.get_displayname(env.schema)} was expected',
-                    context=index.context)
+                    context=index.span)
 
     return node_type
 
@@ -956,13 +956,13 @@ def compile_Indirection(
     for indirection_el in expr.indirection:
         if isinstance(indirection_el, qlast.Index):
             idx = dispatch.compile(indirection_el.index, ctx=ctx)
-            idx.context = indirection_el.index.span
+            idx.span = indirection_el.index.span
             typeref = typegen.type_to_typeref(
                 _infer_index_type(node, idx, ctx=ctx), env=ctx.env
             )
 
             node = irast.IndexIndirection(
-                expr=node, index=idx, typeref=typeref, context=expr.span
+                expr=node, index=idx, typeref=typeref, span=expr.span
             )
         elif isinstance(indirection_el, qlast.Slice):
             start: Optional[irast.Base]

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -26,8 +26,8 @@ from typing import Callable, Optional, Type, Union, Sequence, List, cast
 
 from edb import errors
 
-from edb.common import span as pspan
 from edb.common import parsing
+from edb.common import span as pspan
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
@@ -80,10 +80,10 @@ def compile_Path(
 def _balance(
     elements: Sequence[qlast.Expr],
     ctor: Callable[
-        [qlast.Expr, qlast.Expr, Optional[pspan.Span]],
+        [qlast.Expr, qlast.Expr, Optional[qlast.Span]],
         qlast.Expr
     ],
-    span: Optional[pspan.Span],
+    span: Optional[qlast.Span],
 ) -> qlast.Expr:
     mid = len(elements) // 2
     ls, rs = elements[:mid], elements[mid:]

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -88,7 +88,7 @@ def compile_FunctionCall(
         ):
             raise errors.QueryError(
                 f'parameter `{expr.func}` is not callable',
-                context=expr.span)
+                span=expr.span)
 
         funcname = sn.UnqualName(expr.func)
     else:
@@ -102,7 +102,7 @@ def compile_FunctionCall(
     if funcs is None:
         raise errors.QueryError(
             f'could not resolve function name {funcname}',
-            context=expr.span)
+            span=expr.span)
 
     in_polymorphic_func = (
         ctx.env.options.func_params is not None and
@@ -158,7 +158,7 @@ def compile_FunctionCall(
         raise errors.QueryError(
             f'function "{signature}" does not exist',
             hint=hint,
-            context=expr.span)
+            span=expr.span)
     elif len(matched) > 1:
         if in_abstract_constraint:
             matched_call = matched[0]
@@ -169,7 +169,7 @@ def compile_FunctionCall(
                 hint=f'Please disambiguate between the following '
                      f'alternatives:\n' +
                      ('\n'.join(alts)),
-                context=expr.span)
+                span=expr.span)
     else:
         matched_call = matched[0]
 
@@ -186,7 +186,7 @@ def compile_FunctionCall(
             raise errors.SchemaDefinitionError(
                 f'mutations are invalid in '
                 f'{ctx.env.options.in_ddl_context_name}',
-                context=expr.span,
+                span=expr.span,
             )
         elif (
             (dv := ctx.defining_view) is not None
@@ -203,7 +203,7 @@ def compile_FunctionCall(
                     f'To resolve this try to factor out the mutation '
                     f'expression into the top-level WITH block.'
                 ),
-                context=expr.span,
+                span=expr.span,
             )
 
     func_name = func.get_shortname(env.schema)
@@ -245,7 +245,7 @@ def compile_FunctionCall(
             raise errors.UnsupportedFeatureError(
                 'newly created or updated objects cannot be passed to '
                 'functions',
-                context=arg.expr.span
+                span=arg.expr.span
             )
 
     if not in_abstract_constraint:
@@ -361,7 +361,7 @@ def compile_operator(
     if opers is None:
         raise errors.QueryError(
             f'no operator matches the given name and argument types',
-            context=qlexpr.span)
+            span=qlexpr.span)
 
     typemods = polyres.find_callable_typemods(
         opers, num_args=len(qlargs), kwargs_names=set(), ctx=ctx)
@@ -385,7 +385,7 @@ def compile_operator(
             raise errors.QueryError(
                 f'could not resolve the type of operand '
                 f'#{ai} of {op_name}',
-                context=qlarg.span)
+                span=qlarg.span)
 
         args.append((arg_type, arg_ir))
 
@@ -400,14 +400,14 @@ def compile_operator(
         if len(opers) > 1:
             raise errors.InternalServerError(
                 f'more than one derived operator of the same name: {op_name}',
-                context=qlarg.span)
+                span=qlarg.span)
 
         derivative_op = opers[0]
         opers = schema.get_operators(origin_op)
         if not opers:
             raise errors.InternalServerError(
                 f'cannot find the origin operator for {op_name}',
-                context=qlarg.span)
+                span=qlarg.span)
         actual_typemods = [
             param.get_typemod(schema)
             for param in derivative_op.get_params(schema).objects(schema)
@@ -549,7 +549,7 @@ def compile_operator(
             raise errors.InvalidTypeError(
                 msg,
                 hint=hint,
-                context=qlexpr.span)
+                span=qlexpr.span)
         elif len(matched) > 1:
             if in_abstract_constraint:
                 matched_call = matched[0]
@@ -562,7 +562,7 @@ def compile_operator(
                     f'operator {str(op_name)!r} is ambiguous for '
                     f'operands of type {types}',
                     hint=f'Possible variants: {detail}.',
-                    context=qlexpr.span)
+                    span=qlexpr.span)
 
     oper = matched_call.func
     assert isinstance(oper, s_oper.Operator)
@@ -676,7 +676,7 @@ def _check_free_shape_op(
         if typ.issubclass(ctx.env.schema, virt_obj):
             raise errors.QueryError(
                 f'cannot use {ir.func_shortname.name} on free shape',
-                context=ir.span)
+                span=ir.span)
 
 
 def validate_recursive_operator(
@@ -738,7 +738,7 @@ def compile_func_call_args(
             raise errors.QueryError(
                 f'could not resolve the type of positional argument '
                 f'#{ai} of function {funcname}',
-                context=arg.span)
+                span=arg.span)
 
         args.append((arg_type, arg_ir))
 
@@ -752,7 +752,7 @@ def compile_func_call_args(
             raise errors.QueryError(
                 f'could not resolve the type of named argument '
                 f'${aname} of function {funcname}',
-                context=arg.span)
+                span=arg.span)
 
         kwargs[aname] = (arg_type, arg_ir)
 
@@ -967,7 +967,7 @@ def _validate_has_fts_index(
         raise errors.InvalidReferenceError(
             f"fts::search requires an fts::index index on type "
             f"'{stype.get_displayname(schema)}'",
-            context=span,
+            span=span,
         )
 
 
@@ -1004,7 +1004,7 @@ def compile_fts_with_options(
     if not irutils.is_const(weight_expr):
         raise errors.InvalidValueError(
             f"fts::search weight_category must be a constant",
-            context=weight_expr.span,
+            span=weight_expr.span,
         )
     weight_const = irutils.as_const(weight_expr)
     if weight_const:

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -245,7 +245,7 @@ def compile_FunctionCall(
             raise errors.UnsupportedFeatureError(
                 'newly created or updated objects cannot be passed to '
                 'functions',
-                context=arg.expr.context
+                context=arg.expr.span
             )
 
     if not in_abstract_constraint:
@@ -308,7 +308,6 @@ def compile_FunctionCall(
         preserves_upper_cardinality=func.get_preserves_upper_cardinality(
             env.schema),
         params_typemods=params_typemods,
-        context=expr.span,
         typeref=typegen.type_to_typeref(
             rtype, env=env,
         ),
@@ -320,6 +319,7 @@ def compile_FunctionCall(
         impl_is_strict=func.get_impl_is_strict(env.schema),
         prefer_subquery_args=func.get_prefer_subquery_args(env.schema),
         global_args=global_args,
+        span=expr.span,
     )
 
     # Apply special function handling
@@ -385,7 +385,7 @@ def compile_operator(
             raise errors.QueryError(
                 f'could not resolve the type of operand '
                 f'#{ai} of {op_name}',
-                context=qlarg.context)
+                context=qlarg.span)
 
         args.append((arg_type, arg_ir))
 
@@ -640,12 +640,12 @@ def compile_operator(
         volatility=oper.get_volatility(env.schema),
         operator_kind=oper.get_operator_kind(env.schema),
         params_typemods=params_typemods,
-        context=qlexpr.span,
         typeref=typegen.type_to_typeref(rtype, env=env),
         typemod=oper.get_return_typemod(env.schema),
         tuple_path_ids=[],
         impl_is_strict=oper.get_impl_is_strict(env.schema),
         prefer_subquery_args=oper.get_prefer_subquery_args(env.schema),
+        span=qlexpr.span,        
     )
 
     _check_free_shape_op(node, ctx=ctx)
@@ -676,7 +676,7 @@ def _check_free_shape_op(
         if typ.issubclass(ctx.env.schema, virt_obj):
             raise errors.QueryError(
                 f'cannot use {ir.func_shortname.name} on free shape',
-                context=ir.context)
+                context=ir.span)
 
 
 def validate_recursive_operator(
@@ -738,7 +738,7 @@ def compile_func_call_args(
             raise errors.QueryError(
                 f'could not resolve the type of positional argument '
                 f'#{ai} of function {funcname}',
-                context=arg.context)
+                context=arg.span)
 
         args.append((arg_type, arg_ir))
 
@@ -752,7 +752,7 @@ def compile_func_call_args(
             raise errors.QueryError(
                 f'could not resolve the type of named argument '
                 f'${aname} of function {funcname}',
-                context=arg.context)
+                context=arg.span)
 
         kwargs[aname] = (arg_type, arg_ir)
 
@@ -939,7 +939,7 @@ def compile_fts_search(
     stype_id = object_typeref.id
 
     schema = ctx.env.schema
-    span = object_arg.context
+    span = object_arg.span
 
     stype = schema.get_by_id(stype_id, type=s_types.Type)
 
@@ -1004,7 +1004,7 @@ def compile_fts_with_options(
     if not irutils.is_const(weight_expr):
         raise errors.InvalidValueError(
             f"fts::search weight_category must be a constant",
-            context=weight_expr.context,
+            context=weight_expr.span,
         )
     weight_const = irutils.as_const(weight_expr)
     if weight_const:

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -645,7 +645,7 @@ def compile_operator(
         tuple_path_ids=[],
         impl_is_strict=oper.get_impl_is_strict(env.schema),
         prefer_subquery_args=oper.get_prefer_subquery_args(env.schema),
-        span=qlexpr.span,        
+        span=qlexpr.span,
     )
 
     _check_free_shape_op(node, ctx=ctx)

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -120,7 +120,7 @@ def compile_FunctionCall(
     args, kwargs = compile_func_call_args(
         expr, funcname, typemods, prefer_subquery_args=prefer_subquery_args,
         ctx=ctx)
-    with errors.ensure_context(expr.span):
+    with errors.ensure_span(expr.span):
         matched = polyres.find_callable(
             funcs, args=args, kwargs=kwargs, ctx=ctx)
     if not matched:

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -916,7 +916,7 @@ def finalize_args(
             # casting.
             orig_arg = arg
             arg = casts.compile_cast(
-                arg, paramtype, srcctx=None, ctx=ctx)
+                arg, paramtype, span=None, ctx=ctx)
             if ctx.path_scope.is_optional(orig_arg.path_id):
                 pathctx.register_set_in_scope(arg, optional=True, ctx=ctx)
 
@@ -939,16 +939,16 @@ def compile_fts_search(
     stype_id = object_typeref.id
 
     schema = ctx.env.schema
-    pctx = object_arg.context
+    span = object_arg.context
 
     stype = schema.get_by_id(stype_id, type=s_types.Type)
 
     if union_variants := stype.get_union_of(schema):
         for variant in union_variants.objects(schema):
             schema, variant = variant.material_type(schema)
-            _validate_has_fts_index(variant, schema, pctx)
+            _validate_has_fts_index(variant, schema, span)
     else:
-        _validate_has_fts_index(stype, schema, pctx)
+        _validate_has_fts_index(stype, schema, span)
 
     return call
 
@@ -956,7 +956,7 @@ def compile_fts_search(
 def _validate_has_fts_index(
     stype: s_types.Type,
     schema: s_schema.Schema,
-    pctx: Optional[parsing.Span],
+    span: Optional[parsing.Span],
 ) -> None:
     if isinstance(stype, s_indexes.IndexableSubject):
         (fts_index, _) = s_indexes.get_effective_fts_index(stype, schema)
@@ -967,7 +967,7 @@ def _validate_has_fts_index(
         raise errors.InvalidReferenceError(
             f"fts::search requires an fts::index index on type "
             f"'{stype.get_displayname(schema)}'",
-            context=pctx,
+            context=span,
         )
 
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -956,7 +956,7 @@ def compile_fts_search(
 def _validate_has_fts_index(
     stype: s_types.Type,
     schema: s_schema.Schema,
-    pctx: Optional[parsing.ParserContext],
+    pctx: Optional[parsing.Span],
 ) -> None:
     if isinstance(stype, s_indexes.IndexableSubject):
         (fts_index, _) = s_indexes.get_effective_fts_index(stype, schema)

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -354,7 +354,7 @@ def _infer_pointer_cardinality(
     specified_card: Optional[qltypes.SchemaCardinality] = None,
     is_mut_assignment: bool = False,
     shape_op: qlast.ShapeOp = qlast.ShapeOp.ASSIGN,
-    source_ctx: Optional[parsing.ParserContext] = None,
+    source_ctx: Optional[parsing.Span] = None,
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> None:

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -211,7 +211,7 @@ def _check_op_volatility(
             if cartesian_cardinality(cards2).is_multi():
                 raise errors.QueryError(
                     "can not take cross product of volatile operation",
-                    context=args[i].span
+                    span=args[i].span
                 )
 
 
@@ -275,13 +275,13 @@ def __infer_config_set(
         raise errors.QueryError(
             f"possibly an empty set returned for "
             f"a global declared as 'required'",
-            context=ir.span,
+            span=ir.span,
         )
     if ir.cardinality.is_single() and not card.is_single():
         raise errors.QueryError(
             f"possibly more than one element returned for "
             f"a global declared as 'single'",
-            context=ir.span,
+            span=ir.span,
         )
 
     return card
@@ -415,7 +415,7 @@ def _infer_pointer_cardinality(
                 raise errors.QueryError(
                     f"possibly more than one element returned by an "
                     f"expression for a {desc} declared as 'single'",
-                    context=source_ctx,
+                    span=source_ctx,
                 )
             upper_bound = spec_upper_bound
 
@@ -430,7 +430,7 @@ def _infer_pointer_cardinality(
                     raise errors.QueryError(
                         f"possibly an empty set returned by an "
                         f"expression for a {desc} declared as 'required'",
-                        context=source_ctx,
+                        span=source_ctx,
                     )
             else:
                 lower_bound = spec_lower_bound
@@ -1174,7 +1174,7 @@ def _infer_singleton_only(
         raise errors.QueryError(
             'possibly more than one element returned by an expression '
             'where only singletons are allowed',
-            context=part.span)
+            span=part.span)
     return card
 
 
@@ -1441,7 +1441,7 @@ def infer_cardinality(
         raise errors.QueryError(
             'could not determine the cardinality of '
             'set produced by expression',
-            context=ir.span)
+            span=ir.span)
 
     ctx.inferred_cardinality[key] = result
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -211,7 +211,7 @@ def _check_op_volatility(
             if cartesian_cardinality(cards2).is_multi():
                 raise errors.QueryError(
                     "can not take cross product of volatile operation",
-                    context=args[i].context
+                    context=args[i].span
                 )
 
 
@@ -275,13 +275,13 @@ def __infer_config_set(
         raise errors.QueryError(
             f"possibly an empty set returned for "
             f"a global declared as 'required'",
-            context=ir.context,
+            context=ir.span,
         )
     if ir.cardinality.is_single() and not card.is_single():
         raise errors.QueryError(
             f"possibly more than one element returned for "
             f"a global declared as 'single'",
-            context=ir.context,
+            context=ir.span,
         )
 
     return card
@@ -514,7 +514,7 @@ def _infer_shape(
             _infer_pointer_cardinality(
                 ptrcls=ptrcls,
                 ptrref=ptrref,
-                source_ctx=shape_set.context,
+                source_ctx=shape_set.span,
                 irexpr=shape_set.expr,
                 is_mut_assignment=is_mutation,
                 specified_card=specified_card,
@@ -1223,7 +1223,7 @@ def _infer_singleton_only(
         raise errors.QueryError(
             'possibly more than one element returned by an expression '
             'where only singletons are allowed',
-            context=part.context)
+            context=part.span)
     return card
 
 
@@ -1490,7 +1490,7 @@ def infer_cardinality(
         raise errors.QueryError(
             'could not determine the cardinality of '
             'set produced by expression',
-            context=ir.context)
+            context=ir.span)
 
     ctx.inferred_cardinality[key] = result
 

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -220,7 +220,7 @@ def _infer_shape(
                         f'DISTINCT operator to silently discard duplicate '
                         f'elements.'
                     ),
-                    context=shape_set.span
+                    span=shape_set.span
                 )
 
         _infer_shape(
@@ -953,7 +953,7 @@ def infer_multiplicity(
         raise errors.QueryError(
             'could not determine the multiplicity of '
             'set produced by expression',
-            context=ir.span)
+            span=ir.span)
 
     ctx.inferred_multiplicity[ir, scope_tree, ctx.distinct_iterator] = result
 

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -220,7 +220,7 @@ def _infer_shape(
                         f'DISTINCT operator to silently discard duplicate '
                         f'elements.'
                     ),
-                    context=shape_set.context
+                    context=shape_set.span
                 )
 
         _infer_shape(
@@ -953,7 +953,7 @@ def infer_multiplicity(
         raise errors.QueryError(
             'could not determine the multiplicity of '
             'set produced by expression',
-            context=ir.context)
+            context=ir.span)
 
     ctx.inferred_multiplicity[ir, scope_tree, ctx.distinct_iterator] = result
 

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -400,6 +400,6 @@ def infer_volatility(
         raise errors.QueryError(
             'could not determine the volatility of '
             'set produced by expression',
-            context=ir.context)
+            context=ir.span)
 
     return result

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -400,6 +400,6 @@ def infer_volatility(
         raise errors.QueryError(
             'could not determine the volatility of '
             'set produced by expression',
-            context=ir.span)
+            span=ir.span)
 
     return result

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -90,7 +90,7 @@ def register_set_in_scope(
     path_scope.attach_path(
         ir_set.path_id,
         optional=optional,
-        context=ir_set.context,
+        span=ir_set.span,
     )
 
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -612,7 +612,7 @@ def compile_arg(
 
         if fenced:
             arg_ql = qlast.SelectQuery(
-                result=arg_ql, context=arg_ql.context,
+                result=arg_ql, span=arg_ql.span,
                 implicit=True, rptr_passthrough=True)
 
         argctx.inhibit_implicit_limit = True

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -103,7 +103,7 @@ def get_schema_object(
             item_type=item_type,
             pointer_parent=_get_partial_path_prefix_type(ctx),
             condition=condition,
-            context=span,
+            span=span,
         )
         raise
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -65,12 +65,12 @@ def get_schema_object(
     condition: Optional[Callable[[s_obj.Object], bool]]=None,
     label: Optional[str]=None,
     ctx: context.ContextLevel,
-    srcctx: Optional[parsing.Span] = None,
+    span: Optional[parsing.Span] = None,
 ) -> s_obj.Object:
 
     if isinstance(ref, qlast.ObjectRef):
-        if srcctx is None:
-            srcctx = ref.context
+        if span is None:
+            span = ref.span
         module = ref.module
         lname = ref.name
     elif isinstance(ref, qlast.PseudoObjectRef):
@@ -103,7 +103,7 @@ def get_schema_object(
             item_type=item_type,
             pointer_parent=_get_partial_path_prefix_type(ctx),
             condition=condition,
-            context=srcctx,
+            context=span,
         )
         raise
 
@@ -112,7 +112,7 @@ def get_schema_object(
         # not yet a valid schema object
         raise errors.SchemaDefinitionError(
             f'illegal self-reference in definition of {str(name)!r}',
-            context=srcctx)
+            context=span)
 
     return stype
 
@@ -144,7 +144,7 @@ def get_schema_type(
         item_type = s_types.Type
     obj = get_schema_object(name, module, item_type=item_type,
                             condition=condition, label=label,
-                            ctx=ctx, srcctx=srcctx)
+                            ctx=ctx, span=srcctx)
     assert isinstance(obj, s_types.Type)
     return obj
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -65,7 +65,7 @@ def get_schema_object(
     condition: Optional[Callable[[s_obj.Object], bool]]=None,
     label: Optional[str]=None,
     ctx: context.ContextLevel,
-    srcctx: Optional[parsing.ParserContext] = None,
+    srcctx: Optional[parsing.Span] = None,
 ) -> s_obj.Object:
 
     if isinstance(ref, qlast.ObjectRef):
@@ -138,7 +138,7 @@ def get_schema_type(
     label: Optional[str] = None,
     condition: Optional[Callable[[s_obj.Object], bool]] = None,
     item_type: Optional[Type[s_obj.Object]] = None,
-    srcctx: Optional[parsing.ParserContext] = None,
+    srcctx: Optional[parsing.Span] = None,
 ) -> s_types.Type:
     if item_type is None:
         item_type = s_types.Type

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -112,7 +112,7 @@ def get_schema_object(
         # not yet a valid schema object
         raise errors.SchemaDefinitionError(
             f'illegal self-reference in definition of {str(name)!r}',
-            context=span)
+            span=span)
 
     return stype
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -47,7 +47,6 @@ import enum
 from edb import errors
 
 from edb.common import levenshtein
-from edb.common import parsing
 from edb.common.typeutils import downcast, not_none
 
 from edb.ir import ast as irast

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1191,7 +1191,7 @@ def enum_indirection_set(
     return casts.compile_cast(
         irast.StringConstant(value=ptr_name, typeref=strref),
         source,
-        srcctx=source_context,
+        span=source_context,
         ctx=ctx,
     )
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -133,7 +133,7 @@ def new_set(
 def new_empty_set(*, stype: Optional[s_types.Type]=None, alias: str='e',
                   ctx: context.ContextLevel,
                   srcctx: Optional[
-                      parsing.ParserContext]=None) -> irast.Set:
+                      parsing.Span]=None) -> irast.Set:
     if stype is None:
         stype = s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
         if srcctx is not None:
@@ -173,7 +173,7 @@ def new_set_from_set(
         stype: Optional[s_types.Type]=None,
         rptr: Optional[irast.Pointer | KeepCurrentT]=KeepCurrent,
         expr: Optional[irast.Expr | KeepCurrentT]=KeepCurrent,
-        context: Optional[parsing.ParserContext]=None,
+        context: Optional[parsing.Span]=None,
         is_binding: Optional[irast.BindingKind]=None,
         is_schema_alias: Optional[bool]=None,
         is_materialized_ref: Optional[bool]=None,
@@ -260,7 +260,7 @@ def new_array_set(
         elements: Sequence[irast.Set], *,
         stype: Optional[s_types.Type]=None,
         ctx: context.ContextLevel,
-        srcctx: Optional[parsing.ParserContext]=None) -> irast.Set:
+        srcctx: Optional[parsing.Span]=None) -> irast.Set:
 
     if elements:
         element_type = typegen.infer_common_type(elements, ctx.env)
@@ -287,7 +287,7 @@ def new_array_set(
 
 
 def raise_self_insert_error(
-    stype: s_obj.Object, source_context: Optional[parsing.ParserContext], *,
+    stype: s_obj.Object, source_context: Optional[parsing.Span], *,
     ctx: context.ContextLevel,
 ) -> NoReturn:
     dname = stype.get_displayname(ctx.env.schema)
@@ -687,7 +687,7 @@ def ptr_step_set(
         expr: Optional[qlast.Base],
         ptr_name: str,
         direction: PtrDir = PtrDir.Outbound,
-        source_context: Optional[parsing.ParserContext],
+        source_context: Optional[parsing.Span],
         ignore_computable: bool=False,
         ctx: context.ContextLevel) -> irast.Set:
     ptrcls, path_id_ptrcls = resolve_ptr_with_intersections(
@@ -731,7 +731,7 @@ def resolve_ptr(
     direction: s_pointers.PointerDirection = (
         s_pointers.PointerDirection.Outbound
     ),
-    source_context: Optional[parsing.ParserContext] = None,
+    source_context: Optional[parsing.Span] = None,
     track_ref: Optional[Union[qlast.Base, Literal[False]]],
     ctx: context.ContextLevel,
 ) -> s_pointers.Pointer:
@@ -750,7 +750,7 @@ def resolve_ptr_with_intersections(
     direction: s_pointers.PointerDirection = (
         s_pointers.PointerDirection.Outbound
     ),
-    source_context: Optional[parsing.ParserContext] = None,
+    source_context: Optional[parsing.Span] = None,
     track_ref: Optional[Union[qlast.Base, Literal[False]]],
     ctx: context.ContextLevel,
 ) -> tuple[s_pointers.Pointer, s_pointers.Pointer]:
@@ -943,7 +943,7 @@ def resolve_ptr_with_intersections(
 def _check_secret_ptr(
     ptrcls: s_pointers.Pointer,
     *,
-    srcctx: Optional[parsing.ParserContext]=None,
+    srcctx: Optional[parsing.Span]=None,
     ctx: context.ContextLevel,
 ) -> None:
     module = ptrcls.get_name(ctx.env.schema).module
@@ -976,7 +976,7 @@ def extend_path(
     path_id_ptrcls: Optional[s_pointers.Pointer] = None,
     ignore_computable: bool = False,
     same_computable_scope: bool = False,
-    srcctx: Optional[parsing.ParserContext]=None,
+    srcctx: Optional[parsing.Span]=None,
     ctx: context.ContextLevel,
 ) -> irast.Set:
     """Return a Set node representing the new path tip."""
@@ -1180,7 +1180,7 @@ def enum_indirection_set(
         *,
         source: s_types.Type,
         ptr_name: str,
-        source_context: Optional[parsing.ParserContext],
+        source_context: Optional[parsing.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     strref = typegen.type_to_typeref(
@@ -1200,7 +1200,7 @@ def tuple_indirection_set(
         path_tip: irast.Set, *,
         source: s_types.Type,
         ptr_name: str,
-        source_context: Optional[parsing.ParserContext] = None,
+        source_context: Optional[parsing.Span] = None,
         ctx: context.ContextLevel) -> irast.Set:
 
     assert isinstance(source, s_types.Tuple)
@@ -1230,7 +1230,7 @@ def type_intersection_set(
     stype: s_types.Type,
     *,
     optional: bool,
-    source_context: Optional[parsing.ParserContext] = None,
+    source_context: Optional[parsing.Span] = None,
     ctx: context.ContextLevel,
 ) -> irast.Set:
     """Return an interesection of *source_set* with type *stype*."""
@@ -1413,7 +1413,7 @@ def ensure_set(
         type_override: Optional[s_types.Type]=None,
         typehint: Optional[s_types.Type]=None,
         path_id: Optional[irast.PathId]=None,
-        srcctx: Optional[parsing.ParserContext]=None,
+        srcctx: Optional[parsing.Span]=None,
         ctx: context.ContextLevel) -> irast.Set:
 
     if not isinstance(expr, irast.Set):
@@ -1498,7 +1498,7 @@ def computable_ptr_set(
     path_id: irast.PathId,
     *,
     same_computable_scope: bool=False,
-    srcctx: Optional[parsing.ParserContext]=None,
+    srcctx: Optional[parsing.Span]=None,
     ctx: context.ContextLevel,
 ) -> irast.Set:
     """Return ir.Set for a pointer defined as a computable."""
@@ -2069,7 +2069,7 @@ def get_func_global_param_sets(
 def get_globals_as_json(
     globs: Sequence[s_globals.Global], *,
     ctx: context.ContextLevel,
-    srcctx: Optional[parsing.ParserContext],
+    srcctx: Optional[parsing.Span],
 ) -> irast.Set:
     """Build a json object that contains the values of `globs`
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -535,7 +535,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                     path_tip, typ, optional=False, span=step.span,
                     ctx=ctx)
             except errors.SchemaError as e:
-                e.set_source_context(step.type.span)
+                e.set_span(step.type.span)
                 raise
 
         else:

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -507,7 +507,7 @@ def compile_InsertQuery(
                 compile_views=True,
                 exprtype=s_types.ExprType.Insert,
                 ctx=bodyctx,
-                parser_context=expr.context,
+                span=expr.context,
             )
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
@@ -539,7 +539,7 @@ def compile_InsertQuery(
                 view_name=ctx.toplevel_result_view_name,
                 compile_views=ictx.stmt is ictx.toplevel_stmt,
                 ctx=resultctx,
-                parser_context=expr.context,
+                span=expr.context,
             )
 
         if pol_condition := policies.compile_dml_write_policies(
@@ -577,7 +577,7 @@ def compile_InsertQuery(
                     view_name=ctx.toplevel_result_view_name,
                     compile_views=ictx.stmt is ctx.toplevel_stmt,
                     ctx=resultctx,
-                    parser_context=result.context,
+                    span=result.context,
                 )
 
     return result
@@ -655,7 +655,7 @@ def compile_UpdateQuery(
                 compile_views=True,
                 exprtype=s_types.ExprType.Update,
                 ctx=bodyctx,
-                parser_context=expr.context,
+                span=expr.context,
             )
 
         result = setgen.class_set(
@@ -669,7 +669,7 @@ def compile_UpdateQuery(
                 view_name=ctx.toplevel_result_view_name,
                 compile_views=ictx.stmt is ictx.toplevel_stmt,
                 ctx=resultctx,
-                parser_context=expr.context,
+                span=expr.context,
             )
 
         for dtype in schemactx.get_all_concrete(mat_stype, ctx=ctx):
@@ -788,7 +788,7 @@ def compile_DeleteQuery(
                 shape=None,
                 exprtype=s_types.ExprType.Delete,
                 ctx=bodyctx,
-                parser_context=expr.context,
+                span=expr.context,
             )
 
         result = setgen.class_set(
@@ -802,7 +802,7 @@ def compile_DeleteQuery(
                 view_name=ctx.toplevel_result_view_name,
                 compile_views=ictx.stmt is ictx.toplevel_stmt,
                 ctx=resultctx,
-                parser_context=expr.context,
+                span=expr.context,
             )
 
         for dtype in schemactx.get_all_concrete(mat_stype, ctx=ctx):
@@ -1114,7 +1114,7 @@ def compile_Shape(
             shape=shape.elements,
             compile_views=False,
             ctx=subctx,
-            parser_context=expr.context)
+            span=expr.context)
 
         ir_result = setgen.ensure_set(stmt, ctx=subctx)
 
@@ -1383,7 +1383,7 @@ def compile_result_clause(
             exprtype=exprtype,
             compile_views=ctx.stmt is ctx.toplevel_stmt,
             ctx=sctx,
-            parser_context=result.context)
+            span=result.context)
 
         ctx.partial_path_prefix = ir_result
 
@@ -1401,7 +1401,7 @@ def compile_query_subject(
         exprtype: s_types.ExprType = s_types.ExprType.Select,
         allow_select_shape_inject: bool=True,
         forward_rptr: bool=False,
-        parser_context: Optional[span.Span],
+        span: Optional[span.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     expr_stype = setgen.get_set_type(expr, ctx=ctx)
@@ -1508,7 +1508,7 @@ def compile_query_subject(
             raise errors.QueryError(
                 f'shapes cannot be applied to '
                 f'{expr_stype.get_verbosename(ctx.env.schema)}',
-                context=parser_context,
+                context=span,
             )
 
         view_scls, expr = viewgen.process_view(
@@ -1519,7 +1519,7 @@ def compile_query_subject(
             view_name=view_name,
             exprtype=exprtype,
             ctx=ctx,
-            srcctx=parser_context,
+            srcctx=span,
         )
 
     if view_scls is not None:
@@ -1556,7 +1556,7 @@ def maybe_add_view(ir: irast.Set, *, ctx: context.ContextLevel) -> irast.Set:
     ):
         return compile_query_subject(
             ir, allow_select_shape_inject=True, compile_views=False, ctx=ctx,
-            parser_context=ir.context)
+            span=ir.context)
     else:
         return ir
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -37,7 +37,6 @@ import textwrap
 
 from edb import errors
 from edb.common import ast
-from edb.common import span as span
 from edb.common.typeutils import not_none
 
 from edb.ir import ast as irast
@@ -1402,7 +1401,7 @@ def compile_query_subject(
         exprtype: s_types.ExprType = s_types.ExprType.Select,
         allow_select_shape_inject: bool=True,
         forward_rptr: bool=False,
-        span: Optional[span.Span],
+        span: Optional[qlast.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     expr_stype = setgen.get_set_type(expr, ctx=ctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -37,7 +37,7 @@ import textwrap
 
 from edb import errors
 from edb.common import ast
-from edb.common import context as pctx
+from edb.common import span as span
 from edb.common.typeutils import not_none
 
 from edb.ir import ast as irast
@@ -1401,7 +1401,7 @@ def compile_query_subject(
         exprtype: s_types.ExprType = s_types.ExprType.Select,
         allow_select_shape_inject: bool=True,
         forward_rptr: bool=False,
-        parser_context: Optional[pctx.Span],
+        parser_context: Optional[span.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     expr_stype = setgen.get_set_type(expr, ctx=ctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1401,7 +1401,7 @@ def compile_query_subject(
         exprtype: s_types.ExprType = s_types.ExprType.Select,
         allow_select_shape_inject: bool=True,
         forward_rptr: bool=False,
-        parser_context: Optional[pctx.ParserContext],
+        parser_context: Optional[pctx.Span],
         ctx: context.ContextLevel) -> irast.Set:
 
     expr_stype = setgen.get_set_type(expr, ctx=ctx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -251,7 +251,7 @@ def fini_expression(
             raise errors.QueryError(
                 'expression returns value of indeterminate type',
                 hint='Consider using an explicit type cast.',
-                context=ctx.env.type_origins.get(anytype))
+                span=ctx.env.type_origins.get(anytype))
 
     # Clear out exprs that we decided to omit from the IR
     for ir_set in exprs_to_clear:
@@ -826,7 +826,7 @@ def throw_on_shaped_param(
     raise errors.QueryError(
         f'cannot apply a shape to the parameter',
         hint='Consider adding parentheses around the parameter and type cast',
-        context=shape.span
+        span=shape.span
     )
 
 
@@ -838,14 +838,14 @@ def throw_on_loose_param(
         if ctx.env.options.schema_object_context is s_constr.Constraint:
             raise errors.InvalidConstraintDefinitionError(
                 f'dollar-prefixed "$parameters" cannot be used here',
-                context=param.span)
+                span=param.span)
         else:
             raise errors.InvalidFunctionDefinitionError(
                 f'dollar-prefixed "$parameters" cannot be used here',
-                context=param.span)
+                span=param.span)
     raise errors.QueryError(
         f'missing a type cast before the parameter',
-        context=param.span)
+        span=param.span)
 
 
 def preprocess_script(

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -826,14 +826,14 @@ def throw_on_loose_param(
         if ctx.env.options.schema_object_context is s_constr.Constraint:
             raise errors.InvalidConstraintDefinitionError(
                 f'dollar-prefixed "$parameters" cannot be used here',
-                context=param.context)
+                context=param.span)
         else:
             raise errors.InvalidFunctionDefinitionError(
                 f'dollar-prefixed "$parameters" cannot be used here',
-                context=param.context)
+                context=param.span)
     raise errors.QueryError(
         f'missing a type cast before the parameter',
-        context=param.context)
+        context=param.span)
 
 
 def preprocess_script(

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -826,7 +826,8 @@ def throw_on_shaped_param(
     raise errors.QueryError(
         f'cannot apply a shape to the parameter',
         hint='Consider adding parentheses around the parameter and type cast',
-        context=shape.context)
+        context=shape.span
+    )
 
 
 def throw_on_loose_param(

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -106,7 +106,7 @@ def init_context(
             had_optional |= optional
             path_id = compile_anchor('__', singleton, ctx=ctx).path_id
             ctx.env.path_scope.attach_path(
-                path_id, optional=optional, context=None)
+                path_id, optional=optional, span=None)
             if not optional:
                 ctx.env.singletons.append(path_id)
             ctx.iterator_path_ids |= {path_id}

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -94,7 +94,7 @@ def compile_trigger(
 
         for name, ir in anchors.items():
             if scope == qltypes.TriggerScope.Each:
-                sctx.path_scope.attach_path(ir.path_id, context=None)
+                sctx.path_scope.attach_path(ir.path_id, span=None)
                 sctx.iterator_path_ids |= {ir.path_id}
             sctx.anchors[name] = ir
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -67,7 +67,7 @@ def infer_common_type(
     if not irs:
         raise errors.QueryError(
             'cannot determine common type of an empty set',
-            context=irs[0].context)
+            context=irs[0].span)
 
     types = []
     empties = []
@@ -93,12 +93,12 @@ def infer_common_type(
     if seen_coll + seen_scalar + seen_object > 1:
         raise errors.QueryError(
             'cannot determine common type',
-            context=irs[0].context)
+            context=irs[0].span)
 
     if not types:
         raise errors.QueryError(
             'cannot determine common type of an empty set',
-            context=irs[0].context)
+            context=irs[0].span)
 
     common_type = None
     if seen_scalar or seen_coll:

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -199,25 +199,25 @@ def _ql_typeexpr_to_type(
                 raise errors.UnsupportedFeatureError(
                     f'cannot use type operator {ql_t.op!r} with non-object '
                     f'type {left[0].get_displayname(ctx.env.schema)}',
-                    context=ql_t.left.context)
+                    context=ql_t.left.span)
             if len(right) == 1 and not right[0].is_object_type():
                 raise errors.UnsupportedFeatureError(
                     f'cannot use type operator {ql_t.op!r} with non-object '
                     f'type {right[0].get_displayname(ctx.env.schema)}',
-                    context=ql_t.right.context)
+                    context=ql_t.right.span)
 
             return left + right
 
         raise errors.UnsupportedFeatureError(
             f'type operator {ql_t.op!r} is not implemented',
-            context=ql_t.context)
+            context=ql_t.span)
 
     elif isinstance(ql_t, qlast.TypeName):
         return [_ql_typename_to_type(ql_t, ctx=ctx)]
 
     else:
         raise errors.EdgeQLSyntaxError("Unexpected type expression",
-                                       context=ql_t.context)
+                                       context=ql_t.span)
 
 
 def _ql_typename_to_type(

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -67,7 +67,7 @@ def infer_common_type(
     if not irs:
         raise errors.QueryError(
             'cannot determine common type of an empty set',
-            context=irs[0].span)
+            span=irs[0].span)
 
     types = []
     empties = []
@@ -93,12 +93,12 @@ def infer_common_type(
     if seen_coll + seen_scalar + seen_object > 1:
         raise errors.QueryError(
             'cannot determine common type',
-            context=irs[0].span)
+            span=irs[0].span)
 
     if not types:
         raise errors.QueryError(
             'cannot determine common type of an empty set',
-            context=irs[0].span)
+            span=irs[0].span)
 
     common_type = None
     if seen_scalar or seen_coll:
@@ -199,25 +199,25 @@ def _ql_typeexpr_to_type(
                 raise errors.UnsupportedFeatureError(
                     f'cannot use type operator {ql_t.op!r} with non-object '
                     f'type {left[0].get_displayname(ctx.env.schema)}',
-                    context=ql_t.left.span)
+                    span=ql_t.left.span)
             if len(right) == 1 and not right[0].is_object_type():
                 raise errors.UnsupportedFeatureError(
                     f'cannot use type operator {ql_t.op!r} with non-object '
                     f'type {right[0].get_displayname(ctx.env.schema)}',
-                    context=ql_t.right.span)
+                    span=ql_t.right.span)
 
             return left + right
 
         raise errors.UnsupportedFeatureError(
             f'type operator {ql_t.op!r} is not implemented',
-            context=ql_t.span)
+            span=ql_t.span)
 
     elif isinstance(ql_t, qlast.TypeName):
         return [_ql_typename_to_type(ql_t, ctx=ctx)]
 
     else:
         raise errors.EdgeQLSyntaxError("Unexpected type expression",
-                                       context=ql_t.span)
+                                       span=ql_t.span)
 
 
 def _ql_typename_to_type(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -553,7 +553,7 @@ def _process_view(
                 ir_set,
                 ptrcls,
                 same_computable_scope=True,
-                srcctx=ptr_span or span,
+                span=ptr_span or span,
                 ctx=ctx,
             )
 
@@ -1346,7 +1346,7 @@ def _normalize_view_ptr_expr(
             ptrname,
             track_ref=shape_el_desc.ptr_ql,
             ctx=ctx,
-            source_context=shape_el.span,
+            span=shape_el.span,
         )
         real_ptrcls = None
         if is_polymorphic:
@@ -1362,7 +1362,7 @@ def _normalize_view_ptr_expr(
                     ptrname,
                     track_ref=shape_el_desc.ptr_ql,
                     ctx=ctx,
-                    source_context=shape_el.span,
+                    span=shape_el.span,
                 )
             except errors.InvalidReferenceError:
                 is_independent_polymorphic = True
@@ -1810,13 +1810,13 @@ def _normalize_view_ptr_expr(
                 t2_vn = ptr_target.get_verbosename(ctx.env.schema)
 
                 if compexpr is not None:
-                    source_context = compexpr.span
+                    span = compexpr.span
                 else:
-                    source_context = shape_el.expr.steps[-1].span
+                    span = shape_el.expr.steps[-1].span
                 raise errors.SchemaError(
                     f'cannot redefine {vnp} as {t2_vn}',
                     details=f'{vnp} is defined as {t1_vn}',
-                    context=source_context,
+                    context=span,
                 )
         else:
             ptrcls = schemactx.derive_ptr(
@@ -2413,7 +2413,7 @@ def _late_compile_view_shapes_in_set(
                 path_tip,
                 ptr,
                 same_computable_scope=True,
-                srcctx=srcctx,
+                span=srcctx,
                 ctx=ctx,
             )
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -136,7 +136,7 @@ def process_view(
     view_name: Optional[sn.QualName] = None,
     exprtype: s_types.ExprType = s_types.ExprType.Select,
     ctx: context.ContextLevel,
-    srcctx: Optional[parsing.ParserContext],
+    srcctx: Optional[parsing.Span],
 ) -> Tuple[s_objtypes.ObjectType, irast.Set]:
 
     cache_key = (stype, exprtype, tuple(elements))
@@ -185,7 +185,7 @@ def _process_view(
     elements: Optional[Sequence[qlast.ShapeElement]],
     s_ctx: ShapeContext,
     ctx: context.ContextLevel,
-    srcctx: Optional[parsing.ParserContext],
+    srcctx: Optional[parsing.Span],
 ) -> Tuple[s_objtypes.ObjectType, irast.Set]:
     path_id = ir_set.path_id
     view_rptr = s_ctx.view_rptr
@@ -848,7 +848,7 @@ def _raise_on_missing(
     stype: s_objtypes.ObjectType,
     rewrites: Optional[irast.Rewrites],
     ctx: context.ContextLevel,
-    srcctx: Optional[parsing.ParserContext],
+    srcctx: Optional[parsing.Span],
 ) -> None:
     pointer_names = {
         ptr.get_local_name(ctx.env.schema) for ptr in pointers

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -545,7 +545,7 @@ def _process_view(
             # already has a context, since for explain output that
             # seems nicer, but this is what we want for producing
             # actual error messages.
-            ptr_set.context = ptr_span
+            ptr_set.span = ptr_span
 
         else:
             # The set must be something pretty trivial, so just do it
@@ -789,7 +789,7 @@ def _gen_pointers_from_defaults(
             # add __source__ to anchors
             source_set = ir_set
             scopectx.path_scope.attach_path(
-                source_set.path_id, context=None,
+                source_set.path_id, span=None,
                 optional=False,
             )
             scopectx.iterator_path_ids |= {source_set.path_id}
@@ -1127,7 +1127,7 @@ def _compile_rewrites_for_stype(
 
             for key, anchor in nanchors.items():
                 scopectx.path_scope.attach_path(
-                    anchor.path_id, context=None,
+                    anchor.path_id, span=None,
                     optional=(anchor is subject_set),
                 )
                 scopectx.iterator_path_ids |= {anchor.path_id}
@@ -1592,7 +1592,7 @@ def _normalize_view_ptr_expr(
                     context=shape_el.operation.span,
                 )
 
-        irexpr.context = compexpr.span
+        irexpr.span = compexpr.span
 
         is_inbound_alias = False
         if base_ptrcls is None:
@@ -1960,8 +1960,8 @@ def _normalize_view_ptr_expr(
         ctx.env.schema = ptrcls.set_field_value(
             ctx.env.schema, 'cardinality', qltypes.SchemaCardinality.Unknown)
 
-    if irexpr and not irexpr.context:
-        irexpr.context = shape_el.span
+    if irexpr and not irexpr.span:
+        irexpr.span = shape_el.span
 
     return ptrcls, irexpr
 

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -485,7 +485,7 @@ def sdl_to_ddl(
             # A single schema object with a recursive definition.
             msg = f'{item_vn} is defined recursively'
 
-        raise errors.InvalidDefinitionError(msg, context=node.span) from e
+        raise errors.InvalidDefinitionError(msg, span=node.span) from e
 
     return tuple(mods) + tuple(ordered)
 
@@ -759,7 +759,7 @@ def _trace_item_layout(
             if field_name in ctx.objects:
                 vn = get_verbosename_from_fqname(field_name, ctx)
                 msg = f'{vn} was already declared'
-                raise errors.InvalidDefinitionError(msg, context=decl.span)
+                raise errors.InvalidDefinitionError(msg, span=decl.span)
 
             ctx.objects[field_name] = qltracer.Field(field_name)
 
@@ -1094,7 +1094,7 @@ def _register_item(
     if fq_name in ctx.ddlgraph:
         vn = get_verbosename_from_fqname(fq_name, ctx)
         msg = f'{vn} was already declared'
-        raise errors.InvalidDefinitionError(msg, context=decl.span)
+        raise errors.InvalidDefinitionError(msg, span=decl.span)
 
     if deps:
         deps = set(deps)
@@ -1414,7 +1414,7 @@ def _get_bases(
                 raise errors.SchemaError(
                     f"invalid scalar type definition, enumeration must "
                     f"be the only supertype specified",
-                    context=decl.bases[0].span,
+                    span=decl.bases[0].span,
                 )
 
             bases = [s_name.QualName("std", "anyenum")]
@@ -1504,7 +1504,7 @@ def _get_local_obj(
         raise errors.SchemaError(
             f'invalid type: {obj.get_verbosename(ctx.schema)} is a generic '
             f'type and they are not supported in user-defined schema',
-            context=sourcectx,
+            span=sourcectx,
         )
 
     elif obj is not None and not isinstance(obj, tracer_type):
@@ -1514,7 +1514,7 @@ def _get_local_obj(
             f'{str(refname)!r} exists, but is '
             f'{english.add_a(obj_type.get_schema_class_displayname())}, '
             f'not {english.add_a(real_type.get_schema_class_displayname())}',
-            context=sourcectx,
+            span=sourcectx,
         )
 
     return obj

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -485,7 +485,7 @@ def sdl_to_ddl(
             # A single schema object with a recursive definition.
             msg = f'{item_vn} is defined recursively'
 
-        raise errors.InvalidDefinitionError(msg, context=node.context) from e
+        raise errors.InvalidDefinitionError(msg, context=node.span) from e
 
     return tuple(mods) + tuple(ordered)
 
@@ -759,7 +759,7 @@ def _trace_item_layout(
             if field_name in ctx.objects:
                 vn = get_verbosename_from_fqname(field_name, ctx)
                 msg = f'{vn} was already declared'
-                raise errors.InvalidDefinitionError(msg, context=decl.context)
+                raise errors.InvalidDefinitionError(msg, context=decl.span)
 
             ctx.objects[field_name] = qltracer.Field(field_name)
 
@@ -1094,7 +1094,7 @@ def _register_item(
     if fq_name in ctx.ddlgraph:
         vn = get_verbosename_from_fqname(fq_name, ctx)
         msg = f'{vn} was already declared'
-        raise errors.InvalidDefinitionError(msg, context=decl.context)
+        raise errors.InvalidDefinitionError(msg, context=decl.span)
 
     if deps:
         deps = set(deps)
@@ -1414,7 +1414,7 @@ def _get_bases(
                 raise errors.SchemaError(
                     f"invalid scalar type definition, enumeration must "
                     f"be the only supertype specified",
-                    context=decl.bases[0].context,
+                    context=decl.bases[0].span,
                 )
 
             bases = [s_name.QualName("std", "anyenum")]
@@ -1528,7 +1528,7 @@ def _resolve_type_name(
 ) -> qltracer.ObjectLike:
 
     refname = ctx.get_ref_name(ref)
-    local_obj = _get_local_obj(refname, tracer_type, ref.context, ctx=ctx)
+    local_obj = _get_local_obj(refname, tracer_type, ref.span, ctx=ctx)
     obj: qltracer.ObjectLike
     if local_obj is not None:
         obj = local_obj
@@ -1536,7 +1536,7 @@ def _resolve_type_name(
         obj = _resolve_schema_ref(
             refname,
             type=tracer_type,
-            sourcectx=ref.context,
+            span=ref.span,
             ctx=ctx,
         )
 
@@ -1585,7 +1585,7 @@ def _validate_schema_ref(
         # Bail out and rely on some other validation mechanism
         return
 
-    local_obj = _get_local_obj(refname, tracer_type, decl.context, ctx=ctx)
+    local_obj = _get_local_obj(refname, tracer_type, decl.span, ctx=ctx)
 
     if local_obj is None:
         if (tracer_type is qltracer.Index and
@@ -1595,7 +1595,7 @@ def _validate_schema_ref(
         _resolve_schema_ref(
             refname,
             type=tracer_type,
-            sourcectx=decl.context,
+            span=decl.span,
             ctx=ctx,
         )
 
@@ -1603,13 +1603,13 @@ def _validate_schema_ref(
 def _resolve_schema_ref(
     name: s_name.Name,
     type: Type[qltracer.NamedObject],
-    sourcectx: Optional[parsing.Span],
+    span: Optional[parsing.Span],
     *,
     ctx: LayoutTraceContext | DepTraceContext,
 ) -> s_obj.SubclassableObject:
     real_type = TRACER_TO_REAL_TYPE_MAP[type]
     try:
-        return ctx.schema.get(name, type=real_type, sourcectx=sourcectx)
+        return ctx.schema.get(name, type=real_type, sourcectx=span)
     except errors.InvalidReferenceError as e:
         s_utils.enrich_schema_lookup_error(
             e,
@@ -1617,6 +1617,6 @@ def _resolve_schema_ref(
             schema=ctx.schema,
             modaliases=ctx.modaliases,
             item_type=real_type,
-            context=sourcectx,
+            context=span,
         )
         raise

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1617,6 +1617,6 @@ def _resolve_schema_ref(
             schema=ctx.schema,
             modaliases=ctx.modaliases,
             item_type=real_type,
-            context=span,
+            span=span,
         )
         raise

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1493,7 +1493,7 @@ TRACER_TO_REAL_TYPE_MAP = {
 def _get_local_obj(
     refname: s_name.QualName,
     tracer_type: Type[qltracer.NamedObject],
-    sourcectx: Optional[parsing.ParserContext],
+    sourcectx: Optional[parsing.Span],
     *,
     ctx: LayoutTraceContext | DepTraceContext,
 ) -> Optional[qltracer.NamedObject]:
@@ -1603,7 +1603,7 @@ def _validate_schema_ref(
 def _resolve_schema_ref(
     name: s_name.Name,
     type: Type[qltracer.NamedObject],
-    sourcectx: Optional[parsing.ParserContext],
+    sourcectx: Optional[parsing.Span],
     *,
     ctx: LayoutTraceContext | DepTraceContext,
 ) -> s_obj.SubclassableObject:

--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -107,20 +107,20 @@ def desugar_group(
             return qlast.ObjectRef(name=alias)
         else:
             return qlast.GroupingIdentList(
-                context=el.context,
+                span=el.span,
                 elements=tuple(rewrite_atom(at) for at in el.elements),
             )
 
     def rewrite(el: qlast.GroupingElement) -> qlast.GroupingElement:
         if isinstance(el, qlast.GroupingSimple):
             return qlast.GroupingSimple(
-                context=el.context, element=rewrite_atom(el.element))
+                span=el.span, element=rewrite_atom(el.element))
         elif isinstance(el, qlast.GroupingSets):
             return qlast.GroupingSets(
-                context=el.context, sets=[rewrite(s) for s in el.sets])
+                span=el.span, sets=[rewrite(s) for s in el.sets])
         elif isinstance(el, qlast.GroupingOperation):
             return qlast.GroupingOperation(
-                context=el.context,
+                span=el.span,
                 oper=el.oper,
                 elements=[rewrite_atom(a) for a in el.elements])
         raise AssertionError
@@ -152,7 +152,7 @@ def desugar_group(
     output_shape = make_free_object(output_dict)
 
     return qlast.InternalGroupQuery(
-        context=node.context,
+        span=node.span,
         aliases=node.aliases,
         subject_alias=node.subject_alias,
         subject=node.subject,

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -169,7 +169,7 @@ def parse(
             position=position,
             hint=hint,
             details=details,
-            context=pcontext
+            span=pcontext
         )
 
     return _cst_to_ast(

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -157,7 +157,7 @@ def parse(
         message, span, hint, details = error
         position = qltokenizer.inflate_position(source.text(), span)
 
-        pcontext = parsing.ParserContext(
+        pcontext = parsing.Span(
             'query',
             source.text(),
             start=position[2],
@@ -208,7 +208,7 @@ def _cst_to_ast(
 
             if terminal := node.terminal:
                 # Terminal is simple: just convert to parsing.Token
-                context = parsing.ParserContext(
+                context = parsing.Span(
                     name=filename,
                     buffer=source.text(),
                     start=terminal.start,

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -157,7 +157,7 @@ def parse(
         message, span, hint, details = error
         position = qltokenizer.inflate_position(source.text(), span)
 
-        pcontext = parsing.Span(
+        parsing_span = parsing.Span(
             'query',
             source.text(),
             start=position[2],
@@ -169,7 +169,7 @@ def parse(
             position=position,
             hint=hint,
             details=details,
-            span=pcontext
+            span=parsing_span
         )
 
     return _cst_to_ast(

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -208,7 +208,7 @@ def _cst_to_ast(
 
             if terminal := node.terminal:
                 # Terminal is simple: just convert to parsing.Token
-                context = parsing.Span(
+                span = parsing.Span(
                     name=filename,
                     buffer=source.text(),
                     start=terminal.start,
@@ -216,7 +216,7 @@ def _cst_to_ast(
                 )
                 result.append(
                     parsing.Token(
-                        terminal.text, terminal.value, context
+                        terminal.text, terminal.value, span
                     )
                 )
 

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -49,7 +49,7 @@ def _parse_language(node):
     except ValueError:
         raise EdgeQLSyntaxError(
             f'{node.val} is not a valid language',
-            context=node.span) from None
+            span=node.span) from None
 
 
 def _validate_declarations(
@@ -69,7 +69,7 @@ def _validate_declarations(
             raise EdgeQLSyntaxError(
                 "only fully-qualified name is allowed in "
                 "top-level declaration",
-                context=decl.name.span)
+                span=decl.name.span)
 
 
 def extract_bases(bases, commands):
@@ -80,7 +80,7 @@ def extract_bases(bases, commands):
             if vbases:
                 raise EdgeQLSyntaxError(
                     "specifying EXTENDING twice is not allowed",
-                    context=command.span)
+                    span=command.span)
             vbases = command.bases
         else:
             vcommands.append(command)
@@ -236,12 +236,12 @@ class FuncDeclArgName(Nonterm):
         if dp.val[1].isdigit():
             raise EdgeQLSyntaxError(
                 f'numeric parameters are not supported',
-                context=dp.span)
+                span=dp.span)
         else:
             raise EdgeQLSyntaxError(
                 f"function parameters do not need a $ prefix, "
                 f"rewrite as '{dp.val[1:]}'",
-                context=dp.span)
+                span=dp.span)
 
 
 class FuncDeclArg(Nonterm):
@@ -262,7 +262,7 @@ class FuncDeclArg(Nonterm):
     ):
         raise EdgeQLSyntaxError(
             f'missing type declaration for the `{name.val}` parameter',
-            context=name.span
+            span=name.span
         )
 
 
@@ -289,24 +289,24 @@ class ProcessFunctionParamsMixin:
                 # A tuple here means that it's part of the "param := val"
                 raise EdgeQLSyntaxError(
                     f"Unexpected ':='",
-                    context=arg[1])
+                    span=arg[1])
 
             if arg.name in names:
                 raise EdgeQLSyntaxError(
                     f'duplicate parameter name `{arg.name}`',
-                    context=arg.span)
+                    span=arg.span)
             names.add(arg.name)
 
             if arg.kind is qltypes.ParameterKind.VariadicParam:
                 if variadic_arg is not None:
                     raise EdgeQLSyntaxError(
                         'more than one variadic argument',
-                        context=arg.span)
+                        span=arg.span)
                 elif last_named_arg is not None:
                     raise EdgeQLSyntaxError(
                         f'NAMED ONLY argument `{last_named_arg.name}` '
                         f'before VARIADIC argument `{arg.name}`',
-                        context=last_named_arg.span)
+                        span=last_named_arg.span)
                 else:
                     variadic_arg = arg
 
@@ -314,7 +314,7 @@ class ProcessFunctionParamsMixin:
                     raise EdgeQLSyntaxError(
                         f'VARIADIC argument `{arg.name}` '
                         f'cannot have a default value',
-                        context=arg.span)
+                        span=arg.span)
 
             elif arg.kind is qltypes.ParameterKind.NamedOnlyParam:
                 last_named_arg = arg
@@ -324,13 +324,13 @@ class ProcessFunctionParamsMixin:
                     raise EdgeQLSyntaxError(
                         f'positional argument `{arg.name}` '
                         f'follows NAMED ONLY argument `{last_named_arg.name}`',
-                        context=arg.span)
+                        span=arg.span)
 
                 if variadic_arg is not None:
                     raise EdgeQLSyntaxError(
                         f'positional argument `{arg.name}` '
                         f'follows VARIADIC argument `{variadic_arg.name}`',
-                        context=arg.span)
+                        span=arg.span)
 
             if arg.kind is qltypes.ParameterKind.PositionalParam:
                 if arg.default is None:
@@ -339,7 +339,7 @@ class ProcessFunctionParamsMixin:
                             f'positional argument `{arg.name}` without '
                             f'default follows positional argument '
                             f'`{last_pos_default_arg.name}` with default',
-                            context=arg.span)
+                            span=arg.span)
                 else:
                     last_pos_default_arg = arg
 
@@ -390,7 +390,7 @@ class FromFunction(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING FUNCTION clause',
-                context=ident.span) from None
+                span=ident.span) from None
 
         self.val = qlast.FunctionCode(
             language=lang,
@@ -402,7 +402,7 @@ class FromFunction(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=ident.span) from None
+                span=ident.span) from None
 
         self.val = qlast.FunctionCode(language=lang)
 
@@ -424,7 +424,7 @@ class ProcessFunctionBlockMixin:
                     if from_function is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING FUNCTION clause',
-                            context=node.span)
+                            span=node.span)
                     from_function = node.from_function
                     language = qlast.Language.SQL
 
@@ -432,7 +432,7 @@ class ProcessFunctionBlockMixin:
                     if code is not None or nativecode is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING <code> clause',
-                            context=node.span)
+                            span=node.span)
                     nativecode = node.nativecode
                     language = node.language
 
@@ -440,7 +440,7 @@ class ProcessFunctionBlockMixin:
                     if code is not None or nativecode is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING <code> clause',
-                            context=node.span)
+                            span=node.span)
                     code = node.code
                     language = node.language
 
@@ -460,14 +460,14 @@ class ProcessFunctionBlockMixin:
         ):
             raise EdgeQLSyntaxError(
                 'missing a USING clause',
-                context=block.span)
+                span=block.span)
 
         else:
             if from_expr and (from_function or code):
                 raise EdgeQLSyntaxError(
                     'USING SQL EXPRESSION is mutually exclusive with other '
                     'USING variants',
-                    context=block.span)
+                    span=block.span)
 
             props['code'] = qlast.FunctionCode(
                 language=language,
@@ -632,7 +632,7 @@ class ExtensionVersion(Nonterm):
             raise EdgeQLSyntaxError(
                 'invalid extension version format',
                 details='Expected a SemVer-compatible format.',
-                context=version.span,
+                span=version.span,
             ) from None
 
         self.val = version
@@ -655,7 +655,7 @@ class IndexArg(Nonterm):
         """
         raise EdgeQLSyntaxError(
             f'index parameters have to be NAMED ONLY',
-            context=kids[0].span)
+            span=kids[0].span)
 
     def reduce_kwarg_definition(self, kind, name, _, typemod, type, default):
         r"""%reduce ParameterKind FuncDeclArgName COLON \
@@ -664,7 +664,7 @@ class IndexArg(Nonterm):
         if kind.val is not qltypes.ParameterKind.NamedOnlyParam:
             raise EdgeQLSyntaxError(
                 f'index parameters have to be NAMED ONLY',
-                context=kind.span)
+                span=kind.span)
 
         self.val = qlast.FuncParam(
             kind=kind.val,
@@ -684,7 +684,7 @@ class IndexArg(Nonterm):
     def reduce_FuncDeclArgName_OptDefault(self, name, default):
         raise EdgeQLSyntaxError(
             f'missing type declaration for the `{name.val}` parameter',
-            context=name.span)
+            span=name.span)
 
 
 class IndexArgList(parsing.ListNonterm, element=IndexArg,
@@ -725,13 +725,13 @@ class ProcessIndexMixin(ProcessFunctionParamsMixin):
             if isinstance(argval, qlast.FuncParam):
                 raise EdgeQLSyntaxError(
                     f"unexpected new parameter definition `{argval.name}`",
-                    context=argval.span)
+                    span=argval.span)
 
             argname, argname_ctx, arg = argval
             if argname in kwargs:
                 raise EdgeQLSyntaxError(
                     f"duplicate named argument `{argname}`",
-                    context=argname_ctx)
+                    span=argname_ctx)
 
             kwargs[argname] = arg
 
@@ -762,7 +762,7 @@ class ProcessIndexMixin(ProcessFunctionParamsMixin):
                 if code is not None:
                     raise EdgeQLSyntaxError(
                         'more than one USING <code> clause',
-                        context=node.span)
+                        span=node.span)
                 props['code'] = node
             else:
                 commands.append(node)

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -49,7 +49,7 @@ def _parse_language(node):
     except ValueError:
         raise EdgeQLSyntaxError(
             f'{node.val} is not a valid language',
-            context=node.context) from None
+            context=node.span) from None
 
 
 def _validate_declarations(
@@ -69,7 +69,7 @@ def _validate_declarations(
             raise EdgeQLSyntaxError(
                 "only fully-qualified name is allowed in "
                 "top-level declaration",
-                context=decl.name.context)
+                context=decl.name.span)
 
 
 def extract_bases(bases, commands):
@@ -80,7 +80,7 @@ def extract_bases(bases, commands):
             if vbases:
                 raise EdgeQLSyntaxError(
                     "specifying EXTENDING twice is not allowed",
-                    context=command.context)
+                    context=command.span)
             vbases = command.bases
         else:
             vcommands.append(command)
@@ -230,18 +230,18 @@ class OptParameterKind(Nonterm):
 class FuncDeclArgName(Nonterm):
     def reduce_Identifier(self, dp):
         self.val = dp.val
-        self.context = dp.context
+        self.span = dp.span
 
     def reduce_PARAMETER(self, dp):
         if dp.val[1].isdigit():
             raise EdgeQLSyntaxError(
                 f'numeric parameters are not supported',
-                context=dp.context)
+                context=dp.span)
         else:
             raise EdgeQLSyntaxError(
                 f"function parameters do not need a $ prefix, "
                 f"rewrite as '{dp.val[1:]}'",
-                context=dp.context)
+                context=dp.span)
 
 
 class FuncDeclArg(Nonterm):
@@ -262,7 +262,7 @@ class FuncDeclArg(Nonterm):
     ):
         raise EdgeQLSyntaxError(
             f'missing type declaration for the `{name.val}` parameter',
-            context=name.context
+            context=name.span
         )
 
 
@@ -294,19 +294,19 @@ class ProcessFunctionParamsMixin:
             if arg.name in names:
                 raise EdgeQLSyntaxError(
                     f'duplicate parameter name `{arg.name}`',
-                    context=arg.context)
+                    context=arg.span)
             names.add(arg.name)
 
             if arg.kind is qltypes.ParameterKind.VariadicParam:
                 if variadic_arg is not None:
                     raise EdgeQLSyntaxError(
                         'more than one variadic argument',
-                        context=arg.context)
+                        context=arg.span)
                 elif last_named_arg is not None:
                     raise EdgeQLSyntaxError(
                         f'NAMED ONLY argument `{last_named_arg.name}` '
                         f'before VARIADIC argument `{arg.name}`',
-                        context=last_named_arg.context)
+                        context=last_named_arg.span)
                 else:
                     variadic_arg = arg
 
@@ -314,7 +314,7 @@ class ProcessFunctionParamsMixin:
                     raise EdgeQLSyntaxError(
                         f'VARIADIC argument `{arg.name}` '
                         f'cannot have a default value',
-                        context=arg.context)
+                        context=arg.span)
 
             elif arg.kind is qltypes.ParameterKind.NamedOnlyParam:
                 last_named_arg = arg
@@ -324,13 +324,13 @@ class ProcessFunctionParamsMixin:
                     raise EdgeQLSyntaxError(
                         f'positional argument `{arg.name}` '
                         f'follows NAMED ONLY argument `{last_named_arg.name}`',
-                        context=arg.context)
+                        context=arg.span)
 
                 if variadic_arg is not None:
                     raise EdgeQLSyntaxError(
                         f'positional argument `{arg.name}` '
                         f'follows VARIADIC argument `{variadic_arg.name}`',
-                        context=arg.context)
+                        context=arg.span)
 
             if arg.kind is qltypes.ParameterKind.PositionalParam:
                 if arg.default is None:
@@ -339,7 +339,7 @@ class ProcessFunctionParamsMixin:
                             f'positional argument `{arg.name}` without '
                             f'default follows positional argument '
                             f'`{last_pos_default_arg.name}` with default',
-                            context=arg.context)
+                            context=arg.span)
                 else:
                     last_pos_default_arg = arg
 
@@ -390,7 +390,7 @@ class FromFunction(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING FUNCTION clause',
-                context=ident.context) from None
+                context=ident.span) from None
 
         self.val = qlast.FunctionCode(
             language=lang,
@@ -402,7 +402,7 @@ class FromFunction(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=ident.context) from None
+                context=ident.span) from None
 
         self.val = qlast.FunctionCode(language=lang)
 
@@ -424,7 +424,7 @@ class ProcessFunctionBlockMixin:
                     if from_function is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING FUNCTION clause',
-                            context=node.context)
+                            context=node.span)
                     from_function = node.from_function
                     language = qlast.Language.SQL
 
@@ -432,7 +432,7 @@ class ProcessFunctionBlockMixin:
                     if code is not None or nativecode is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING <code> clause',
-                            context=node.context)
+                            context=node.span)
                     nativecode = node.nativecode
                     language = node.language
 
@@ -440,7 +440,7 @@ class ProcessFunctionBlockMixin:
                     if code is not None or nativecode is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING <code> clause',
-                            context=node.context)
+                            context=node.span)
                     code = node.code
                     language = node.language
 
@@ -460,14 +460,14 @@ class ProcessFunctionBlockMixin:
         ):
             raise EdgeQLSyntaxError(
                 'missing a USING clause',
-                context=block.context)
+                context=block.span)
 
         else:
             if from_expr and (from_function or code):
                 raise EdgeQLSyntaxError(
                     'USING SQL EXPRESSION is mutually exclusive with other '
                     'USING variants',
-                    context=block.context)
+                    context=block.span)
 
             props['code'] = qlast.FunctionCode(
                 language=language,
@@ -632,7 +632,7 @@ class ExtensionVersion(Nonterm):
             raise EdgeQLSyntaxError(
                 'invalid extension version format',
                 details='Expected a SemVer-compatible format.',
-                context=version.context,
+                context=version.span,
             ) from None
 
         self.val = version
@@ -655,7 +655,7 @@ class IndexArg(Nonterm):
         """
         raise EdgeQLSyntaxError(
             f'index parameters have to be NAMED ONLY',
-            context=kids[0].context)
+            context=kids[0].span)
 
     def reduce_kwarg_definition(self, kind, name, _, typemod, type, default):
         r"""%reduce ParameterKind FuncDeclArgName COLON \
@@ -664,7 +664,7 @@ class IndexArg(Nonterm):
         if kind.val is not qltypes.ParameterKind.NamedOnlyParam:
             raise EdgeQLSyntaxError(
                 f'index parameters have to be NAMED ONLY',
-                context=kind.context)
+                context=kind.span)
 
         self.val = qlast.FuncParam(
             kind=kind.val,
@@ -677,14 +677,14 @@ class IndexArg(Nonterm):
     def reduce_AnyIdentifier_ASSIGN_Expr(self, ident, _, expr):
         self.val = (
             ident.val,
-            ident.context,
+            ident.span,
             expr.val,
         )
 
     def reduce_FuncDeclArgName_OptDefault(self, name, default):
         raise EdgeQLSyntaxError(
             f'missing type declaration for the `{name.val}` parameter',
-            context=name.context)
+            context=name.span)
 
 
 class IndexArgList(parsing.ListNonterm, element=IndexArg,
@@ -725,7 +725,7 @@ class ProcessIndexMixin(ProcessFunctionParamsMixin):
             if isinstance(argval, qlast.FuncParam):
                 raise EdgeQLSyntaxError(
                     f"unexpected new parameter definition `{argval.name}`",
-                    context=argval.context)
+                    context=argval.span)
 
             argname, argname_ctx, arg = argval
             if argname in kwargs:
@@ -762,7 +762,7 @@ class ProcessIndexMixin(ProcessFunctionParamsMixin):
                 if code is not None:
                     raise EdgeQLSyntaxError(
                         'more than one USING <code> clause',
-                        context=node.context)
+                        context=node.span)
                 props['code'] = node
             else:
                 commands.append(node)

--- a/edb/edgeql/parser/grammar/config.py
+++ b/edb/edgeql/parser/grammar/config.py
@@ -75,7 +75,7 @@ class ConfigStmt(Nonterm):
             f"Did you mean '{configure.val} "
             f"{'current' if database.val[0] == 'd' else 'CURRENT'} "
             f"{database.val}'?",
-            context=database.span)
+            span=database.span)
 
     def reduce_CONFIGURE_BRANCH_ConfigOp(self, configure, database, _config):
         raise errors.EdgeQLSyntaxError(
@@ -83,7 +83,7 @@ class ConfigStmt(Nonterm):
             f"Did you mean '{configure.val} "
             f"{'current' if database.val[0] == 'd' else 'CURRENT'} "
             f"{database.val}'?",
-            context=database.span)
+            span=database.span)
 
     def reduce_CONFIGURE_ConfigScope_ConfigOp(self, _, scope, op):
         self.val = op.val

--- a/edb/edgeql/parser/grammar/config.py
+++ b/edb/edgeql/parser/grammar/config.py
@@ -75,7 +75,7 @@ class ConfigStmt(Nonterm):
             f"Did you mean '{configure.val} "
             f"{'current' if database.val[0] == 'd' else 'CURRENT'} "
             f"{database.val}'?",
-            context=database.context)
+            context=database.span)
 
     def reduce_CONFIGURE_BRANCH_ConfigOp(self, configure, database, _config):
         raise errors.EdgeQLSyntaxError(
@@ -83,7 +83,7 @@ class ConfigStmt(Nonterm):
             f"Did you mean '{configure.val} "
             f"{'current' if database.val[0] == 'd' else 'CURRENT'} "
             f"{database.val}'?",
-            context=database.context)
+            context=database.span)
 
     def reduce_CONFIGURE_ConfigScope_ConfigOp(self, _, scope, op):
         self.val = op.val

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -30,7 +30,7 @@ from edb.errors import EdgeQLSyntaxError
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
-from edb.common import context as pctx
+from edb.common import span as span
 from edb.common import parsing
 
 from . import expressions
@@ -434,7 +434,7 @@ class NestedQLBlock(ProductionTpl):
         if sc2.context is not None:
             contexts.append(sc2.context)
         contexts.append(rbrace.context)
-        body.context = pctx.merge_context(contexts)
+        body.context = span.merge_context(contexts)
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
 
@@ -442,7 +442,7 @@ class NestedQLBlock(ProductionTpl):
         # LBRACE Semicolons NestedQLBlock OptSemicolons RBRACE
         fields, stmts = self._process_body(cmdlist.val)
         body = qlast.NestedQLBlock(commands=stmts)
-        body.context = pctx.merge_context(
+        body.context = span.merge_context(
             [sc1.context, cmdlist.context, sc2.context])
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
@@ -454,7 +454,7 @@ class NestedQLBlock(ProductionTpl):
         if len(kids) > 1:
             body.context = kids[1].context
         if body.context is None:
-            body.context = pctx.empty_context()
+            body.context = span.empty_context()
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=[])
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -30,7 +30,7 @@ from edb.errors import EdgeQLSyntaxError
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
-from edb.common import span as pspan
+from edb.common import span as edb_span
 from edb.common import parsing
 
 from . import expressions
@@ -434,7 +434,7 @@ class NestedQLBlock(ProductionTpl):
         if sc2.span is not None:
             contexts.append(sc2.span)
         contexts.append(rbrace.span)
-        body.span = pspan.merge_spans(contexts)
+        body.span = edb_span.merge_spans(contexts)
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
 
@@ -442,7 +442,7 @@ class NestedQLBlock(ProductionTpl):
         # LBRACE Semicolons NestedQLBlock OptSemicolons RBRACE
         fields, stmts = self._process_body(cmdlist.val)
         body = qlast.NestedQLBlock(commands=stmts)
-        body.span = pspan.merge_spans(
+        body.span = edb_span.merge_spans(
             [sc1.span, cmdlist.span, sc2.span])
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -285,7 +285,7 @@ class UnqualifiedPointerName(Nonterm):
         if kids[0].val.module:
             raise EdgeQLSyntaxError(
                 'unexpected fully-qualified name',
-                context=kids[0].val.context)
+                context=kids[0].val.span)
         self.val = kids[0].val
 
 
@@ -403,12 +403,12 @@ class NestedQLBlock(ProductionTpl):
                 if stmt.name not in self.allowed_fields:
                     raise errors.InvalidSyntaxError(
                         f'unexpected field: {stmt.name!r}',
-                        context=stmt.context,
+                        context=stmt.span,
                     )
                 if stmt.name in uniq_check:
                     raise errors.InvalidSyntaxError(
                         f'duplicate `SET {stmt.name} := ...`',
-                        context=stmt.context,
+                        context=stmt.span,
                     )
                 uniq_check.add(stmt.name)
                 fields.append(stmt)
@@ -420,9 +420,9 @@ class NestedQLBlock(ProductionTpl):
     def _get_text(self, body):
         # XXX: Workaround the rust lexer issue of returning
         # byte token offsets instead of character offsets.
-        src_start = body.context.start
-        src_end = body.context.end
-        buffer = body.context.buffer.encode('utf-8')
+        src_start = body.span.start
+        src_end = body.span.end
+        buffer = body.span.buffer.encode('utf-8')
         text = buffer[src_start:src_end].decode('utf-8').strip().strip('}{\n')
         return textwrap.dedent(text).strip('\n')
 
@@ -430,11 +430,11 @@ class NestedQLBlock(ProductionTpl):
         # LBRACE NestedQLBlock OptSemicolons RBRACE
         fields, stmts = self._process_body(cmdlist.val)
         body = qlast.NestedQLBlock(commands=stmts)
-        contexts = [lbrace.context, cmdlist.context]
-        if sc2.context is not None:
-            contexts.append(sc2.context)
-        contexts.append(rbrace.context)
-        body.context = span.merge_context(contexts)
+        contexts = [lbrace.span, cmdlist.span]
+        if sc2.span is not None:
+            contexts.append(sc2.span)
+        contexts.append(rbrace.span)
+        body.span = span.merge_spans(contexts)
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
 
@@ -442,8 +442,8 @@ class NestedQLBlock(ProductionTpl):
         # LBRACE Semicolons NestedQLBlock OptSemicolons RBRACE
         fields, stmts = self._process_body(cmdlist.val)
         body = qlast.NestedQLBlock(commands=stmts)
-        body.context = span.merge_context(
-            [sc1.context, cmdlist.context, sc2.context])
+        body.span = span.merge_spans(
+            [sc1.span, cmdlist.span, sc2.span])
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
 
@@ -452,9 +452,9 @@ class NestedQLBlock(ProductionTpl):
         self.val = []
         body = qlast.NestedQLBlock(commands=[])
         if len(kids) > 1:
-            body.context = kids[1].context
-        if body.context is None:
-            body.context = span.empty_context()
+            body.span = kids[1].span
+        if body.span is None:
+            body.span = span.empty_span()
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=[])
 
@@ -684,7 +684,7 @@ class DatabaseName(Nonterm):
             # few remaining reserved __keywords__.
             raise EdgeQLSyntaxError(
                 "identifiers surrounded by double underscores are forbidden",
-                context=kids[0].context)
+                context=kids[0].span)
 
         self.val = qlast.ObjectRef(
             module=None,
@@ -1866,17 +1866,17 @@ class CreateConcretePropertyStmt(Nonterm):
                 if target is not None:
                     raise EdgeQLSyntaxError(
                         f'computed property with more than one expression',
-                        context=kids[3].context)
+                        context=kids[3].span)
                 target = cmd.value
             elif isinstance(cmd, qlast.AlterAddInherit):
                 raise EdgeQLSyntaxError(
                     f'computed property cannot specify EXTENDING',
-                    context=kids[3].context)
+                    context=kids[3].span)
 
         if target is None:
             raise EdgeQLSyntaxError(
                 f'computed property without expression',
-                context=kids[3].context)
+                context=kids[3].span)
 
         self.val = qlast.CreateConcreteProperty(
             name=kids[3].val,
@@ -2203,17 +2203,17 @@ class CreateConcreteLinkStmt(Nonterm):
                 if target is not None:
                     raise EdgeQLSyntaxError(
                         f'computed link with more than one expression',
-                        context=kids[3].context)
+                        context=kids[3].span)
                 target = cmd.value
             elif isinstance(cmd, qlast.AlterAddInherit):
                 raise EdgeQLSyntaxError(
                     f'computed link cannot specify EXTENDING',
-                    context=kids[3].context)
+                    context=kids[3].span)
 
         if target is None:
             raise EdgeQLSyntaxError(
                 f'computed link without expression',
-                context=kids[3].context)
+                context=kids[3].span)
 
         self.val = qlast.CreateConcreteLink(
             name=kids[3].val,
@@ -2814,13 +2814,13 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING OPERATOR clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         m = re.match(SQL_OP_RE, kids[3].val.value)
         if not m:
             raise EdgeQLSyntaxError(
                 f'invalid syntax for USING OPERATOR clause',
-                context=kids[3].context) from None
+                context=kids[3].span) from None
 
         sql_operator = (m.group(1),)
         if m.group(2):
@@ -2834,13 +2834,13 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING FUNCTION clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         m = re.match(SQL_OP_RE, kids[3].val.value)
         if not m:
             raise EdgeQLSyntaxError(
                 f'invalid syntax for USING FUNCTION clause',
-                context=kids[3].context) from None
+                context=kids[3].span) from None
 
         sql_function = (m.group(1),)
         if m.group(2):
@@ -2854,7 +2854,7 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         self.val = qlast.OperatorCode(language=lang,
                                       code=kids[2].val.value)
@@ -2864,7 +2864,7 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         self.val = qlast.OperatorCode(language=lang)
 
@@ -2937,28 +2937,28 @@ class CreateOperatorStmt(Nonterm):
                     raise errors.InvalidOperatorDefinitionError(
                         'unexpected USING clause in abstract '
                         'operator definition',
-                        context=node.context,
+                        context=node.span,
                     )
 
                 if node.from_function:
                     if from_function is not None:
                         raise errors.InvalidOperatorDefinitionError(
                             'more than one USING FUNCTION clause',
-                            context=node.context)
+                            context=node.span)
                     from_function = node.from_function
 
                 elif node.from_operator:
                     if from_operator is not None:
                         raise errors.InvalidOperatorDefinitionError(
                             'more than one USING OPERATOR clause',
-                            context=node.context)
+                            context=node.span)
                     from_operator = node.from_operator
 
                 elif node.code:
                     if code is not None:
                         raise errors.InvalidOperatorDefinitionError(
                             'more than one USING <code> clause',
-                            context=node.context)
+                            context=node.span)
                     code = node.code
 
                 else:
@@ -2973,14 +2973,14 @@ class CreateOperatorStmt(Nonterm):
                     and not from_expr):
                 raise errors.InvalidOperatorDefinitionError(
                     'CREATE OPERATOR requires at least one USING clause',
-                    context=block.context)
+                    context=block.span)
 
             else:
                 if from_expr and (from_operator or from_function or code):
                     raise errors.InvalidOperatorDefinitionError(
                         'USING SQL EXPRESSION is mutually exclusive with '
                         'other USING variants',
-                        context=block.context)
+                        context=block.span)
 
                 props['code'] = qlast.OperatorCode(
                     language=qlast.Language.SQL,
@@ -3067,7 +3067,7 @@ class CastCode(Nonterm):
         if lang not in {qlast.Language.SQL, qlast.Language.EdgeQL}:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING FUNCTION clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang,
                                   from_function=kids[3].val.value)
@@ -3077,7 +3077,7 @@ class CastCode(Nonterm):
         if lang not in {qlast.Language.SQL, qlast.Language.EdgeQL}:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang,
                                   code=kids[2].val.value)
@@ -3087,7 +3087,7 @@ class CastCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING CAST clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang, from_cast=True)
 
@@ -3096,7 +3096,7 @@ class CastCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING EXPRESSION clause',
-                context=kids[1].context) from None
+                context=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang)
 
@@ -3142,14 +3142,14 @@ class CreateCastStmt(Nonterm):
                     if from_function is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING FUNCTION clause',
-                            context=node.context)
+                            context=node.span)
                     from_function = node.from_function
 
                 elif node.code:
                     if code is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING <code> clause',
-                            context=node.context)
+                            context=node.span)
                     code = node.code
 
                 elif node.from_cast:
@@ -3158,7 +3158,7 @@ class CreateCastStmt(Nonterm):
                     if from_cast:
                         raise EdgeQLSyntaxError(
                             'more than one USING CAST clause',
-                            context=node.context)
+                            context=node.span)
 
                     from_cast = True
 
@@ -3168,7 +3168,7 @@ class CreateCastStmt(Nonterm):
                     if from_expr:
                         raise EdgeQLSyntaxError(
                             'more than one USING EXPRESSION clause',
-                            context=node.context)
+                            context=node.span)
 
                     from_expr = True
 
@@ -3181,7 +3181,7 @@ class CreateCastStmt(Nonterm):
                 else:
                     raise EdgeQLSyntaxError(
                         'unexpected ALLOW clause',
-                        context=node.context)
+                        context=node.span)
 
             else:
                 commands.append(node)
@@ -3190,20 +3190,20 @@ class CreateCastStmt(Nonterm):
                 and not from_expr and not from_cast):
             raise EdgeQLSyntaxError(
                 'CREATE CAST requires at least one USING clause',
-                context=block.context)
+                context=block.span)
 
         else:
             if from_expr and (from_function or code or from_cast):
                 raise EdgeQLSyntaxError(
                     'USING SQL EXPRESSION is mutually exclusive with other '
                     'USING variants',
-                    context=block.context)
+                    context=block.span)
 
             if from_cast and (from_function or code or from_expr):
                 raise EdgeQLSyntaxError(
                     'USING SQL CAST is mutually exclusive with other '
                     'USING variants',
-                    context=block.context)
+                    context=block.span)
 
             props['code'] = qlast.CastCode(
                 language=qlast.Language.SQL,
@@ -3330,13 +3330,13 @@ class CreateGlobalStmt(Nonterm):
                 if target is not None:
                     raise EdgeQLSyntaxError(
                         f'computed global with more than one expression',
-                        context=kids[3].context)
+                        context=kids[3].span)
                 target = cmd.value
 
         if target is None:
             raise EdgeQLSyntaxError(
                 f'computed global without expression',
-                context=kids[3].context)
+                context=kids[3].span)
 
         self.val = qlast.CreateGlobal(
             name=kids[3].val,

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -285,7 +285,7 @@ class UnqualifiedPointerName(Nonterm):
         if kids[0].val.module:
             raise EdgeQLSyntaxError(
                 'unexpected fully-qualified name',
-                context=kids[0].val.span)
+                span=kids[0].val.span)
         self.val = kids[0].val
 
 
@@ -403,12 +403,12 @@ class NestedQLBlock(ProductionTpl):
                 if stmt.name not in self.allowed_fields:
                     raise errors.InvalidSyntaxError(
                         f'unexpected field: {stmt.name!r}',
-                        context=stmt.span,
+                        span=stmt.span,
                     )
                 if stmt.name in uniq_check:
                     raise errors.InvalidSyntaxError(
                         f'duplicate `SET {stmt.name} := ...`',
-                        context=stmt.span,
+                        span=stmt.span,
                     )
                 uniq_check.add(stmt.name)
                 fields.append(stmt)
@@ -684,7 +684,7 @@ class DatabaseName(Nonterm):
             # few remaining reserved __keywords__.
             raise EdgeQLSyntaxError(
                 "identifiers surrounded by double underscores are forbidden",
-                context=kids[0].span)
+                span=kids[0].span)
 
         self.val = qlast.ObjectRef(
             module=None,
@@ -1866,17 +1866,17 @@ class CreateConcretePropertyStmt(Nonterm):
                 if target is not None:
                     raise EdgeQLSyntaxError(
                         f'computed property with more than one expression',
-                        context=kids[3].span)
+                        span=kids[3].span)
                 target = cmd.value
             elif isinstance(cmd, qlast.AlterAddInherit):
                 raise EdgeQLSyntaxError(
                     f'computed property cannot specify EXTENDING',
-                    context=kids[3].span)
+                    span=kids[3].span)
 
         if target is None:
             raise EdgeQLSyntaxError(
                 f'computed property without expression',
-                context=kids[3].span)
+                span=kids[3].span)
 
         self.val = qlast.CreateConcreteProperty(
             name=kids[3].val,
@@ -2203,17 +2203,17 @@ class CreateConcreteLinkStmt(Nonterm):
                 if target is not None:
                     raise EdgeQLSyntaxError(
                         f'computed link with more than one expression',
-                        context=kids[3].span)
+                        span=kids[3].span)
                 target = cmd.value
             elif isinstance(cmd, qlast.AlterAddInherit):
                 raise EdgeQLSyntaxError(
                     f'computed link cannot specify EXTENDING',
-                    context=kids[3].span)
+                    span=kids[3].span)
 
         if target is None:
             raise EdgeQLSyntaxError(
                 f'computed link without expression',
-                context=kids[3].span)
+                span=kids[3].span)
 
         self.val = qlast.CreateConcreteLink(
             name=kids[3].val,
@@ -2814,13 +2814,13 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING OPERATOR clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         m = re.match(SQL_OP_RE, kids[3].val.value)
         if not m:
             raise EdgeQLSyntaxError(
                 f'invalid syntax for USING OPERATOR clause',
-                context=kids[3].span) from None
+                span=kids[3].span) from None
 
         sql_operator = (m.group(1),)
         if m.group(2):
@@ -2834,13 +2834,13 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING FUNCTION clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         m = re.match(SQL_OP_RE, kids[3].val.value)
         if not m:
             raise EdgeQLSyntaxError(
                 f'invalid syntax for USING FUNCTION clause',
-                context=kids[3].span) from None
+                span=kids[3].span) from None
 
         sql_function = (m.group(1),)
         if m.group(2):
@@ -2854,7 +2854,7 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         self.val = qlast.OperatorCode(language=lang,
                                       code=kids[2].val.value)
@@ -2864,7 +2864,7 @@ class OperatorCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         self.val = qlast.OperatorCode(language=lang)
 
@@ -2937,28 +2937,28 @@ class CreateOperatorStmt(Nonterm):
                     raise errors.InvalidOperatorDefinitionError(
                         'unexpected USING clause in abstract '
                         'operator definition',
-                        context=node.span,
+                        span=node.span,
                     )
 
                 if node.from_function:
                     if from_function is not None:
                         raise errors.InvalidOperatorDefinitionError(
                             'more than one USING FUNCTION clause',
-                            context=node.span)
+                            span=node.span)
                     from_function = node.from_function
 
                 elif node.from_operator:
                     if from_operator is not None:
                         raise errors.InvalidOperatorDefinitionError(
                             'more than one USING OPERATOR clause',
-                            context=node.span)
+                            span=node.span)
                     from_operator = node.from_operator
 
                 elif node.code:
                     if code is not None:
                         raise errors.InvalidOperatorDefinitionError(
                             'more than one USING <code> clause',
-                            context=node.span)
+                            span=node.span)
                     code = node.code
 
                 else:
@@ -2973,14 +2973,14 @@ class CreateOperatorStmt(Nonterm):
                     and not from_expr):
                 raise errors.InvalidOperatorDefinitionError(
                     'CREATE OPERATOR requires at least one USING clause',
-                    context=block.span)
+                    span=block.span)
 
             else:
                 if from_expr and (from_operator or from_function or code):
                     raise errors.InvalidOperatorDefinitionError(
                         'USING SQL EXPRESSION is mutually exclusive with '
                         'other USING variants',
-                        context=block.span)
+                        span=block.span)
 
                 props['code'] = qlast.OperatorCode(
                     language=qlast.Language.SQL,
@@ -3067,7 +3067,7 @@ class CastCode(Nonterm):
         if lang not in {qlast.Language.SQL, qlast.Language.EdgeQL}:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING FUNCTION clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang,
                                   from_function=kids[3].val.value)
@@ -3077,7 +3077,7 @@ class CastCode(Nonterm):
         if lang not in {qlast.Language.SQL, qlast.Language.EdgeQL}:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang,
                                   code=kids[2].val.value)
@@ -3087,7 +3087,7 @@ class CastCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING CAST clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang, from_cast=True)
 
@@ -3096,7 +3096,7 @@ class CastCode(Nonterm):
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
                 f'{lang} language is not supported in USING EXPRESSION clause',
-                context=kids[1].span) from None
+                span=kids[1].span) from None
 
         self.val = qlast.CastCode(language=lang)
 
@@ -3142,14 +3142,14 @@ class CreateCastStmt(Nonterm):
                     if from_function is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING FUNCTION clause',
-                            context=node.span)
+                            span=node.span)
                     from_function = node.from_function
 
                 elif node.code:
                     if code is not None:
                         raise EdgeQLSyntaxError(
                             'more than one USING <code> clause',
-                            context=node.span)
+                            span=node.span)
                     code = node.code
 
                 elif node.from_cast:
@@ -3158,7 +3158,7 @@ class CreateCastStmt(Nonterm):
                     if from_cast:
                         raise EdgeQLSyntaxError(
                             'more than one USING CAST clause',
-                            context=node.span)
+                            span=node.span)
 
                     from_cast = True
 
@@ -3168,7 +3168,7 @@ class CreateCastStmt(Nonterm):
                     if from_expr:
                         raise EdgeQLSyntaxError(
                             'more than one USING EXPRESSION clause',
-                            context=node.span)
+                            span=node.span)
 
                     from_expr = True
 
@@ -3181,7 +3181,7 @@ class CreateCastStmt(Nonterm):
                 else:
                     raise EdgeQLSyntaxError(
                         'unexpected ALLOW clause',
-                        context=node.span)
+                        span=node.span)
 
             else:
                 commands.append(node)
@@ -3190,20 +3190,20 @@ class CreateCastStmt(Nonterm):
                 and not from_expr and not from_cast):
             raise EdgeQLSyntaxError(
                 'CREATE CAST requires at least one USING clause',
-                context=block.span)
+                span=block.span)
 
         else:
             if from_expr and (from_function or code or from_cast):
                 raise EdgeQLSyntaxError(
                     'USING SQL EXPRESSION is mutually exclusive with other '
                     'USING variants',
-                    context=block.span)
+                    span=block.span)
 
             if from_cast and (from_function or code or from_expr):
                 raise EdgeQLSyntaxError(
                     'USING SQL CAST is mutually exclusive with other '
                     'USING variants',
-                    context=block.span)
+                    span=block.span)
 
             props['code'] = qlast.CastCode(
                 language=qlast.Language.SQL,
@@ -3330,13 +3330,13 @@ class CreateGlobalStmt(Nonterm):
                 if target is not None:
                     raise EdgeQLSyntaxError(
                         f'computed global with more than one expression',
-                        context=kids[3].span)
+                        span=kids[3].span)
                 target = cmd.value
 
         if target is None:
             raise EdgeQLSyntaxError(
                 f'computed global without expression',
-                context=kids[3].span)
+                span=kids[3].span)
 
         self.val = qlast.CreateGlobal(
             name=kids[3].val,

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -30,7 +30,7 @@ from edb.errors import EdgeQLSyntaxError
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
-from edb.common import span as span
+from edb.common import span as pspan
 from edb.common import parsing
 
 from . import expressions
@@ -434,7 +434,7 @@ class NestedQLBlock(ProductionTpl):
         if sc2.span is not None:
             contexts.append(sc2.span)
         contexts.append(rbrace.span)
-        body.span = span.merge_spans(contexts)
+        body.span = pspan.merge_spans(contexts)
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
 
@@ -442,7 +442,7 @@ class NestedQLBlock(ProductionTpl):
         # LBRACE Semicolons NestedQLBlock OptSemicolons RBRACE
         fields, stmts = self._process_body(cmdlist.val)
         body = qlast.NestedQLBlock(commands=stmts)
-        body.span = span.merge_spans(
+        body.span = pspan.merge_spans(
             [sc1.span, cmdlist.span, sc2.span])
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
@@ -454,7 +454,7 @@ class NestedQLBlock(ProductionTpl):
         if len(kids) > 1:
             body.span = kids[1].span
         if body.span is None:
-            body.span = span.empty_span()
+            body.span = qlast.Span.empty()
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=[])
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -430,11 +430,11 @@ class NestedQLBlock(ProductionTpl):
         # LBRACE NestedQLBlock OptSemicolons RBRACE
         fields, stmts = self._process_body(cmdlist.val)
         body = qlast.NestedQLBlock(commands=stmts)
-        contexts = [lbrace.span, cmdlist.span]
+        spans = [lbrace.span, cmdlist.span]
         if sc2.span is not None:
-            contexts.append(sc2.span)
-        contexts.append(rbrace.span)
-        body.span = edb_span.merge_spans(contexts)
+            spans.append(sc2.span)
+        spans.append(rbrace.span)
+        body.span = edb_span.merge_spans(spans)
         body.text = self._get_text(body)
         self.val = self.result(body=body, fields=fields)
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -299,7 +299,7 @@ class SimpleInsert(Nonterm):
             if not subj.expr:
                 raise errors.EdgeQLSyntaxError(
                     "insert shape expressions must have a type name",
-                    context=subj.span
+                    span=subj.span
                 )
             subj_path = subj.expr
             shape = subj.elements
@@ -324,7 +324,7 @@ class SimpleInsert(Nonterm):
                     f"the INSERT will be triggered conditionally in one of "
                     f"the branches."
                 ),
-                context=subj_path.span)
+                span=subj_path.span)
         else:
             raise errors.EdgeQLSyntaxError(
                 f"INSERT only works with object types, not arbitrary "
@@ -334,7 +334,7 @@ class SimpleInsert(Nonterm):
                     f"statement with parentheses in order to separate it "
                     f"from the rest of the expression."
                 ),
-                context=subj_path.span)
+                span=subj_path.span)
 
         self.val = qlast.InsertQuery(
             subject=objtype,
@@ -1716,7 +1716,7 @@ class FuncApplication(Nonterm):
                 if argname in kwargs:
                     raise errors.EdgeQLSyntaxError(
                         f"duplicate named argument `{argname}`",
-                        context=argname_ctx)
+                        span=argname_ctx)
 
                 last_named_seen = argname
                 kwargs[argname] = arg
@@ -1726,7 +1726,7 @@ class FuncApplication(Nonterm):
                     raise errors.EdgeQLSyntaxError(
                         f"positional argument after named "
                         f"argument `{last_named_seen}`",
-                        context=arg.span)
+                        span=arg.span)
                 args.append(arg)
 
         self.val = qlast.FunctionCall(func=name, args=args, kwargs=kwargs)
@@ -1757,12 +1757,12 @@ class FuncCallArgExpr(Nonterm):
         if kids[0].val[1].isdigit():
             raise errors.EdgeQLSyntaxError(
                 f"numeric named parameters are not supported",
-                context=kids[0].span)
+                span=kids[0].span)
         else:
             raise errors.EdgeQLSyntaxError(
                 f"named parameters do not need a '$' prefix, "
                 f"rewrite as '{kids[0].val[1:]} := ...'",
-                context=kids[0].span)
+                span=kids[0].span)
 
 
 class FuncCallArg(Nonterm):
@@ -1853,7 +1853,7 @@ class AnyIdentifier(Nonterm):
             # few remaining reserved __keywords__.
             raise errors.EdgeQLSyntaxError(
                 "identifiers surrounded by double underscores are forbidden",
-                context=kids[0].span)
+                span=kids[0].span)
 
         self.val = name
 
@@ -1954,20 +1954,20 @@ class CollectionTypeName(Nonterm):
             # `enum<bbbb, 'aaaa'>`
             raise errors.EdgeQLSyntaxError(
                 "mixing string type literals and type names is not supported",
-                context=lst.span)
+                span=lst.span)
 
         if has_items and has_nonstrval:
             # Prohibit cases like `tuple<a: int64, int32>`
             raise errors.EdgeQLSyntaxError(
                 "mixing named and unnamed subtype declarations "
                 "is not supported",
-                context=lst.span)
+                span=lst.span)
 
     def reduce_NodeName_LANGBRACKET_RANGBRACKET(self, *kids):
         # Constructs like `enum<>` or `array<>` aren't legal.
         raise errors.EdgeQLSyntaxError(
             'parametrized type must have at least one argument',
-            context=kids[1].span,
+            span=kids[1].span,
         )
 
     def reduce_NodeName_LANGBRACKET_SubtypeList_RANGBRACKET(self, *kids):

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -299,7 +299,7 @@ class SimpleInsert(Nonterm):
             if not subj.expr:
                 raise errors.EdgeQLSyntaxError(
                     "insert shape expressions must have a type name",
-                    context=subj.context
+                    context=subj.span
                 )
             subj_path = subj.expr
             shape = subj.elements
@@ -324,7 +324,7 @@ class SimpleInsert(Nonterm):
                     f"the INSERT will be triggered conditionally in one of "
                     f"the branches."
                 ),
-                context=subj_path.context)
+                context=subj_path.span)
         else:
             raise errors.EdgeQLSyntaxError(
                 f"INSERT only works with object types, not arbitrary "
@@ -334,7 +334,7 @@ class SimpleInsert(Nonterm):
                     f"statement with parentheses in order to separate it "
                     f"from the rest of the expression."
                 ),
-                context=subj_path.context)
+                context=subj_path.span)
 
         self.val = qlast.InsertQuery(
             subject=objtype,
@@ -458,7 +458,7 @@ class SimpleShapePath(Nonterm):
             qlast.Ptr(
                 name=kids[0].val.name,
                 direction=s_pointers.PointerDirection.Outbound,
-                context=kids[0].val.context,
+                span=kids[0].val.span,
             ),
         ]
 
@@ -470,7 +470,7 @@ class SimpleShapePath(Nonterm):
                 qlast.Ptr(
                     name=kids[1].val.name,
                     type='property',
-                    context=kids[1].val.context,
+                    span=kids[1].val.span,
                 )
             ]
         )
@@ -498,7 +498,7 @@ class FreeSimpleShapePointer(Nonterm):
             qlast.Ptr(
                 name=kids[0].val.name,
                 direction=s_pointers.PointerDirection.Outbound,
-                context=kids[0].val.context,
+                span=kids[0].val.span,
             ),
         ]
 
@@ -525,7 +525,7 @@ class ShapePath(Nonterm):
             qlast.Ptr(
                 name=kids[0].val.name,
                 direction=s_pointers.PointerDirection.Outbound,
-                context=kids[0].val.context,
+                span=kids[0].val.span,
             ),
         ]
 
@@ -544,7 +544,7 @@ class ShapePath(Nonterm):
                 qlast.Ptr(
                     name=kids[1].val.name,
                     type='property',
-                    context=kids[1].val.context,
+                    span=kids[1].val.span,
                 )
             ]
         )
@@ -558,7 +558,7 @@ class ShapePath(Nonterm):
             qlast.Ptr(
                 name=kids[2].val.name,
                 direction=s_pointers.PointerDirection.Outbound,
-                context=kids[2].val.context,
+                span=kids[2].val.span,
             ),
         ]
 
@@ -781,7 +781,7 @@ class ComputableShapePointer(Nonterm):
         self.val.required = False
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_REQUIRED_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -790,7 +790,7 @@ class ComputableShapePointer(Nonterm):
         self.val.required = True
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -799,7 +799,7 @@ class ComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.Many
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -808,7 +808,7 @@ class ComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.One
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_OPTIONAL_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -818,7 +818,7 @@ class ComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.Many
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_OPTIONAL_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -828,7 +828,7 @@ class ComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.One
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_REQUIRED_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -838,7 +838,7 @@ class ComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.Many
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_REQUIRED_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -848,7 +848,7 @@ class ComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.One
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_SimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -856,7 +856,7 @@ class ComputableShapePointer(Nonterm):
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[1].context,
+            span=kids[1].span,
         )
 
     def reduce_SimpleShapePointer_ADDASSIGN_Expr(self, *kids):
@@ -864,7 +864,7 @@ class ComputableShapePointer(Nonterm):
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.APPEND,
-            context=kids[1].context,
+            span=kids[1].span,
         )
 
     def reduce_SimpleShapePointer_REMASSIGN_Expr(self, *kids):
@@ -872,7 +872,7 @@ class ComputableShapePointer(Nonterm):
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.SUBTRACT,
-            context=kids[1].context,
+            span=kids[1].span,
         )
 
 
@@ -885,7 +885,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.required = False
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_REQUIRED_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -894,7 +894,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.required = True
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -903,7 +903,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.Many
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -912,7 +912,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.One
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[2].context,
+            span=kids[2].span,
         )
 
     def reduce_OPTIONAL_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -922,7 +922,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.Many
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_OPTIONAL_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -932,7 +932,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.One
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_REQUIRED_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -942,7 +942,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.Many
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_REQUIRED_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -952,7 +952,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.cardinality = qltypes.SchemaCardinality.One
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[3].context,
+            span=kids[3].span,
         )
 
     def reduce_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
@@ -960,7 +960,7 @@ class FreeComputableShapePointer(Nonterm):
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
-            context=kids[1].context,
+            span=kids[1].span,
         )
 
 
@@ -1474,7 +1474,7 @@ class NamedTuple(Nonterm):
 class NamedTupleElement(Nonterm):
     def reduce_ShortNodeName_ASSIGN_Expr(self, *kids):
         self.val = qlast.TupleElement(
-            name=qlast.Ptr(name=kids[0].val.name, context=kids[0].val.context),
+            name=qlast.Ptr(name=kids[0].val.name, span=kids[0].val.span),
             val=kids[2].val
         )
 
@@ -1726,7 +1726,7 @@ class FuncApplication(Nonterm):
                     raise errors.EdgeQLSyntaxError(
                         f"positional argument after named "
                         f"argument `{last_named_seen}`",
-                        context=arg.context)
+                        context=arg.span)
                 args.append(arg)
 
         self.val = qlast.FunctionCall(func=name, args=args, kwargs=kwargs)
@@ -1749,7 +1749,7 @@ class FuncCallArgExpr(Nonterm):
     def reduce_AnyIdentifier_ASSIGN_Expr(self, *kids):
         self.val = (
             kids[0].val,
-            kids[0].context,
+            kids[0].span,
             kids[2].val,
         )
 
@@ -1757,12 +1757,12 @@ class FuncCallArgExpr(Nonterm):
         if kids[0].val[1].isdigit():
             raise errors.EdgeQLSyntaxError(
                 f"numeric named parameters are not supported",
-                context=kids[0].context)
+                context=kids[0].span)
         else:
             raise errors.EdgeQLSyntaxError(
                 f"named parameters do not need a '$' prefix, "
                 f"rewrite as '{kids[0].val[1:]} := ...'",
-                context=kids[0].context)
+                context=kids[0].span)
 
 
 class FuncCallArg(Nonterm):
@@ -1853,7 +1853,7 @@ class AnyIdentifier(Nonterm):
             # few remaining reserved __keywords__.
             raise errors.EdgeQLSyntaxError(
                 "identifiers surrounded by double underscores are forbidden",
-                context=kids[0].context)
+                context=kids[0].span)
 
         self.val = name
 
@@ -1954,20 +1954,20 @@ class CollectionTypeName(Nonterm):
             # `enum<bbbb, 'aaaa'>`
             raise errors.EdgeQLSyntaxError(
                 "mixing string type literals and type names is not supported",
-                context=lst.context)
+                context=lst.span)
 
         if has_items and has_nonstrval:
             # Prohibit cases like `tuple<a: int64, int32>`
             raise errors.EdgeQLSyntaxError(
                 "mixing named and unnamed subtype declarations "
                 "is not supported",
-                context=lst.context)
+                context=lst.span)
 
     def reduce_NodeName_LANGBRACKET_RANGBRACKET(self, *kids):
         # Constructs like `enum<>` or `array<>` aren't legal.
         raise errors.EdgeQLSyntaxError(
             'parametrized type must have at least one argument',
-            context=kids[1].context,
+            context=kids[1].span,
         )
 
     def reduce_NodeName_LANGBRACKET_SubtypeList_RANGBRACKET(self, *kids):
@@ -2181,7 +2181,7 @@ class Keyword(parsing.Nonterm):
         for token in keywords.by_type[type].values():
             def method(inst, *kids):
                 inst.val = kids[0].val
-            method = span.has_context(method)
+            method = span.wrap_function_to_infer_spans(method)
             method.__doc__ = "%%reduce %s" % token
             method.__name__ = 'reduce_%s' % token
             setattr(cls, method.__name__, method)

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import collections
 import typing
 
-from edb.common import parsing, context
+from edb.common import parsing, span
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -2181,7 +2181,7 @@ class Keyword(parsing.Nonterm):
         for token in keywords.by_type[type].values():
             def method(inst, *kids):
                 inst.val = kids[0].val
-            method = context.has_context(method)
+            method = span.has_context(method)
             method.__doc__ = "%%reduce %s" % token
             method.__name__ = 'reduce_%s' % token
             setattr(cls, method.__name__, method)

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -816,7 +816,7 @@ class ConcreteUnknownPointerBlock(Nonterm):
                 else:
                     on_target_delete = cmd
 
-    def _extract_target(self, target, cmds, context, *, overloaded=False):
+    def _extract_target(self, target, cmds, span, *, overloaded=False):
         if target:
             return target, cmds
 
@@ -825,13 +825,13 @@ class ConcreteUnknownPointerBlock(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed link with more than one expression',
-                        span=context)
+                        span=span)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed link without expression',
-                span=context)
+                span=span)
 
         return target, cmds
 
@@ -1053,7 +1053,7 @@ sdl_commands_block(
 
 
 class ConcretePropertyBlock(Nonterm):
-    def _extract_target(self, target, cmds, context, *, overloaded=False):
+    def _extract_target(self, target, cmds, span, *, overloaded=False):
         if target:
             return target, cmds
 
@@ -1062,13 +1062,13 @@ class ConcretePropertyBlock(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed property with more than one expression',
-                        span=context)
+                        span=span)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed property without expression',
-                span=context)
+                span=span)
 
         return target, cmds
 
@@ -1310,7 +1310,7 @@ class ConcreteLinkBlock(Nonterm):
                 else:
                     on_target_delete = cmd
 
-    def _extract_target(self, target, cmds, context, *, overloaded=False):
+    def _extract_target(self, target, cmds, span, *, overloaded=False):
         if target:
             return target, cmds
 
@@ -1319,13 +1319,13 @@ class ConcreteLinkBlock(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed link with more than one expression',
-                        span=context)
+                        span=span)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed link without expression',
-                span=context)
+                span=span)
 
         return target, cmds
 
@@ -1772,7 +1772,7 @@ sdl_commands_block(
 
 
 class GlobalDeclaration(Nonterm):
-    def _extract_target(self, target, cmds, context, *, overloaded=False):
+    def _extract_target(self, target, cmds, span, *, overloaded=False):
         if target:
             return target, cmds
 
@@ -1781,13 +1781,13 @@ class GlobalDeclaration(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed global with more than one expression',
-                        span=context)
+                        span=span)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed property without expression',
-                span=context)
+                span=span)
 
         return target, cmds
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -342,16 +342,16 @@ class ModuleDeclaration(Nonterm):
             if isinstance(decl, qlast.ExtensionCommand):
                 raise errors.EdgeQLSyntaxError(
                     "'using extension' cannot be used inside a module block",
-                    context=decl.span)
+                    span=decl.span)
             elif isinstance(decl, qlast.FutureCommand):
                 raise errors.EdgeQLSyntaxError(
                     "'using future' cannot be used inside a module block",
-                    context=decl.span)
+                    span=decl.span)
             elif decl.name.module is not None:
                 raise errors.EdgeQLSyntaxError(
                     "fully-qualified name is not allowed in "
                     "a module declaration",
-                    context=decl.name.span)
+                    span=decl.name.span)
 
         self.val = qlast.ModuleDeclaration(
             # mirror what we do in CREATE MODULE
@@ -812,7 +812,7 @@ class ConcreteUnknownPointerBlock(Nonterm):
                 if on_target_delete:
                     raise errors.EdgeQLSyntaxError(
                         f"more than one 'on target delete' specification",
-                        context=cmd.span)
+                        span=cmd.span)
                 else:
                     on_target_delete = cmd
 
@@ -825,13 +825,13 @@ class ConcreteUnknownPointerBlock(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed link with more than one expression',
-                        context=context)
+                        span=context)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed link without expression',
-                context=context)
+                span=context)
 
         return target, cmds
 
@@ -1062,13 +1062,13 @@ class ConcretePropertyBlock(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed property with more than one expression',
-                        context=context)
+                        span=context)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed property without expression',
-                context=context)
+                span=context)
 
         return target, cmds
 
@@ -1306,7 +1306,7 @@ class ConcreteLinkBlock(Nonterm):
                 if on_target_delete:
                     raise errors.EdgeQLSyntaxError(
                         f"more than one 'on target delete' specification",
-                        context=cmd.span)
+                        span=cmd.span)
                 else:
                     on_target_delete = cmd
 
@@ -1319,13 +1319,13 @@ class ConcreteLinkBlock(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed link with more than one expression',
-                        context=context)
+                        span=context)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed link without expression',
-                context=context)
+                span=context)
 
         return target, cmds
 
@@ -1781,13 +1781,13 @@ class GlobalDeclaration(Nonterm):
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
                         f'computed global with more than one expression',
-                        context=context)
+                        span=context)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
                 f'computed property without expression',
-                context=context)
+                span=context)
 
         return target, cmds
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -342,16 +342,16 @@ class ModuleDeclaration(Nonterm):
             if isinstance(decl, qlast.ExtensionCommand):
                 raise errors.EdgeQLSyntaxError(
                     "'using extension' cannot be used inside a module block",
-                    context=decl.context)
+                    context=decl.span)
             elif isinstance(decl, qlast.FutureCommand):
                 raise errors.EdgeQLSyntaxError(
                     "'using future' cannot be used inside a module block",
-                    context=decl.context)
+                    context=decl.span)
             elif decl.name.module is not None:
                 raise errors.EdgeQLSyntaxError(
                     "fully-qualified name is not allowed in "
                     "a module declaration",
-                    context=decl.name.context)
+                    context=decl.name.span)
 
         self.val = qlast.ModuleDeclaration(
             # mirror what we do in CREATE MODULE
@@ -786,12 +786,12 @@ class PtrTarget(Nonterm):
         _arrow, type_expr = kids
 
         self.val = type_expr.val
-        self.context = type_expr.val.context
+        self.span = type_expr.val.span
 
     def reduce_COLON_FullTypeExpr(self, *kids):
         _, type_expr = kids
         self.val = type_expr.val
-        self.context = type_expr.val.context
+        self.span = type_expr.val.span
 
 
 class OptPtrTarget(Nonterm):
@@ -812,7 +812,7 @@ class ConcreteUnknownPointerBlock(Nonterm):
                 if on_target_delete:
                     raise errors.EdgeQLSyntaxError(
                         f"more than one 'on target delete' specification",
-                        context=cmd.context)
+                        context=cmd.span)
                 else:
                     on_target_delete = cmd
 
@@ -842,7 +842,7 @@ class ConcreteUnknownPointerBlock(Nonterm):
         """
         name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context)
+            opt_target.val, block.val, name.span)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteUnknownPointer(
             name=name.val,
@@ -859,7 +859,7 @@ class ConcreteUnknownPointerBlock(Nonterm):
         """
         quals, name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context)
+            opt_target.val, block.val, name.span)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteUnknownPointer(
             is_required=quals.val.required,
@@ -878,7 +878,7 @@ class ConcreteUnknownPointerBlock(Nonterm):
         """
         _, name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context, overloaded=True)
+            opt_target.val, block.val, name.span, overloaded=True)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteUnknownPointer(
             name=name.val,
@@ -898,7 +898,7 @@ class ConcreteUnknownPointerBlock(Nonterm):
         """
         _, quals, name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context, overloaded=True)
+            opt_target.val, block.val, name.span, overloaded=True)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteUnknownPointer(
             name=name.val,
@@ -1080,7 +1080,7 @@ class ConcretePropertyBlock(Nonterm):
         _, name, extending, target, commands_block = kids
 
         target, cmds = self._extract_target(
-            target.val, commands_block.val, name.context
+            target.val, commands_block.val, name.span
         )
         vbases, vcmds = commondl.extract_bases(extending.val, cmds)
         self.val = qlast.CreateConcreteProperty(
@@ -1098,7 +1098,7 @@ class ConcretePropertyBlock(Nonterm):
         (quals, property, name, extending, target, commands) = kids
 
         target, cmds = self._extract_target(
-            target.val, commands.val, property.context
+            target.val, commands.val, property.span
         )
         vbases, vcmds = commondl.extract_bases(extending.val, cmds)
         self.val = qlast.CreateConcreteProperty(
@@ -1117,7 +1117,7 @@ class ConcretePropertyBlock(Nonterm):
         """
         _, _, name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context, overloaded=True)
+            opt_target.val, block.val, name.span, overloaded=True)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteProperty(
             name=name.val,
@@ -1136,7 +1136,7 @@ class ConcretePropertyBlock(Nonterm):
         """
         _, quals, _, name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context, overloaded=True)
+            opt_target.val, block.val, name.span, overloaded=True)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteProperty(
             name=name.val,
@@ -1306,7 +1306,7 @@ class ConcreteLinkBlock(Nonterm):
                 if on_target_delete:
                     raise errors.EdgeQLSyntaxError(
                         f"more than one 'on target delete' specification",
-                        context=cmd.context)
+                        context=cmd.span)
                 else:
                     on_target_delete = cmd
 
@@ -1336,7 +1336,7 @@ class ConcreteLinkBlock(Nonterm):
         """
         _, name, extending, target, commands = kids
         target, cmds = self._extract_target(
-            target.val, commands.val, name.context
+            target.val, commands.val, name.span
         )
         vbases, vcmds = commondl.extract_bases(extending.val, cmds)
         self.val = qlast.CreateConcreteLink(
@@ -1354,7 +1354,7 @@ class ConcreteLinkBlock(Nonterm):
         """
         quals, _, name, extending, target, commands = kids
         target, cmds = self._extract_target(
-            target.val, commands.val, name.context
+            target.val, commands.val, name.span
         )
         vbases, vcmds = commondl.extract_bases(extending.val, cmds)
         self.val = qlast.CreateConcreteLink(
@@ -1374,7 +1374,7 @@ class ConcreteLinkBlock(Nonterm):
         """
         _, _, name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context, overloaded=True)
+            opt_target.val, block.val, name.span, overloaded=True)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteLink(
             name=name.val,
@@ -1394,7 +1394,7 @@ class ConcreteLinkBlock(Nonterm):
         """
         _, quals, _, name, opt_bases, opt_target, block = kids
         target, cmds = self._extract_target(
-            opt_target.val, block.val, name.context, overloaded=True)
+            opt_target.val, block.val, name.span, overloaded=True)
         vbases, vcmds = commondl.extract_bases(opt_bases.val, cmds)
         self.val = qlast.CreateConcreteLink(
             name=name.val,
@@ -1798,7 +1798,7 @@ class GlobalDeclaration(Nonterm):
         """
         quals, glob, name, target, commands = kids
         target, cmds = self._extract_target(
-            target.val, commands.val, glob.context
+            target.val, commands.val, glob.span
         )
         self.val = qlast.CreateGlobal(
             name=name.val,
@@ -1815,7 +1815,7 @@ class GlobalDeclaration(Nonterm):
         """
         glob, name, target, commands = kids
         target, cmds = self._extract_target(
-            target.val, commands.val, glob.context
+            target.val, commands.val, glob.span
         )
         self.val = qlast.CreateGlobal(
             name=name.val,

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -111,14 +111,14 @@ class TransactionStmt(Nonterm):
                 if isolation is not None:
                     raise errors.EdgeQLSyntaxError(
                         f"only one isolation level can be specified",
-                        context=mode_ctx)
+                        span=mode_ctx)
                 isolation = mode
 
             elif isinstance(mode, qltypes.TransactionAccessMode):
                 if access is not None:
                     raise errors.EdgeQLSyntaxError(
                         f"only one access mode can be specified",
-                        context=mode_ctx)
+                        span=mode_ctx)
                 access = mode
 
             else:
@@ -126,7 +126,7 @@ class TransactionStmt(Nonterm):
                 if deferrable is not None:
                     raise errors.EdgeQLSyntaxError(
                         f"deferrable mode can only be specified once",
-                        context=mode_ctx)
+                        span=mode_ctx)
                 deferrable = mode
 
         self.val = qlast.StartTransaction(
@@ -267,12 +267,12 @@ class DescribeStmt(Nonterm):
         ):
             raise errors.InvalidSyntaxError(
                 f'unexpected DESCRIBE format: {lang!r}',
-                context=kids[3].span,
+                span=kids[3].span,
             )
         if kids[3].val.options:
             raise errors.InvalidSyntaxError(
                 f'DESCRIBE CURRENT MIGRATION does not support options',
-                context=kids[3].span,
+                span=kids[3].span,
             )
 
         self.val = qlast.DescribeCurrentMigration(

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -63,23 +63,23 @@ class TransactionMode(Nonterm):
 
     def reduce_ISOLATION_SERIALIZABLE(self, *kids):
         self.val = (qltypes.TransactionIsolationLevel.SERIALIZABLE,
-                    kids[0].context)
+                    kids[0].span)
 
     def reduce_READ_WRITE(self, *kids):
         self.val = (qltypes.TransactionAccessMode.READ_WRITE,
-                    kids[0].context)
+                    kids[0].span)
 
     def reduce_READ_ONLY(self, *kids):
         self.val = (qltypes.TransactionAccessMode.READ_ONLY,
-                    kids[0].context)
+                    kids[0].span)
 
     def reduce_DEFERRABLE(self, *kids):
         self.val = (qltypes.TransactionDeferMode.DEFERRABLE,
-                    kids[0].context)
+                    kids[0].span)
 
     def reduce_NOT_DEFERRABLE(self, *kids):
         self.val = (qltypes.TransactionDeferMode.NOT_DEFERRABLE,
-                    kids[0].context)
+                    kids[0].span)
 
 
 class TransactionModeList(ListNonterm, element=TransactionMode,
@@ -191,7 +191,7 @@ class DescribeFormat(Nonterm):
             language=qltypes.DescribeLanguage.TEXT,
             options=qlast.Options(
                 options={'VERBOSE': qlast.OptionFlag(
-                    name='VERBOSE', val=True, context=kids[2].context)}
+                    name='VERBOSE', val=True, span=kids[2].span)}
             ),
         )
 
@@ -267,12 +267,12 @@ class DescribeStmt(Nonterm):
         ):
             raise errors.InvalidSyntaxError(
                 f'unexpected DESCRIBE format: {lang!r}',
-                context=kids[3].context,
+                context=kids[3].span,
             )
         if kids[3].val.options:
             raise errors.InvalidSyntaxError(
                 f'DESCRIBE CURRENT MIGRATION does not support options',
-                context=kids[3].context,
+                context=kids[3].span,
             )
 
         self.val = qlast.DescribeCurrentMigration(

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -643,7 +643,7 @@ def trace_Global(
         ctx.refs.add(refname)
         tip = ctx.objects[refname]
     else:
-        tip = ctx.schema.get(refname, sourcectx=node.context)
+        tip = ctx.schema.get(refname, sourcectx=node.span)
     return tip
 
 
@@ -739,7 +739,7 @@ def trace_Path(
                     ctx.refs.add(refname)
                     tip = ctx.objects[refname]
                 else:
-                    tip = ctx.schema.get(refname, sourcectx=step.context)
+                    tip = ctx.schema.get(refname, sourcectx=step.span)
 
         elif isinstance(step, qlast.Ptr):
             pname = sn.UnqualName(step.name)
@@ -926,7 +926,7 @@ def _resolve_type_expr(
             obj: TypeLike
             if local_obj is None:
                 obj = ctx.schema.get(
-                    refname, type=s_types.Type, sourcectx=texpr.context)
+                    refname, type=s_types.Type, sourcectx=texpr.span)
             else:
                 assert isinstance(local_obj, Type)
                 obj = local_obj

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -88,7 +88,7 @@ def index_parameters(
         raise errors.SchemaDefinitionError(
             f'Expected {len(params) - 1} arguments, but found '
             f'{len(ql_args) - 1}',
-            context=ql_args[-1].context,
+            context=ql_args[-1].span,
             details='Did you mean to use ON (...) for specifying the subject?',
         )
 

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -88,7 +88,7 @@ def index_parameters(
         raise errors.SchemaDefinitionError(
             f'Expected {len(params) - 1} arguments, but found '
             f'{len(ql_args) - 1}',
-            context=ql_args[-1].span,
+            span=ql_args[-1].span,
             details='Did you mean to use ON (...) for specifying the subject?',
         )
 

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Any, Optional, Type, Iterator, Dict
 
-from edb.common import span as span
+from edb.common import span
 from edb.common import exceptions as ex
 
 import contextlib

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Any, Optional, Type, Iterator, Dict
 
-from edb.common import context as pctx
+from edb.common import span as span
 from edb.common import exceptions as ex
 
 import contextlib
@@ -103,7 +103,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         self._attrs = {}
         self._pgext_code = pgext_code
 
-        if isinstance(context, pctx.Span):
+        if isinstance(context, span.Span):
             self.set_source_context(context)
         elif position:
             self.set_position(*position)
@@ -143,7 +143,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def has_source_context(self):
         return FIELD_DETAILS in self._attrs
 
-    def set_source_context(self, context: Optional[pctx.Span]):
+    def set_source_context(self, context: Optional[span.Span]):
         if not context:
             return
 

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -89,22 +89,20 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         *,
         hint: Optional[str] = None,
         details: Optional[str] = None,
-        context=None,
+        span: Optional[edb_span.Span] = None,
         position: Optional[tuple[int, int, int, int | None]] = None,
         filename: Optional[str] = None,
-        token=None,
         pgext_code: Optional[str] = None,
     ):
         if type(self) is EdgeDBError:
             raise RuntimeError(
                 'EdgeDBError is not supposed to be instantiated directly')
 
-        self.token = token
         self._attrs = {}
         self._pgext_code = pgext_code
 
-        if isinstance(context, edb_span.Span):
-            self.set_span(context)
+        if span:
+            self.set_span(span)
         elif position:
             self.set_position(*position)
 

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -141,7 +141,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
             self._attrs[FIELD_DETAILS] = details
 
     def has_span(self):
-        return FIELD_DETAILS in self._attrs
+        return FIELD_POSITION_START in self._attrs
 
     def set_span(self, span: Optional[edb_span.Span]):
         if not span:

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -103,7 +103,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         self._attrs = {}
         self._pgext_code = pgext_code
 
-        if isinstance(context, pctx.ParserContext):
+        if isinstance(context, pctx.Span):
             self.set_source_context(context)
         elif position:
             self.set_position(*position)
@@ -143,7 +143,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def has_source_context(self):
         return FIELD_DETAILS in self._attrs
 
-    def set_source_context(self, context: Optional[pctx.ParserContext]):
+    def set_source_context(self, context: Optional[pctx.Span]):
         if not context:
             return
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -94,7 +94,7 @@ class Base(ast.AST):
     __abstract_node__ = True
     __ast_hidden__ = {'context'}
 
-    context: typing.Optional[parsing.ParserContext] = None
+    context: typing.Optional[parsing.Span] = None
 
     def __repr__(self) -> str:
         return (

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -70,7 +70,7 @@ import dataclasses
 import typing
 import uuid
 
-from edb.common import ast, compiler, parsing, markup, enum as s_enum
+from edb.common import ast, compiler, span, markup, enum as s_enum
 
 from edb.schema import modules as s_mod
 from edb.schema import name as sn
@@ -86,6 +86,8 @@ from .pathid import PathId, Namespace  # noqa
 from .scopetree import ScopeTreeNode  # noqa
 
 
+Span = span.Span
+
 def new_scope_tree() -> ScopeTreeNode:
     return ScopeTreeNode(fenced=True)
 
@@ -94,7 +96,7 @@ class Base(ast.AST):
     __abstract_node__ = True
     __ast_hidden__ = {'span'}
 
-    span: typing.Optional[parsing.Span] = None
+    span: typing.Optional[Span] = None
 
     def __repr__(self) -> str:
         return (

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -92,9 +92,9 @@ def new_scope_tree() -> ScopeTreeNode:
 
 class Base(ast.AST):
     __abstract_node__ = True
-    __ast_hidden__ = {'context'}
+    __ast_hidden__ = {'span'}
 
-    context: typing.Optional[parsing.Span] = None
+    span: typing.Optional[parsing.Span] = None
 
     def __repr__(self) -> str:
         return (
@@ -107,9 +107,9 @@ class Base(ast.AST):
 def _serialize_to_markup_base(
         ir: Base, *, ctx: typing.Any) -> typing.Any:
     node = ast.serialize_to_markup(ir, ctx=ctx)
-    has_context = bool(ir.context)
+    has_span = bool(ir.span)
     node.add_child(
-        label='has_context', node=markup.serialize(has_context, ctx=ctx))
+        label='has_span', node=markup.serialize(has_span, ctx=ctx))
     child = node.children.pop()
     node.children.insert(1, child)
     return node

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -44,7 +44,7 @@ import textwrap
 import weakref
 
 from edb import errors
-from edb.common import span as span
+from edb.common import span
 from edb.common import term
 from . import pathid
 from . import ast as irast

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -395,7 +395,7 @@ class ScopeTreeNode:
                 if child.path_id == node.path_id:
                     raise errors.InvalidReferenceError(
                         f'{node.path_id} is already present in {self!r}',
-                        context=span,
+                        span=span,
                     )
 
         if node.unique_id is not None:
@@ -533,7 +533,7 @@ class ScopeTreeNode:
                     raise errors.InvalidReferenceError(
                         f'cannot reference correlated set '
                         f'{path_id.pformat()!r} here',
-                        context=span,
+                        span=span,
                     )
 
                 # This path is already present in the tree, discard,
@@ -641,7 +641,7 @@ class ScopeTreeNode:
             raise errors.InvalidReferenceError(
                 f'cannot reference correlated set '
                 f'{path_id.pformat()!r} here',
-                context=span,
+                span=span,
             )
 
         if (
@@ -681,7 +681,7 @@ class ScopeTreeNode:
                 f'{imp}reference to {offending_id} '
                 f'changes the interpretation of {existing_id} '
                 f'elsewhere in the query',
-                context=span,
+                span=span,
             )
 
     def _node_paths_are_not_links(self) -> bool:

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -384,7 +384,7 @@ class ScopeTreeNode:
             pd.path_id = pd.path_id.strip_namespace(ns)
 
     def attach_child(self, node: ScopeTreeNode,
-                     context: Optional[span.Span]=None) -> None:
+                     span: Optional[span.Span]=None) -> None:
         """Attach a child node to this node.
 
         This is a low-level operation, no tree validation is
@@ -395,7 +395,7 @@ class ScopeTreeNode:
                 if child.path_id == node.path_id:
                     raise errors.InvalidReferenceError(
                         f'{node.path_id} is already present in {self!r}',
-                        context=context,
+                        context=span,
                     )
 
         if node.unique_id is not None:
@@ -422,7 +422,7 @@ class ScopeTreeNode:
         path_id: pathid.PathId,
         *,
         optional: bool=False,
-        context: Optional[span.Span],
+        span: Optional[span.Span],
     ) -> None:
         """Attach a scope subtree representing *path_id*."""
 
@@ -492,11 +492,11 @@ class ScopeTreeNode:
             if not prefix.is_tuple_indirection_path():
                 parent = new_child
 
-        self.attach_subtree(subtree, context=context)
+        self.attach_subtree(subtree, span=span)
 
     def attach_subtree(self, node: ScopeTreeNode,
                        was_fenced: bool=False,
-                       context: Optional[span.Span]=None) -> None:
+                       span: Optional[span.Span]=None) -> None:
         """Attach a subtree to this node.
 
         *node* is expected to be a balanced scope tree and may be modified
@@ -533,7 +533,7 @@ class ScopeTreeNode:
                     raise errors.InvalidReferenceError(
                         f'cannot reference correlated set '
                         f'{path_id.pformat()!r} here',
-                        context=context,
+                        context=span,
                     )
 
                 # This path is already present in the tree, discard,
@@ -551,7 +551,7 @@ class ScopeTreeNode:
                     descendant,
                     self_fenced=False,
                     node_fenced=desc_fenced,
-                    context=context)
+                    span=span)
 
             elif descendant.parent_fence is node:
                 # Unfenced path.
@@ -588,7 +588,7 @@ class ScopeTreeNode:
 
                     self._check_factoring_errors(
                         path_id, descendant, factor_point, existing,
-                        unnest_fence, existing_finfo, context,
+                        unnest_fence, existing_finfo, span,
                     )
 
                     existing_fenced = existing.parent_fence is not factor_point
@@ -610,7 +610,7 @@ class ScopeTreeNode:
                         current,
                         self_fenced=existing_fenced,
                         node_fenced=node_fenced,
-                        context=context)
+                        span=span)
 
                     current = existing
 
@@ -631,7 +631,7 @@ class ScopeTreeNode:
         existing: ScopeTreeNodeWithPathId,
         unnest_fence: bool,
         existing_finfo: FenceInfo,
-        context: Optional[span.Span],
+        span: Optional[span.Span],
     ) -> None:
         if existing_finfo.factoring_fence:
             # This node is already present in the surrounding
@@ -641,7 +641,7 @@ class ScopeTreeNode:
             raise errors.InvalidReferenceError(
                 f'cannot reference correlated set '
                 f'{path_id.pformat()!r} here',
-                context=context,
+                context=span,
             )
 
         if (
@@ -681,7 +681,7 @@ class ScopeTreeNode:
                 f'{imp}reference to {offending_id} '
                 f'changes the interpretation of {existing_id} '
                 f'elsewhere in the query',
-                context=context,
+                context=span,
             )
 
     def _node_paths_are_not_links(self) -> bool:
@@ -713,7 +713,7 @@ class ScopeTreeNode:
         node: ScopeTreeNode,
         self_fenced: bool=False,
         node_fenced: bool=False,
-        context: Optional[span.Span]=None,
+        span: Optional[span.Span]=None,
     ) -> None:
         node.remove()
 
@@ -730,7 +730,7 @@ class ScopeTreeNode:
         else:
             subtree = node
 
-        self.attach_subtree(subtree, was_fenced=self_fenced, context=context)
+        self.attach_subtree(subtree, was_fenced=self_fenced, span=span)
 
     def remove_subtree(self, node: ScopeTreeNode) -> None:
         """Remove the given subtree from this node."""

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -384,7 +384,7 @@ class ScopeTreeNode:
             pd.path_id = pd.path_id.strip_namespace(ns)
 
     def attach_child(self, node: ScopeTreeNode,
-                     context: Optional[pctx.ParserContext]=None) -> None:
+                     context: Optional[pctx.Span]=None) -> None:
         """Attach a child node to this node.
 
         This is a low-level operation, no tree validation is
@@ -422,7 +422,7 @@ class ScopeTreeNode:
         path_id: pathid.PathId,
         *,
         optional: bool=False,
-        context: Optional[pctx.ParserContext],
+        context: Optional[pctx.Span],
     ) -> None:
         """Attach a scope subtree representing *path_id*."""
 
@@ -496,7 +496,7 @@ class ScopeTreeNode:
 
     def attach_subtree(self, node: ScopeTreeNode,
                        was_fenced: bool=False,
-                       context: Optional[pctx.ParserContext]=None) -> None:
+                       context: Optional[pctx.Span]=None) -> None:
         """Attach a subtree to this node.
 
         *node* is expected to be a balanced scope tree and may be modified
@@ -631,7 +631,7 @@ class ScopeTreeNode:
         existing: ScopeTreeNodeWithPathId,
         unnest_fence: bool,
         existing_finfo: FenceInfo,
-        context: Optional[pctx.ParserContext],
+        context: Optional[pctx.Span],
     ) -> None:
         if existing_finfo.factoring_fence:
             # This node is already present in the surrounding
@@ -713,7 +713,7 @@ class ScopeTreeNode:
         node: ScopeTreeNode,
         self_fenced: bool=False,
         node_fenced: bool=False,
-        context: Optional[pctx.ParserContext]=None,
+        context: Optional[pctx.Span]=None,
     ) -> None:
         node.remove()
 

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -44,7 +44,7 @@ import textwrap
 import weakref
 
 from edb import errors
-from edb.common import context as pctx
+from edb.common import span as span
 from edb.common import term
 from . import pathid
 from . import ast as irast
@@ -384,7 +384,7 @@ class ScopeTreeNode:
             pd.path_id = pd.path_id.strip_namespace(ns)
 
     def attach_child(self, node: ScopeTreeNode,
-                     context: Optional[pctx.Span]=None) -> None:
+                     context: Optional[span.Span]=None) -> None:
         """Attach a child node to this node.
 
         This is a low-level operation, no tree validation is
@@ -422,7 +422,7 @@ class ScopeTreeNode:
         path_id: pathid.PathId,
         *,
         optional: bool=False,
-        context: Optional[pctx.Span],
+        context: Optional[span.Span],
     ) -> None:
         """Attach a scope subtree representing *path_id*."""
 
@@ -496,7 +496,7 @@ class ScopeTreeNode:
 
     def attach_subtree(self, node: ScopeTreeNode,
                        was_fenced: bool=False,
-                       context: Optional[pctx.Span]=None) -> None:
+                       context: Optional[span.Span]=None) -> None:
         """Attach a subtree to this node.
 
         *node* is expected to be a balanced scope tree and may be modified
@@ -631,7 +631,7 @@ class ScopeTreeNode:
         existing: ScopeTreeNodeWithPathId,
         unnest_fence: bool,
         existing_finfo: FenceInfo,
-        context: Optional[pctx.Span],
+        context: Optional[span.Span],
     ) -> None:
         if existing_finfo.factoring_fence:
             # This node is already present in the surrounding
@@ -713,7 +713,7 @@ class ScopeTreeNode:
         node: ScopeTreeNode,
         self_fenced: bool=False,
         node_fenced: bool=False,
-        context: Optional[pctx.Span]=None,
+        context: Optional[span.Span]=None,
     ) -> None:
         node.remove()
 

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -101,7 +101,7 @@ def evaluate_SelectStmt(
         return evaluate(ir_stmt.result, schema)
     else:
         raise UnsupportedExpressionError(
-            'expression is not constant', context=ir_stmt.span)
+            'expression is not constant', span=ir_stmt.span)
 
 
 @evaluate.register(irast.TypeCast)
@@ -140,7 +140,7 @@ def evaluate_Set(
         return evaluate(ir_set.expr, schema=schema)
     else:
         raise UnsupportedExpressionError(
-            'expression is not constant', context=ir_set.span)
+            'expression is not constant', span=ir_set.span)
 
 
 @evaluate.register(irast.ConstExpr)
@@ -176,7 +176,7 @@ def _process_op_result(
         qlconst = qlast.BooleanConstant.from_python(value)
     else:
         raise UnsupportedExpressionError(
-            f"unsupported result type: {type(value)}", context=srcctx
+            f"unsupported result type: {type(value)}", span=srcctx
         )
 
     result = qlcompiler.compile_constant_tree_to_ir(
@@ -212,7 +212,7 @@ def evaluate_OperatorCall(
     if eval_func is None:
         raise UnsupportedExpressionError(
             f'unsupported operator: {opcall.func_shortname}',
-            context=opcall.span)
+            span=opcall.span)
 
     args = []
     for arg in opcall.args:
@@ -220,11 +220,11 @@ def evaluate_OperatorCall(
         if isinstance(arg_val, tuple):
             raise UnsupportedExpressionError(
                 f'non-singleton operations are not supported',
-                context=opcall.span)
+                span=opcall.span)
         if arg_val is None:
             raise UnsupportedExpressionError(
                 f'empty operations are not supported',
-                context=opcall.span)
+                span=opcall.span)
 
         args.append(arg_val)
 
@@ -250,11 +250,11 @@ def evaluate_SliceIndirection(
         if isinstance(arg_val, tuple):
             raise UnsupportedExpressionError(
                 f'non-singleton operations are not supported',
-                context=slice.span)
+                span=slice.span)
         if arg_val is None:
             raise UnsupportedExpressionError(
                 f'empty operations are not supported',
-                context=slice.span)
+                span=slice.span)
 
     base, start, stop = vals
 
@@ -277,7 +277,7 @@ def _evaluate_union(
                 if isinstance(el, irast.Parameter):
                     raise UnsupportedExpressionError(
                         f'{el!r} not supported in UNION',
-                        context=opcall.span)
+                        span=opcall.span)
                 elements.append(el)
         elif isinstance(val, irast.EmptySet):
             empty_set = val
@@ -286,7 +286,7 @@ def _evaluate_union(
         else:
             raise UnsupportedExpressionError(
                 f'{val!r} not supported in UNION',
-                context=opcall.span)
+                span=opcall.span)
 
     if elements:
         return irast.ConstantSet(

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -167,7 +167,7 @@ def _process_op_result(
     typeref: irast.TypeRef,
     schema: s_schema.Schema,
     *,
-    srcctx: Optional[parsing.ParserContext]=None,
+    srcctx: Optional[parsing.Span]=None,
 ) -> irast.ConstExpr:
     qlconst: qlast.BaseConstant
     if isinstance(value, str):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -186,12 +186,12 @@ def get_source_context_as_json(
     expr: irast.Base,
     exctype: Type[errors.EdgeDBError] = errors.InternalServerError,
 ) -> str:
-    if expr.context:
+    if expr.span:
         details = json.dumps({
             # TODO(tailhook) should we add offset, utf16column here?
-            'line': expr.context.start_point.line,
-            'column': expr.context.start_point.column,
-            'name': expr.context.name,
+            'line': expr.span.start_point.line,
+            'column': expr.span.start_point.column,
+            'name': expr.span.name,
             'code': exctype.get_code(),
         })
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -182,7 +182,7 @@ def get_path_root(ir_set: irast.Set) -> irast.Set:
     return result
 
 
-def get_source_context_as_json(
+def get_span_as_json(
     expr: irast.Base,
     exctype: Type[errors.EdgeDBError] = errors.InternalServerError,
 ) -> str:

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -24,7 +24,7 @@ import dataclasses
 import typing
 import uuid
 
-from edb.common import ast, parsing
+from edb.common import ast, span
 from edb.common import typeutils
 from edb.edgeql import ast as qlast
 from edb.ir import ast as irast
@@ -38,10 +38,13 @@ from edb.ir import ast as irast
 # compiler.
 
 
+Span = span.Span
+
+
 class Base(ast.AST):
     __ast_hidden__ = {'span'}
 
-    span: typing.Optional[parsing.Span] = None
+    span: typing.Optional[Span] = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -39,9 +39,9 @@ from edb.ir import ast as irast
 
 
 class Base(ast.AST):
-    __ast_hidden__ = {'context'}
+    __ast_hidden__ = {'span'}
 
-    context: typing.Optional[parsing.Span] = None
+    span: typing.Optional[parsing.Span] = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -41,7 +41,7 @@ from edb.ir import ast as irast
 class Base(ast.AST):
     __ast_hidden__ = {'context'}
 
-    context: typing.Optional[parsing.ParserContext] = None
+    context: typing.Optional[parsing.Span] = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -183,7 +183,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
     def visit(self, node):  # type: ignore
         if self.with_translation_data:
             translation_data = TranslationData(
-                source_start=node.context.start if node.context else 0,
+                source_start=node.span.start if node.span else 0,
                 output_start=self.write_index,
             )
             old_top = self.translation_data

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -265,8 +265,10 @@ def compile_IndexIndirection(
     # line, column and filename are captured here to be used with the
     # error message
     srcctx = pgast.StringConstant(
-        val=irutils.get_source_context_as_json(expr.index,
-                                               errors.InvalidValueError))
+        val=irutils.get_span_as_json(
+            expr.index, errors.InvalidValueError
+        )
+    )
 
     with ctx.new() as subctx:
         subctx.expr_exposed = False

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3344,7 +3344,7 @@ def process_set_as_func_expr(
                         val=expr.error_on_null_result,
                     ),
                     pgast.StringConstant(
-                        val=irutils.get_source_context_as_json(
+                        val=irutils.get_span_as_json(
                             expr, errors.InvalidValueError),
                     ),
                 ]
@@ -3538,7 +3538,7 @@ def process_set_as_agg_expr_inner(
                         val=expr.error_on_null_result,
                     ),
                     pgast.StringConstant(
-                        val=irutils.get_source_context_as_json(
+                        val=irutils.get_span_as_json(
                             expr, errors.InvalidValueError),
                     ),
                 ]

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2149,7 +2149,7 @@ class ConstraintCommand(MetaCommand):
         cls,
         constraint: s_constr.Constraint,
         schema: s_schema.Schema,
-        source_context: Optional[parsing.ParserContext] = None,
+        source_context: Optional[parsing.Span] = None,
     ) -> dbops.Command:
         op = dbops.CommandGroup()
         if cls.constraint_is_effective(schema, constraint):
@@ -2169,7 +2169,7 @@ class ConstraintCommand(MetaCommand):
         cls,
         constraint: s_constr.Constraint,
         schema: s_schema.Schema,
-        source_context: Optional[parsing.ParserContext] = None,
+        source_context: Optional[parsing.Span] = None,
     ) -> dbops.Command:
         op = dbops.CommandGroup()
         if cls.constraint_is_effective(schema, constraint):
@@ -2189,7 +2189,7 @@ class ConstraintCommand(MetaCommand):
         cls,
         constraint: s_constr.Constraint,
         schema: s_schema.Schema,
-        source_context: Optional[parsing.ParserContext] = None,
+        source_context: Optional[parsing.Span] = None,
     ) -> dbops.Command:
 
         if cls.constraint_is_effective(schema, constraint):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3728,8 +3728,8 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
             self.pgops.add(self.create_index(index, schema, context))
 
         except errors.EdgeDBError as e:
-            if not e.has_source_context():
-                e.set_source_context(self.span)
+            if not e.has_span():
+                e.set_span(self.span)
             raise e
 
         # FTS

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2117,7 +2117,7 @@ class ConstraintCommand(MetaCommand):
     @classmethod
     def fixup_base_constraint_triggers(
         cls, constraint, orig_schema, schema, context,
-        source_context=None, *, is_delete
+        span=None, *, is_delete
     ):
         base_schema = orig_schema if is_delete else schema
 
@@ -2137,7 +2137,7 @@ class ConstraintCommand(MetaCommand):
             ):
                 subject = base.get_subject(schema)
                 bconstr = schemamech.compile_constraint(
-                    subject, base, schema, source_context
+                    subject, base, schema, span
                 )
                 op.add_command(bconstr.alter_ops(
                     bconstr, only_modify_enabled=True))
@@ -2149,7 +2149,7 @@ class ConstraintCommand(MetaCommand):
         cls,
         constraint: s_constr.Constraint,
         schema: s_schema.Schema,
-        source_context: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> dbops.Command:
         op = dbops.CommandGroup()
         if cls.constraint_is_effective(schema, constraint):
@@ -2157,7 +2157,7 @@ class ConstraintCommand(MetaCommand):
 
             if subject is not None:
                 bconstr = schemamech.compile_constraint(
-                    subject, constraint, schema, source_context
+                    subject, constraint, schema, span
                 )
 
                 op.add_command(bconstr.create_ops())
@@ -2169,7 +2169,7 @@ class ConstraintCommand(MetaCommand):
         cls,
         constraint: s_constr.Constraint,
         schema: s_schema.Schema,
-        source_context: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> dbops.Command:
         op = dbops.CommandGroup()
         if cls.constraint_is_effective(schema, constraint):
@@ -2177,7 +2177,7 @@ class ConstraintCommand(MetaCommand):
 
             if subject is not None:
                 bconstr = schemamech.compile_constraint(
-                    subject, constraint, schema, source_context
+                    subject, constraint, schema, span
                 )
 
                 op.add_command(bconstr.delete_ops())
@@ -2189,7 +2189,7 @@ class ConstraintCommand(MetaCommand):
         cls,
         constraint: s_constr.Constraint,
         schema: s_schema.Schema,
-        source_context: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> dbops.Command:
 
         if cls.constraint_is_effective(schema, constraint):
@@ -2197,7 +2197,7 @@ class ConstraintCommand(MetaCommand):
 
             if subject is not None:
                 bconstr = schemamech.compile_constraint(
-                    subject, constraint, schema, source_context
+                    subject, constraint, schema, span
                 )
 
                 return bconstr.enforce_ops()

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1112,7 +1112,7 @@ class FunctionCommand(MetaCommand):
             raise errors.QueryError(
                 f'could not compile parameter type {obj!r} '
                 f'of function {func.get_shortname(schema)}',
-                context=self.span) from None
+                span=self.span) from None
 
     def compile_default(self, func: s_funcs.Function,
                         default: s_expr.Expression, schema):
@@ -1134,7 +1134,7 @@ class FunctionCommand(MetaCommand):
             raise errors.QueryError(
                 f'could not compile default expression {default!r} '
                 f'of function {func.get_shortname(schema)}: {ex}',
-                context=self.span) from ex
+                span=self.span) from ex
 
     def compile_args(self, func: s_funcs.Function, schema):
         func_params = func.get_params(schema)
@@ -1559,7 +1559,7 @@ class FunctionCommand(MetaCommand):
                 raise errors.QueryError(
                     f'cannot compile function {func.get_shortname(schema)}: '
                     f'unsupported language {func_language}',
-                    context=self.span)
+                    span=self.span)
 
             op = dbops.CreateFunction(dbf, or_replace=or_replace)
             return (op,)
@@ -1890,7 +1890,7 @@ class CreateOperator(OperatorCommand, adapts=s_opers.CreateOperator):
                 f'cannot create operator {oper.get_shortname(schema)}: '
                 f'only "FROM SQL" and "FROM SQL OPERATOR" operators '
                 f'are currently supported',
-                context=self.span)
+                span=self.span)
 
         return schema
 
@@ -1979,7 +1979,7 @@ class CreateCast(CastCommand, adapts=s_casts.CreateCast):
                 f'cannot create cast: '
                 f'only "FROM SQL" and "FROM SQL FUNCTION" casts '
                 f'are currently supported',
-                context=self.span)
+                span=self.span)
 
         return schema
 
@@ -4849,7 +4849,7 @@ class PointerMetaCommand(
             raise errors.UnsupportedFeatureError(
                 f'{problem} may not be used when converting/populating '
                 f'data in migrations',
-                context=self.span,
+                span=self.span,
             )
 
         # Non-trivial conversion expression means that we
@@ -5725,7 +5725,7 @@ class PropertyMetaCommand(PointerMetaCommand[s_props.Property]):
                             f'{prop.get_verbosename(schema, with_parent=True)}'
                             f' is too complicated; link property defaults '
                             f'must not depend on database contents',
-                            context=self.span)
+                            span=self.span)
 
                     cols = self.get_columns(
                         prop, schema, default_value, sets_required)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3724,13 +3724,8 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
             # Don't do anything for abstract indexes
             return schema
 
-        try:
+        with errors.ensure_span(self.span):
             self.pgops.add(self.create_index(index, schema, context))
-
-        except errors.EdgeDBError as e:
-            if not e.has_span():
-                e.set_span(self.span)
-            raise e
 
         # FTS
         if index.has_base_with_name(schema, sn.QualName('fts', 'index')):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1112,7 +1112,7 @@ class FunctionCommand(MetaCommand):
             raise errors.QueryError(
                 f'could not compile parameter type {obj!r} '
                 f'of function {func.get_shortname(schema)}',
-                context=self.source_context) from None
+                context=self.span) from None
 
     def compile_default(self, func: s_funcs.Function,
                         default: s_expr.Expression, schema):
@@ -1134,7 +1134,7 @@ class FunctionCommand(MetaCommand):
             raise errors.QueryError(
                 f'could not compile default expression {default!r} '
                 f'of function {func.get_shortname(schema)}: {ex}',
-                context=self.source_context) from ex
+                context=self.span) from ex
 
     def compile_args(self, func: s_funcs.Function, schema):
         func_params = func.get_params(schema)
@@ -1559,7 +1559,7 @@ class FunctionCommand(MetaCommand):
                 raise errors.QueryError(
                     f'cannot compile function {func.get_shortname(schema)}: '
                     f'unsupported language {func_language}',
-                    context=self.source_context)
+                    context=self.span)
 
             op = dbops.CreateFunction(dbf, or_replace=or_replace)
             return (op,)
@@ -1890,7 +1890,7 @@ class CreateOperator(OperatorCommand, adapts=s_opers.CreateOperator):
                 f'cannot create operator {oper.get_shortname(schema)}: '
                 f'only "FROM SQL" and "FROM SQL OPERATOR" operators '
                 f'are currently supported',
-                context=self.source_context)
+                context=self.span)
 
         return schema
 
@@ -1979,7 +1979,7 @@ class CreateCast(CastCommand, adapts=s_casts.CreateCast):
                 f'cannot create cast: '
                 f'only "FROM SQL" and "FROM SQL FUNCTION" casts '
                 f'are currently supported',
-                context=self.source_context)
+                context=self.span)
 
         return schema
 
@@ -2215,10 +2215,10 @@ class CreateConstraint(ConstraintCommand, adapts=s_constr.CreateConstraint):
         schema = super().apply(schema, context)
         constraint = self.scls
 
-        op = self.create_constraint(constraint, schema, self.source_context)
+        op = self.create_constraint(constraint, schema, self.span)
         self.pgops.add(op)
         self.pgops.add(self.fixup_base_constraint_triggers(
-            constraint, orig_schema, schema, context, self.source_context,
+            constraint, orig_schema, schema, context, self.span,
             is_delete=False))
 
         # If the constraint is being added to existing data,
@@ -2232,7 +2232,7 @@ class CreateConstraint(ConstraintCommand, adapts=s_constr.CreateConstraint):
             and not context.is_creating(subject)
         ):
             op = self.enforce_constraint(
-                constraint, schema, self.source_context
+                constraint, schema, self.span
             )
 
             # XXX: PostCommand or maybe even pg_ops have incorrect type
@@ -2284,14 +2284,14 @@ class AlterConstraint(
 
         if subject is not None:
             bconstr = schemamech.compile_constraint(
-                subject, constraint, schema, self.source_context
+                subject, constraint, schema, self.span
             )
 
             orig_bconstr = schemamech.compile_constraint(
                 constraint.get_subject(orig_schema),
                 constraint,
                 orig_schema,
-                self.source_context,
+                self.span,
             )
 
             op = dbops.CommandGroup()
@@ -2304,13 +2304,13 @@ class AlterConstraint(
                         child.get_subject(orig_schema),
                         child,
                         orig_schema,
-                        self.source_context,
+                        self.span,
                     )
                     cbconstr = schemamech.compile_constraint(
                         child.get_subject(schema),
                         child,
                         schema,
-                        self.source_context,
+                        self.span,
                     )
                     op.add_command(cbconstr.alter_ops(orig_cbconstr))
             elif not self.constraint_is_effective(schema, constraint):
@@ -2321,13 +2321,13 @@ class AlterConstraint(
                         child.get_subject(orig_schema),
                         child,
                         orig_schema,
-                        self.source_context,
+                        self.span,
                     )
                     cbconstr = schemamech.compile_constraint(
                         child.get_subject(schema),
                         child,
                         schema,
-                        self.source_context,
+                        self.span,
                     )
                     op.add_command(cbconstr.alter_ops(orig_cbconstr))
             else:
@@ -2342,7 +2342,7 @@ class AlterConstraint(
                 and not context.is_deleting(subject)
             ):
                 op = self.enforce_constraint(
-                    constraint, schema, self.source_context
+                    constraint, schema, self.span
                 )
                 self.schedule_post_inhview_update_command(
                     schema,
@@ -2352,7 +2352,7 @@ class AlterConstraint(
                     s_sources.SourceCommandContext)
 
             self.pgops.add(self.fixup_base_constraint_triggers(
-                constraint, orig_schema, schema, context, self.source_context,
+                constraint, orig_schema, schema, context, self.span,
                 is_delete=False))
 
         return schema
@@ -2370,12 +2370,12 @@ class DeleteConstraint(ConstraintCommand, adapts=s_constr.DeleteConstraint):
 
         schema = super().apply(schema, context)
         op = self.delete_constraint(
-            constraint, orig_schema, self.source_context
+            constraint, orig_schema, self.span
         )
         self.pgops.add(op)
 
         self.pgops.add(self.fixup_base_constraint_triggers(
-            constraint, orig_schema, schema, context, self.source_context,
+            constraint, orig_schema, schema, context, self.span,
             is_delete=True))
 
         return schema
@@ -3729,7 +3729,7 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
 
         except errors.EdgeDBError as e:
             if not e.has_source_context():
-                e.set_source_context(self.source_context)
+                e.set_source_context(self.span)
             raise e
 
         # FTS
@@ -4854,7 +4854,7 @@ class PointerMetaCommand(
             raise errors.UnsupportedFeatureError(
                 f'{problem} may not be used when converting/populating '
                 f'data in migrations',
-                context=self.source_context,
+                context=self.span,
             )
 
         # Non-trivial conversion expression means that we
@@ -5730,7 +5730,7 @@ class PropertyMetaCommand(PointerMetaCommand[s_props.Property]):
                             f'{prop.get_verbosename(schema, with_parent=True)}'
                             f' is too complicated; link property defaults '
                             f'must not depend on database contents',
-                            context=self.source_context)
+                            context=self.span)
 
                     cols = self.get_columns(
                         prop, schema, default_value, sets_required)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -35,7 +35,6 @@ import re
 
 import edb._edgeql_parser as ql_parser
 
-from edb.common import span
 from edb.common import debug
 from edb.common import exceptions
 from edb.common import uuidgen
@@ -7458,8 +7457,9 @@ async def execute_sql_script(
             text = sql_text
 
         if point is not None:
-            pcontext = span.Span(
-                'query', text, start=point, end=point, context_lines=30)
-            exceptions.replace_context(e, pcontext)
+            span = qlast.Span(
+                'query', text, start=point, end=point, context_lines=30
+            )
+            exceptions.replace_context(e, span)
 
         raise

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -35,7 +35,7 @@ import re
 
 import edb._edgeql_parser as ql_parser
 
-from edb.common import span as parser_context
+from edb.common import span
 from edb.common import debug
 from edb.common import exceptions
 from edb.common import uuidgen
@@ -7458,7 +7458,7 @@ async def execute_sql_script(
             text = sql_text
 
         if point is not None:
-            pcontext = parser_context.Span(
+            pcontext = span.Span(
                 'query', text, start=point, end=point, context_lines=30)
             exceptions.replace_context(e, pcontext)
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -7458,7 +7458,7 @@ async def execute_sql_script(
             text = sql_text
 
         if point is not None:
-            pcontext = parser_context.ParserContext(
+            pcontext = parser_context.Span(
                 'query', text, start=point, end=point, context_lines=30)
             exceptions.replace_context(e, pcontext)
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -35,7 +35,7 @@ import re
 
 import edb._edgeql_parser as ql_parser
 
-from edb.common import context as parser_context
+from edb.common import span as parser_context
 from edb.common import debug
 from edb.common import exceptions
 from edb.common import uuidgen

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -810,21 +810,21 @@ def _build_base_range_var(n: Node, c: Context) -> pgast.BaseRangeVar:
 
 def _build_const(n: Node, c: Context) -> pgast.BaseConstant:
     val = n["val"]
-    context = _build_span(n, c)
+    span = _build_span(n, c)
 
     if "Integer" in val:
         return pgast.NumericConstant(
-            val=str(val["Integer"]["ival"]), span=context
+            val=str(val["Integer"]["ival"]), span=span
         )
 
     if "Float" in val:
-        return pgast.NumericConstant(val=val["Float"]["str"], span=context)
+        return pgast.NumericConstant(val=val["Float"]["str"], span=span)
 
     if "Null" in val:
-        return pgast.NullConstant(span=context)
+        return pgast.NullConstant(span=span)
 
     if "String" in val:
-        return pgast.StringConstant(val=_build_str(val, c), span=context)
+        return pgast.StringConstant(val=_build_str(val, c), span=span)
 
     raise PSqlUnsupportedError(n)
 

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -31,7 +31,7 @@ from typing import (
     cast,
 )
 
-from edb.common.parsing import ParserContext
+from edb.common.parsing import Span
 
 from edb.pgsql import ast as pgast
 from edb.edgeql import ast as qlast
@@ -172,11 +172,11 @@ def _as_column_ref(name: str) -> pgast.ColumnRef:
     )
 
 
-def _build_context(n: Node, c: Context) -> Optional[ParserContext]:
+def _build_context(n: Node, c: Context) -> Optional[Span]:
     if 'location' not in n:
         return None
 
-    return ParserContext(
+    return Span(
         name="<string>",
         buffer=c.source_sql,
         start=n["location"],

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -172,7 +172,7 @@ def _as_column_ref(name: str) -> pgast.ColumnRef:
     )
 
 
-def _build_context(n: Node, c: Context) -> Optional[Span]:
+def _build_span(n: Node, c: Context) -> Optional[Span]:
     if 'location' not in n:
         return None
 
@@ -311,14 +311,14 @@ def _build_variable_set_stmt(n: Node, c: Context) -> pgast.Statement:
             scope=pgast.OptionsScope.TRANSACTION
             if n["name"] in tx_only_vars
             else pgast.OptionsScope.SESSION,
-            context=_build_context(n, c),
+            span=_build_span(n, c),
         )
 
     if n["kind"] == "VAR_RESET_ALL":
         return pgast.VariableResetStmt(
             name=None,
             scope=pgast.OptionsScope.SESSION,
-            context=_build_context(n, c),
+            span=_build_span(n, c),
         )
 
     if n["kind"] == "VAR_SET_MULTI":
@@ -338,7 +338,7 @@ def _build_variable_set_stmt(n: Node, c: Context) -> pgast.Statement:
             scope=pgast.OptionsScope.TRANSACTION
             if n["name"] in tx_only_vars or "is_local" in n and n["is_local"]
             else pgast.OptionsScope.SESSION,
-            context=_build_context(n, c),
+            span=_build_span(n, c),
         )
 
     if n["kind"] == "VAR_SET_DEFAULT":
@@ -347,7 +347,7 @@ def _build_variable_set_stmt(n: Node, c: Context) -> pgast.Statement:
             scope=pgast.OptionsScope.TRANSACTION
             if n["name"] in tx_only_vars or "is_local" in n and n["is_local"]
             else pgast.OptionsScope.SESSION,
-            context=_build_context(n, c),
+            span=_build_span(n, c),
         )
 
     raise PSqlUnsupportedError(n)
@@ -356,7 +356,7 @@ def _build_variable_set_stmt(n: Node, c: Context) -> pgast.Statement:
 def _build_variable_show_stmt(n: Node, c: Context) -> pgast.Statement:
     return pgast.VariableShowStmt(
         name=n["name"],
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -466,7 +466,7 @@ def _build_create(n: Node, c: Context) -> pgast.CreateStmt:
         relation=_build_relation(relation, c),
         table_elements=_maybe_list(n, c, 'tableElts', _build_table_element)
         or [],
-        context=_build_context(n, c),
+        span=_build_span(n, c),
         on_commit=_maybe(n, c, 'oncommit', _build_on_commit),
     )
 
@@ -500,7 +500,7 @@ def _build_column_def(n: Node, c: Context) -> pgast.ColumnDef:
         typename=_build_type_name(n['typeName'], c),
         default_expr=default_expr,
         is_not_null=is_not_null,
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -609,23 +609,23 @@ def _build_cte(n: Node, c: Context) -> pgast.CommonTableExpr:
         recursive=recursive,
         aliascolnames=_maybe_list(n, c, "aliascolnames", _build_str),
         materialized=materialized,
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
 def _build_keyword(name: str) -> Builder[pgast.Keyword]:
-    return lambda n, c: pgast.Keyword(name=name, context=_build_context(n, c))
+    return lambda n, c: pgast.Keyword(name=name, span=_build_span(n, c))
 
 
 def _build_param_ref(n: Node, c: Context) -> pgast.ParamRef:
-    return pgast.ParamRef(number=n["number"], context=_build_context(n, c))
+    return pgast.ParamRef(number=n["number"], span=_build_span(n, c))
 
 
 def _build_collate_clause(n: Node, c: Context) -> pgast.CollateClause:
     return pgast.CollateClause(
         arg=_build_base_expr(n['arg'], c),
         collname='.'.join(_list(n, c, 'collname', _build_str)),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -641,7 +641,7 @@ def _build_min_max_expr(n: Node, c: Context) -> pgast.MinMaxExpr:
     return pgast.MinMaxExpr(
         op=op,
         args=_list(n, c, 'args', _build_base_expr),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -695,7 +695,7 @@ def _build_sub_link(n: Node, c: Context) -> pgast.SubLink:
         operator=operator,
         expr=_build_query(n["subselect"], c),
         test_expr=_maybe(n, c, 'testexpr', _build_base_expr),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -706,9 +706,9 @@ def _build_row_expr(n: Node, c: Context) -> pgast.BaseExpr:
 
     format = n.get('row_format', None)
     if format in {'COERCE_EXPLICIT_CALL', 'COERCE_EXPLICIT_CAST'}:
-        return pgast.RowExpr(args=args, context=_build_context(n, c))
+        return pgast.RowExpr(args=args, span=_build_span(n, c))
     else:
-        return pgast.ImplicitRowExpr(args=args, context=_build_context(n, c))
+        return pgast.ImplicitRowExpr(args=args, span=_build_span(n, c))
 
 
 def _build_boolean_test(n: Node, c: Context) -> pgast.BooleanTest:
@@ -716,7 +716,7 @@ def _build_boolean_test(n: Node, c: Context) -> pgast.BooleanTest:
         arg=_build_base_expr(n["arg"], c),
         negated=n["booltesttype"].startswith("IS_NOT"),
         is_true=n["booltesttype"].endswith("TRUE"),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -724,7 +724,7 @@ def _build_null_test(n: Node, c: Context) -> pgast.NullTest:
     return pgast.NullTest(
         arg=_build_base_expr(n["arg"], c),
         negated=n["nulltesttype"] == "IS_NOT_NULL",
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -732,7 +732,7 @@ def _build_type_cast(n: Node, c: Context) -> pgast.TypeCast:
     return pgast.TypeCast(
         arg=_build_base_expr(n["arg"], c),
         type_name=_build_type_name(n["typeName"], c),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -753,7 +753,7 @@ def _build_type_name(n: Node, c: Context) -> pgast.TypeName:
         setof=_bool_or_false(n, "setof"),
         typmods=None,
         array_bounds=_maybe_list(n, c, "arrayBounds", unwrap_int),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -762,7 +762,7 @@ def _build_case_expr(n: Node, c: Context) -> pgast.CaseExpr:
         arg=_maybe(n, c, "arg", _build_base_expr),
         args=_list(n, c, "args", _build_case_when),
         defresult=_maybe(n, c, "defresult", _build_base_expr),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -771,7 +771,7 @@ def _build_case_when(n: Node, c: Context) -> pgast.CaseWhen:
     return pgast.CaseWhen(
         expr=_build_base_expr(n["expr"], c),
         result=_build_base_expr(n["result"], c),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -782,14 +782,14 @@ def _build_bool_expr(n: Node, c: Context) -> pgast.Expr:
         name=name,
         lexpr=_build_base_expr(args.pop(0), c) if len(args) > 1 else None,
         rexpr=_build_base_expr(args.pop(0), c) if len(args) > 0 else None,
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
     while len(args) > 0:
         res = pgast.Expr(
             name=_build_str(n["boolop"], c)[0:-5],
             lexpr=res,
             rexpr=_build_base_expr(args.pop(0), c) if len(args) > 0 else None,
-            context=_build_context(n, c),
+            span=_build_span(n, c),
         )
     return res
 
@@ -810,21 +810,21 @@ def _build_base_range_var(n: Node, c: Context) -> pgast.BaseRangeVar:
 
 def _build_const(n: Node, c: Context) -> pgast.BaseConstant:
     val = n["val"]
-    context = _build_context(n, c)
+    context = _build_span(n, c)
 
     if "Integer" in val:
         return pgast.NumericConstant(
-            val=str(val["Integer"]["ival"]), context=context
+            val=str(val["Integer"]["ival"]), span=context
         )
 
     if "Float" in val:
-        return pgast.NumericConstant(val=val["Float"]["str"], context=context)
+        return pgast.NumericConstant(val=val["Float"]["str"], span=context)
 
     if "Null" in val:
-        return pgast.NullConstant(context=context)
+        return pgast.NullConstant(span=context)
 
     if "String" in val:
-        return pgast.StringConstant(val=_build_str(val, c), context=context)
+        return pgast.StringConstant(val=_build_str(val, c), span=context)
 
     raise PSqlUnsupportedError(n)
 
@@ -871,7 +871,7 @@ def _build_rel_range_var(n: Node, c: Context) -> pgast.RelRangeVar:
         alias=_maybe(n, c, "alias", _build_alias) or pgast.Alias(aliasname=""),
         relation=_build_relation(n, c),
         include_inherited=_bool_or_false(n, "inh"),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -900,7 +900,7 @@ def _build_relation(n: Node, c: Context) -> pgast.Relation:
         catalogname=_maybe(n, c, "catalogname", _build_str),
         schemaname=_maybe(n, c, "schemaname", _build_str),
         is_temporary=_maybe(n, c, "relpersistence", lambda n, _c: n == 't'),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -946,7 +946,7 @@ def _build_a_expr(n: Node, c: Context) -> pgast.BaseExpr:
             operator=name + " " + operator,
             test_expr=_maybe(n, c, "lexpr", _build_base_expr),
             expr=_build_base_expr(n["rexpr"], c),
-            context=_build_context(n, c),
+            span=_build_span(n, c),
         )
     elif n['kind'] == 'AEXPR_NULLIF':
         return pgast.FuncCall(
@@ -967,7 +967,7 @@ def _build_a_expr(n: Node, c: Context) -> pgast.BaseExpr:
         name=name,
         lexpr=_maybe(n, c, "lexpr", _build_base_expr),
         rexpr=_maybe(n, c, "rexpr", _build_base_expr),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -983,7 +983,7 @@ def _build_func_call(n: Node, c: Context) -> pgast.FuncCall:
         agg_distinct=_bool_or_false(n, "agg_distinct"),
         over=_maybe(n, c, "over", _build_window_def),
         with_ordinality=_bool_or_false(n, "withOrdinality"),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1012,7 +1012,7 @@ def _build_res_target(n: Node, c: Context) -> pgast.ResTarget:
         name=_maybe(n, c, "name", _build_str),
         indirection=_maybe_list(n, c, "indirection", _build_indirection_op),
         val=_build_base_expr(n["val"], c),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1020,7 +1020,7 @@ def _build_insert_target(n: Node, c: Context) -> pgast.InsertTarget:
     n = _unwrap(n, "ResTarget")
     return pgast.InsertTarget(
         name=_build_str(n['name'], c),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1030,7 +1030,7 @@ def _build_update_target(n: Node, c: Context) -> pgast.UpdateTarget:
         name=_build_str(n['name'], c),
         val=_build_base_expr(n['val'], c),
         indirection=_maybe_list(n, c, "indirection", _build_indirection_op),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1045,7 +1045,7 @@ def _build_window_def(n: Node, c: Context) -> pgast.WindowDef:
         frame_options=None,
         start_offset=_maybe(n, c, "startOffset", _build_base_expr),
         end_offset=_maybe(n, c, "endOffset", _build_base_expr),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1055,7 +1055,7 @@ def _build_sort_by(n: Node, c: Context) -> pgast.SortBy:
         node=_build_base_expr(n["node"], c),
         dir=_maybe(n, c, "sortby_dir", _build_sort_order),
         nulls=_maybe(n, c, "sortby_nulls", _build_nones_order),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1090,7 +1090,7 @@ def _build_multi_assign_ref(
         columns=[
             _as_column_ref(target['ResTarget']['name']) for target in targets
         ],
-        context=_build_context(targets[0]['ResTarget'], c),
+        span=_build_span(targets[0]['ResTarget'], c),
     )
 
 
@@ -1098,7 +1098,7 @@ def _build_column_ref(n: Node, c: Context) -> pgast.ColumnRef:
     return pgast.ColumnRef(
         name=_list(n, c, "fields", _build_string_or_star),
         optional=_maybe(n, c, "optional", _build_bool),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1107,7 +1107,7 @@ def _build_infer_clause(n: Node, c: Context) -> pgast.InferClause:
         index_elems=_maybe_list(n, c, "indexElems", _build_str),
         where_clause=_maybe(n, c, "whereClause", _build_base_expr),
         conname=_maybe(n, c, "conname", _build_str),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1117,7 +1117,7 @@ def _build_on_conflict(n: Node, c: Context) -> pgast.OnConflictClause:
         infer=_maybe(n, c, "infer", _build_infer_clause),
         target_list=_build_on_conflict_targets(n, c, "targetList"),
         where=_maybe(n, c, "where", _build_base_expr),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )
 
 
@@ -1213,5 +1213,5 @@ def _build_copy(n: Node, c: Context) -> pgast.CopyStmt:
             _maybe(n, c, 'options', _build_copy_options) or pgast.CopyOptions()
         ),
         where_clause=_maybe(n, c, "whereClause", _build_base_expr),
-        context=_build_context(n, c),
+        span=_build_span(n, c),
     )

--- a/edb/pgsql/resolver/dispatch.py
+++ b/edb/pgsql/resolver/dispatch.py
@@ -39,7 +39,7 @@ def _resolve(
 
 def resolve(ir: Base_T, *, ctx: context.ResolverContextLevel) -> Base_T:
     res = _resolve(ir, ctx=ctx)
-    return typing.cast(Base_T, res.replace(context=ir.span))
+    return typing.cast(Base_T, res.replace(span=ir.span))
 
 
 def resolve_opt(
@@ -77,7 +77,7 @@ def resolve_relation(
     ir: BaseRelation_T, *, ctx: context.ResolverContextLevel
 ) -> typing.Tuple[BaseRelation_T, context.Table]:
     res, tab = _resolve_relation(ir, ctx=ctx)
-    return typing.cast(BaseRelation_T, res.replace(context=ir.span)), tab
+    return typing.cast(BaseRelation_T, res.replace(span=ir.span)), tab
 
 
 @_resolve.register

--- a/edb/pgsql/resolver/dispatch.py
+++ b/edb/pgsql/resolver/dispatch.py
@@ -39,7 +39,7 @@ def _resolve(
 
 def resolve(ir: Base_T, *, ctx: context.ResolverContextLevel) -> Base_T:
     res = _resolve(ir, ctx=ctx)
-    return typing.cast(Base_T, res.replace(context=ir.context))
+    return typing.cast(Base_T, res.replace(context=ir.span))
 
 
 def resolve_opt(
@@ -77,7 +77,7 @@ def resolve_relation(
     ir: BaseRelation_T, *, ctx: context.ResolverContextLevel
 ) -> typing.Tuple[BaseRelation_T, context.Table]:
     res, tab = _resolve_relation(ir, ctx=ctx)
-    return typing.cast(BaseRelation_T, res.replace(context=ir.context)), tab
+    return typing.cast(BaseRelation_T, res.replace(context=ir.span)), tab
 
 
 @_resolve.register

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -92,7 +92,7 @@ def resolve_ResTarget(
 
     col = context.Column(name=alias, reference_as=alias)
     new_target = pgast.ResTarget(
-        val=val, name=alias, context=res_target.context
+        val=val, name=alias, span=res_target.span
     )
     return (new_target,), (col,)
 
@@ -169,7 +169,7 @@ def _lookup_column(
         try:
             table = _lookup_table(cast(str, tab_name), ctx)
         except errors.QueryError as e:
-            e.set_source_context(column_ref.context)
+            e.set_source_context(column_ref.span)
             raise
 
         if isinstance(col_name, pgast.Star):
@@ -179,7 +179,7 @@ def _lookup_column(
 
     if not matched_columns:
         raise errors.QueryError(
-            f'cannot find column `{col_name}`', context=column_ref.context
+            f'cannot find column `{col_name}`', context=column_ref.span
         )
 
     # apply precedence
@@ -194,7 +194,7 @@ def _lookup_column(
         raise errors.QueryError(
             f'ambiguous column `{col_name}` could belong to '
             f'following tables: {potential_tables}',
-            context=column_ref.context,
+            context=column_ref.span,
         )
 
     return (matched_columns[0],)

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -169,7 +169,7 @@ def _lookup_column(
         try:
             table = _lookup_table(cast(str, tab_name), ctx)
         except errors.QueryError as e:
-            e.set_source_context(column_ref.span)
+            e.set_span(column_ref.span)
             raise
 
         if isinstance(col_name, pgast.Star):

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -179,7 +179,7 @@ def _lookup_column(
 
     if not matched_columns:
         raise errors.QueryError(
-            f'cannot find column `{col_name}`', context=column_ref.span
+            f'cannot find column `{col_name}`', span=column_ref.span
         )
 
     # apply precedence
@@ -194,7 +194,7 @@ def _lookup_column(
         raise errors.QueryError(
             f'ambiguous column `{col_name}` could belong to '
             f'following tables: {potential_tables}',
-            context=column_ref.span,
+            span=column_ref.span,
         )
 
     return (matched_columns[0],)

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -23,7 +23,7 @@ import functools
 from typing import Optional, Tuple, Union, Iterable, List, cast
 
 from edb import errors
-from edb.common.parsing import ParserContext
+from edb.common.parsing import Span
 from edb.server.pgcon import errors as pgerror
 
 from edb.pgsql import ast as pgast
@@ -330,7 +330,7 @@ def _resolve_RangeFunction(
 def _zip_column_alias(
     columns: List[context.Column],
     alias: pgast.Alias,
-    ctx: Optional[ParserContext],
+    ctx: Optional[Span],
 ) -> Iterable[Tuple[context.Column, Optional[str]]]:
     if not alias.colnames:
         return map(lambda c: (c, None), columns)

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -52,7 +52,7 @@ def resolve_BaseRangeVar(
 
     # general case
     node, table = _resolve_range_var(range_var, alias, ctx=ctx)
-    node = node.replace(context=range_var.span)
+    node = node.replace(span=range_var.span)
 
     # infer public name and internal alias
     table.alias = range_var.alias.aliasname

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -52,7 +52,7 @@ def resolve_BaseRangeVar(
 
     # general case
     node, table = _resolve_range_var(range_var, alias, ctx=ctx)
-    node = node.replace(context=range_var.context)
+    node = node.replace(context=range_var.span)
 
     # infer public name and internal alias
     table.alias = range_var.alias.aliasname
@@ -106,7 +106,7 @@ def _resolve_RelRangeVar(
             static_val=col.static_val,
         )
         for col, alias in _zip_column_alias(
-            table.columns, alias, ctx=range_var.context
+            table.columns, alias, ctx=range_var.span
         )
     ]
 
@@ -135,7 +135,7 @@ def _resolve_RangeSubselect(
                     reference_as=alias or col.name,
                 )
                 for col, alias in _zip_column_alias(
-                    subtable.columns, alias, ctx=range_var.context
+                    subtable.columns, alias, ctx=range_var.span
                 )
             ],
         )
@@ -236,7 +236,7 @@ def resolve_CommonTableExpr(
 
         alias = pgast.Alias(aliasname=cte.name, colnames=aliascolnames)
 
-        for col, al in _zip_column_alias(table.columns, alias, cte.context):
+        for col, al in _zip_column_alias(table.columns, alias, cte.span):
             result.columns.append(
                 context.Column(
                     name=al or col.name,
@@ -250,7 +250,7 @@ def resolve_CommonTableExpr(
 
     node = pgast.CommonTableExpr(
         name=cte.name,
-        context=cte.context,
+        span=cte.span,
         aliascolnames=reference_as,
         query=query,
         recursive=cte.recursive,
@@ -303,7 +303,7 @@ def _resolve_RangeFunction(
                     reference_as=al or ctx.names.get('col'),
                 )
                 for col, al in _zip_column_alias(
-                    inferred_columns, alias, ctx=range_var.context
+                    inferred_columns, alias, ctx=range_var.span
                 )
             ]
         )

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -342,7 +342,7 @@ def _zip_column_alias(
             f'Table alias for `{alias.aliasname}` contains '
             f'{len(alias.colnames)} columns, but the query resolves to '
             f'{len(columns)} columns',
-            context=ctx,
+            span=ctx,
             pgext_code=pgerror.ERROR_INVALID_COLUMN_REFERENCE,
         )
     return zip(columns, alias.colnames)

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -77,7 +77,7 @@ def resolve_SelectStmt(
         if len(ltable.columns) != len(rtable.columns):
             raise errors.QueryError(
                 f'{stmt.op} requires equal number of columns in both sides',
-                context=stmt.span,
+                span=stmt.span,
             )
 
         relation = pgast.SelectStmt(
@@ -184,7 +184,7 @@ def resolve_DMLQuery(
 ) -> Tuple[pgast.DMLQuery, context.Table]:
     raise errors.UnsupportedFeatureError(
         'DML queries (INSERT/UPDATE/DELETE) are not supported',
-        context=query.span,
+        span=query.span,
     )
 
 
@@ -206,7 +206,7 @@ def resolve_relation(
     if relation.catalogname and relation.catalogname != 'postgres':
         raise errors.QueryError(
             f'queries cross databases are not supported',
-            context=relation.span,
+            span=relation.span,
         )
 
     # try information_schema, pg_catalog and pg_toast
@@ -273,7 +273,7 @@ def resolve_relation(
         rel_name = pgcodegen.generate_source(relation)
         raise errors.QueryError(
             f'unknown table `{rel_name}`',
-            context=relation.span,
+            span=relation.span,
             pgext_code=pgerror.ERROR_UNDEFINED_TABLE,
         )
 

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -77,7 +77,7 @@ def resolve_SelectStmt(
         if len(ltable.columns) != len(rtable.columns):
             raise errors.QueryError(
                 f'{stmt.op} requires equal number of columns in both sides',
-                context=stmt.context,
+                context=stmt.span,
             )
 
         relation = pgast.SelectStmt(
@@ -184,7 +184,7 @@ def resolve_DMLQuery(
 ) -> Tuple[pgast.DMLQuery, context.Table]:
     raise errors.UnsupportedFeatureError(
         'DML queries (INSERT/UPDATE/DELETE) are not supported',
-        context=query.context,
+        context=query.span,
     )
 
 
@@ -206,7 +206,7 @@ def resolve_relation(
     if relation.catalogname and relation.catalogname != 'postgres':
         raise errors.QueryError(
             f'queries cross databases are not supported',
-            context=relation.context,
+            context=relation.span,
         )
 
     # try information_schema, pg_catalog and pg_toast
@@ -273,7 +273,7 @@ def resolve_relation(
         rel_name = pgcodegen.generate_source(relation)
         raise errors.QueryError(
             f'unknown table `{rel_name}`',
-            context=relation.context,
+            context=relation.span,
             pgext_code=pgerror.ERROR_UNDEFINED_TABLE,
         )
 

--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -108,7 +108,7 @@ def eval_TypeCast(
 
             if 'false'.startswith(string) or 'no'.startswith(string):
                 return pgast.BooleanConstant(val=False)
-            raise errors.QueryError('invalid cast', context=expr.arg)
+            raise errors.QueryError('invalid cast', span=expr.arg.span)
 
     return None
 
@@ -138,7 +138,7 @@ def eval_FuncCall(
     ctx: Context,
 ) -> Optional[pgast.BaseExpr]:
     if len(expr.name) >= 3:
-        raise errors.QueryError("unknown function", context=expr.span)
+        raise errors.QueryError("unknown function", span=expr.span)
 
     fn_name = name_in_pg_catalog(expr.name)
     if not fn_name:
@@ -198,7 +198,7 @@ def eval_FuncCall(
                     return value
 
         raise errors.QueryError(
-            "function set_config is not supported", context=expr.span
+            "function set_config is not supported", span=expr.span
         )
 
     if fn_name == 'current_setting':
@@ -214,7 +214,7 @@ def eval_FuncCall(
     if fn_name == "pg_filenode_relation":
         raise errors.QueryError(
             f"function pg_catalog.{fn_name} is not supported",
-            context=expr.span,
+            span=expr.span,
         )
 
     if fn_name == "to_regclass":
@@ -287,7 +287,7 @@ def require_a_string_literal(
     ):
         raise errors.QueryError(
             f"function pg_catalog.{fn_name} requires a string literal",
-            context=expr.span,
+            span=expr.span,
         )
 
     return args[0].val
@@ -309,7 +309,7 @@ def cast_to_regclass(param: pgast.BaseExpr, ctx: Context) -> pgast.BaseExpr:
         return expr
     raise errors.QueryError(
         "casting to `regclass` requires a string or number literal",
-        context=param.span,
+        span=param.span,
     )
 
 

--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -138,7 +138,7 @@ def eval_FuncCall(
     ctx: Context,
 ) -> Optional[pgast.BaseExpr]:
     if len(expr.name) >= 3:
-        raise errors.QueryError("unknown function", context=expr.context)
+        raise errors.QueryError("unknown function", context=expr.span)
 
     fn_name = name_in_pg_catalog(expr.name)
     if not fn_name:
@@ -198,7 +198,7 @@ def eval_FuncCall(
                     return value
 
         raise errors.QueryError(
-            "function set_config is not supported", context=expr.context
+            "function set_config is not supported", context=expr.span
         )
 
     if fn_name == 'current_setting':
@@ -214,7 +214,7 @@ def eval_FuncCall(
     if fn_name == "pg_filenode_relation":
         raise errors.QueryError(
             f"function pg_catalog.{fn_name} is not supported",
-            context=expr.context,
+            context=expr.span,
         )
 
     if fn_name == "to_regclass":
@@ -287,7 +287,7 @@ def require_a_string_literal(
     ):
         raise errors.QueryError(
             f"function pg_catalog.{fn_name} requires a string literal",
-            context=expr.context,
+            context=expr.span,
         )
 
     return args[0].val
@@ -309,7 +309,7 @@ def cast_to_regclass(param: pgast.BaseExpr, ctx: Context) -> pgast.BaseExpr:
         return expr
     raise errors.QueryError(
         "casting to `regclass` requires a string or number literal",
-        context=param.context,
+        context=param.span,
     )
 
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -287,7 +287,7 @@ def compile_constraint(
             f'Constraint {constraint.get_displayname(schema)} on '
             f'{subject.get_displayname(schema)} is not supported '
             f'because it would depend on multiple objects',
-            context=span,
+            span=span,
         )
     elif ref_tables:
         subject_db_name, info = next(iter(ref_tables.items()))

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -225,7 +225,7 @@ def compile_constraint(
     subject: s_constraints.ConsistencySubject,
     constraint: s_constraints.Constraint,
     schema: s_schema.Schema,
-    source_context: Optional[parsing.Span],
+    span: Optional[parsing.Span],
 ) -> SchemaDomainConstraint | SchemaTableConstraint:
     assert constraint.get_subject(schema) is not None
     TypeOrPointer = s_types.Type | s_pointers.Pointer
@@ -287,7 +287,7 @@ def compile_constraint(
             f'Constraint {constraint.get_displayname(schema)} on '
             f'{subject.get_displayname(schema)} is not supported '
             f'because it would depend on multiple objects',
-            context=source_context,
+            context=span,
         )
     elif ref_tables:
         subject_db_name, info = next(iter(ref_tables.items()))

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -225,7 +225,7 @@ def compile_constraint(
     subject: s_constraints.ConsistencySubject,
     constraint: s_constraints.Constraint,
     schema: s_schema.Schema,
-    source_context: Optional[parsing.ParserContext],
+    source_context: Optional[parsing.Span],
 ) -> SchemaDomainConstraint | SchemaTableConstraint:
     assert constraint.get_subject(schema) is not None
     TypeOrPointer = s_types.Type | s_pointers.Pointer

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -309,7 +309,7 @@ class CreateAnnotationValue(
             vn = ir.stype.get_verbosename(schema)
             raise errors.InvalidValueError(
                 f"annotation values must be 'std::str', got {vn}",
-                context=astnode.value.context,
+                context=astnode.value.span,
             )
 
         anno = utils.ast_objref_to_object_shell(
@@ -388,7 +388,7 @@ class AlterAnnotationValue(
                 vn = ir.stype.get_verbosename(schema)
                 raise errors.InvalidValueError(
                     f"annotation values must be 'std::str', got {vn}",
-                    context=astnode.value.context,
+                    context=astnode.value.span,
                 )
 
             cmd.set_attribute_value(

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -309,7 +309,7 @@ class CreateAnnotationValue(
             vn = ir.stype.get_verbosename(schema)
             raise errors.InvalidValueError(
                 f"annotation values must be 'std::str', got {vn}",
-                context=astnode.value.span,
+                span=astnode.value.span,
             )
 
         anno = utils.ast_objref_to_object_shell(
@@ -388,7 +388,7 @@ class AlterAnnotationValue(
                 vn = ir.stype.get_verbosename(schema)
                 raise errors.InvalidValueError(
                     f"annotation values must be 'std::str', got {vn}",
-                    context=astnode.value.span,
+                    span=astnode.value.span,
                 )
 
             cmd.set_attribute_value(

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -331,7 +331,7 @@ class CreateCast(CastCommand, sd.CreateObject[Cast]):
             raise errors.DuplicateCastDefinitionError(
                 f'a cast from {from_type.get_displayname(schema)!r} '
                 f'to {to_type.get_displayname(schema)!r} is already defined',
-                context=self.source_context)
+                context=self.span)
 
         return super()._create_begin(schema, context)
 

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -270,7 +270,7 @@ class CastCommand(sd.QualifiedObjectCommand[Cast],
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined casts are not supported',
-                context=astnode.context
+                context=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -270,7 +270,7 @@ class CastCommand(sd.QualifiedObjectCommand[Cast],
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined casts are not supported',
-                context=astnode.span
+                span=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)
@@ -331,7 +331,7 @@ class CreateCast(CastCommand, sd.CreateObject[Cast]):
             raise errors.DuplicateCastDefinitionError(
                 f'a cast from {from_type.get_displayname(schema)!r} '
                 f'to {to_type.get_displayname(schema)!r} is already defined',
-                context=self.span)
+                span=self.span)
 
         return super()._create_begin(schema, context)
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -731,7 +731,7 @@ class ConstraintCommand(
         name: sn.QualName,
         subjectexpr: Optional[s_expr.Expression] = None,
         subjectexpr_inherited: bool = False,
-        sourcectx: Optional[c_parsing.ParserContext] = None,
+        sourcectx: Optional[c_parsing.Span] = None,
         args: Any = None,
         **kwargs: Any
     ) -> None:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -431,7 +431,7 @@ class ConstraintCommand(
                 if cname in {'subject', 'subjectexpr'}:
                     raise errors.InvalidConstraintDefinitionError(
                         f'{cname} is not a valid constraint annotation',
-                        context=command.span)
+                        span=command.span)
 
     @classmethod
     def _classname_quals_from_ast(
@@ -764,7 +764,7 @@ class ConstraintCommand(
                 and subjectexpr.text != base_subjectexpr.text):
             raise errors.InvalidConstraintDefinitionError(
                 f'subjectexpr is already defined for {name}',
-                context=sourcectx,
+                span=sourcectx,
             )
 
         if (isinstance(subject_obj, s_scalars.ScalarType)
@@ -772,7 +772,7 @@ class ConstraintCommand(
             raise errors.InvalidConstraintDefinitionError(
                 f'{constr_base.get_verbosename(schema)} may not '
                 f'be used on scalar types',
-                context=sourcectx,
+                span=sourcectx,
             )
 
         if (
@@ -781,7 +781,7 @@ class ConstraintCommand(
         ):
             raise errors.InvalidConstraintDefinitionError(
                 "constraints on object types must have an 'on' clause",
-                context=sourcectx,
+                span=sourcectx,
             )
 
         if subjectexpr is not None:
@@ -861,7 +861,7 @@ class ConstraintCommand(
                 f'{name} constraint expression expected '
                 f'to return a bool value, got '
                 f'{expr_type.get_verbosename(expr_schema)}',
-                context=sourcectx
+                span=sourcectx
             )
 
         except_expr = attrs.get('except_expr')
@@ -869,7 +869,7 @@ class ConstraintCommand(
             if isinstance(subject, s_pointers.Pointer):
                 raise errors.InvalidConstraintDefinitionError(
                     "only object constraints may use EXCEPT",
-                    context=sourcectx
+                    span=sourcectx
                 )
 
         if subjectexpr is not None:
@@ -924,13 +924,13 @@ class ConstraintCommand(
                             raise errors.InvalidConstraintDefinitionError(
                                 "link constraints may not access "
                                 "the link target",
-                                context=sourcectx
+                                span=sourcectx
                             )
                         else:
                             raise errors.InvalidConstraintDefinitionError(
                                 "constraints cannot contain paths with more "
                                 "than one hop",
-                                context=sourcectx
+                                span=sourcectx
                             )
 
                     ref = rptr.source
@@ -939,7 +939,7 @@ class ConstraintCommand(
                 raise errors.InvalidConstraintDefinitionError(
                     "cannot reference multiple links or properties in a "
                     "constraint where at least one link or property is MULTI",
-                    context=sourcectx
+                    span=sourcectx
                 )
 
             if has_any_multi and ir_utils.contains_set_of_op(
@@ -947,7 +947,7 @@ class ConstraintCommand(
                 raise errors.InvalidConstraintDefinitionError(
                     "cannot use aggregate functions or operators "
                     "in a non-aggregating constraint",
-                    context=sourcectx
+                    span=sourcectx
                 )
 
             if (
@@ -956,7 +956,7 @@ class ConstraintCommand(
             ):
                 raise errors.InvalidConstraintDefinitionError(
                     f'constraint expressions must be immutable',
-                    context=final_subjectexpr.irast.span,
+                    span=final_subjectexpr.irast.span,
                 )
 
             if final_except_expr:
@@ -966,13 +966,13 @@ class ConstraintCommand(
                 ):
                     raise errors.InvalidConstraintDefinitionError(
                         f'constraint expressions must be immutable',
-                        context=final_except_expr.irast.context,
+                        span=final_except_expr.irast.context,
                     )
 
         if final_expr.irast.volatility != qltypes.Volatility.Immutable:
             raise errors.InvalidConstraintDefinitionError(
                 f'constraint expressions must be immutable',
-                context=sourcectx,
+                span=sourcectx,
             )
 
         attrs['finalexpr'] = final_expr
@@ -1050,7 +1050,7 @@ class CreateConstraint(
                         f'{self.get_verbosename()} '
                         f'extends multiple constraints '
                         f'with parameters',
-                        context=self.span,
+                        span=self.span,
                     )
                 base_params = params
                 base_with_params = base
@@ -1067,7 +1067,7 @@ class CreateConstraint(
                     f'must define parameters to reflect parameters of '
                     f'the {base_with_params.get_verbosename(schema)} '
                     f'it extends',
-                    context=self.span,
+                    span=self.span,
                 )
 
             if len(params) < len(base_params):
@@ -1076,7 +1076,7 @@ class CreateConstraint(
                     f'has fewer parameters than the '
                     f'{base_with_params.get_verbosename(schema)} '
                     f'it extends',
-                    context=self.span,
+                    span=self.span,
                 )
 
             # Skipping the __subject__ param
@@ -1093,7 +1093,7 @@ class CreateConstraint(
                         f'must be renamed to {base_param_name!r} '
                         f'to match the signature of the base '
                         f'{base_with_params.get_verbosename(schema)} ',
-                        context=self.span,
+                        span=self.span,
                     )
 
                 param_type = param.get_type(schema)
@@ -1110,7 +1110,7 @@ class CreateConstraint(
                         f'parameter of the '
                         f'{base_with_params.get_verbosename(schema)} '
                         f'it extends has a concrete type',
-                        context=self.span,
+                        span=self.span,
                     )
 
                 if (
@@ -1127,7 +1127,7 @@ class CreateConstraint(
                         f'corresponding parameter of the '
                         f'{base_with_params.get_verbosename(schema)} with '
                         f'type {base_param_type.get_displayname(schema)}',
-                        context=self.span,
+                        span=self.span,
                     )
 
     def _create_begin(
@@ -1146,7 +1146,7 @@ class CreateConstraint(
             raise errors.UnsupportedFeatureError(
                 f'constraints cannot be defined on '
                 f'{subject.get_verbosename(schema)}',
-                context=self.span,
+                span=self.span,
             )
 
         if not context.canonical:
@@ -1230,13 +1230,13 @@ class CreateConstraint(
                     raise errors.InvalidConstraintDefinitionError(
                         'named only parameters are not allowed '
                         'in this context',
-                        context=astnode.span)
+                        span=astnode.span)
 
                 if param.get_default(schema) is not None:
                     raise errors.InvalidConstraintDefinitionError(
                         'constraints do not support parameters '
                         'with defaults',
-                        context=astnode.span)
+                        span=astnode.span)
 
             if cmd.get_attribute_value('return_type') is None:
                 cmd.set_attribute_value(
@@ -1533,7 +1533,7 @@ class AlterConstraint(
             raise errors.InvalidConstraintDefinitionError(
                 f'cannot redefine {tgt_repr} as delegated:'
                 f' it is defined as non-delegated in {bases_repr}',
-                context=self.span,
+                span=self.span,
             )
 
     def canonicalize_alter_from_external_ref(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -431,7 +431,7 @@ class ConstraintCommand(
                 if cname in {'subject', 'subjectexpr'}:
                     raise errors.InvalidConstraintDefinitionError(
                         f'{cname} is not a valid constraint annotation',
-                        context=command.context)
+                        context=command.span)
 
     @classmethod
     def _classname_quals_from_ast(
@@ -1230,13 +1230,13 @@ class CreateConstraint(
                     raise errors.InvalidConstraintDefinitionError(
                         'named only parameters are not allowed '
                         'in this context',
-                        context=astnode.context)
+                        context=astnode.span)
 
                 if param.get_default(schema) is not None:
                     raise errors.InvalidConstraintDefinitionError(
                         'constraints do not support parameters '
                         'with defaults',
-                        context=astnode.context)
+                        context=astnode.span)
 
             if cmd.get_attribute_value('return_type') is None:
                 cmd.set_attribute_value(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -956,7 +956,7 @@ class ConstraintCommand(
             ):
                 raise errors.InvalidConstraintDefinitionError(
                     f'constraint expressions must be immutable',
-                    context=final_subjectexpr.irast.context,
+                    context=final_subjectexpr.irast.span,
                 )
 
             if final_except_expr:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1050,7 +1050,7 @@ class CreateConstraint(
                         f'{self.get_verbosename()} '
                         f'extends multiple constraints '
                         f'with parameters',
-                        context=self.source_context,
+                        context=self.span,
                     )
                 base_params = params
                 base_with_params = base
@@ -1067,7 +1067,7 @@ class CreateConstraint(
                     f'must define parameters to reflect parameters of '
                     f'the {base_with_params.get_verbosename(schema)} '
                     f'it extends',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             if len(params) < len(base_params):
@@ -1076,7 +1076,7 @@ class CreateConstraint(
                     f'has fewer parameters than the '
                     f'{base_with_params.get_verbosename(schema)} '
                     f'it extends',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             # Skipping the __subject__ param
@@ -1093,7 +1093,7 @@ class CreateConstraint(
                         f'must be renamed to {base_param_name!r} '
                         f'to match the signature of the base '
                         f'{base_with_params.get_verbosename(schema)} ',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
                 param_type = param.get_type(schema)
@@ -1110,7 +1110,7 @@ class CreateConstraint(
                         f'parameter of the '
                         f'{base_with_params.get_verbosename(schema)} '
                         f'it extends has a concrete type',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
                 if (
@@ -1127,7 +1127,7 @@ class CreateConstraint(
                         f'corresponding parameter of the '
                         f'{base_with_params.get_verbosename(schema)} with '
                         f'type {base_param_type.get_displayname(schema)}',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
     def _create_begin(
@@ -1146,7 +1146,7 @@ class CreateConstraint(
             raise errors.UnsupportedFeatureError(
                 f'constraints cannot be defined on '
                 f'{subject.get_verbosename(schema)}',
-                context=self.source_context,
+                context=self.span,
             )
 
         if not context.canonical:
@@ -1164,7 +1164,7 @@ class CreateConstraint(
                 name=shortname,
                 subjectexpr_inherited=self.is_attribute_inherited(
                     'subjectexpr'),
-                sourcectx=self.source_context,
+                sourcectx=self.span,
                 **props,
             )
 
@@ -1453,7 +1453,7 @@ class AlterConstraint(
                 subjectexpr=subjectexpr,
                 subjectexpr_inherited=subjectexpr_inherited,
                 args=args,
-                sourcectx=self.source_context,
+                sourcectx=self.span,
                 **props,
             )
 
@@ -1533,7 +1533,7 @@ class AlterConstraint(
             raise errors.InvalidConstraintDefinitionError(
                 f'cannot redefine {tgt_repr} as delegated:'
                 f' it is defined as non-delegated in {bases_repr}',
-                context=self.source_context,
+                context=self.span,
             )
 
     def canonicalize_alter_from_external_ref(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -864,7 +864,7 @@ class ConstraintCommand(
                 span=sourcectx
             )
 
-        except_expr = attrs.get('except_expr')
+        except_expr: s_expr.Expression | None = attrs.get('except_expr')
         if except_expr:
             if isinstance(subject, s_pointers.Pointer):
                 raise errors.InvalidConstraintDefinitionError(
@@ -887,7 +887,7 @@ class ConstraintCommand(
 
             refs = ir_utils.get_longest_paths(final_expr.irast)
 
-            final_except_expr = None
+            final_except_expr: s_expr.CompiledExpression | None = None
             if except_expr:
                 final_except_expr = except_expr.compiled(
                     schema=schema, options=options
@@ -966,7 +966,7 @@ class ConstraintCommand(
                 ):
                     raise errors.InvalidConstraintDefinitionError(
                         f'constraint expressions must be immutable',
-                        span=final_except_expr.irast.context,
+                        span=final_except_expr.irast.span,
                     )
 
         if final_expr.irast.volatility != qltypes.Volatility.Immutable:

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -62,7 +62,7 @@ class DatabaseCommand(
     ) -> None:
         name = self.get_attribute_value('name')
         if len(str(name)) > s_def.MAX_NAME_LENGTH:
-            span = self.get_attribute_source_context('name')
+            span = self.get_attribute_span('name')
             raise errors.SchemaDefinitionError(
                 f'Database names longer than {s_def.MAX_NAME_LENGTH} '
                 f'characters are not supported',

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -62,11 +62,11 @@ class DatabaseCommand(
     ) -> None:
         name = self.get_attribute_value('name')
         if len(str(name)) > s_def.MAX_NAME_LENGTH:
-            source_context = self.get_attribute_source_context('name')
+            span = self.get_attribute_source_context('name')
             raise errors.SchemaDefinitionError(
                 f'Database names longer than {s_def.MAX_NAME_LENGTH} '
                 f'characters are not supported',
-                context=source_context,
+                context=span,
             )
 
 

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -66,7 +66,7 @@ class DatabaseCommand(
             raise errors.SchemaDefinitionError(
                 f'Database names longer than {s_def.MAX_NAME_LENGTH} '
                 f'characters are not supported',
-                context=span,
+                span=span,
             )
 
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -712,7 +712,7 @@ class Command(
         computed: bool = False,
         from_default: bool = False,
         orig_computed: Optional[bool] = None,
-        source_context: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Command:
         orig_op = op = self._get_simple_attribute_set_cmd(attr_name)
         if op is None:
@@ -731,8 +731,8 @@ class Command(
         op.old_computed = orig_computed
         op.from_default = from_default
 
-        if source_context is not None:
-            op.source_context = source_context
+        if span is not None:
+            op.source_context = span
         if orig_value is not None:
             op.old_value = orig_value
 
@@ -1962,7 +1962,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         computed: bool = False,
         orig_computed: Optional[bool] = None,
         from_default: bool = False,
-        source_context: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Command:
         special = type(self)._get_special_handler(attr_name)
         op = self._get_attribute_set_cmd(attr_name)
@@ -1984,7 +1984,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                 new_computed=computed,
                 old_computed=orig_computed,
                 from_default=from_default,
-                source_context=source_context,
+                source_context=span,
             )
 
             top_op = self._special_attrs.get(attr_name)
@@ -2009,8 +2009,8 @@ class ObjectCommand(Command, Generic[so.Object_T]):
             op.old_computed = orig_computed
             op.from_default = from_default
 
-            if source_context is not None:
-                op.source_context = source_context
+            if span is not None:
+                op.source_context = span
             if orig_value is not None:
                 op.old_value = orig_value
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -455,7 +455,7 @@ class Command(
     markup.MarkupCapableMixin,
     metaclass=CommandMeta,
 ):
-    source_context = struct.Field(parsing.ParserContext, default=None)
+    source_context = struct.Field(parsing.Span, default=None)
     canonical = struct.Field(bool, default=False)
 
     _context_class: Optional[Type[CommandContextToken[Command]]] = None
@@ -694,7 +694,7 @@ class Command(
     def get_attribute_source_context(
         self,
         attr_name: str,
-    ) -> Optional[parsing.ParserContext]:
+    ) -> Optional[parsing.Span]:
         op = self._get_attribute_set_cmd(attr_name)
         if op is not None:
             return op.source_context
@@ -712,7 +712,7 @@ class Command(
         computed: bool = False,
         from_default: bool = False,
         orig_computed: Optional[bool] = None,
-        source_context: Optional[parsing.ParserContext] = None,
+        source_context: Optional[parsing.Span] = None,
     ) -> Command:
         orig_op = op = self._get_simple_attribute_set_cmd(attr_name)
         if op is None:
@@ -1962,7 +1962,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         computed: bool = False,
         orig_computed: Optional[bool] = None,
         from_default: bool = False,
-        source_context: Optional[parsing.ParserContext] = None,
+        source_context: Optional[parsing.Span] = None,
     ) -> Command:
         special = type(self)._get_special_handler(attr_name)
         op = self._get_attribute_set_cmd(attr_name)
@@ -2564,7 +2564,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> so.Object_T:
         ...
 
@@ -2576,7 +2576,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.Object_T]:
         ...
 
@@ -2587,7 +2587,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.Object_T]:
         metaclass = self.get_schema_metaclass()
         if name is None:
@@ -2922,7 +2922,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         *,
         name: Optional[sn.Name] = None,
         default: Union[so.QualifiedObject_T, so.NoDefaultT] = so.NoDefault,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> so.QualifiedObject_T:
         ...
 
@@ -2934,7 +2934,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.QualifiedObject_T]:
         ...
 
@@ -2946,7 +2946,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         name: Optional[sn.Name] = None,
         default: Union[
             so.QualifiedObject_T, so.NoDefaultT, None] = so.NoDefault,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.QualifiedObject_T]:
         if name is None:
             name = self.classname

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2530,7 +2530,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                 raise errors.SchemaDefinitionError(
                     f'cannot {self._delta_action} {self.get_verbosename()}: '
                     f'module {modroot} is read-only',
-                    context=self.span)
+                    span=self.span)
 
     def get_verbosename(self, parent: Optional[str] = None) -> str:
         mcls = self.get_schema_metaclass()
@@ -2921,7 +2921,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         if module is None:
             raise errors.SchemaDefinitionError(
                 f'unqualified name and no default module set',
-                context=objref.span,
+                span=objref.span,
             )
 
         return sn.QualName(module=module, name=objref.name)
@@ -4074,7 +4074,7 @@ class AlterObjectProperty(Command):
             except LookupError:
                 raise errors.SchemaDefinitionError(
                     f'{propname!r} is not a valid field',
-                    context=astnode.span)
+                    span=astnode.span)
 
         if not (
             astnode.special_syntax
@@ -4084,12 +4084,12 @@ class AlterObjectProperty(Command):
         ):
             raise errors.SchemaDefinitionError(
                 f'{propname!r} is not a valid field',
-                context=astnode.span)
+                span=astnode.span)
 
         if field.name == 'id' and not isinstance(parent_op, CreateObject):
             raise errors.SchemaDefinitionError(
                 f'cannot alter object id',
-                context=astnode.span)
+                span=astnode.span)
 
         new_value: Any
 
@@ -4212,7 +4212,7 @@ class AlterObjectProperty(Command):
         if field is None:
             raise errors.SchemaDefinitionError(
                 f'{self.property!r} is not a valid field',
-                context=self.span)
+                span=self.span)
 
         if self.property == 'id':
             return None

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1098,7 +1098,7 @@ class Command(
         context: CommandContext,
     ) -> Command:
         cmd = cls._cmd_from_ast(schema, astnode, context)
-        cmd.source_context = astnode.context
+        cmd.source_context = astnode.span
         cmd.qlast = astnode
         ctx = context.current()
         if ctx is not None and type(ctx) is cls.get_context_class():
@@ -1659,7 +1659,7 @@ class Query(Command):
         context: CommandContext,
     ) -> Command:
         return cls(
-            source_context=astnode.context,
+            source_context=astnode.span,
             expr=s_expr.Expression.from_ast(
                 astnode,  # type: ignore
                 schema=schema,
@@ -2909,7 +2909,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         if module is None:
             raise errors.SchemaDefinitionError(
                 f'unqualified name and no default module set',
-                context=objref.context,
+                context=objref.span,
             )
 
         return sn.QualName(module=module, name=objref.name)
@@ -4062,7 +4062,7 @@ class AlterObjectProperty(Command):
             except LookupError:
                 raise errors.SchemaDefinitionError(
                     f'{propname!r} is not a valid field',
-                    context=astnode.context)
+                    context=astnode.span)
 
         if not (
             astnode.special_syntax
@@ -4072,12 +4072,12 @@ class AlterObjectProperty(Command):
         ):
             raise errors.SchemaDefinitionError(
                 f'{propname!r} is not a valid field',
-                context=astnode.context)
+                context=astnode.span)
 
         if field.name == 'id' and not isinstance(parent_op, CreateObject):
             raise errors.SchemaDefinitionError(
                 f'cannot alter object id',
-                context=astnode.context)
+                context=astnode.span)
 
         new_value: Any
 
@@ -4163,7 +4163,7 @@ class AlterObjectProperty(Command):
         return cls(
             property=propname,
             new_value=new_value,
-            source_context=astnode.context,
+            source_context=astnode.span,
         )
 
     def is_data_safe(self) -> bool:

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -314,7 +314,7 @@ class CreateAliasLike(
                 classname=alias_name,
                 schema=schema,
                 context=context,
-                span=self.get_attribute_source_context('expr'),
+                span=self.get_attribute_span('expr'),
             )
             self.add_prerequisite(type_cmd)
             self.set_attribute_value('expr', expr)
@@ -387,7 +387,7 @@ class AlterAliasLike(
                     schema=schema,
                     context=context,
                     is_alter=is_computable,
-                    span=self.get_attribute_source_context('expr'),
+                    span=self.get_attribute_span('expr'),
                 )
 
                 self.add_prerequisite(type_cmd)

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -201,7 +201,7 @@ class AliasLikeCommand(
         schema: s_schema.Schema,
         context: sd.CommandContext,
         is_alter: bool = False,
-        parser_context: Optional[parsing.ParserContext] = None,
+        parser_context: Optional[parsing.Span] = None,
     ) -> Tuple[
         sd.Command,
         s_types.TypeShell[s_types.Type],
@@ -462,7 +462,7 @@ def compile_alias_expr(
     classname: sn.QualName,
     schema: s_schema.Schema,
     context: sd.CommandContext,
-    parser_context: Optional[parsing.ParserContext] = None,
+    parser_context: Optional[parsing.Span] = None,
 ) -> irast.Statement:
     cached: Optional[irast.Statement] = (
         context.get_cached((expr, classname)))
@@ -502,7 +502,7 @@ def _create_alias_types(
     classname: sn.QualName,
     schema: s_schema.Schema,
     is_global: bool,
-    parser_context: Optional[parsing.ParserContext] = None,
+    parser_context: Optional[parsing.Span] = None,
 ) -> Tuple[
     sd.Command,
     s_types.TypeShell[s_types.Type],

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -201,7 +201,7 @@ class AliasLikeCommand(
         schema: s_schema.Schema,
         context: sd.CommandContext,
         is_alter: bool = False,
-        parser_context: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Tuple[
         sd.Command,
         s_types.TypeShell[s_types.Type],
@@ -224,7 +224,7 @@ class AliasLikeCommand(
             classname,
             pschema,
             context,
-            parser_context=parser_context,
+            span=span,
         )
 
         expr = s_expr.Expression.from_ir(expr, ir, schema=schema)
@@ -236,7 +236,7 @@ class AliasLikeCommand(
             classname=classname,
             schema=schema,
             is_global=is_global,
-            parser_context=parser_context,
+            span=span,
         )
         if drop_old_types_cmd:
             cmd.prepend(drop_old_types_cmd)
@@ -314,7 +314,7 @@ class CreateAliasLike(
                 classname=alias_name,
                 schema=schema,
                 context=context,
-                parser_context=self.get_attribute_source_context('expr'),
+                span=self.get_attribute_source_context('expr'),
             )
             self.add_prerequisite(type_cmd)
             self.set_attribute_value('expr', expr)
@@ -387,7 +387,7 @@ class AlterAliasLike(
                     schema=schema,
                     context=context,
                     is_alter=is_computable,
-                    parser_context=self.get_attribute_source_context('expr'),
+                    span=self.get_attribute_source_context('expr'),
                 )
 
                 self.add_prerequisite(type_cmd)
@@ -462,7 +462,7 @@ def compile_alias_expr(
     classname: sn.QualName,
     schema: s_schema.Schema,
     context: sd.CommandContext,
-    parser_context: Optional[parsing.Span] = None,
+    span: Optional[parsing.Span] = None,
 ) -> irast.Statement:
     cached: Optional[irast.Statement] = (
         context.get_cached((expr, classname)))
@@ -488,7 +488,7 @@ def compile_alias_expr(
         raise errors.SchemaDefinitionError(
             f'volatile functions are not permitted in schema-defined '
             f'computed expressions',
-            context=parser_context,
+            context=span,
         )
 
     context.cache_value((expr, classname), ir)
@@ -502,7 +502,7 @@ def _create_alias_types(
     classname: sn.QualName,
     schema: s_schema.Schema,
     is_global: bool,
-    parser_context: Optional[parsing.Span] = None,
+    span: Optional[parsing.Span] = None,
 ) -> Tuple[
     sd.Command,
     s_types.TypeShell[s_types.Type],
@@ -569,7 +569,7 @@ def _create_alias_types(
         name=classname,
         origname=classname,
         schemaclass=type_cmd.get_schema_metaclass(),
-        sourcectx=parser_context,
+        sourcectx=span,
     )
     return result, type_shell, created_type_shells
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -488,7 +488,7 @@ def compile_alias_expr(
         raise errors.SchemaDefinitionError(
             f'volatile functions are not permitted in schema-defined '
             f'computed expressions',
-            context=span,
+            span=span,
         )
 
     context.cache_value((expr, classname), ir)

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -180,7 +180,7 @@ class ExtensionPackageCommand(
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined extension packages are not supported yet',
-                context=astnode.span
+                span=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -180,7 +180,7 @@ class ExtensionPackageCommand(
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined extension packages are not supported yet',
-                context=astnode.context
+                context=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1417,7 +1417,7 @@ class Function(
                         f'overloading an object type-receiving '
                         f'function with differences in the remaining '
                         f'parameters is not supported',
-                        context=srcctx,
+                        span=srcctx,
                         details=(
                             f"Other function is defined as `{other_sig}`"
                         )
@@ -1437,7 +1437,7 @@ class Function(
                         f'function: overloading an object type-receiving '
                         f'function with differences in the names of '
                         f'parameters is not supported',
-                        context=srcctx,
+                        span=srcctx,
                         details=(
                             f"Other function is defined as `{other_sig}`"
                         )
@@ -1457,7 +1457,7 @@ class Function(
                         f'function: overloading an object type-receiving '
                         f'function with differences in the type modifiers of '
                         f'parameters is not supported',
-                        context=srcctx,
+                        span=srcctx,
                         details=(
                             f"Other function is defined as `{other_sig}`"
                         )
@@ -1473,7 +1473,7 @@ class Function(
                         f'object type-receiving '
                         f'functions may not be overloaded on an OPTIONAL '
                         f'parameter',
-                        context=srcctx,
+                        span=srcctx,
                     )
 
                 diff_param = this_diff_param
@@ -1651,7 +1651,7 @@ class FunctionCommand(
                 raise errors.InvalidFunctionDefinitionError(
                     'data-modifying statements are not allowed in function'
                     ' bodies',
-                    context=ir.dml_exprs[0].span,
+                    span=ir.dml_exprs[0].span,
                 )
 
         spec_volatility: Optional[ft.Volatility] = (
@@ -1676,7 +1676,7 @@ class FunctionCommand(
                     f'{str(spec_volatility).lower()}',
                     details=f'Actual volatility is '
                             f'{str(ir.volatility).lower()}',
-                    context=body.qlast.span,
+                    span=body.qlast.span,
                 )
 
         globs = {schema.get(glob.global_name, type=s_globals.Global)
@@ -1721,7 +1721,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                 f'cannot create the `{signature}` function: '
                 f'a function with the same signature '
                 f'is already defined',
-                context=self.span)
+                span=self.span)
 
         if not context.canonical:
             fullname = self.classname
@@ -1778,14 +1778,14 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                 f'cannot create `{signature}` function: '
                 f'"preserves_optionality" makes no sense '
                 f'in a non-aggregate function',
-                context=self.span)
+                span=self.span)
 
         if preserves_upper_card and not has_set_of:
             raise errors.InvalidFunctionDefinitionError(
                 f'cannot create `{signature}` function: '
                 f'"preserves_upper_cardinality" makes no sense '
                 f'in a non-aggregate function',
-                context=self.span)
+                span=self.span)
 
         if preserves_upper_card and (
             return_typemod is not ft.TypeModifier.SetOfType
@@ -1794,7 +1794,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                 f'cannot create `{signature}` function: '
                 f'"preserves_upper_cardinality" makes no sense '
                 f'in a function not returning SET OF',
-                context=self.span)
+                span=self.span)
 
         # Certain syntax is only allowed in "EdgeDB developer" mode,
         # i.e. when populating std library, etc.
@@ -1804,26 +1804,26 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'cannot create `{signature}` function: '
                     f'generic types are not supported in '
                     f'user-defined functions',
-                    context=self.span)
+                    span=self.span)
             elif from_function:
                 raise errors.InvalidFunctionDefinitionError(
                     f'cannot create `{signature}` function: '
                     f'"USING SQL FUNCTION" is not supported in '
                     f'user-defined functions',
-                    context=self.span)
+                    span=self.span)
             elif language != qlast.Language.EdgeQL:
                 raise errors.InvalidFunctionDefinitionError(
                     f'cannot create `{signature}` function: '
                     f'"USING {language}" is not supported in '
                     f'user-defined functions',
-                    context=self.span)
+                    span=self.span)
 
         if polymorphic_return_type and not has_polymorphic:
             raise errors.InvalidFunctionDefinitionError(
                 f'cannot create `{signature}` function: '
                 f'function returns a generic type but has no '
                 f'generic parameters',
-                context=self.span)
+                span=self.span)
 
         overloaded_funcs = schema.get_functions(shortname, ())
         has_from_function = from_function
@@ -1842,7 +1842,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'overloading another function with different '
                     f'named only parameters: '
                     f'"{func.get_signature_as_str(schema)}"',
-                    context=self.span)
+                    span=self.span)
 
             if ((has_polymorphic or func_params.has_polymorphic(schema)) and (
                     func.get_return_typemod(schema) != return_typemod)):
@@ -1855,7 +1855,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'function: overloading another function with different '
                     f'return type {func_return_typemod.to_edgeql()} '
                     f'{func.get_return_type(schema).get_displayname(schema)}',
-                    context=self.span)
+                    span=self.span)
 
             if fallback and func.get_fallback(schema) and self.scls != func:
                 raise errors.InvalidFunctionDefinitionError(
@@ -1864,7 +1864,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'{return_type.get_displayname(schema)}` '
                     f'function: only one generic fallback per polymorphic '
                     f'function is allowed',
-                    context=self.span)
+                    span=self.span)
 
             if func_from_function:
                 has_from_function = func_from_function
@@ -1875,7 +1875,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'overloading another function with different '
                     f'"preserves_optionality" attribute: '
                     f'`{func.get_signature_as_str(schema)}`',
-                    context=self.span)
+                    span=self.span)
 
             if func_preserves_upper_card != preserves_upper_card:
                 raise errors.InvalidFunctionDefinitionError(
@@ -1883,7 +1883,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'overloading another function with different '
                     f'"preserves_upper_cardinality" attribute: '
                     f'`{func.get_signature_as_str(schema)}`',
-                    context=self.span)
+                    span=self.span)
 
         if has_objects:
             self.scls.find_object_param_overloads(
@@ -1901,7 +1901,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'overloading "USING SQL FUNCTION" functions is '
                     f'allowed only when all functions point to the same '
                     f'SQL function',
-                    context=self.span)
+                    span=self.span)
 
         if (language == qlast.Language.EdgeQL and
                 any(p.get_typemod(schema) is ft.TypeModifier.SetOfType
@@ -1910,7 +1910,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                 f'cannot create the `{signature}` function: '
                 f'SET OF parameters in user-defined EdgeQL functions are '
                 f'not supported',
-                context=self.span)
+                span=self.span)
 
         # check that params of type 'anytype' don't have defaults
         for p in params.objects(schema):
@@ -1927,7 +1927,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     f'cannot create the `{signature}` function: '
                     f'invalid default value {p_default.text!r} of parameter '
                     f'{p.get_displayname(schema)!r}: {ex}',
-                    context=self.span)
+                    span=self.span)
 
             check_default_type = True
             if p_type.is_polymorphic(schema):
@@ -1939,7 +1939,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                         f'polymorphic parameter of type '
                         f'{p_type.get_displayname(schema)} cannot '
                         f'have a non-empty default value',
-                        context=self.span)
+                        span=self.span)
             elif (p.get_typemod(schema) is ft.TypeModifier.OptionalType and
                     irutils.is_empty(ir_default.expr)):
                 check_default_type = False
@@ -1954,7 +1954,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                         f'unexpected type of the default expression: '
                         f'{default_type.get_displayname(schema)}, expected '
                         f'{p_type.get_displayname(schema)}',
-                        context=self.span)
+                        span=self.span)
 
         # Make sure variadic parameters do not contain optional types in
         # user-defined functions
@@ -1968,7 +1968,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                         f'`{variadic.get_displayname(schema)}` '
                         f'illegally declared with optional type in '
                         f'user-defined function',
-                        context=self.span)
+                        span=self.span)
 
         return schema
 
@@ -2114,7 +2114,7 @@ class RenameFunction(RenameCallableObject[Function], FunctionCommand):
         if len(existing) > 1:
             raise errors.SchemaError(
                 'renaming an overloaded function is not allowed',
-                context=self.span)
+                span=self.span)
 
         target = schema.get_functions(new_name, ())
         if target:
@@ -2122,7 +2122,7 @@ class RenameFunction(RenameCallableObject[Function], FunctionCommand):
                 f"can not rename function to '{new_name!s}' because "
                 f"a function with the same name already exists, and "
                 f"renaming into an overload is not supported",
-                context=self.span)
+                span=self.span)
 
 
 class AlterFunction(AlterCallableObject[Function], FunctionCommand):
@@ -2151,7 +2151,7 @@ class AlterFunction(AlterCallableObject[Function], FunctionCommand):
                     f'{self.scls.get_verbosename(schema)}: '
                     f'only one generic fallback per polymorphic '
                     f'function is allowed',
-                    context=self.span)
+                    span=self.span)
 
         # If volatility or nativecode changed, propagate that to
         # referring exprs
@@ -2204,7 +2204,7 @@ class AlterFunction(AlterCallableObject[Function], FunctionCommand):
                 raise errors.EdgeQLSyntaxError(
                     'altering function code is only supported for '
                     'pure EdgeQL functions',
-                    context=astnode.span
+                    span=astnode.span
                 )
 
             nativecode_expr: Optional[qlast.Expr] = None
@@ -2416,7 +2416,7 @@ def compile_function(
             f'{return_type.get_verbosename(schema)}',
             details=f'Actual return type is '
                     f'{ir.stype.get_verbosename(schema)}',
-            context=body.qlast.span,
+            span=body.qlast.span,
         )
 
     if (return_typemod is not ft.TypeModifier.SetOfType
@@ -2427,7 +2427,7 @@ def compile_function(
             details=(
                 f'Function may return a set with more than one element.'
             ),
-            context=body.qlast.span,
+            span=body.qlast.span,
         )
     elif (return_typemod is ft.TypeModifier.SingletonType
             and ir.cardinality.can_be_zero()):
@@ -2437,7 +2437,7 @@ def compile_function(
             details=(
                 f'Function may return an empty set.'
             ),
-            context=body.qlast.span,
+            span=body.qlast.span,
         )
 
     return compiled

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1340,7 +1340,7 @@ class Function(
         self,
         schema: s_schema.Schema,
         *,
-        srcctx: Optional[parsing.ParserContext] = None,
+        srcctx: Optional[parsing.Span] = None,
     ) -> Optional[Tuple[List[Function], int]]:
         """Find if this function overloads another in object parameter.
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1651,7 +1651,7 @@ class FunctionCommand(
                 raise errors.InvalidFunctionDefinitionError(
                     'data-modifying statements are not allowed in function'
                     ' bodies',
-                    context=ir.dml_exprs[0].context,
+                    context=ir.dml_exprs[0].span,
                 )
 
         spec_volatility: Optional[ft.Volatility] = (
@@ -1676,7 +1676,7 @@ class FunctionCommand(
                     f'{str(spec_volatility).lower()}',
                     details=f'Actual volatility is '
                             f'{str(ir.volatility).lower()}',
-                    context=body.qlast.context,
+                    context=body.qlast.span,
                 )
 
         globs = {schema.get(glob.global_name, type=s_globals.Global)
@@ -2204,7 +2204,7 @@ class AlterFunction(AlterCallableObject[Function], FunctionCommand):
                 raise errors.EdgeQLSyntaxError(
                     'altering function code is only supported for '
                     'pure EdgeQL functions',
-                    context=astnode.context
+                    context=astnode.span
                 )
 
             nativecode_expr: Optional[qlast.Expr] = None
@@ -2416,7 +2416,7 @@ def compile_function(
             f'{return_type.get_verbosename(schema)}',
             details=f'Actual return type is '
                     f'{ir.stype.get_verbosename(schema)}',
-            context=body.qlast.context,
+            context=body.qlast.span,
         )
 
     if (return_typemod is not ft.TypeModifier.SetOfType
@@ -2427,7 +2427,7 @@ def compile_function(
             details=(
                 f'Function may return a set with more than one element.'
             ),
-            context=body.qlast.context,
+            context=body.qlast.span,
         )
     elif (return_typemod is ft.TypeModifier.SingletonType
             and ir.cardinality.can_be_zero()):
@@ -2437,7 +2437,7 @@ def compile_function(
             details=(
                 f'Function may return an empty set.'
             ),
-            context=body.qlast.context,
+            context=body.qlast.span,
         )
 
     return compiled

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -148,7 +148,7 @@ class GlobalCommand(
         glob_name = self.get_verbosename()
 
         if spec_required and not required:
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.SchemaDefinitionError(
                 f'possibly an empty set returned by an '
                 f'expression for the computed '
@@ -161,7 +161,7 @@ class GlobalCommand(
             spec_card is qltypes.SchemaCardinality.One
             and card is not qltypes.SchemaCardinality.One
         ):
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.SchemaDefinitionError(
                 f'possibly more than one element returned by an '
                 f'expression for the computed '
@@ -210,17 +210,17 @@ class GlobalCommand(
             ):
                 raise errors.SchemaDefinitionError(
                     "required globals must have a default",
-                    context=self.source_context,
+                    context=self.span,
                 )
             if scls.get_cardinality(schema) == qltypes.SchemaCardinality.Many:
                 raise errors.SchemaDefinitionError(
                     "non-computed globals may not be multi",
-                    context=self.source_context,
+                    context=self.span,
                 )
             if target.contains_object(schema):
                 raise errors.SchemaDefinitionError(
                     "non-computed globals may not have have object type",
-                    context=self.source_context,
+                    context=self.span,
                 )
 
         default_expr = scls.get_default(schema)
@@ -231,7 +231,7 @@ class GlobalCommand(
             default_schema = default_expr.irast.schema
             default_type = default_expr.irast.stype
 
-            span = self.get_attribute_source_context('default')
+            span = self.get_attribute_span('default')
 
             if is_computable:
                 raise errors.SchemaDefinitionError(
@@ -483,7 +483,7 @@ class AlterGlobal(
             ):
                 raise errors.UnsupportedFeatureError(
                     "cannot specify a type and an expression for a global",
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             if clears_expr and old_expr:
@@ -537,7 +537,7 @@ class SetGlobalType(
                 raise errors.UnsupportedFeatureError(
                     f'USING casts for SET TYPE on globals are not supported',
                     hint='Use RESET TO DEFAULT instead',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             if not self.reset_value:
@@ -545,7 +545,7 @@ class SetGlobalType(
                     f"SET TYPE on global must explicitly reset the "
                     f"global's value",
                     hint='Use RESET TO DEFAULT after the type',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
         return schema

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -382,14 +382,14 @@ class CreateGlobal(
             cmd.set_attribute_value(
                 'required',
                 astnode.is_required,
-                source_context=astnode.context,
+                source_context=astnode.span,
             )
 
         if astnode.cardinality is not None:
             cmd.set_attribute_value(
                 'cardinality',
                 astnode.cardinality,
-                source_context=astnode.context,
+                source_context=astnode.span,
             )
 
         assert astnode.target is not None
@@ -404,7 +404,7 @@ class CreateGlobal(
             cmd.set_attribute_value(
                 'target',
                 type_ref,
-                source_context=astnode.target.context,
+                source_context=astnode.target.span,
             )
 
         else:
@@ -428,7 +428,7 @@ class CreateGlobal(
         ):
             raise errors.UnsupportedFeatureError(
                 "cannot specify a type and an expression for a global",
-                context=astnode.context,
+                context=astnode.span,
             )
 
         return cmd

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -231,12 +231,12 @@ class GlobalCommand(
             default_schema = default_expr.irast.schema
             default_type = default_expr.irast.stype
 
-            source_context = self.get_attribute_source_context('default')
+            span = self.get_attribute_source_context('default')
 
             if is_computable:
                 raise errors.SchemaDefinitionError(
                     f'computed globals may not have default values',
-                    context=source_context,
+                    context=span,
                 )
 
             if not default_type.assignment_castable_to(target, default_schema):
@@ -244,7 +244,7 @@ class GlobalCommand(
                     f'default expression is of invalid type: '
                     f'{default_type.get_displayname(default_schema)}, '
                     f'expected {target.get_displayname(schema)}',
-                    context=source_context,
+                    context=span,
                 )
 
             ptr_cardinality = scls.get_cardinality(schema)
@@ -258,7 +258,7 @@ class GlobalCommand(
                     f'the default expression for '
                     f'{scls.get_verbosename(schema)} declared as '
                     f"'single'",
-                    context=source_context,
+                    context=span,
                 )
 
             if scls.get_required(schema) and not default_required:
@@ -267,14 +267,14 @@ class GlobalCommand(
                     f'the default expression for '
                     f'{scls.get_verbosename(schema)} declared as '
                     f"'required'",
-                    context=source_context,
+                    context=span,
                 )
 
             if default_expr.irast.volatility.is_volatile():
                 raise errors.SchemaDefinitionError(
                     f'{scls.get_verbosename(schema)} has a volatile '
                     f'default expression, which is not allowed',
-                    context=source_context,
+                    context=span,
                 )
 
     def get_dummy_expr_field_value(
@@ -382,14 +382,14 @@ class CreateGlobal(
             cmd.set_attribute_value(
                 'required',
                 astnode.is_required,
-                source_context=astnode.span,
+                span=astnode.span,
             )
 
         if astnode.cardinality is not None:
             cmd.set_attribute_value(
                 'cardinality',
                 astnode.cardinality,
-                source_context=astnode.span,
+                span=astnode.span,
             )
 
         assert astnode.target is not None
@@ -404,7 +404,7 @@ class CreateGlobal(
             cmd.set_attribute_value(
                 'target',
                 type_ref,
-                source_context=astnode.target.span,
+                span=astnode.target.span,
             )
 
         else:

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -154,7 +154,7 @@ class GlobalCommand(
                 f'expression for the computed '
                 f'{glob_name} '
                 f"explicitly declared as 'required'",
-                context=srcctx
+                span=srcctx
             )
 
         if (
@@ -167,7 +167,7 @@ class GlobalCommand(
                 f'expression for the computed '
                 f'{glob_name} '
                 f"explicitly declared as 'single'",
-                context=srcctx
+                span=srcctx
             )
 
         if spec_card is None:
@@ -210,17 +210,17 @@ class GlobalCommand(
             ):
                 raise errors.SchemaDefinitionError(
                     "required globals must have a default",
-                    context=self.span,
+                    span=self.span,
                 )
             if scls.get_cardinality(schema) == qltypes.SchemaCardinality.Many:
                 raise errors.SchemaDefinitionError(
                     "non-computed globals may not be multi",
-                    context=self.span,
+                    span=self.span,
                 )
             if target.contains_object(schema):
                 raise errors.SchemaDefinitionError(
                     "non-computed globals may not have have object type",
-                    context=self.span,
+                    span=self.span,
                 )
 
         default_expr = scls.get_default(schema)
@@ -236,7 +236,7 @@ class GlobalCommand(
             if is_computable:
                 raise errors.SchemaDefinitionError(
                     f'computed globals may not have default values',
-                    context=span,
+                    span=span,
                 )
 
             if not default_type.assignment_castable_to(target, default_schema):
@@ -244,7 +244,7 @@ class GlobalCommand(
                     f'default expression is of invalid type: '
                     f'{default_type.get_displayname(default_schema)}, '
                     f'expected {target.get_displayname(schema)}',
-                    context=span,
+                    span=span,
                 )
 
             ptr_cardinality = scls.get_cardinality(schema)
@@ -258,7 +258,7 @@ class GlobalCommand(
                     f'the default expression for '
                     f'{scls.get_verbosename(schema)} declared as '
                     f"'single'",
-                    context=span,
+                    span=span,
                 )
 
             if scls.get_required(schema) and not default_required:
@@ -267,14 +267,14 @@ class GlobalCommand(
                     f'the default expression for '
                     f'{scls.get_verbosename(schema)} declared as '
                     f"'required'",
-                    context=span,
+                    span=span,
                 )
 
             if default_expr.irast.volatility.is_volatile():
                 raise errors.SchemaDefinitionError(
                     f'{scls.get_verbosename(schema)} has a volatile '
                     f'default expression, which is not allowed',
-                    context=span,
+                    span=span,
                 )
 
     def get_dummy_expr_field_value(
@@ -428,7 +428,7 @@ class CreateGlobal(
         ):
             raise errors.UnsupportedFeatureError(
                 "cannot specify a type and an expression for a global",
-                context=astnode.span,
+                span=astnode.span,
             )
 
         return cmd
@@ -483,7 +483,7 @@ class AlterGlobal(
             ):
                 raise errors.UnsupportedFeatureError(
                     "cannot specify a type and an expression for a global",
-                    context=self.span,
+                    span=self.span,
                 )
 
             if clears_expr and old_expr:
@@ -537,7 +537,7 @@ class SetGlobalType(
                 raise errors.UnsupportedFeatureError(
                     f'USING casts for SET TYPE on globals are not supported',
                     hint='Use RESET TO DEFAULT instead',
-                    context=self.span,
+                    span=self.span,
                 )
 
             if not self.reset_value:
@@ -545,7 +545,7 @@ class SetGlobalType(
                     f"SET TYPE on global must explicitly reset the "
                     f"global's value",
                     hint='Use RESET TO DEFAULT after the type',
-                    context=self.span,
+                    span=self.span,
                 )
 
         return schema

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -698,7 +698,7 @@ class IndexCommand(
                 raise errors.SchemaDefinitionError(
                     "cannot use aggregate functions or operators "
                     "in an index expression",
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             return expr
@@ -868,7 +868,7 @@ class CreateIndex(
         if not params:
             raise errors.SchemaDefinitionError(
                 f'the {ancestor_name} does not support any parameters',
-                context=self.source_context
+                context=self.span
             )
 
         # Make sure that the kwargs are valid.
@@ -878,7 +878,7 @@ class CreateIndex(
             if param is None:
                 raise errors.SchemaDefinitionError(
                     f'the {ancestor_name} does not have a parameter {key!r}',
-                    context=self.source_context
+                    context=self.span
                 )
 
             param_type = param.get_type(schema)
@@ -899,7 +899,7 @@ class CreateIndex(
                     f'corresponding parameter of the '
                     f'{ancestor_name} with type '
                     f'{param_type.get_displayname(schema)}',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
     def validate_object(
@@ -939,7 +939,7 @@ class CreateIndex(
                         raise errors.SchemaDefinitionError(
                             f'cannot create {self.get_verbosename()} '
                             f'because it extends incompatible abstract indxes',
-                            context=self.source_context
+                            context=self.span
                         )
 
                 # We should have found a root because we have bases.
@@ -960,7 +960,7 @@ class CreateIndex(
                         f'cannot create {self.get_verbosename()} '
                         f'because user-defined abstract indexes are not '
                         f'supported',
-                        context=self.source_context
+                        context=self.span
                     )
 
             return
@@ -975,7 +975,7 @@ class CreateIndex(
             if isinstance(subject, s_pointers.Pointer):
                 raise errors.SchemaDefinitionError(
                     "fts::index cannot be declared on links",
-                    context=self.source_context
+                    context=self.span
                 )
 
         # Ensure that the name of the index (if given) matches an existing
@@ -1028,7 +1028,7 @@ class CreateIndex(
                     f'cannot create {self.get_verbosename()} '
                     f'because the following parameters are still undefined: '
                     f'{names}.',
-                    context=self.source_context
+                    context=self.span
                 )
 
             # Make sure that the concrete index expression type matches the
@@ -1062,7 +1062,7 @@ class CreateIndex(
                     f'index expression ({expr.text}) '
                     f'is not of a valid type for the '
                     f'{self.scls.get_verbosename(comp_expr.schema)}',
-                    context=self.source_context,
+                    context=self.span,
                     details=hint,
                 )
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -664,13 +664,13 @@ class IndexCommand(
                     f'possibly more than one element returned by '
                     f'the index expression where only singletons '
                     f'are allowed',
-                    context=value.qlast.span,
+                    span=value.qlast.span,
                 )
 
             if expr.irast.volatility != qltypes.Volatility.Immutable:
                 raise errors.SchemaDefinitionError(
                     f'index expressions must be immutable',
-                    context=value.qlast.span,
+                    span=value.qlast.span,
                 )
 
             refs = irutils.get_longest_paths(expr.irast)
@@ -698,7 +698,7 @@ class IndexCommand(
                 raise errors.SchemaDefinitionError(
                     "cannot use aggregate functions or operators "
                     "in an index expression",
-                    context=self.span,
+                    span=self.span,
                 )
 
             return expr
@@ -868,7 +868,7 @@ class CreateIndex(
         if not params:
             raise errors.SchemaDefinitionError(
                 f'the {ancestor_name} does not support any parameters',
-                context=self.span
+                span=self.span
             )
 
         # Make sure that the kwargs are valid.
@@ -878,7 +878,7 @@ class CreateIndex(
             if param is None:
                 raise errors.SchemaDefinitionError(
                     f'the {ancestor_name} does not have a parameter {key!r}',
-                    context=self.span
+                    span=self.span
                 )
 
             param_type = param.get_type(schema)
@@ -899,7 +899,7 @@ class CreateIndex(
                     f'corresponding parameter of the '
                     f'{ancestor_name} with type '
                     f'{param_type.get_displayname(schema)}',
-                    context=self.span,
+                    span=self.span,
                 )
 
     def validate_object(
@@ -939,7 +939,7 @@ class CreateIndex(
                         raise errors.SchemaDefinitionError(
                             f'cannot create {self.get_verbosename()} '
                             f'because it extends incompatible abstract indxes',
-                            context=self.span
+                            span=self.span
                         )
 
                 # We should have found a root because we have bases.
@@ -960,7 +960,7 @@ class CreateIndex(
                         f'cannot create {self.get_verbosename()} '
                         f'because user-defined abstract indexes are not '
                         f'supported',
-                        context=self.span
+                        span=self.span
                     )
 
             return
@@ -975,7 +975,7 @@ class CreateIndex(
             if isinstance(subject, s_pointers.Pointer):
                 raise errors.SchemaDefinitionError(
                     "fts::index cannot be declared on links",
-                    context=self.span
+                    span=self.span
                 )
 
         # Ensure that the name of the index (if given) matches an existing
@@ -1028,7 +1028,7 @@ class CreateIndex(
                     f'cannot create {self.get_verbosename()} '
                     f'because the following parameters are still undefined: '
                     f'{names}.',
-                    context=self.span
+                    span=self.span
                 )
 
             # Make sure that the concrete index expression type matches the
@@ -1062,7 +1062,7 @@ class CreateIndex(
                     f'index expression ({expr.text}) '
                     f'is not of a valid type for the '
                     f'{self.scls.get_verbosename(comp_expr.schema)}',
-                    context=self.span,
+                    span=self.span,
                     details=hint,
                 )
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -513,7 +513,7 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: Union[Index, so.NoDefaultT] = so.NoDefault,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Index:
         ...
 
@@ -525,7 +525,7 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[Index]:
         ...
 
@@ -536,7 +536,7 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: Union[Index, so.NoDefaultT, None] = so.NoDefault,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[Index]:
         try:
             return super().get_object(

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -664,13 +664,13 @@ class IndexCommand(
                     f'possibly more than one element returned by '
                     f'the index expression where only singletons '
                     f'are allowed',
-                    context=value.qlast.context,
+                    context=value.qlast.span,
                 )
 
             if expr.irast.volatility != qltypes.Volatility.Immutable:
                 raise errors.SchemaDefinitionError(
                     f'index expressions must be immutable',
-                    context=value.qlast.context,
+                    context=value.qlast.span,
                 )
 
             refs = irutils.get_longest_paths(expr.irast)

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -816,7 +816,7 @@ class CreateInheritingObject(
         cmd.set_attribute_value(
             'bases',
             so.ObjectCollectionShell(bases, collection_type=so.ObjectList),
-            source_context=span,
+            span=span,
         )
 
         return cmd

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -141,7 +141,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                     schema=schema,
                 )
             except errors.SchemaDefinitionError as e:
-                if (srcctx := self.get_attribute_source_context(field_name)):
+                if (srcctx := self.get_attribute_span(field_name)):
                     e.set_source_context(srcctx)
                 raise
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -37,7 +37,7 @@ from typing import (
 
 from edb import errors
 
-from edb.common import span as ctx_utils
+from edb.common import span as span
 from edb.common import struct
 from edb.edgeql import ast as qlast
 from edb.schema import schema as s_schema
@@ -810,7 +810,7 @@ class CreateInheritingObject(
         bases = cls._classbases_from_ast(schema, astnode, context)
         ctxes = [b.sourcectx for b in bases if b.sourcectx is not None]
         if ctxes:
-            srcctx = ctx_utils.merge_context(ctxes)
+            srcctx = span.merge_spans(ctxes)
         else:
             srcctx = None
         cmd.set_attribute_value(

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -37,7 +37,7 @@ from typing import (
 
 from edb import errors
 
-from edb.common import span as span
+from edb.common import span as pspan
 from edb.common import struct
 from edb.edgeql import ast as qlast
 from edb.schema import schema as s_schema
@@ -808,15 +808,15 @@ class CreateInheritingObject(
 
         assert isinstance(astnode, qlast.ObjectDDL)
         bases = cls._classbases_from_ast(schema, astnode, context)
-        ctxes = [b.sourcectx for b in bases if b.sourcectx is not None]
-        if ctxes:
-            srcctx = span.merge_spans(ctxes)
+        spans = [b.sourcectx for b in bases if b.sourcectx is not None]
+        if spans:
+            span = pspan.merge_spans(spans)
         else:
-            srcctx = None
+            span = None
         cmd.set_attribute_value(
             'bases',
             so.ObjectCollectionShell(bases, collection_type=so.ObjectList),
-            source_context=srcctx,
+            source_context=span,
         )
 
         return cmd

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -37,7 +37,7 @@ from typing import (
 
 from edb import errors
 
-from edb.common import context as ctx_utils
+from edb.common import span as ctx_utils
 from edb.common import struct
 from edb.edgeql import ast as qlast
 from edb.schema import schema as s_schema

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -142,7 +142,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                 )
             except errors.SchemaDefinitionError as e:
                 if (srcctx := self.get_attribute_span(field_name)):
-                    e.set_source_context(srcctx)
+                    e.set_span(srcctx)
                 raise
 
             if not ignore_local_field:

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -37,7 +37,7 @@ from typing import (
 
 from edb import errors
 
-from edb.common import span as pspan
+from edb.common import span as edb_span
 from edb.common import struct
 from edb.edgeql import ast as qlast
 from edb.schema import schema as s_schema
@@ -810,7 +810,7 @@ class CreateInheritingObject(
         bases = cls._classbases_from_ast(schema, astnode, context)
         spans = [b.sourcectx for b in bases if b.sourcectx is not None]
         if spans:
-            span = pspan.merge_spans(spans)
+            span = edb_span.merge_spans(spans)
         else:
             span = None
         cmd.set_attribute_value(

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -273,7 +273,7 @@ class LinkCommand(
             raise errors.InvalidLinkTargetError(
                 f'invalid link target type, expected object type, got '
                 f'{target.get_verbosename(schema)}',
-                context=srcctx,
+                span=srcctx,
                 hint=hint,
             )
 
@@ -281,7 +281,7 @@ class LinkCommand(
             srcctx = self.get_attribute_span('target')
             raise errors.InvalidLinkTargetError(
                 f'{target.get_verbosename(schema)} is not a valid link target',
-                context=srcctx,
+                span=srcctx,
             )
 
         if (
@@ -293,7 +293,7 @@ class LinkCommand(
             raise errors.InvalidLinkTargetError(
                 f'invalid link type: {target.get_displayname(schema)!r}'
                 f' is an expression alias, not a proper object type',
-                context=srcctx,
+                span=srcctx,
             )
 
         if (
@@ -304,7 +304,7 @@ class LinkCommand(
             raise errors.InvalidLinkTargetError(
                 'required links may not use `on target delete '
                 'deferred restrict`',
-                context=self.span,
+                span=self.span,
             )
 
     def _get_ast(

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -260,7 +260,7 @@ class LinkCommand(
         assert target is not None
 
         if not target.is_object_type():
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             if isinstance(target, s_types.Array):
                 # Custom error message for link -> array<...>
                 link_dn = scls.get_displayname(schema)
@@ -277,7 +277,7 @@ class LinkCommand(
             )
 
         if target.is_free_object_type(schema):
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.InvalidLinkTargetError(
                 f'{target.get_verbosename(schema)} is not a valid link target',
                 context=srcctx,
@@ -288,7 +288,7 @@ class LinkCommand(
             and not scls.get_from_alias(schema)
             and target.is_view(schema)
         ):
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.InvalidLinkTargetError(
                 f'invalid link type: {target.get_displayname(schema)!r}'
                 f' is an expression alias, not a proper object type',
@@ -303,7 +303,7 @@ class LinkCommand(
             raise errors.InvalidLinkTargetError(
                 'required links may not use `on target delete '
                 'deferred restrict`',
-                context=self.source_context,
+                context=self.span,
             )
 
     def _get_ast(

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -135,7 +135,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
                 f'specified migration name does not match the name derived '
                 f'from the migration contents: {specified_name!r}, expected '
                 f'{name!r}',
-                context=astnode.name.span,
+                span=astnode.name.span,
             )
 
         if specified_name is not None and schema.has_migration(specified_name):
@@ -144,7 +144,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
             # parent (and you can't specify parent without a name).
             raise errors.DuplicateMigrationError(
                 f'migration {name!r} is already applied',
-                context=astnode.name.span,
+                span=astnode.name.span,
             )
 
         if astnode.parent is not None:
@@ -152,7 +152,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
                 if astnode.parent.name.lower() != 'initial':
                     raise errors.SchemaDefinitionError(
                         f'specified migration parent does not exist',
-                        context=astnode.parent.span,
+                        span=astnode.parent.span,
                     )
             else:
                 astnode_parent = s_utils.ast_objref_to_object_shell(
@@ -167,7 +167,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
                     raise errors.SchemaDefinitionError(
                         f'specified migration parent is not the most recent '
                         f'migration, expected {str(actual_parent_name)!r}',
-                        context=astnode.parent.span,
+                        span=astnode.parent.span,
                     )
 
         cmd = cls(classname=sn.UnqualName(name))

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -135,7 +135,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
                 f'specified migration name does not match the name derived '
                 f'from the migration contents: {specified_name!r}, expected '
                 f'{name!r}',
-                context=astnode.name.context,
+                context=astnode.name.span,
             )
 
         if specified_name is not None and schema.has_migration(specified_name):
@@ -144,7 +144,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
             # parent (and you can't specify parent without a name).
             raise errors.DuplicateMigrationError(
                 f'migration {name!r} is already applied',
-                context=astnode.name.context,
+                context=astnode.name.span,
             )
 
         if astnode.parent is not None:
@@ -152,7 +152,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
                 if astnode.parent.name.lower() != 'initial':
                     raise errors.SchemaDefinitionError(
                         f'specified migration parent does not exist',
-                        context=astnode.parent.context,
+                        context=astnode.parent.span,
                     )
             else:
                 astnode_parent = s_utils.ast_objref_to_object_shell(
@@ -167,7 +167,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
                     raise errors.SchemaDefinitionError(
                         f'specified migration parent is not the most recent '
                         f'migration, expected {str(actual_parent_name)!r}',
-                        context=astnode.parent.context,
+                        context=astnode.parent.span,
                     )
 
         cmd = cls(classname=sn.UnqualName(name))

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -85,7 +85,7 @@ class ModuleCommand(
             raise errors.SchemaDefinitionError(
                 f'cannot {self._delta_action} {self.get_verbosename()}: '
                 f'module {first} is read-only',
-                context=self.span)
+                span=self.span)
 
 
 class CreateModule(ModuleCommand, sd.CreateObject[Module]):

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -85,7 +85,7 @@ class ModuleCommand(
             raise errors.SchemaDefinitionError(
                 f'cannot {self._delta_action} {self.get_verbosename()}: '
                 f'module {first} is read-only',
-                context=self.source_context)
+                context=self.span)
 
 
 class CreateModule(ModuleCommand, sd.CreateObject[Module]):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1016,7 +1016,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
 
     # Schema source context for this object
     sourcectx = SchemaField(
-        parsing.ParserContext,
+        parsing.Span,
         default=None,
         compcoef=None,
         inheritable=False,
@@ -2199,7 +2199,7 @@ class ObjectShell(Shell, Generic[Object_T_co]):
         schemaclass: Type[Object_T_co],
         displayname: Optional[str] = None,
         origname: Optional[sn.Name] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> None:
         self.name = name
         self.origname = origname

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -513,7 +513,7 @@ class ObjectTypeCommand(
                 ):
                     raise errors.SchemaDefinitionError(
                         f"cannot extend system type '{name}'",
-                        context=self.span,
+                        span=self.span,
                     )
 
     def get_dummy_expr_field_value(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -513,7 +513,7 @@ class ObjectTypeCommand(
                 ):
                     raise errors.SchemaDefinitionError(
                         f"cannot extend system type '{name}'",
-                        context=self.source_context,
+                        context=self.span,
                     )
 
     def get_dummy_expr_field_value(

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -142,7 +142,7 @@ class OperatorCommand(
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined operators are not supported',
-                context=astnode.context
+                context=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -142,7 +142,7 @@ class OperatorCommand(
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined operators are not supported',
-                context=astnode.span
+                span=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)
@@ -188,7 +188,7 @@ class CreateOperator(
                 f'cannot create the `{signature}` operator: '
                 f'an operator with the same signature '
                 f'is already defined',
-                context=self.span)
+                span=self.span)
 
         schema = super()._create_begin(schema, context)
 
@@ -205,7 +205,7 @@ class CreateOperator(
             raise errors.InvalidOperatorDefinitionError(
                 f'cannot create the `{signature}` operator: '
                 f'an operator must have operands',
-                context=self.span)
+                span=self.span)
 
         # We'll need to make sure that there's no mix of recursive and
         # non-recursive operators being overloaded.
@@ -224,7 +224,7 @@ class CreateOperator(
                 f'cannot create the `{signature}` operator: '
                 f'operands of a recursive operator must either be '
                 f'all arrays or all tuples',
-                context=self.span)
+                span=self.span)
 
         for oper in schema.get_operators(shortname, ()):
             if oper == self.scls:
@@ -237,7 +237,7 @@ class CreateOperator(
                     f'operator: overloading another operator with different '
                     f'return type {oper_return_typemod.to_edgeql()} '
                     f'{oper.get_return_type(schema).name}',
-                    context=self.span)
+                    span=self.span)
 
             oper_derivative_of = oper.get_derivative_of(schema)
             if oper_derivative_of:
@@ -245,13 +245,13 @@ class CreateOperator(
                     f'cannot create the `{signature}` '
                     f'operator: there exists a derivative operator of the '
                     f'same name',
-                    context=self.span)
+                    span=self.span)
             elif derivative_of:
                 raise errors.DuplicateOperatorDefinitionError(
                     f'cannot create `{signature}` '
                     f'as a derivative operator: there already exists an '
                     f'operator of the same name',
-                    context=self.span)
+                    span=self.span)
 
             # Check if there is a recursive/non-recursive operator
             # overloading.
@@ -282,7 +282,7 @@ class CreateOperator(
                         f'overloading a {oper_rec} operator '
                         f'`{oper_signature}` with a {new_rec} one '
                         f'is not allowed',
-                        context=self.span)
+                        span=self.span)
 
         return schema
 

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -188,7 +188,7 @@ class CreateOperator(
                 f'cannot create the `{signature}` operator: '
                 f'an operator with the same signature '
                 f'is already defined',
-                context=self.source_context)
+                context=self.span)
 
         schema = super()._create_begin(schema, context)
 
@@ -205,7 +205,7 @@ class CreateOperator(
             raise errors.InvalidOperatorDefinitionError(
                 f'cannot create the `{signature}` operator: '
                 f'an operator must have operands',
-                context=self.source_context)
+                context=self.span)
 
         # We'll need to make sure that there's no mix of recursive and
         # non-recursive operators being overloaded.
@@ -224,7 +224,7 @@ class CreateOperator(
                 f'cannot create the `{signature}` operator: '
                 f'operands of a recursive operator must either be '
                 f'all arrays or all tuples',
-                context=self.source_context)
+                context=self.span)
 
         for oper in schema.get_operators(shortname, ()):
             if oper == self.scls:
@@ -237,7 +237,7 @@ class CreateOperator(
                     f'operator: overloading another operator with different '
                     f'return type {oper_return_typemod.to_edgeql()} '
                     f'{oper.get_return_type(schema).name}',
-                    context=self.source_context)
+                    context=self.span)
 
             oper_derivative_of = oper.get_derivative_of(schema)
             if oper_derivative_of:
@@ -245,13 +245,13 @@ class CreateOperator(
                     f'cannot create the `{signature}` '
                     f'operator: there exists a derivative operator of the '
                     f'same name',
-                    context=self.source_context)
+                    context=self.span)
             elif derivative_of:
                 raise errors.DuplicateOperatorDefinitionError(
                     f'cannot create `{signature}` '
                     f'as a derivative operator: there already exists an '
                     f'operator of the same name',
-                    context=self.source_context)
+                    context=self.span)
 
             # Check if there is a recursive/non-recursive operator
             # overloading.
@@ -282,7 +282,7 @@ class CreateOperator(
                         f'overloading a {oper_rec} operator '
                         f'`{oper_signature}` with a {new_rec} one '
                         f'is not allowed',
-                        context=self.source_context)
+                        context=self.span)
 
         return schema
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1444,7 +1444,7 @@ class PointerCommandOrFragment(
         expr_description: Optional[str] = None,
         no_query_rewrites: bool = False,
         make_globals_empty: bool = False,
-        source_context: Optional[parsing.ParserContext] = None,
+        source_context: Optional[parsing.Span] = None,
         detached: bool = False,
         should_set_path_prefix_anchor: bool = True
     ) -> s_expr.CompiledExpression:

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1200,7 +1200,7 @@ class PointerCommandOrFragment(
             inf_target_ref = None
 
         if inf_target_ref is not None:
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             self.set_attribute_value(
                 'target',
                 inf_target_ref,
@@ -1329,7 +1329,7 @@ class PointerCommandOrFragment(
         # and best to consistently give an understandable error.
         for schema_ref in expression.irast.schema_refs:
             if isinstance(schema_ref, s_expraliases.Alias):
-                srcctx = self.get_attribute_source_context('target')
+                srcctx = self.get_attribute_span('target')
                 an = schema_ref.get_verbosename(expression.irast.schema)
                 raise errors.UnsupportedFeatureError(
                     f'referring to {an} from computed {ptr_name} '
@@ -1345,7 +1345,7 @@ class PointerCommandOrFragment(
             raise errors.UnsupportedFeatureError(
                 f'including a shape on schema-defined computed links '
                 f'is not yet supported',
-                context=self.source_context,
+                context=self.span,
             )
 
         spec_target: Optional[
@@ -1377,7 +1377,7 @@ class PointerCommandOrFragment(
                 expression.irast.schema)
 
             if spec_target_type != inferred_target_type:
-                srcctx = self.get_attribute_source_context('target')
+                srcctx = self.get_attribute_span('target')
                 raise errors.SchemaDefinitionError(
                     f'the type inferred from the expression '
                     f'of the computed {ptr_name} '
@@ -1388,7 +1388,7 @@ class PointerCommandOrFragment(
                 )
 
         if spec_required and not required:
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.SchemaDefinitionError(
                 f'possibly an empty set returned by an '
                 f'expression for the computed '
@@ -1401,7 +1401,7 @@ class PointerCommandOrFragment(
             spec_card is qltypes.SchemaCardinality.One
             and card is not qltypes.SchemaCardinality.One
         ):
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.SchemaDefinitionError(
                 f'possibly more than one element returned by an '
                 f'expression for the computed '
@@ -1420,7 +1420,7 @@ class PointerCommandOrFragment(
             not is_view_source(source, schema)
             and expression.irast.volatility == qltypes.Volatility.Volatile
         ):
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.SchemaDefinitionError(
                 f'volatile functions are not permitted in schema-defined '
                 f'computed expressions',
@@ -1627,7 +1627,7 @@ class PointerCommand(
                     f'{scls.get_verbosename(schema, with_parent=True)} '
                     f'to extend an abstract '
                     f'{scls.get_schema_class_displayname()}',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
         # Get the non-generic, explicitly declared ancestors as the
@@ -1664,7 +1664,7 @@ class PointerCommand(
                 f'{scls.get_verbosename(schema, with_parent=True)} '
                 f'to overload an existing '
                 f'{scls.get_schema_class_displayname()}',
-                context=self.source_context,
+                context=self.span,
             )
         else:
             if status is LineageStatus.MIXED:
@@ -1673,7 +1673,7 @@ class PointerCommand(
                     f'{scls.get_verbosename(schema, with_parent=True)} '
                     f'to extend both a computed and a non-computed '
                     f'{scls.get_schema_class_displayname()}',
-                    context=self.source_context,
+                    context=self.span,
                 )
             elif status is LineageStatus.MULTIPLE_COMPUTABLES:
                 raise errors.SchemaDefinitionError(
@@ -1681,7 +1681,7 @@ class PointerCommand(
                     f'{scls.get_verbosename(schema, with_parent=True)} '
                     f'to extend more than one computed '
                     f'{scls.get_schema_class_displayname()}',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
     def _validate_lineage(
@@ -1765,7 +1765,7 @@ class PointerCommand(
                 self._check_id_default(
                     schema, context, default_expr.irast.expr)
 
-            span = self.get_attribute_source_context('default')
+            span = self.get_attribute_span('default')
             ir = default_expr.irast
             default_schema = ir.schema
             default_type = ir.stype
@@ -1849,7 +1849,7 @@ class PointerCommand(
                     f"cannot specify a rewrite for "
                     f"{scls.get_verbosename(schema, with_parent=True)} "
                     f"because it is multi",
-                    context=self.source_context,
+                    context=self.span,
                     hint='this is a temporary implementation restriction'
                 )
 
@@ -1858,7 +1858,7 @@ class PointerCommand(
                     f"cannot specify a rewrite for "
                     f"{scls.get_verbosename(schema, with_parent=True)} "
                     f"because it has link properties",
-                    context=self.source_context,
+                    context=self.span,
                     hint='this is a temporary implementation restriction'
                 )
 
@@ -1890,7 +1890,7 @@ class PointerCommand(
             and isinstance(expr.expr, irast.FunctionCall)
             and str(expr.expr.func_shortname) in ID_ALLOWLIST
         ):
-            span = self.get_attribute_source_context('default')
+            span = self.get_attribute_span('default')
             options = ', '.join(ID_ALLOWLIST)
             raise errors.SchemaDefinitionError(
                 "invalid default value for 'id' property",
@@ -2156,7 +2156,7 @@ class AlterPointer(
                     aop = sd.AlterObjectProperty(
                         property='expr',
                         new_value=None,
-                        source_context=astnode.span,
+                        span=astnode.span,
                     )
                     cmd.add(aop)
 
@@ -2471,7 +2471,7 @@ class SetPointerType(
             # on a non-inherited type.
             raise errors.SchemaError(
                 f'cannot RESET TYPE of {vn} because it is not inherited',
-                context=self.source_context,
+                context=self.span,
             )
 
         if not context.canonical and orig_target != new_target:
@@ -2498,7 +2498,7 @@ class SetPointerType(
                         'You might need to specify a conversion '
                         'expression in a USING clause'
                     ),
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             if self.cast_expr is not None:
@@ -2527,20 +2527,20 @@ class SetPointerType(
                         f'{vn} cannot be cast automatically from '
                         f'{ot} to {nt} ',
                         hint='You might need to add an explicit cast.',
-                        context=self.source_context,
+                        context=self.span,
                     )
                 if using_type.is_view(self.cast_expr.schema):
                     raise errors.SchemaError(
                         f'result of USING clause for the alteration of '
                         f'{vn} may not include a shape',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
                 if irutils.contains_dml(self.cast_expr.ir_statement):
                     raise errors.SchemaError(
                         f'USING clause for the alteration of type of {vn} '
                         f'cannot include mutating statements',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
             schema = self._propagate_if_expr_refs(
@@ -2692,7 +2692,7 @@ class AlterPointerUpperCardinality(
                         'You need to specify a conversion '
                         'expression in a USING clause'
                     ),
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             if self.conv_expr is not None:
@@ -2722,13 +2722,13 @@ class AlterPointerUpperCardinality(
                         f'{vn} cannot be cast automatically from '
                         f'{ot} to {nt} ',
                         hint='You might need to add an explicit cast.',
-                        context=self.source_context,
+                        context=self.span,
                     )
                 if using_type.is_view(self.conv_expr.schema):
                     raise errors.SchemaError(
                         f'result of USING clause for the alteration of '
                         f'{vn} may not include a shape',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
             schema = self._propagate_if_expr_refs(schema, context, action=desc)
@@ -2949,13 +2949,13 @@ class AlterPointerLowerCardinality(
                         f'{vn} cannot be cast automatically from '
                         f'{ot} to {nt} ',
                         hint='You might need to add an explicit cast.',
-                        context=self.source_context,
+                        context=self.span,
                     )
                 if using_type.is_view(self.fill_expr.schema):
                     raise errors.SchemaError(
                         f'result of USING clause for the alteration of '
                         f'{vn} may not include a shape',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
             schema = self._propagate_if_expr_refs(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1521,7 +1521,7 @@ class PointerCommandOrFragment(
                 raise errors.SchemaError(
                     f'possibly more than one element returned by '
                     f'{expr_description}, while a singleton is expected',
-                    context=expr.qlast.context,
+                    context=expr.qlast.span,
                 )
 
             return compiled
@@ -1530,7 +1530,7 @@ class PointerCommandOrFragment(
             if source_context:
                 e.set_source_context(source_context)
             if not e.has_source_context():
-                e.set_source_context(expr.qlast.context)
+                e.set_source_context(expr.qlast.span)
             raise
 
     def compile_expr_field(
@@ -1918,7 +1918,7 @@ class PointerCommand(
                 typ = cls.get_schema_metaclass().get_schema_class_displayname()
                 raise errors.SchemaDefinitionError(
                     f"'default' is not a valid field for an abstract {typ}",
-                    context=astnode.context)
+                    context=astnode.span)
         return cmd
 
     def _process_create_or_alter_ast(
@@ -1937,7 +1937,7 @@ class PointerCommand(
             self.set_attribute_value(
                 'required',
                 astnode.is_required,
-                source_context=astnode.context,
+                source_context=astnode.span,
             )
 
         if astnode.cardinality is not None:
@@ -1945,7 +1945,7 @@ class PointerCommand(
                 self.set_attribute_value(
                     'cardinality',
                     astnode.cardinality,
-                    source_context=astnode.context,
+                    source_context=astnode.span,
                 )
             else:
                 handler = sd.get_special_field_alter_handler_for_context(
@@ -1957,7 +1957,7 @@ class PointerCommand(
                         str(astnode.cardinality),
                     ),
                     special_syntax=True,
-                    context=astnode.context,
+                    span=astnode.span,
                 )
                 apc = handler._cmd_tree_from_ast(schema, set_field, context)
                 self.add(apc)
@@ -1997,7 +1997,7 @@ class PointerCommand(
             self.set_attribute_value(
                 'target',
                 target_ref,
-                source_context=astnode.target.context,
+                source_context=astnode.target.span,
             )
 
         elif target_ref is not None:
@@ -2005,7 +2005,7 @@ class PointerCommand(
             self.set_attribute_value(
                 'target',
                 target_ref,
-                source_context=astnode.target.context,
+                source_context=astnode.target.span,
             )
 
     def _process_alter_ast(
@@ -2032,7 +2032,7 @@ class PointerCommand(
                 self.set_attribute_value(
                     'target',
                     target_ref,
-                    source_context=expr.context,
+                    source_context=expr.span,
                 )
                 self.discard_attribute('expr')
 
@@ -2156,7 +2156,7 @@ class AlterPointer(
                     aop = sd.AlterObjectProperty(
                         property='expr',
                         new_value=None,
-                        source_context=astnode.context,
+                        source_context=astnode.span,
                     )
                     cmd.add(aop)
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1528,9 +1528,9 @@ class PointerCommandOrFragment(
 
         except errors.QueryError as e:
             if span:
-                e.set_source_context(span)
-            if not e.has_source_context():
-                e.set_source_context(expr.qlast.span)
+                e.set_span(span)
+            if not e.has_span():
+                e.set_span(expr.qlast.span)
             raise
 
     def compile_expr_field(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1334,7 +1334,7 @@ class PointerCommandOrFragment(
                 raise errors.UnsupportedFeatureError(
                     f'referring to {an} from computed {ptr_name} '
                     f'is unsupported',
-                    context=srcctx,
+                    span=srcctx,
                 )
 
         if (
@@ -1345,7 +1345,7 @@ class PointerCommandOrFragment(
             raise errors.UnsupportedFeatureError(
                 f'including a shape on schema-defined computed links '
                 f'is not yet supported',
-                context=self.span,
+                span=self.span,
             )
 
         spec_target: Optional[
@@ -1384,7 +1384,7 @@ class PointerCommandOrFragment(
                     f'is {inferred_target_type.get_verbosename(mschema)}, '
                     f'which does not match the explicitly specified '
                     f'{spec_target_type.get_verbosename(schema)}',
-                    context=srcctx
+                    span=srcctx
                 )
 
         if spec_required and not required:
@@ -1394,7 +1394,7 @@ class PointerCommandOrFragment(
                 f'expression for the computed '
                 f'{ptr_name} '
                 f"explicitly declared as 'required'",
-                context=srcctx
+                span=srcctx
             )
 
         if (
@@ -1407,7 +1407,7 @@ class PointerCommandOrFragment(
                 f'expression for the computed '
                 f'{ptr_name} '
                 f"explicitly declared as 'single'",
-                context=srcctx
+                span=srcctx
             )
 
         if spec_card is None:
@@ -1424,7 +1424,7 @@ class PointerCommandOrFragment(
             raise errors.SchemaDefinitionError(
                 f'volatile functions are not permitted in schema-defined '
                 f'computed expressions',
-                context=srcctx
+                span=srcctx
             )
 
         self.set_attribute_value('computable', True)
@@ -1619,7 +1619,7 @@ class PointerCommand(
                     f'{scls.get_verbosename(schema, with_parent=True)} '
                     f'to extend an abstract '
                     f'{scls.get_schema_class_displayname()}',
-                    context=self.span,
+                    span=self.span,
                 )
 
         # Get the non-generic, explicitly declared ancestors as the
@@ -1656,7 +1656,7 @@ class PointerCommand(
                 f'{scls.get_verbosename(schema, with_parent=True)} '
                 f'to overload an existing '
                 f'{scls.get_schema_class_displayname()}',
-                context=self.span,
+                span=self.span,
             )
         else:
             if status is LineageStatus.MIXED:
@@ -1665,7 +1665,7 @@ class PointerCommand(
                     f'{scls.get_verbosename(schema, with_parent=True)} '
                     f'to extend both a computed and a non-computed '
                     f'{scls.get_schema_class_displayname()}',
-                    context=self.span,
+                    span=self.span,
                 )
             elif status is LineageStatus.MULTIPLE_COMPUTABLES:
                 raise errors.SchemaDefinitionError(
@@ -1673,7 +1673,7 @@ class PointerCommand(
                     f'{scls.get_verbosename(schema, with_parent=True)} '
                     f'to extend more than one computed '
                     f'{scls.get_schema_class_displayname()}',
-                    context=self.span,
+                    span=self.span,
                 )
 
     def _validate_lineage(
@@ -1777,7 +1777,7 @@ class PointerCommand(
             ):
                 raise errors.SchemaDefinitionError(
                     f'default expression may not include a shape',
-                    context=span,
+                    span=span,
                 )
             if not default_type.assignment_castable_to(
                     ptr_target, default_schema):
@@ -1785,7 +1785,7 @@ class PointerCommand(
                     f'default expression is of invalid type: '
                     f'{default_type.get_displayname(default_schema)}, '
                     f'expected {ptr_target.get_displayname(schema)}',
-                    context=span,
+                    span=span,
                 )
             # "required" status of defaults should not be enforced
             # because it's impossible to actually guarantee that any
@@ -1801,7 +1801,7 @@ class PointerCommand(
                     f'the default expression for '
                     f'{scls.get_verbosename(schema)} declared as '
                     f"'single'",
-                    context=span,
+                    span=span,
                 )
 
             # prevent references to local links, only properties
@@ -1820,7 +1820,7 @@ class PointerCommand(
                     raise errors.SchemaDefinitionError(
                         f"default expression cannot refer to multi properties "
                         "of inserted object",
-                        context=span,
+                        span=span,
                         hint="this is a temporary implementation restriction",
                     )
 
@@ -1828,7 +1828,7 @@ class PointerCommand(
                     raise errors.SchemaDefinitionError(
                         f"default expression cannot refer to links "
                         "of inserted object",
-                        context=span,
+                        span=span,
                         hint='this is a temporary implementation restriction'
                     )
 
@@ -1841,7 +1841,7 @@ class PointerCommand(
                     f"cannot specify a rewrite for "
                     f"{scls.get_verbosename(schema, with_parent=True)} "
                     f"because it is multi",
-                    context=self.span,
+                    span=self.span,
                     hint='this is a temporary implementation restriction'
                 )
 
@@ -1850,7 +1850,7 @@ class PointerCommand(
                     f"cannot specify a rewrite for "
                     f"{scls.get_verbosename(schema, with_parent=True)} "
                     f"because it has link properties",
-                    context=self.span,
+                    span=self.span,
                     hint='this is a temporary implementation restriction'
                 )
 
@@ -1887,7 +1887,7 @@ class PointerCommand(
             raise errors.SchemaDefinitionError(
                 "invalid default value for 'id' property",
                 hint=f'default must be a call to one of: {options}',
-                context=span,
+                span=span,
             )
 
     @classmethod
@@ -1910,7 +1910,7 @@ class PointerCommand(
                 typ = cls.get_schema_metaclass().get_schema_class_displayname()
                 raise errors.SchemaDefinitionError(
                     f"'default' is not a valid field for an abstract {typ}",
-                    context=astnode.span)
+                    span=astnode.span)
         return cmd
 
     def _process_create_or_alter_ast(
@@ -2463,7 +2463,7 @@ class SetPointerType(
             # on a non-inherited type.
             raise errors.SchemaError(
                 f'cannot RESET TYPE of {vn} because it is not inherited',
-                context=self.span,
+                span=self.span,
             )
 
         if not context.canonical and orig_target != new_target:
@@ -2490,7 +2490,7 @@ class SetPointerType(
                         'You might need to specify a conversion '
                         'expression in a USING clause'
                     ),
-                    context=self.span,
+                    span=self.span,
                 )
 
             if self.cast_expr is not None:
@@ -2519,20 +2519,20 @@ class SetPointerType(
                         f'{vn} cannot be cast automatically from '
                         f'{ot} to {nt} ',
                         hint='You might need to add an explicit cast.',
-                        context=self.span,
+                        span=self.span,
                     )
                 if using_type.is_view(self.cast_expr.schema):
                     raise errors.SchemaError(
                         f'result of USING clause for the alteration of '
                         f'{vn} may not include a shape',
-                        context=self.span,
+                        span=self.span,
                     )
 
                 if irutils.contains_dml(self.cast_expr.ir_statement):
                     raise errors.SchemaError(
                         f'USING clause for the alteration of type of {vn} '
                         f'cannot include mutating statements',
-                        context=self.span,
+                        span=self.span,
                     )
 
             schema = self._propagate_if_expr_refs(
@@ -2684,7 +2684,7 @@ class AlterPointerUpperCardinality(
                         'You need to specify a conversion '
                         'expression in a USING clause'
                     ),
-                    context=self.span,
+                    span=self.span,
                 )
 
             if self.conv_expr is not None:
@@ -2714,13 +2714,13 @@ class AlterPointerUpperCardinality(
                         f'{vn} cannot be cast automatically from '
                         f'{ot} to {nt} ',
                         hint='You might need to add an explicit cast.',
-                        context=self.span,
+                        span=self.span,
                     )
                 if using_type.is_view(self.conv_expr.schema):
                     raise errors.SchemaError(
                         f'result of USING clause for the alteration of '
                         f'{vn} may not include a shape',
-                        context=self.span,
+                        span=self.span,
                     )
 
             schema = self._propagate_if_expr_refs(schema, context, action=desc)
@@ -2941,13 +2941,13 @@ class AlterPointerLowerCardinality(
                         f'{vn} cannot be cast automatically from '
                         f'{ot} to {nt} ',
                         hint='You might need to add an explicit cast.',
-                        context=self.span,
+                        span=self.span,
                     )
                 if using_type.is_view(self.fill_expr.schema):
                     raise errors.SchemaError(
                         f'result of USING clause for the alteration of '
                         f'{vn} may not include a shape',
-                        context=self.span,
+                        span=self.span,
                     )
 
             schema = self._propagate_if_expr_refs(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1204,7 +1204,7 @@ class PointerCommandOrFragment(
             self.set_attribute_value(
                 'target',
                 inf_target_ref,
-                source_context=srcctx,
+                span=srcctx,
                 computed=True,
             )
 
@@ -1444,7 +1444,7 @@ class PointerCommandOrFragment(
         expr_description: Optional[str] = None,
         no_query_rewrites: bool = False,
         make_globals_empty: bool = False,
-        source_context: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
         detached: bool = False,
         should_set_path_prefix_anchor: bool = True
     ) -> s_expr.CompiledExpression:
@@ -1527,8 +1527,8 @@ class PointerCommandOrFragment(
             return compiled
 
         except errors.QueryError as e:
-            if source_context:
-                e.set_source_context(source_context)
+            if span:
+                e.set_source_context(span)
             if not e.has_source_context():
                 e.set_source_context(expr.qlast.span)
             raise
@@ -1765,7 +1765,7 @@ class PointerCommand(
                 self._check_id_default(
                     schema, context, default_expr.irast.expr)
 
-            source_context = self.get_attribute_source_context('default')
+            span = self.get_attribute_source_context('default')
             ir = default_expr.irast
             default_schema = ir.schema
             default_type = ir.stype
@@ -1785,7 +1785,7 @@ class PointerCommand(
             ):
                 raise errors.SchemaDefinitionError(
                     f'default expression may not include a shape',
-                    context=source_context,
+                    context=span,
                 )
             if not default_type.assignment_castable_to(
                     ptr_target, default_schema):
@@ -1793,7 +1793,7 @@ class PointerCommand(
                     f'default expression is of invalid type: '
                     f'{default_type.get_displayname(default_schema)}, '
                     f'expected {ptr_target.get_displayname(schema)}',
-                    context=source_context,
+                    context=span,
                 )
             # "required" status of defaults should not be enforced
             # because it's impossible to actually guarantee that any
@@ -1809,7 +1809,7 @@ class PointerCommand(
                     f'the default expression for '
                     f'{scls.get_verbosename(schema)} declared as '
                     f"'single'",
-                    context=source_context,
+                    context=span,
                 )
 
             # prevent references to local links, only properties
@@ -1828,7 +1828,7 @@ class PointerCommand(
                     raise errors.SchemaDefinitionError(
                         f"default expression cannot refer to multi properties "
                         "of inserted object",
-                        context=source_context,
+                        context=span,
                         hint="this is a temporary implementation restriction",
                     )
 
@@ -1836,7 +1836,7 @@ class PointerCommand(
                     raise errors.SchemaDefinitionError(
                         f"default expression cannot refer to links "
                         "of inserted object",
-                        context=source_context,
+                        context=span,
                         hint='this is a temporary implementation restriction'
                     )
 
@@ -1890,12 +1890,12 @@ class PointerCommand(
             and isinstance(expr.expr, irast.FunctionCall)
             and str(expr.expr.func_shortname) in ID_ALLOWLIST
         ):
-            source_context = self.get_attribute_source_context('default')
+            span = self.get_attribute_source_context('default')
             options = ', '.join(ID_ALLOWLIST)
             raise errors.SchemaDefinitionError(
                 "invalid default value for 'id' property",
                 hint=f'default must be a call to one of: {options}',
-                context=source_context,
+                context=span,
             )
 
     @classmethod
@@ -1937,7 +1937,7 @@ class PointerCommand(
             self.set_attribute_value(
                 'required',
                 astnode.is_required,
-                source_context=astnode.span,
+                span=astnode.span,
             )
 
         if astnode.cardinality is not None:
@@ -1945,7 +1945,7 @@ class PointerCommand(
                 self.set_attribute_value(
                     'cardinality',
                     astnode.cardinality,
-                    source_context=astnode.span,
+                    span=astnode.span,
                 )
             else:
                 handler = sd.get_special_field_alter_handler_for_context(
@@ -1997,7 +1997,7 @@ class PointerCommand(
             self.set_attribute_value(
                 'target',
                 target_ref,
-                source_context=astnode.target.span,
+                span=astnode.target.span,
             )
 
         elif target_ref is not None:
@@ -2005,7 +2005,7 @@ class PointerCommand(
             self.set_attribute_value(
                 'target',
                 target_ref,
-                source_context=astnode.target.span,
+                span=astnode.target.span,
             )
 
     def _process_alter_ast(
@@ -2032,7 +2032,7 @@ class PointerCommand(
                 self.set_attribute_value(
                     'target',
                     target_ref,
-                    source_context=expr.span,
+                    span=expr.span,
                 )
                 self.discard_attribute('expr')
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1492,7 +1492,7 @@ class PointerCommandOrFragment(
             else:
                 singletons.append(self.scls)
 
-        try:
+        with errors.ensure_span(span or expr.qlast.span):
             options = qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,
                 schema_object_context=self.get_schema_metaclass(),
@@ -1520,18 +1520,10 @@ class PointerCommandOrFragment(
 
                 raise errors.SchemaError(
                     f'possibly more than one element returned by '
-                    f'{expr_description}, while a singleton is expected',
-                    context=expr.qlast.span,
+                    f'{expr_description}, while a singleton is expected'
                 )
 
             return compiled
-
-        except errors.QueryError as e:
-            if span:
-                e.set_span(span)
-            if not e.has_span():
-                e.set_span(expr.qlast.span)
-            raise
 
     def compile_expr_field(
         self,

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -162,7 +162,7 @@ class AccessPolicyCommand(
                 value=expr,
             )
 
-            srcctx = self.get_attribute_source_context(field)
+            srcctx = self.get_attribute_span(field)
 
             if expression.irast.cardinality.can_be_zero():
                 raise errors.SchemaDefinitionError(
@@ -188,12 +188,12 @@ class AccessPolicyCommand(
             target = schema.get(sn.QualName('std', 'bool'), type=s_types.Type)
             expr_type = expression.irast.stype
             if not expr_type.issubclass(expression.irast.schema, target):
-                srcctx = self.get_attribute_source_context(field)
+                srcctx = self.get_attribute_span(field)
                 raise errors.SchemaDefinitionError(
                     f'{vname} expression for {pol_name} is of invalid type: '
                     f'{expr_type.get_displayname(schema)}, '
                     f'expected {target.get_displayname(schema)}',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
         return schema
@@ -277,7 +277,7 @@ class AccessPolicyCommand(
                         f'insert and update write access policies may not '
                         f'refer to link properties with default values: '
                         f'{pol_name} refers to {obj_name}',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
 
@@ -389,7 +389,7 @@ class AlterAccessPolicy(
             raise errors.SchemaDefinitionError(
                 f'cannot alter the definition of inherited access policy '
                 f'{self.scls.get_displayname(schema)}',
-                context=self.source_context
+                context=self.span
             )
 
         return schema
@@ -436,14 +436,14 @@ class AlterAccessPolicyPerms(
             sd.AlterObjectProperty(
                 property='action',
                 new_value=astnode.action,
-                source_context=astnode.span,
+                span=astnode.span,
             )
         )
         cmd.add(
             sd.AlterObjectProperty(
                 property='access_kinds',
                 new_value=astnode.access_kinds,
-                source_context=astnode.span,
+                span=astnode.span,
             )
         )
         return cmd

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -168,21 +168,21 @@ class AccessPolicyCommand(
                 raise errors.SchemaDefinitionError(
                     f'possibly an empty set returned by {vname} '
                     f'expression for the {pol_name} ',
-                    context=srcctx
+                    span=srcctx
                 )
 
             if expression.irast.cardinality.is_multi():
                 raise errors.SchemaDefinitionError(
                     f'possibly more than one element returned by {vname} '
                     f'expression for the {pol_name} ',
-                    context=srcctx
+                    span=srcctx
                 )
 
             if expression.irast.volatility.is_volatile():
                 raise errors.SchemaDefinitionError(
                     f'{pol_name} has a volatile {vname} expression, '
                     f'which is not allowed',
-                    context=srcctx
+                    span=srcctx
                 )
 
             target = schema.get(sn.QualName('std', 'bool'), type=s_types.Type)
@@ -193,7 +193,7 @@ class AccessPolicyCommand(
                     f'{vname} expression for {pol_name} is of invalid type: '
                     f'{expr_type.get_displayname(schema)}, '
                     f'expected {target.get_displayname(schema)}',
-                    context=self.span,
+                    span=self.span,
                 )
 
         return schema
@@ -277,7 +277,7 @@ class AccessPolicyCommand(
                         f'insert and update write access policies may not '
                         f'refer to link properties with default values: '
                         f'{pol_name} refers to {obj_name}',
-                        context=self.span,
+                        span=self.span,
                     )
 
 
@@ -389,7 +389,7 @@ class AlterAccessPolicy(
             raise errors.SchemaDefinitionError(
                 f'cannot alter the definition of inherited access policy '
                 f'{self.scls.get_displayname(schema)}',
-                context=self.span
+                span=self.span
             )
 
         return schema

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -319,7 +319,7 @@ class CreateAccessPolicy(
                     astnode.condition, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.condition.context,
+                source_context=astnode.condition.span,
             )
 
         if astnode.expr:
@@ -329,7 +329,7 @@ class CreateAccessPolicy(
                     astnode.expr, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.expr.context,
+                source_context=astnode.expr.span,
             )
 
         cmd.set_attribute_value('action', astnode.action)
@@ -436,14 +436,14 @@ class AlterAccessPolicyPerms(
             sd.AlterObjectProperty(
                 property='action',
                 new_value=astnode.action,
-                source_context=astnode.context,
+                source_context=astnode.span,
             )
         )
         cmd.add(
             sd.AlterObjectProperty(
                 property='access_kinds',
                 new_value=astnode.access_kinds,
-                source_context=astnode.context,
+                source_context=astnode.span,
             )
         )
         return cmd

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -319,7 +319,7 @@ class CreateAccessPolicy(
                     astnode.condition, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.condition.span,
+                span=astnode.condition.span,
             )
 
         if astnode.expr:
@@ -329,7 +329,7 @@ class CreateAccessPolicy(
                     astnode.expr, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.expr.span,
+                span=astnode.expr.span,
             )
 
         cmd.set_attribute_value('action', astnode.action)

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -243,13 +243,13 @@ class PropertyCommand(
             if self.get_attribute_value('required'):
                 raise errors.InvalidPropertyDefinitionError(
                     'link properties cannot be required',
-                    context=self.span,
+                    span=self.span,
                 )
             if (self.get_attribute_value('cardinality')
                     is qltypes.SchemaCardinality.Many):
                 raise errors.InvalidPropertyDefinitionError(
                     "multi properties aren't supported for links",
-                    context=self.span,
+                    span=self.span,
                 )
 
         target_type = scls.get_target(schema)
@@ -262,7 +262,7 @@ class PropertyCommand(
                 f'invalid property type: '
                 f'{target_type.get_verbosename(schema)} '
                 f'is a generic type',
-                context=srcctx,
+                span=srcctx,
             )
 
         if (target_type.is_object_type()
@@ -273,7 +273,7 @@ class PropertyCommand(
                 f'invalid property type: expected a scalar type, '
                 f'or a scalar collection, got '
                 f'{target_type.get_verbosename(schema)}',
-                context=srcctx,
+                span=srcctx,
             )
 
     def _check_linkprop_errors(self, node: qlast.DDLOperation) -> None:
@@ -282,7 +282,7 @@ class PropertyCommand(
             if isinstance(sub, qlast.CreateConcretePointer):
                 raise errors.InvalidDefinitionError(
                     f'cannot create a link property on a property',
-                    context=node.span,
+                    span=node.span,
                     hint='Link properties can only be created on links, whose '
                          'target types are object types.',
                 )

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -243,13 +243,13 @@ class PropertyCommand(
             if self.get_attribute_value('required'):
                 raise errors.InvalidPropertyDefinitionError(
                     'link properties cannot be required',
-                    context=self.source_context,
+                    context=self.span,
                 )
             if (self.get_attribute_value('cardinality')
                     is qltypes.SchemaCardinality.Many):
                 raise errors.InvalidPropertyDefinitionError(
                     "multi properties aren't supported for links",
-                    context=self.source_context,
+                    context=self.span,
                 )
 
         target_type = scls.get_target(schema)
@@ -257,7 +257,7 @@ class PropertyCommand(
             raise TypeError(f'missing target type in scls {scls}')
 
         if target_type.is_polymorphic(schema):
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.InvalidPropertyTargetError(
                 f'invalid property type: '
                 f'{target_type.get_verbosename(schema)} '
@@ -268,7 +268,7 @@ class PropertyCommand(
         if (target_type.is_object_type()
                 or (isinstance(target_type, s_types.Collection)
                     and target_type.contains_object(schema))):
-            srcctx = self.get_attribute_source_context('target')
+            srcctx = self.get_attribute_span('target')
             raise errors.InvalidPropertyTargetError(
                 f'invalid property type: expected a scalar type, '
                 f'or a scalar collection, got '

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -282,7 +282,7 @@ class PropertyCommand(
             if isinstance(sub, qlast.CreateConcretePointer):
                 raise errors.InvalidDefinitionError(
                     f'cannot create a link property on a property',
-                    context=node.context,
+                    context=node.span,
                     hint='Link properties can only be created on links, whose '
                          'target types are object types.',
                 )

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -163,7 +163,7 @@ class PseudoTypeShell(s_types.TypeShell[PseudoType]):
         self,
         *,
         name: sn.Name,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> None:
         super().__init__(
             name=name, schemaclass=PseudoType, sourcectx=sourcectx)

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -200,7 +200,7 @@ class CreatePseudoType(PseudoTypeCommand, sd.CreateObject[PseudoType]):
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined pseudotypes are not supported',
-                context=astnode.span
+                span=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -200,7 +200,7 @@ class CreatePseudoType(PseudoTypeCommand, sd.CreateObject[PseudoType]):
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined pseudotypes are not supported',
-                context=astnode.context
+                context=astnode.span
             )
 
         return super()._cmd_tree_from_ast(schema, astnode, context)

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -809,7 +809,7 @@ class ReferencedInheritingObjectCommand(
                     f'{self.scls.get_verbosename(schema, with_parent=True)} '
                     f'must be declared using the `overloaded` keyword because '
                     f'it is defined in the following ancestor(s): {alist}',
-                    context=self.span,
+                    span=self.span,
                 )
             elif (not implicit_bases
                     and self.get_attribute_value('declared_overloaded')):
@@ -818,7 +818,7 @@ class ReferencedInheritingObjectCommand(
                     f'{self.scls.get_verbosename(schema, with_parent=True)}: '
                     f'cannot be declared `overloaded` as there are no '
                     f'ancestors defining it.',
-                    context=self.span,
+                    span=self.span,
                 )
 
     def get_implicit_bases(
@@ -940,7 +940,7 @@ class ReferencedInheritingObjectCommand(
                         f'{vn} is inherited from '
                         f'{bases_str}'
                     ),
-                    context=self.span,
+                    span=self.span,
                 )
 
         value = self.get_attribute_value(field_name)
@@ -1392,7 +1392,7 @@ class RenameReferencedInheritingObject(
                             f'{vn} is inherited from '
                             f'{bases_str}, which {verb} not being renamed'
                         ),
-                        context=self.span,
+                        span=self.span,
                     )
 
             self._propagate_ref_rename(schema, context, scls)
@@ -1489,7 +1489,7 @@ class DeleteReferencedInheritingObject(
 
                 raise errors.SchemaError(
                     f'cannot drop inherited {vn}',
-                    context=self.span,
+                    span=self.span,
                     details=f'{vn} is inherited from:\n- {pnames}'
                 )
 
@@ -1605,7 +1605,7 @@ class AlterOwned(
                 raise errors.InvalidDefinitionError(
                     f'cannot drop owned {vn}, as it is not inherited, '
                     f'use DROP {sn} instead',
-                    context=self.span,
+                    span=self.span,
                 )
 
             # DROP OWNED requires special handling: the object in question

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -806,7 +806,7 @@ class ReferencedInheritingObjectCommand(
                     f'{self.scls.get_verbosename(schema, with_parent=True)} '
                     f'must be declared using the `overloaded` keyword because '
                     f'it is defined in the following ancestor(s): {alist}',
-                    context=self.source_context,
+                    context=self.span,
                 )
             elif (not implicit_bases
                     and self.get_attribute_value('declared_overloaded')):
@@ -815,7 +815,7 @@ class ReferencedInheritingObjectCommand(
                     f'{self.scls.get_verbosename(schema, with_parent=True)}: '
                     f'cannot be declared `overloaded` as there are no '
                     f'ancestors defining it.',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
     def get_implicit_bases(
@@ -937,7 +937,7 @@ class ReferencedInheritingObjectCommand(
                         f'{vn} is inherited from '
                         f'{bases_str}'
                     ),
-                    context=self.source_context,
+                    context=self.span,
                 )
 
         value = self.get_attribute_value(field_name)
@@ -1389,7 +1389,7 @@ class RenameReferencedInheritingObject(
                             f'{vn} is inherited from '
                             f'{bases_str}, which {verb} not being renamed'
                         ),
-                        context=self.source_context,
+                        context=self.span,
                     )
 
             self._propagate_ref_rename(schema, context, scls)
@@ -1486,7 +1486,7 @@ class DeleteReferencedInheritingObject(
 
                 raise errors.SchemaError(
                     f'cannot drop inherited {vn}',
-                    context=self.source_context,
+                    context=self.span,
                     details=f'{vn} is inherited from:\n- {pnames}'
                 )
 
@@ -1602,7 +1602,7 @@ class AlterOwned(
                 raise errors.InvalidDefinitionError(
                     f'cannot drop owned {vn}, as it is not inherited, '
                     f'use DROP {sn} instead',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
             # DROP OWNED requires special handling: the object in question

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -155,7 +155,7 @@ class RewriteCommand(
                 subject = source.get_target(schema)
                 assert subject
 
-                span = self.get_attribute_source_context('expr')
+                span = self.get_attribute_span('expr')
                 raise errors.SchemaDefinitionError(
                     'rewrites on link properties are not supported',
                     context=span,
@@ -266,7 +266,7 @@ class RewriteCommand(
                 and shape[0].is_id_pointer(compiled_schema)
             )
         ):
-            span = self.get_attribute_source_context('expr')
+            span = self.get_attribute_span('expr')
             raise errors.SchemaDefinitionError(
                 f'rewrite expression may not include a shape',
                 context=span,
@@ -274,7 +274,7 @@ class RewriteCommand(
 
         ptr_target = self.scls.get_ptr_target(compiled_schema)
         if not typ.assignment_castable_to(ptr_target, compiled_schema):
-            span = self.get_attribute_source_context('expr')
+            span = self.get_attribute_span('expr')
             raise errors.SchemaDefinitionError(
                 f'rewrite expression is of invalid type: '
                 f'{typ.get_displayname(compiled_schema)}, '
@@ -406,7 +406,7 @@ class AlterRewrite(
             raise errors.SchemaDefinitionError(
                 f'cannot alter the definition of inherited trigger '
                 f'{self.scls.get_displayname(schema)}',
-                context=self.source_context,
+                context=self.span,
             )
 
         return schema

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -155,10 +155,10 @@ class RewriteCommand(
                 subject = source.get_target(schema)
                 assert subject
 
-                source_context = self.get_attribute_source_context('expr')
+                span = self.get_attribute_source_context('expr')
                 raise errors.SchemaDefinitionError(
                     'rewrites on link properties are not supported',
-                    context=source_context,
+                    context=span,
                 )
             else:
                 raise NotImplementedError('unsupported rewrite source')
@@ -266,20 +266,20 @@ class RewriteCommand(
                 and shape[0].is_id_pointer(compiled_schema)
             )
         ):
-            source_context = self.get_attribute_source_context('expr')
+            span = self.get_attribute_source_context('expr')
             raise errors.SchemaDefinitionError(
                 f'rewrite expression may not include a shape',
-                context=source_context,
+                context=span,
             )
 
         ptr_target = self.scls.get_ptr_target(compiled_schema)
         if not typ.assignment_castable_to(ptr_target, compiled_schema):
-            source_context = self.get_attribute_source_context('expr')
+            span = self.get_attribute_source_context('expr')
             raise errors.SchemaDefinitionError(
                 f'rewrite expression is of invalid type: '
                 f'{typ.get_displayname(compiled_schema)}, '
                 f'expected {ptr_target.get_displayname(compiled_schema)}',
-                context=source_context,
+                context=span,
             )
 
     @classmethod
@@ -353,7 +353,7 @@ class CreateRewrite(
                     context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.expr.span,
+                span=astnode.expr.span,
             )
         return group
 

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -158,7 +158,7 @@ class RewriteCommand(
                 span = self.get_attribute_span('expr')
                 raise errors.SchemaDefinitionError(
                     'rewrites on link properties are not supported',
-                    context=span,
+                    span=span,
                 )
             else:
                 raise NotImplementedError('unsupported rewrite source')
@@ -269,7 +269,7 @@ class RewriteCommand(
             span = self.get_attribute_span('expr')
             raise errors.SchemaDefinitionError(
                 f'rewrite expression may not include a shape',
-                context=span,
+                span=span,
             )
 
         ptr_target = self.scls.get_ptr_target(compiled_schema)
@@ -279,7 +279,7 @@ class RewriteCommand(
                 f'rewrite expression is of invalid type: '
                 f'{typ.get_displayname(compiled_schema)}, '
                 f'expected {ptr_target.get_displayname(compiled_schema)}',
-                context=span,
+                span=span,
             )
 
     @classmethod
@@ -406,7 +406,7 @@ class AlterRewrite(
             raise errors.SchemaDefinitionError(
                 f'cannot alter the definition of inherited trigger '
                 f'{self.scls.get_displayname(schema)}',
-                context=self.span,
+                span=self.span,
             )
 
         return schema

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -353,7 +353,7 @@ class CreateRewrite(
                     context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.expr.context,
+                source_context=astnode.expr.span,
             )
         return group
 

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -91,7 +91,7 @@ class RoleCommand(
                 raise errors.EdgeQLSyntaxError(
                     'cannot specify both `password` and `password_hash` in'
                     ' the same statement',
-                    context=astnode.context,
+                    context=astnode.span,
                 )
             salted_password = scram.build_verifier(password)
             cmd.set_attribute_value('password', salted_password)
@@ -103,7 +103,7 @@ class RoleCommand(
             except ValueError as e:
                 raise errors.InvalidValueError(
                     e.args[0],
-                    context=astnode.context)
+                    context=astnode.span)
             cmd.set_attribute_value('password', password_hash)
 
     @classmethod
@@ -155,7 +155,7 @@ class CreateRole(RoleCommand, inheriting.CreateInheritingObject[Role]):
         if not astnode.superuser and not context.testmode:
             raise errors.EdgeQLSyntaxError(
                 'missing required SUPERUSER qualifier',
-                context=astnode.context,
+                context=astnode.span,
             )
 
         cmd.set_attribute_value('superuser', astnode.superuser)

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -91,7 +91,7 @@ class RoleCommand(
                 raise errors.EdgeQLSyntaxError(
                     'cannot specify both `password` and `password_hash` in'
                     ' the same statement',
-                    context=astnode.span,
+                    span=astnode.span,
                 )
             salted_password = scram.build_verifier(password)
             cmd.set_attribute_value('password', salted_password)
@@ -103,7 +103,7 @@ class RoleCommand(
             except ValueError as e:
                 raise errors.InvalidValueError(
                     e.args[0],
-                    context=astnode.span)
+                    span=astnode.span)
             cmd.set_attribute_value('password', password_hash)
 
     @classmethod
@@ -135,7 +135,7 @@ class RoleCommand(
             raise errors.SchemaDefinitionError(
                 f'Role names longer than {s_def.MAX_NAME_LENGTH} '
                 f'characters are not supported',
-                context=span,
+                span=span,
             )
 
 
@@ -155,7 +155,7 @@ class CreateRole(RoleCommand, inheriting.CreateInheritingObject[Role]):
         if not astnode.superuser and not context.testmode:
             raise errors.EdgeQLSyntaxError(
                 'missing required SUPERUSER qualifier',
-                context=astnode.span,
+                span=astnode.span,
             )
 
         cmd.set_attribute_value('superuser', astnode.superuser)

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -131,7 +131,7 @@ class RoleCommand(
     ) -> None:
         name = self.get_attribute_value('name')
         if len(str(name)) > s_def.MAX_NAME_LENGTH:
-            span = self.get_attribute_source_context('name')
+            span = self.get_attribute_span('name')
             raise errors.SchemaDefinitionError(
                 f'Role names longer than {s_def.MAX_NAME_LENGTH} '
                 f'characters are not supported',

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -131,11 +131,11 @@ class RoleCommand(
     ) -> None:
         name = self.get_attribute_value('name')
         if len(str(name)) > s_def.MAX_NAME_LENGTH:
-            source_context = self.get_attribute_source_context('name')
+            span = self.get_attribute_source_context('name')
             raise errors.SchemaDefinitionError(
                 f'Role names longer than {s_def.MAX_NAME_LENGTH} '
                 f'characters are not supported',
-                context=source_context,
+                context=span,
             )
 
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -377,7 +377,7 @@ class ScalarTypeCommand(
             if len(self.scls.get_constraints(schema)):
                 raise errors.SchemaError(
                     f'parameterized scalar types may not have constraints',
-                    context=self.span,
+                    span=self.span,
                 )
 
         if args := self.scls.get_arg_values(schema):
@@ -387,14 +387,14 @@ class ScalarTypeCommand(
                 raise errors.SchemaDefinitionError(
                     f'base type {base.get_name(schema)} does not '
                     f'accept parameters',
-                    context=self.span,
+                    span=self.span,
                 )
             if num_params != len(args):
                 raise errors.SchemaDefinitionError(
                     f'incorrect number of arguments provided to base type '
                     f'{base.get_name(schema)}: expected {num_params} '
                     f'but got {len(args)}',
-                    context=self.span,
+                    span=self.span,
                 )
 
     def validate_scalar_ancestors(
@@ -424,7 +424,7 @@ class ScalarTypeCommand(
             raise errors.SchemaError(
                 f'scalar type may not have more than '
                 f'one concrete base type',
-                context=self.span,
+                span=self.span,
             )
         abstract = self.get_attribute_value('abstract')
         enum = self.get_attribute_value('enum_values')
@@ -445,7 +445,7 @@ class ScalarTypeCommand(
 
             raise errors.SchemaError(
                 f'scalar type must have a concrete base type',
-                context=self.span,
+                span=self.span,
                 hint=hint,
             )
 
@@ -523,7 +523,7 @@ class CreateScalarType(
                 if isinstance(b, s_types.CollectionTypeShell):
                     raise errors.SchemaError(
                         f'scalar type may not have a collection base type',
-                        context=ab.span,
+                        span=ab.span,
                     )
 
             # We don't support FINAL, but old dumps and migrations specify
@@ -532,7 +532,7 @@ class CreateScalarType(
             if not is_enum and astnode.final:
                 raise errors.UnsupportedFeatureError(
                     f'FINAL is not supported',
-                    context=astnode.span,
+                    span=astnode.span,
                 )
 
             if is_enum:
@@ -542,12 +542,12 @@ class CreateScalarType(
                     raise errors.SchemaError(
                         f'invalid scalar type definition, enumeration must be'
                         f' the only supertype specified',
-                        context=astnode.bases[0].span,
+                        span=astnode.bases[0].span,
                     )
                 if create_cmd.has_attribute_value('default'):
                     raise errors.UnsupportedFeatureError(
                         f'enumerated types do not support defaults',
-                        context=(
+                        span=(
                             create_cmd.get_attribute_span('default')
                         ),
                     )
@@ -557,7 +557,7 @@ class CreateScalarType(
                 if len(set(shell.elements)) != len(shell.elements):
                     raise errors.SchemaDefinitionError(
                         f'enums cannot contain duplicate values',
-                        context=astnode.bases[0].span,
+                        span=astnode.bases[0].span,
                     )
                 create_cmd.set_attribute_value('enum_values', shell.elements)
                 create_cmd.set_attribute_value(
@@ -580,7 +580,7 @@ class CreateScalarType(
                         raise errors.SchemaDefinitionError(
                             'scalars with parameterized bases may '
                             'only have one',
-                            context=astnode.bases[0].span,
+                            span=astnode.bases[0].span,
                         )
                     base = bases[0]
                     args = []
@@ -591,7 +591,7 @@ class CreateScalarType(
                         ):
                             raise errors.SchemaDefinitionError(
                                 'invalid scalar type argument',
-                                context=x.span,
+                                span=x.span,
                             )
                         args.append(x.val.value)
                     cmd.set_attribute_value('arg_values', args)
@@ -736,7 +736,7 @@ class RebaseScalarType(
                 if isinstance(b, s_types.CollectionTypeShell):
                     raise errors.SchemaError(
                         f'scalar type may not have a collection base type',
-                        context=self.span,
+                        span=self.span,
                     )
 
             schema = super().apply(schema, context)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -523,7 +523,7 @@ class CreateScalarType(
                 if isinstance(b, s_types.CollectionTypeShell):
                     raise errors.SchemaError(
                         f'scalar type may not have a collection base type',
-                        context=ab.context,
+                        context=ab.span,
                     )
 
             # We don't support FINAL, but old dumps and migrations specify
@@ -532,7 +532,7 @@ class CreateScalarType(
             if not is_enum and astnode.final:
                 raise errors.UnsupportedFeatureError(
                     f'FINAL is not supported',
-                    context=astnode.context,
+                    context=astnode.span,
                 )
 
             if is_enum:
@@ -542,7 +542,7 @@ class CreateScalarType(
                     raise errors.SchemaError(
                         f'invalid scalar type definition, enumeration must be'
                         f' the only supertype specified',
-                        context=astnode.bases[0].context,
+                        context=astnode.bases[0].span,
                     )
                 if create_cmd.has_attribute_value('default'):
                     raise errors.UnsupportedFeatureError(
@@ -557,7 +557,7 @@ class CreateScalarType(
                 if len(set(shell.elements)) != len(shell.elements):
                     raise errors.SchemaDefinitionError(
                         f'enums cannot contain duplicate values',
-                        context=astnode.bases[0].context,
+                        context=astnode.bases[0].span,
                     )
                 create_cmd.set_attribute_value('enum_values', shell.elements)
                 create_cmd.set_attribute_value(
@@ -580,7 +580,7 @@ class CreateScalarType(
                         raise errors.SchemaDefinitionError(
                             'scalars with parameterized bases may '
                             'only have one',
-                            context=astnode.bases[0].context,
+                            context=astnode.bases[0].span,
                         )
                     base = bases[0]
                     args = []
@@ -591,7 +591,7 @@ class CreateScalarType(
                         ):
                             raise errors.SchemaDefinitionError(
                                 'invalid scalar type argument',
-                                context=x.context,
+                                context=x.span,
                             )
                         args.append(x.val.value)
                     cmd.set_attribute_value('arg_values', args)
@@ -599,8 +599,8 @@ class CreateScalarType(
                 cmd.set_attribute_value(
                     'bases',
                     so.ObjectCollectionShell(
-                        bases, collection_type=so.ObjectList),
-                    # source_context=srcctx,
+                        bases, collection_type=so.ObjectList
+                    ),
                 )
 
         return cmd

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -377,7 +377,7 @@ class ScalarTypeCommand(
             if len(self.scls.get_constraints(schema)):
                 raise errors.SchemaError(
                     f'parameterized scalar types may not have constraints',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
         if args := self.scls.get_arg_values(schema):
@@ -387,14 +387,14 @@ class ScalarTypeCommand(
                 raise errors.SchemaDefinitionError(
                     f'base type {base.get_name(schema)} does not '
                     f'accept parameters',
-                    context=self.source_context,
+                    context=self.span,
                 )
             if num_params != len(args):
                 raise errors.SchemaDefinitionError(
                     f'incorrect number of arguments provided to base type '
                     f'{base.get_name(schema)}: expected {num_params} '
                     f'but got {len(args)}',
-                    context=self.source_context,
+                    context=self.span,
                 )
 
     def validate_scalar_ancestors(
@@ -424,7 +424,7 @@ class ScalarTypeCommand(
             raise errors.SchemaError(
                 f'scalar type may not have more than '
                 f'one concrete base type',
-                context=self.source_context,
+                context=self.span,
             )
         abstract = self.get_attribute_value('abstract')
         enum = self.get_attribute_value('enum_values')
@@ -445,7 +445,7 @@ class ScalarTypeCommand(
 
             raise errors.SchemaError(
                 f'scalar type must have a concrete base type',
-                context=self.source_context,
+                context=self.span,
                 hint=hint,
             )
 
@@ -548,7 +548,7 @@ class CreateScalarType(
                     raise errors.UnsupportedFeatureError(
                         f'enumerated types do not support defaults',
                         context=(
-                            create_cmd.get_attribute_source_context('default')
+                            create_cmd.get_attribute_span('default')
                         ),
                     )
 
@@ -736,7 +736,7 @@ class RebaseScalarType(
                 if isinstance(b, s_types.CollectionTypeShell):
                     raise errors.SchemaError(
                         f'scalar type may not have a collection base type',
-                        context=self.source_context,
+                        context=self.span,
                     )
 
             schema = super().apply(schema, context)

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1415,7 +1415,7 @@ class FlatSchema(Schema):
                 raise errors.InvalidReferenceError(
                     f'{refname!r} exists, but is {english.add_a(got_name)}, '
                     f'not {english.add_a(exp_name)}',
-                    context=sourcectx,
+                    span=sourcectx,
                 )
 
             return obj  # type: ignore
@@ -1463,7 +1463,7 @@ class FlatSchema(Schema):
 
         raise errors.InvalidReferenceError(
             f'{label} {refname!r} does not exist',
-            context=sourcectx,
+            span=sourcectx,
         )
 
     def has_object(self, object_id: uuid.UUID) -> bool:

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -362,7 +362,7 @@ class Schema(abc.ABC):
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> so.Object:
         ...
 
@@ -375,7 +375,7 @@ class Schema(abc.ABC):
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.Object]:
         ...
 
@@ -389,7 +389,7 @@ class Schema(abc.ABC):
         type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> so.Object_T:
         ...
 
@@ -403,7 +403,7 @@ class Schema(abc.ABC):
         type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.Object_T]:
         ...
 
@@ -417,7 +417,7 @@ class Schema(abc.ABC):
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.Object]:
         ...
 
@@ -430,7 +430,7 @@ class Schema(abc.ABC):
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> Optional[so.Object]:
         return self._get(
             name,
@@ -452,7 +452,7 @@ class Schema(abc.ABC):
         type: Optional[Type[so.Object_T]],
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
-        sourcectx: Optional[parsing.ParserContext],
+        sourcectx: Optional[parsing.Span],
         disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
         raise NotImplementedError
@@ -1383,7 +1383,7 @@ class FlatSchema(Schema):
         type: Optional[Type[so.Object_T]],
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
-        sourcectx: Optional[parsing.ParserContext],
+        sourcectx: Optional[parsing.Span],
         disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
         def getter(schema: FlatSchema, name: sn.Name) -> Optional[so.Object]:
@@ -1434,7 +1434,7 @@ class FlatSchema(Schema):
         *,
         label: Optional[str] = None,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
         type: Optional[Type[so.Object]] = None,
     ) -> NoReturn:
         refname = str(name)
@@ -2037,7 +2037,7 @@ class ChainedSchema(Schema):
         type: Optional[Type[so.Object_T]],
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
-        sourcectx: Optional[parsing.ParserContext],
+        sourcectx: Optional[parsing.Span],
         disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
         obj = self._top_schema._get(

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -314,7 +314,7 @@ class CreateTrigger(
                     astnode.expr, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.expr.span,
+                span=astnode.expr.span,
             )
         if astnode.condition is not None:
             cmd.set_attribute_value(
@@ -323,7 +323,7 @@ class CreateTrigger(
                     astnode.condition, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.condition.span,
+                span=astnode.condition.span,
             )
 
         cmd.set_attribute_value('timing', astnode.timing)

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -155,14 +155,14 @@ class TriggerCommand(
                         f'type: '
                         f'{expr_type.get_displayname(schema)}, '
                         f'expected {target.get_displayname(schema)}',
-                        context=srcctx,
+                        span=srcctx,
                     )
 
                 if expression.irast.dml_exprs:
                     raise errors.SchemaDefinitionError(
                         'data-modifying statements are not allowed in trigger '
                         'when clauses',
-                        context=expression.irast.dml_exprs[0].span,
+                        span=expression.irast.dml_exprs[0].span,
                     )
 
         return schema
@@ -370,7 +370,7 @@ class AlterTrigger(
             raise errors.SchemaDefinitionError(
                 f'cannot alter the definition of inherited trigger '
                 f'{self.scls.get_displayname(schema)}',
-                context=self.span
+                span=self.span
             )
 
         return schema

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -162,7 +162,7 @@ class TriggerCommand(
                     raise errors.SchemaDefinitionError(
                         'data-modifying statements are not allowed in trigger '
                         'when clauses',
-                        context=expression.irast.dml_exprs[0].context,
+                        context=expression.irast.dml_exprs[0].span,
                     )
 
         return schema
@@ -314,7 +314,7 @@ class CreateTrigger(
                     astnode.expr, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.expr.context,
+                source_context=astnode.expr.span,
             )
         if astnode.condition is not None:
             cmd.set_attribute_value(
@@ -323,7 +323,7 @@ class CreateTrigger(
                     astnode.condition, schema, context.modaliases,
                     context.localnames,
                 ),
-                source_context=astnode.condition.context,
+                source_context=astnode.condition.span,
             )
 
         cmd.set_attribute_value('timing', astnode.timing)

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -149,7 +149,7 @@ class TriggerCommand(
                     sn.QualName('std', 'bool'), type=s_types.Type)
                 expr_type = expression.irast.stype
                 if not expr_type.issubclass(expression.irast.schema, target):
-                    srcctx = self.get_attribute_source_context(field)
+                    srcctx = self.get_attribute_span(field)
                     raise errors.SchemaDefinitionError(
                         f'{vname} expression for {trig_name} is of invalid '
                         f'type: '
@@ -246,7 +246,8 @@ class TriggerCommand(
             except errors.QueryError as e:
                 if not e.has_source_context():
                     e.set_source_context(
-                        self.get_attribute_source_context(field.name))
+                        self.get_attribute_span(field.name)
+                    )
                 raise
         else:
             return super().compile_expr_field(
@@ -369,7 +370,7 @@ class AlterTrigger(
             raise errors.SchemaDefinitionError(
                 f'cannot alter the definition of inherited trigger '
                 f'{self.scls.get_displayname(schema)}',
-                context=self.source_context
+                context=self.span
             )
 
         return schema

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -244,8 +244,8 @@ class TriggerCommand(
                     ),
                 )
             except errors.QueryError as e:
-                if not e.has_source_context():
-                    e.set_source_context(
+                if not e.has_span():
+                    e.set_span(
                         self.get_attribute_span(field.name)
                     )
                 raise

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2896,7 +2896,9 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
         expr = qlast.get_ddl_field_value(astnode, 'expr')
         if expr is None:
             raise errors.InvalidAliasDefinitionError(
-                f'missing required view expression', context=astnode.context)
+                f'missing required view expression',
+                context=astnode.span
+            )
         assert isinstance(expr, qlast.Expr)
         return expr
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -3414,7 +3414,7 @@ def materialize_type_in_attribute(
     if type_ref is None:
         return schema
 
-    srcctx = cmd.get_attribute_source_context('target')
+    srcctx = cmd.get_attribute_span('target')
 
     if isinstance(type_ref, TypeExprShell):
         cc_cmd = ensure_schema_type_expr_type(

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2877,7 +2877,7 @@ def ensure_schema_type_expr_type(
     type_shell: TypeExprShell[Type],
     parent_cmd: sd.Command,
     *,
-    src_context: typing.Optional[parsing.Span] = None,
+    span: typing.Optional[parsing.Span] = None,
     context: sd.CommandContext,
 ) -> Optional[sd.Command]:
 
@@ -3424,7 +3424,7 @@ def materialize_type_in_attribute(
             schema,
             type_ref,
             parent_cmd=cmd,
-            src_context=srcctx,
+            span=srcctx,
             context=context,
         )
         if cc_cmd is not None:
@@ -3453,7 +3453,7 @@ def materialize_type_in_attribute(
                     modaliases=context.modaliases,
                     schema=schema,
                     item_type=Type,
-                    context=srcctx,
+                    span=srcctx,
                 )
             raise
         except errors.InvalidPropertyDefinitionError as e:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -625,7 +625,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
             f'unsupported type intersection in schema {str(view_name)}',
             hint=f'Type intersections are currently '
                  f'unsupported as valid link targets.',
-            context=self.sourcectx,
+            span=self.sourcectx,
         )
 
 
@@ -2900,7 +2900,7 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
         if expr is None:
             raise errors.InvalidAliasDefinitionError(
                 f'missing required view expression',
-                context=astnode.span
+                span=astnode.span
             )
         assert isinstance(expr, qlast.Expr)
         return expr
@@ -2992,7 +2992,7 @@ class InheritingTypeCommand(
                 shell = shells.get(base.get_name(schema))
                 raise errors.SchemaError(
                     f"{base_type_name!r} cannot be a parent type",
-                    context=shell.sourcectx if shell is not None else None,
+                    span=shell.sourcectx if shell is not None else None,
                 )
 
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -594,7 +594,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         displayname: Optional[str] = None,
         expr: Optional[str] = None,
         schemaclass: typing.Type[TypeT_co],
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
         extra_args: tuple[qlast.Expr] | None = None,
     ) -> None:
         super().__init__(
@@ -636,7 +636,7 @@ class TypeExprShell(TypeShell[TypeT_co]):
         name: s_name.Name,
         components: Iterable[TypeShell[TypeT_co]],
         schemaclass: typing.Type[TypeT_co],
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -667,7 +667,7 @@ class UnionTypeShell(TypeExprShell[TypeT_co]):
         components: Iterable[TypeShell[TypeT_co]],
         opaque: bool = False,
         schemaclass: typing.Type[TypeT_co],
-        sourcectx: Optional[parsing.ParserContext] = None,
+        sourcectx: Optional[parsing.Span] = None,
     ) -> None:
         name = get_union_type_name(
             (c.name for c in components),
@@ -905,7 +905,7 @@ class IntersectionTypeShell(TypeExprShell[TypeT_co]):
         module: str,
         components: Iterable[TypeShell[TypeT_co]],
         schemaclass: type[TypeT_co],
-        sourcectx: parsing.ParserContext | None = None,
+        sourcectx: parsing.Span | None = None,
     ) -> None:
         name = get_intersection_type_name(
             (c.name for c in components),
@@ -2874,7 +2874,7 @@ def ensure_schema_type_expr_type(
     type_shell: TypeExprShell[Type],
     parent_cmd: sd.Command,
     *,
-    src_context: typing.Optional[parsing.ParserContext] = None,
+    src_context: typing.Optional[parsing.Span] = None,
     context: sd.CommandContext,
 ) -> Optional[sd.Command]:
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -3454,7 +3454,7 @@ def materialize_type_in_attribute(
                 )
             raise
         except errors.InvalidPropertyDefinitionError as e:
-            e.set_source_context(srcctx)
+            e.set_span(srcctx)
             raise
     elif not isinstance(type_ref, Type):
         raise AssertionError(

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -83,7 +83,7 @@ def ast_ref_to_unqualname(ref: qlast.ObjectRef) -> sn.UnqualName:
     if ref.module:
         raise errors.InternalServerError(
             f'unexpected fully-qualified name: {ast_ref_to_name(ref)}',
-            context=ref.span,
+            span=ref.span,
         )
     else:
         return sn.UnqualName(name=ref.name)
@@ -222,7 +222,7 @@ def ast_to_type_shell(
                         not isinstance(est.maintype, qlast.ObjectRef)):
                     raise errors.EdgeQLSyntaxError(
                         f'enums do not support mapped values',
-                        context=est.span,
+                        span=est.span,
                     )
                 elements.append(est.maintype.name)
             return s_scalars.AnonymousEnumTypeShell(  # type: ignore
@@ -270,7 +270,7 @@ def ast_to_type_shell(
                     if type_name in names:
                         raise errors.SchemaError(
                             f"named tuple has duplicate field '{type_name}'",
-                            context=st.span)
+                            span=st.span)
                     names.add(type_name)
                 else:
                     unnamed = True
@@ -280,7 +280,7 @@ def ast_to_type_shell(
                     raise errors.EdgeQLSyntaxError(
                         f'mixing named and unnamed tuple declaration '
                         f'is not supported',
-                        context=node.subtypes[0].span,
+                        span=node.subtypes[0].span,
                     )
 
                 subtypes[type_name] = ast_to_type_shell(
@@ -317,13 +317,13 @@ def ast_to_type_shell(
                 raise errors.SchemaError(
                     f'unexpected number of subtypes,'
                     f' expecting 1, got {len(subtypes_list)}',
-                    context=node.span,
+                    span=node.span,
                 )
 
             if isinstance(subtypes_list[0], s_types.ArrayTypeShell):
                 raise errors.UnsupportedFeatureError(
                     'nested arrays are not supported',
-                    context=node.subtypes[0].span,
+                    span=node.subtypes[0].span,
                 )
 
             try:
@@ -350,7 +350,7 @@ def ast_to_type_shell(
                 raise errors.SchemaError(
                     f'unexpected number of subtypes,'
                     f' expecting 1, got {len(subtypes_list)}',
-                    context=node.span,
+                    span=node.span,
                 )
 
             # FIXME: need to check that subtypes are only anypoint
@@ -395,7 +395,7 @@ def type_op_ast_to_type_shell(
     if node.op != '|':
         raise errors.UnsupportedFeatureError(
             f'unsupported type expression operator: {node.op}',
-            context=node.span,
+            span=node.span,
         )
 
     if module is None:
@@ -404,7 +404,7 @@ def type_op_ast_to_type_shell(
     if module is None:
         raise errors.InternalServerError(
             'cannot determine module for derived compound type',
-            context=node.span,
+            span=node.span,
         )
 
     left = ast_to_type_shell(

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -299,7 +299,7 @@ def ast_to_type_shell(
             except errors.SchemaError as e:
                 # all errors raised inside are pertaining to subtypes, so
                 # the context should point to the first subtype
-                e.set_source_context(node.subtypes[0].span)
+                e.set_span(node.subtypes[0].span)
                 raise e
 
         elif issubclass(coll, s_types.Array):
@@ -332,7 +332,7 @@ def ast_to_type_shell(
                     subtypes=subtypes_list,
                 )
             except errors.SchemaError as e:
-                e.set_source_context(node.span)
+                e.set_span(node.span)
                 raise e
 
         elif issubclass(coll, (s_types.Range, s_types.MultiRange)):
@@ -361,7 +361,7 @@ def ast_to_type_shell(
                     subtypes=subtypes_list,
                 )
             except errors.SchemaError as e:
-                e.set_source_context(node.span)
+                e.set_span(node.span)
                 raise e
 
     elif isinstance(node.maintype, qlast.PseudoObjectRef):
@@ -979,7 +979,7 @@ def enrich_schema_lookup_error(
         error.set_hint_and_details(hint=hint)
 
     if context is not None:
-        error.set_source_context(context)
+        error.set_span(context)
 
 
 def ensure_union_type(

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -93,7 +93,7 @@ def resolve_name(
     lname: sn.Name,
     *,
     metaclass: Optional[Type[so.Object]] = None,
-    sourcectx: Optional[parsing.ParserContext] = None,
+    sourcectx: Optional[parsing.Span] = None,
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
 ) -> sn.Name:
@@ -949,7 +949,7 @@ def enrich_schema_lookup_error(
     item_type: Optional[so.ObjectMeta] = None,
     suggestion_limit: int = 3,
     condition: Optional[Callable[[so.Object], bool]] = None,
-    context: Optional[parsing.ParserContext] = None,
+    context: Optional[parsing.Span] = None,
     pointer_parent: Optional[so.Object] = None,
 ) -> None:
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -949,7 +949,7 @@ def enrich_schema_lookup_error(
     item_type: Optional[so.ObjectMeta] = None,
     suggestion_limit: int = 3,
     condition: Optional[Callable[[so.Object], bool]] = None,
-    context: Optional[parsing.Span] = None,
+    span: Optional[parsing.Span] = None,
     pointer_parent: Optional[so.Object] = None,
 ) -> None:
 
@@ -978,8 +978,8 @@ def enrich_schema_lookup_error(
 
         error.set_hint_and_details(hint=hint)
 
-    if context is not None:
-        error.set_span(context)
+    if span is not None:
+        error.set_span(span)
 
 
 def ensure_union_type(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -155,7 +155,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} in a migration block',
-                context=ql.span,
+                span=ql.span,
             )
 
     def _assert_in_migration_block(
@@ -169,7 +169,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} outside of a migration block',
-                context=ql.span,
+                span=ql.span,
             )
         return mstate
 
@@ -184,7 +184,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} in a migration rewrite block',
-                context=ql.span,
+                span=ql.span,
             )
 
     def _assert_in_migration_rewrite_block(
@@ -198,7 +198,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} outside of a migration rewrite block',
-                context=ql.span,
+                span=ql.span,
             )
         return mstate
 
@@ -1702,7 +1702,7 @@ def _compile_ql_explain(
             if name not in EXPLAIN_PARAMS:
                 raise errors.QueryError(
                     f"unknown ANALYZE argument '{name}'",
-                    context=el.span,
+                    span=el.span,
                 )
             arg_ir = qlcompiler.compile_ast_to_ir(
                 el.val,
@@ -1717,7 +1717,7 @@ def _compile_ql_explain(
                     f"incorrect type for ANALYZE argument '{name}': "
                     f"expected '{exp_typ.get_name(schema)}', "
                     f"got '{arg_ir.stype.get_name(schema)}'",
-                    context=el.span,
+                    span=el.span,
                 )
 
             args[name] = ireval.evaluate_to_python_val(arg_ir.expr, schema)
@@ -1744,7 +1744,7 @@ def _compile_ql_explain(
     if isinstance(query, dbstate.NullQuery):
         raise errors.QueryError(
             f"cannot ANALYZE inside of a migration",
-            context=ql.span,
+            span=ql.span,
         )
 
     assert len(query.sql) == 1, query.sql
@@ -1785,12 +1785,12 @@ def _compile_ql_administer(
         if not _get_config_val(ctx, '__internal_testmode'):
             raise errors.QueryError(
                 'statistics_update() can only be executed in test mode',
-                context=ql.span)
+                span=ql.span)
 
         if ql.expr.args or ql.expr.kwargs:
             raise errors.QueryError(
                 'statistics_update() does not take arguments',
-                context=ql.expr.span,
+                span=ql.expr.span,
             )
 
         return dbstate.MaintenanceQuery(sql=(b'ANALYZE',))
@@ -1803,7 +1803,7 @@ def _compile_ql_administer(
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',
-            context=ql.expr.span,
+            span=ql.expr.span,
         )
 
 
@@ -2641,14 +2641,14 @@ def _try_compile(
                 raise errors.QueryError(
                     f'cannot execute {status.get_status(stmt).decode()} '
                     f'with other commands in one block',
-                    context=stmt.span,
+                    span=stmt.span,
                 )
 
             if not ctx.state.current_tx().is_implicit():
                 raise errors.QueryError(
                     f'cannot execute {status.get_status(stmt).decode()} '
                     f'in a transaction',
-                    context=stmt.span,
+                    span=stmt.span,
                 )
 
             unit.is_transactional = False

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -155,7 +155,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} in a migration block',
-                context=ql.context,
+                context=ql.span,
             )
 
     def _assert_in_migration_block(
@@ -169,7 +169,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} outside of a migration block',
-                context=ql.context,
+                context=ql.span,
             )
         return mstate
 
@@ -184,7 +184,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} in a migration rewrite block',
-                context=ql.context,
+                context=ql.span,
             )
 
     def _assert_in_migration_rewrite_block(
@@ -198,7 +198,7 @@ class CompileContext:
             stmt = status.get_status(ql).decode()
             raise errors.QueryError(
                 f'cannot execute {stmt} outside of a migration rewrite block',
-                context=ql.context,
+                context=ql.span,
             )
         return mstate
 
@@ -1702,7 +1702,7 @@ def _compile_ql_explain(
             if name not in EXPLAIN_PARAMS:
                 raise errors.QueryError(
                     f"unknown ANALYZE argument '{name}'",
-                    context=el.context,
+                    context=el.span,
                 )
             arg_ir = qlcompiler.compile_ast_to_ir(
                 el.val,
@@ -1717,7 +1717,7 @@ def _compile_ql_explain(
                     f"incorrect type for ANALYZE argument '{name}': "
                     f"expected '{exp_typ.get_name(schema)}', "
                     f"got '{arg_ir.stype.get_name(schema)}'",
-                    context=el.context,
+                    context=el.span,
                 )
 
             args[name] = ireval.evaluate_to_python_val(arg_ir.expr, schema)
@@ -1744,7 +1744,7 @@ def _compile_ql_explain(
     if isinstance(query, dbstate.NullQuery):
         raise errors.QueryError(
             f"cannot ANALYZE inside of a migration",
-            context=ql.context,
+            context=ql.span,
         )
 
     assert len(query.sql) == 1, query.sql
@@ -1785,12 +1785,12 @@ def _compile_ql_administer(
         if not _get_config_val(ctx, '__internal_testmode'):
             raise errors.QueryError(
                 'statistics_update() can only be executed in test mode',
-                context=ql.context)
+                context=ql.span)
 
         if ql.expr.args or ql.expr.kwargs:
             raise errors.QueryError(
                 'statistics_update() does not take arguments',
-                context=ql.expr.context,
+                context=ql.expr.span,
             )
 
         return dbstate.MaintenanceQuery(sql=(b'ANALYZE',))
@@ -1803,7 +1803,7 @@ def _compile_ql_administer(
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',
-            context=ql.expr.context,
+            context=ql.expr.span,
         )
 
 
@@ -2641,14 +2641,14 @@ def _try_compile(
                 raise errors.QueryError(
                     f'cannot execute {status.get_status(stmt).decode()} '
                     f'with other commands in one block',
-                    context=stmt.context,
+                    context=stmt.span,
                 )
 
             if not ctx.state.current_tx().is_implicit():
                 raise errors.QueryError(
                     f'cannot execute {status.get_status(stmt).decode()} '
                     f'in a transaction',
-                    context=stmt.context,
+                    context=stmt.span,
                 )
 
             unit.is_transactional = False

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -90,7 +90,7 @@ def compile_and_apply_ddl_stmt(
                     f"to avoid accidental schema changes outside of "
                     f"the migration flow."
                 ),
-                context=stmt.span,
+                span=stmt.span,
             )
         cm = qlast.CreateMigration(  # type: ignore
             body=qlast.NestedQLBlock(
@@ -811,7 +811,7 @@ def _commit_migration(
                 ' to let the system populate the outstanding DDL'
                 ' automatically.'
             ),
-            context=ql.span,
+            span=ql.span,
         )
 
     if debug.flags.delta_plan:
@@ -1001,7 +1001,7 @@ def _commit_migration_rewrite(
         raise errors.QueryError(
             'cannot commit migration rewrite: schema resulting '
             'from rewrite does not match committed schema',
-            context=ql.span,
+            span=ql.span,
         )
 
     schema = mrstate.target_schema
@@ -1099,7 +1099,7 @@ def _reset_schema(
         raise errors.QueryError(
             f'Unknown schema version "{ql.target.name}". '
             'Currently, only revision supported is "initial"',
-            context=ql.target.span,
+            span=ql.target.span,
         )
 
     current_tx = ctx.state.current_tx()
@@ -1243,7 +1243,7 @@ def administer_repair_schema(
     if ql.expr.args or ql.expr.kwargs:
         raise errors.QueryError(
             'repair_schema() does not take arguments',
-            context=ql.expr.span,
+            span=ql.expr.span,
         )
 
     current_tx = ctx.state.current_tx()
@@ -1278,7 +1278,7 @@ def administer_reindex(
     if len(ql.expr.args) != 1 or ql.expr.kwargs:
         raise errors.QueryError(
             'reindex() takes exactly one position argument',
-            context=ql.expr.span,
+            span=ql.expr.span,
         )
 
     arg = ql.expr.args[0]
@@ -1296,7 +1296,7 @@ def administer_reindex(
         case _:
             raise errors.QueryError(
                 'argument to reindex() must be an object type',
-                context=arg.span,
+                span=arg.span,
             )
 
     current_tx = ctx.state.current_tx()
@@ -1319,7 +1319,7 @@ def administer_reindex(
         ):
             raise errors.QueryError(
                 'invalid pointer argument to reindex()',
-                context=arg.span,
+                span=arg.span,
             )
         rptr = expr.expr.result.rptr
         source = rptr.source
@@ -1334,7 +1334,7 @@ def administer_reindex(
     ):
         raise errors.QueryError(
             'argument to reindex() must be a regular object type',
-            context=arg.span,
+            span=arg.span,
         )
 
     tables: set[s_pointers.Pointer | s_objtypes.ObjectType] = set()
@@ -1355,7 +1355,7 @@ def administer_reindex(
         if not isinstance(rptr.ptrref, irast.PointerRef):
             raise errors.QueryError(
                 'invalid pointer argument to reindex()',
-                context=arg.span,
+                span=arg.span,
             )
         schema, ptrcls = irtypeutils.ptrcls_from_ptrref(
             rptr.ptrref, schema=schema)
@@ -1419,12 +1419,12 @@ def administer_vacuum(
         if name != 'full':
             raise errors.QueryError(
                 f'unrecognized keyword argument {name!r} for vacuum()',
-                context=val.span,
+                span=val.span,
             )
         elif not isinstance(val, qlast.BooleanConstant):
             raise errors.QueryError(
                 f'argument {name!r} for vacuum() must be a boolean literal',
-                context=val.span,
+                span=val.span,
             )
         kwargs[name] = val.value
 
@@ -1450,7 +1450,7 @@ def administer_vacuum(
                 raise errors.QueryError(
                     'argument to vacuum() must be an object type '
                     'or a link or property reference',
-                    context=arg.span,
+                    span=arg.span,
                 )
 
         ir: irast.Statement = qlcompiler.compile_ast_to_ir(
@@ -1469,7 +1469,7 @@ def administer_vacuum(
             ):
                 raise errors.QueryError(
                     'invalid pointer argument to vacuum()',
-                    context=arg.span,
+                    span=arg.span,
                 )
             rptr = expr.expr.result.rptr
             source = rptr.source
@@ -1485,7 +1485,7 @@ def administer_vacuum(
             raise errors.QueryError(
                 'argument to vacuum() must be an object type '
                 'or a link or property reference',
-                context=arg.span,
+                span=arg.span,
             )
         args.append((rptr, obj))
 
@@ -1504,7 +1504,7 @@ def administer_vacuum(
             if not isinstance(rptr.ptrref, irast.PointerRef):
                 raise errors.QueryError(
                     'invalid pointer argument to vacuum()',
-                    context=arg.span,
+                    span=arg.span,
                 )
             schema, ptrcls = irtypeutils.ptrcls_from_ptrref(
                 rptr.ptrref, schema=schema)
@@ -1518,14 +1518,14 @@ def administer_vacuum(
                     raise errors.QueryError(
                         f'{vn} is not a valid argument to vacuum() '
                         f'because it is not a multi property',
-                        context=arg.span,
+                        span=arg.span,
                     )
                 else:
                     raise errors.QueryError(
                         f'{vn} is not a valid argument to vacuum() '
                         f'because it is neither a multi link nor '
                         f'does it have link properties',
-                        context=arg.span,
+                        span=arg.span,
                     )
 
             ptrclses = {ptrcls} | {

--- a/edb/server/compiler/explain/__init__.py
+++ b/edb/server/compiler/explain/__init__.py
@@ -120,8 +120,8 @@ def analyze_explain_output(
 
     if info:
         buffers = info.buffers
-    elif ql.context:
-        buffers = [ql.context.buffer]
+    elif ql.span:
+        buffers = [ql.span.buffer]
     else:
         buffers = []  # should never happen
 

--- a/edb/server/compiler/explain/ir_analyze.py
+++ b/edb/server/compiler/explain/ir_analyze.py
@@ -134,17 +134,17 @@ def analyze_queries(
     contexts = {(ql.span.buffer, ql.span.name): 0}
 
     def get_context(node: irast.Set) -> ContextDesc:
-        assert node.context, node
-        context = node.context
-        key = context.buffer, context.name
+        assert node.span, node
+        span = node.span
+        key = span.buffer, span.name
         if (idx := contexts.get(key)) is None:
             idx = len(contexts)
             contexts[key] = idx
-        text = context.buffer[context.start:context.end]
+        text = span.buffer[span.start:span.end]
 
         return ContextDesc(
-            start=context.start,
-            end=context.end,
+            start=span.start,
+            end=span.end,
             buffer_idx=idx,
             text=text,
         )
@@ -194,7 +194,7 @@ def analyze_queries(
         asets = []
         while True:
             ns = cast(list[irast.Set], rvar.ir_origins or [])
-            if len(ns) >= 1 and ns[0].context:
+            if len(ns) >= 1 and ns[0].span:
                 if ns[0] not in asets:
                     asets.append(ns[0])
 
@@ -215,14 +215,14 @@ def analyze_queries(
 
             rvar = subq_to_rvar[source]
 
-        sctxs = [get_context(x) for x in asets if x.context]
+        spans = [get_context(x) for x in asets if x.span]
         if debug_spew:
             print(alias, asets)
             for x in asets:
-                debug.dump(x.context)
+                debug.dump(x.span)
 
         # Using the first set of contexts found
-        alias_contexts.setdefault(alias, sctxs)
+        alias_contexts.setdefault(alias, spans)
 
     alias_info = {
         alias: AliasInfo(

--- a/edb/server/compiler/explain/ir_analyze.py
+++ b/edb/server/compiler/explain/ir_analyze.py
@@ -130,8 +130,8 @@ def analyze_queries(
 ) -> AnalysisInfo:
     debug_spew = debug.flags.edgeql_explain
 
-    assert ql.context
-    contexts = {(ql.context.buffer, ql.context.name): 0}
+    assert ql.span
+    contexts = {(ql.span.buffer, ql.span.name): 0}
 
     def get_context(node: irast.Set) -> ContextDesc:
         assert node.context, node

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -79,7 +79,6 @@ from edb.schema import objects as s_obj
 from edb import errors
 from edb.errors import base as base_errors, EdgeQLSyntaxError
 from edb.common import debug
-from edb.common import context as pctx
 
 from edb.protocol import messages
 

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -330,7 +330,7 @@ class BaseSchemaTest(BaseDocTest):
                     raise errors.QueryError(
                         'unexpected POPULATE MIGRATION:'
                         ' not currently in a migration block',
-                        context=stmt.context,
+                        span=stmt.context,
                     )
 
                 migration_diff = s_ddl.delta_schemas(
@@ -379,7 +379,7 @@ class BaseSchemaTest(BaseDocTest):
                     raise errors.QueryError(
                         'unexpected COMMIT MIGRATION:'
                         ' not currently in a migration block',
-                        context=stmt.context,
+                        span=stmt.context,
                     )
 
                 last_migration = current_schema.get_last_migration()

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -194,7 +194,7 @@ class BaseSyntaxTest(BaseDocTest):
             markup.dump(inast)
 
         # make sure that the AST has context
-        span.ContextValidator().visit(inast)
+        span.SpanValidator().visit(inast)
 
         processed_src = self.ast_to_source(inast)
 

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -28,7 +28,7 @@ import os
 import re
 import unittest
 
-from edb.common import context
+from edb.common import span
 from edb.common import debug
 from edb.common import devmode
 from edb.common import markup
@@ -194,7 +194,7 @@ class BaseSyntaxTest(BaseDocTest):
             markup.dump(inast)
 
         # make sure that the AST has context
-        context.ContextValidator().visit(inast)
+        span.ContextValidator().visit(inast)
 
         processed_src = self.ast_to_source(inast)
 

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -330,7 +330,7 @@ class BaseSchemaTest(BaseDocTest):
                     raise errors.QueryError(
                         'unexpected POPULATE MIGRATION:'
                         ' not currently in a migration block',
-                        span=stmt.context,
+                        span=stmt.span,
                     )
 
                 migration_diff = s_ddl.delta_schemas(
@@ -379,7 +379,7 @@ class BaseSchemaTest(BaseDocTest):
                     raise errors.QueryError(
                         'unexpected COMMIT MIGRATION:'
                         ' not currently in a migration block',
-                        span=stmt.context,
+                        span=stmt.span,
                     )
 
                 last_migration = current_schema.get_last_migration()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1984,7 +1984,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         asdf = obj.getptr(schema, s_name.UnqualName('asdf'))
         expr_ast = asdf.get_expr(schema).qlast
         self.assertEqual(
-            expr_ast.context.name,
+            expr_ast.span.name,
             f'<{asdf.id} expr>'
         )
 
@@ -1996,7 +1996,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         x = obj.getptr(schema, s_name.UnqualName('x'))
         default_ast = x.get_default(schema).qlast
         self.assertEqual(
-            default_ast.context.name,
+            default_ast.span.name,
             f'<{x.id} default>'
         )
 


### PR DESCRIPTION
Closes #6968

As a references, this used to be named:
- `parser_context`,
- `source_context`,
- `context`,
- `ParsingContext`,
- `pctx`,
- `span`.

This PR does have an enormous diff, it cannot be backported to old branches, but it probably should be backported to 5.x, so new fixed don't cause too much conflicts.
