### PR TITLE
Fix update rewrites on types that are children of updated type

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -907,9 +907,6 @@ class RewriteContext:
     base_type: s_objtypes.ObjectType
     shape_type: s_objtypes.ObjectType
 
-    # Cache for computing `prepare_rewrite_anchors`, since that is expensive
-    anchor_cache: Dict[s_objtypes.ObjectType, RewriteAnchors]
-
 
 def _compile_rewrites(
     specified_ptrs: Set[sn.UnqualName],
@@ -926,14 +923,12 @@ def _compile_rewrites(
         kind=kind,
         base_type=stype,
         shape_type=view_scls,
-        anchor_cache=dict(),
     )
 
     # Computing anchors isn't cheap, so we want to only do it once,
     # and only do it when it is necessary.
     anchors: Dict[s_objtypes.ObjectType, RewriteAnchors] = {}
     def get_anchors(stype: s_objtypes.ObjectType) -> RewriteAnchors:
-        nonlocal anchors
         if stype not in anchors:
             anchors[stype] = prepare_rewrite_anchors(stype, r_ctx, s_ctx, ctx)
         return anchors[stype]

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1108,9 +1108,6 @@ def _compile_rewrites_for_stype(
                 old_set = setgen.class_set(
                     rewrite_view, path_id=old_set.path_id, ctx=ctx)
 
-            ir_set = setgen.class_set(
-                rewrite_view, path_id=ir_set.path_id, ctx=ctx)
-
         rewrite_expr = rewrite.get_expr(ctx.env.schema)
         assert rewrite_expr
 


### PR DESCRIPTION
Closes #7048
Closes #6801

When type X is updated, but has child Y with an update rewrite, we were using type X as the subject where we should have been using Y.

Review commit-by-commit as I had to do a little refactor first.