### PR TITLE
Set "Connection: close" for non-keep-alive requests

### DIFF
--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -360,7 +360,7 @@ cdef class HttpProtocol:
             response.content_type,
             response.custom_headers,
             response.body,
-            response.close_connection)
+            response.close_connection or not request.should_keep_alive)
 
     def _switch_to_binary_protocol(self, data=None):
         binproto = binary.new_edge_connection(


### PR DESCRIPTION
See a similar boolean check in the `_handle_response` method: https://github.com/edgedb/edgedb/blob/0a7db6281124c13733e43e3980559eaf17698356/edb/server/protocol/protocol.pyx#L490-L491

This fixes an issue where we were not setting the `Connection: close` header unless you specifically set `response.close_connection`, but some HTTP Request implementations (in this case `node.Request` via Remix's fetch implementation) were treating that as a `socket hang up` error (meaning it didn't send the `end` event before closing the socket).