### PR TITLE
Remove unused ENV variable from the Docker guides

### DIFF
--- a/docs/guides/deployment/docker.rst
+++ b/docs/guides/deployment/docker.rst
@@ -39,7 +39,6 @@ Docker volume, run:
 .. code-block:: bash
 
    $ docker run -it --rm --link=edgedb \
-       -e EDGEDB_SERVER_PASSWORD=secret \
        -v edgedb-cli-config:/.config/edgedb edgedb/edgedb-cli \
        -H edgedb instance link my_instance
 


### PR DESCRIPTION
The line in question doesn't actually matter. This is because it is used in the CLIENT, while the variable's actual use is in the SERVER.

Having it there is a red flag.