### PR TITLE
Restore cheatsheets to side navigation

### DIFF
--- a/docs/guides/cheatsheet/index.rst
+++ b/docs/guides/cheatsheet/index.rst
@@ -45,8 +45,8 @@ EdgeQL
 Schema
 ======
 
-* :ref:`Booleans <ref_cheatsheet_object_types>` -- Boolean expressions can be
-  tricky sometimes, so here are a handful of tips and gotchas.
+* :ref:`Booleans <ref_cheatsheet_boolean>` -- Boolean expressions can be tricky
+  sometimes, so here are a handful of tips and gotchas.
 * :ref:`Object Types <ref_cheatsheet_object_types>` -- Make your own object
   and abstract types on top of existing system types.
 * :ref:`User Defined Functions <ref_cheatsheet_functions>` -- Write and

--- a/docs/guides/cheatsheet/index.rst
+++ b/docs/guides/cheatsheet/index.rst
@@ -6,6 +6,26 @@ Cheatsheets
 
 :edb-alt-title: Cheatsheets: EdgeDB by example
 
+.. toctree::
+    :maxdepth: 3
+    :hidden:
+
+
+    select
+    insert
+    update
+    delete
+    link_properties
+    boolean
+    objects
+    functions
+    aliases
+    annotations
+    cli
+    repl
+    admin
+
+
 Just getting started? Keep an eye on this collection of cheatsheets with
 handy examples for what you'll need to get started with EdgeDB.
 After familiarizing yourself with them, feel free to dive into more EdgeDB
@@ -46,23 +66,3 @@ CLI/Admin
   frequently used commands in the EdgeDB Interactive Shell.
 * :ref:`Administration <ref_cheatsheet_admin>` -- Database and role creation,
   passwords, port configuration, etc.
-
-
-.. toctree::
-    :maxdepth: 3
-    :hidden:
-
-
-    select
-    insert
-    update
-    delete
-    link_properties
-    boolean
-    objects
-    functions
-    aliases
-    annotations
-    cli
-    repl
-    admin


### PR DESCRIPTION
Discovered this problem this morning. Position of the TOC in the file now determines what gets rendered in the navigation sidebar, which resulted in the individual cheatsheet links not being rendered there. This was further complicated by the fact that the booleans cheatsheet link at Cheatsheets > Overview was set to the incorrect target, making that cheatsheet difficult to access except via search.