### PR TITLE
Separate triggers by kind in compilation.

### DIFF
--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from edb.schema import types as s_types
     from edb.schema import pointers as s_pointers
     from edb.ir import pathid
+    from edb.edgeql import qltypes
 
     SourceOrPathId = s_types.Type | s_pointers.Pointer | pathid.PathId
 
@@ -146,3 +147,9 @@ class CompilerOptions(GlobalCompilerOptions):
     )
 
     detached: bool = False
+
+    #: In order to prevent recursive triggers, these fields are used to track
+    #: the sources of a given trigger. These will only be present if
+    #: schema_object_context is set to Trigger.
+    trigger_type: Optional[s_types.Type] = None
+    trigger_kinds: Optional[Collection[qltypes.TriggerKind]] = None

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -138,6 +138,7 @@ def compile_trigger(
 def compile_triggers_phase(
     dml_stmts: Collection[irast.MutatingStmt],
     defining_trigger_on: Optional[s_types.Type],
+    defining_trigger_kinds: Optional[Collection[qltypes.TriggerKind]],
     *,
     ctx: context.ContextLevel,
 ) -> tuple[irast.Trigger, ...]:
@@ -165,11 +166,13 @@ def compile_triggers_phase(
 
         # Process all the types, starting with the base type
         for subtype in sorted(stypes, key=lambda t: t != stype):
-            if defining_trigger_on and subtype.issubclass(
-                    ctx.env.schema, defining_trigger_on):
+            if (defining_trigger_on and defining_trigger_kinds and
+                kind in defining_trigger_kinds and
+                subtype.issubclass(ctx.env.schema, defining_trigger_on)
+            ):
                 name = str(defining_trigger_on.get_name(ctx.env.schema))
                 raise errors.SchemaDefinitionError(
-                    f"trigger on {name} is recursive"
+                    f"trigger on {name} after {kind} is recursive"
                 )
 
             for trigger in subtype.get_relevant_triggers(kind, schema):
@@ -201,31 +204,51 @@ def compile_triggers(
     defining_trigger = (
         ctx.env.options.schema_object_context == s_triggers.Trigger)
     defining_trigger_on = None
+    defining_trigger_kinds = None
     if defining_trigger:
         defining_trigger_on = setgen.get_set_type(
             ctx.anchors['__trigger_type__'], ctx=ctx)
+        trigger_kinds_anchor = ctx.anchors['__trigger_kinds__']
+        if isinstance(trigger_kinds_anchor.expr, irast.Array):
+            defining_trigger_kinds = [
+                qltypes.TriggerKind(element.expr.value)
+                for element in trigger_kinds_anchor.expr.elements
+                if isinstance(element.expr, irast.StringConstant)
+            ]
 
     ir_triggers: list[tuple[irast.Trigger, ...]] = []
     start = 0
-    all_trigger_types: set[irast.TypeRef] = set()
+    all_trigger_causes: set[tuple[irast.TypeRef, qltypes.TriggerKind]] = set()
     while start < len(ctx.env.dml_stmts):
         end = len(ctx.env.dml_stmts)
-        new = compile_triggers_phase(
-            ctx.env.dml_stmts[start:], defining_trigger_on, ctx=ctx)
-        new_types = {x for t in new for x in t.all_affected_types}
+        compiled_triggers = compile_triggers_phase(
+            ctx.env.dml_stmts[start:],
+            defining_trigger_on,
+            defining_trigger_kinds,
+            ctx=ctx
+        )
+        new_causes = {
+            (affected_type, kind)
+            for compiled_trigger in compiled_triggers
+            for affected_type in compiled_trigger.all_affected_types
+            for kind in compiled_trigger.kinds
+        }
 
         # Any given type is allowed allowed to have its triggers fire
         # in *one* phase of trigger execution, since the semantics get
         # a little unclear otherwise. We might relax this later.
-        overlap = new_types & all_trigger_types
+        overlap = new_causes & all_trigger_causes
         if overlap:
-            names = sorted(str(t.name_hint) for t in overlap)
+            names = sorted(
+                f"{str(cause[0].name_hint)} after {cause[1]}"
+                for cause in overlap
+            )
             raise errors.QueryError(
                 f"trigger would need to be executed in multiple stages on "
                 f"{', '.join(names)}"
             )
-        all_trigger_types |= new_types
-        ir_triggers.append(new)
+        all_trigger_causes |= new_causes
+        ir_triggers.append(compiled_triggers)
         start = end
 
     return tuple(ir_triggers)

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -38,6 +38,7 @@ from edb.edgeql import qltypes
 
 from . import context
 from . import dispatch
+from . import options
 from . import schemactx
 from . import setgen
 from . import typegen
@@ -205,16 +206,12 @@ def compile_triggers(
         ctx.env.options.schema_object_context == s_triggers.Trigger)
     defining_trigger_on = None
     defining_trigger_kinds = None
-    if defining_trigger:
-        defining_trigger_on = setgen.get_set_type(
-            ctx.anchors['__trigger_type__'], ctx=ctx)
-        trigger_kinds_anchor = ctx.anchors['__trigger_kinds__']
-        if isinstance(trigger_kinds_anchor.expr, irast.Array):
-            defining_trigger_kinds = [
-                qltypes.TriggerKind(element.expr.value)
-                for element in trigger_kinds_anchor.expr.elements
-                if isinstance(element.expr, irast.StringConstant)
-            ]
+    if (
+        defining_trigger and
+        isinstance(ctx.env.options, options.CompilerOptions)
+    ):
+        defining_trigger_on = ctx.env.options.trigger_type
+        defining_trigger_kinds = ctx.env.options.trigger_kinds
 
     ir_triggers: list[tuple[irast.Trigger, ...]] = []
     start = 0

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -167,9 +167,9 @@ def compile_triggers_phase(
 
         # Process all the types, starting with the base type
         for subtype in sorted(stypes, key=lambda t: t != stype):
-            if (defining_trigger_on and defining_trigger_kinds and
-                kind in defining_trigger_kinds and
-                subtype.issubclass(ctx.env.schema, defining_trigger_on)
+            if (defining_trigger_on and defining_trigger_kinds
+                and kind in defining_trigger_kinds
+                and subtype.issubclass(ctx.env.schema, defining_trigger_on)
             ):
                 name = str(defining_trigger_on.get_name(ctx.env.schema))
                 raise errors.SchemaDefinitionError(

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -173,7 +173,7 @@ def compile_triggers_phase(
             ):
                 name = str(defining_trigger_on.get_name(ctx.env.schema))
                 raise errors.SchemaDefinitionError(
-                    f"trigger on {name} after {kind} is recursive"
+                    f"trigger on {name} after {kind.lower()} is recursive"
                 )
 
             for trigger in subtype.get_relevant_triggers(kind, schema):
@@ -224,7 +224,7 @@ def compile_triggers(
             defining_trigger_kinds,
             ctx=ctx
         )
-        new_causes = {
+        new_causes: set[tuple[irast.TypeRef, qltypes.TriggerKind]] = {
             (affected_type, kind)
             for compiled_trigger in compiled_triggers
             for affected_type in compiled_trigger.all_affected_types
@@ -236,8 +236,8 @@ def compile_triggers(
         # a little unclear otherwise. We might relax this later.
         overlap = new_causes & all_trigger_causes
         if overlap:
-            names = sorted(
-                f"{str(cause[0].name_hint)} after {cause[1]}"
+            names: Collection[str] = sorted(
+                f"{str(cause[0].name_hint)} after {cause[1].lower()}"
                 for cause in overlap
             )
             raise errors.QueryError(

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -1077,7 +1077,7 @@ class TestTriggers(tb.QueryTestCase):
     async def test_edgeql_triggers_chain_02(self):
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaDefinitionError,
-                'trigger on default::InsertTest after Insert is recursive'):
+                'trigger on default::InsertTest after insert is recursive'):
             await self.con.execute('''
                 alter type InsertTest {
                   create trigger log after insert for each do (
@@ -1103,7 +1103,7 @@ class TestTriggers(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
                 'would need to be executed in multiple stages on default::Note '
-                'after Insert'):
+                'after insert'):
             await self.con.execute('''
                 select {
                     (insert InsertTest { name := "foo" }),

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -1077,7 +1077,7 @@ class TestTriggers(tb.QueryTestCase):
     async def test_edgeql_triggers_chain_02(self):
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaDefinitionError,
-                'trigger on default::InsertTest is recursive'):
+                'trigger on default::InsertTest after Insert is recursive'):
             await self.con.execute('''
                 alter type InsertTest {
                   create trigger log after insert for each do (
@@ -1102,13 +1102,75 @@ class TestTriggers(tb.QueryTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
-                'would need to be executed in multiple stages'):
+                'would need to be executed in multiple stages on default::Note '
+                'after Insert'):
             await self.con.execute('''
                 select {
                     (insert InsertTest { name := "foo" }),
                     (insert Note { name := "foo" }),
                 }
             ''')
+
+    async def test_edgeql_triggers_chain_04(self):
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log after update for each do (
+                insert InsertTest { name := __new__.name ++ "!" }
+              );
+            };
+        ''')
+
+        await self.con.execute('''
+            insert InsertTest { name := "test" }
+        ''')
+
+        await self.con.execute('''
+            update InsertTest
+            filter InsertTest.name = "test"
+            set { name := "updated" }
+        ''')
+
+        await self.assert_query_result(
+            '''
+            select InsertTest { name }
+            ''',
+            [{'name': 'updated'}, {'name': 'updated!'}],
+        )
+
+    async def test_edgeql_triggers_chain_05(self):
+        await self.con.execute('''
+            alter type InsertTest {
+              create trigger log after insert for each do (
+                insert Note { name := "insert", note := __new__.name }
+              );
+            };
+        ''')
+
+        await self.con.execute('''
+            select {
+                (insert Note { name := "foo" }),
+            }
+        ''')
+
+        await self.assert_notes([
+            {'name': "foo", 'notes': set()},
+        ])
+
+        await self.con.execute('''
+            select {
+                (insert InsertTest { name := "foo_insert" }),
+                (
+                  update Note
+                  filter Note.name = "foo"
+                  set { name := "foo_update" }
+                ),
+            }
+        ''')
+
+        await self.assert_notes([
+            {'name': "foo_update", 'notes': set()},
+            {'name': "insert", 'notes': set(["foo_insert"])},
+        ])
 
     async def test_edgeql_triggers_tricky_01(self):
         await self.con.execute('''


### PR DESCRIPTION
Fix #5794

When checking for recursive triggers, the compilation now checks `insert`, `update`, and `delete` separately.

Given the schema in #5794, running the following:
```
insert Theme {name := "hello"};
update Theme filter Theme.name = "hello" set {name := "world
"};
select Theme {*}
```

Produces:
```
{
  default::Theme {id: c893e790-e645-11ee-a4e6-a74c0e50141c, name: 'world'},
  default::Theme {id: f4f70b0a-e645-11ee-a4e6-c360cb91f3c6, name: 'hello'},
}
```

As another example, this schema is now valid but becomes invalid if `update` is changed to `insert`
```  type A {
    required name: str;
    trigger create_A after update for each do (
      insert B {
        name := __new__.name
      }
    );
  }

  type B {
    required name: str;
    trigger create_B after insert for each do (
      insert A {
        name := __new__.name
      }
    );
  }
```
