### PR TITLE
Drop special handling of type intersection in card inference

### DIFF
--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -101,6 +101,10 @@ type Eert {
     }
 }
 
+type Asdf {
+    link children -> Eert;
+}
+
 
 type Report extending Named {
     property subtitle -> str;

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -366,6 +366,33 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         parent: AT_MOST_ONE
         """
 
+    def test_edgeql_ir_card_inference_36b(self):
+        """
+        SELECT Eert {
+            asdf := .<children[is Eert]
+        }
+% OK %
+        asdf: AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_36c(self):
+        """
+        SELECT Eert {
+            asdf := .<children[is Asdf]
+        }
+% OK %
+        asdf: MANY
+        """
+
+    def test_edgeql_ir_card_inference_36d(self):
+        """
+        SELECT Eert {
+            asdf := .<children[is Object]
+        }
+% OK %
+        asdf: MANY
+        """
+
     def test_edgeql_ir_card_inference_37(self):
         """
         SELECT Report {


### PR DESCRIPTION
The goal of all that code is so that when you do things like `.<foo[is
Bar]`, if `Bar.foo` is an exclusive link then the card can be inferred
as `AT_MOST_ONE`. But setgen already restricts the backlink pointer
using the intersections in `resolve_ptr`, so I don't think this is
needed.