### PR TITLE
Drop explicit use of EmptySet as a dummy set

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -580,7 +580,7 @@ def _find_cast(
         else:
             return None
 
-    dummy_set = irast.EmptySet()  # type: ignore
+    dummy_set = irast.DUMMY_SET
     args = [
         (orig_stype, dummy_set),
         (new_stype, dummy_set),

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -104,7 +104,7 @@ def find_callable_typemods(
     """
 
     typ = s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
-    dummy = irast.EmptySet()  # type: ignore
+    dummy = irast.DUMMY_SET
     args = [(typ, dummy)] * num_args
     kwargs = {k: (typ, dummy) for k in kwargs_names}
     options = find_callable(

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -584,6 +584,9 @@ else:
     Set = SetE
 
 
+DUMMY_SET = Set()  # type: ignore[call-arg]
+
+
 class Command(Base):
     __abstract_node__ = True
 
@@ -1086,8 +1089,8 @@ class Stmt(Expr):
     name: typing.Optional[str] = None
     # Parts of the edgeql->IR compiler need to create statements and fill in
     # the result later, but making it Optional would cause lots of errors,
-    # so we stick a bogus Empty set in.
-    result: Set = EmptySet()  # type: ignore
+    # so we stick a dummy set set in.
+    result: Set = DUMMY_SET
     parent_stmt: typing.Optional[Stmt] = None
     iterator_stmt: typing.Optional[Set] = None
     bindings: typing.Optional[typing.List[Set]] = None
@@ -1118,12 +1121,12 @@ class SelectStmt(FilteredStmt):
 
 
 class GroupStmt(FilteredStmt):
-    subject: Set = EmptySet()  # type: ignore
+    subject: Set = DUMMY_SET
     using: typing.Dict[str, typing.Tuple[Set, qltypes.Cardinality]] = (
         ast.field(factory=dict))
     by: typing.List[qlast.GroupingElement]
-    result: Set = EmptySet()  # type: ignore
-    group_binding: Set = EmptySet()  # type: ignore
+    result: Set = DUMMY_SET
+    group_binding: Set = DUMMY_SET
     grouping_binding: typing.Optional[Set] = None
     orderby: typing.Optional[typing.List[SortExpr]] = None
     # Optimization information
@@ -1158,8 +1161,8 @@ class MutatingStmt(Stmt, MutatingLikeStmt):
     __abstract_node__ = True
     # Parts of the edgeql->IR compiler need to create statements and fill in
     # the subject later, but making it Optional would cause lots of errors,
-    # so we stick a bogus Empty set in.
-    subject: Set = EmptySet()  # type: ignore
+    # so we stick a dummy set in.
+    subject: Set = DUMMY_SET
     # Conflict checks that we should manually raise constraint violations
     # for.
     conflict_checks: typing.Optional[typing.List[OnConflictClause]] = None


### PR DESCRIPTION
Instead declare a DUMMY_SET in irast. This generally seems cleaner and
helps prepare for eliminating EmptySet as part of the IR refactors.