### PR TITLE
Fix "Delta Plan Input" debug spew, perform one fewer apply in some cases

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -36,6 +36,7 @@ import itertools
 from edb import errors
 
 from edb import edgeql
+from edb.common import debug
 from edb.common import uuidgen
 from edb.common import verutils
 from edb.edgeql import ast as qlast
@@ -623,7 +624,7 @@ def apply_ddl_script_ex(
     for ddl_stmt in edgeql.parse_block(ddl_text):
         if not isinstance(ddl_stmt, qlast.DDLCommand):
             raise AssertionError(f'expected DDLCommand node, got {ddl_stmt!r}')
-        schema, cmd = _delta_from_ddl(
+        schema, cmd = delta_and_schema_from_ddl(
             ddl_stmt,
             schema=schema,
             modaliases=modaliases,
@@ -653,7 +654,7 @@ def delta_from_ddl(
     ]=None,
     compat_ver: Optional[verutils.Version] = None,
 ) -> sd.DeltaRoot:
-    _, cmd = _delta_from_ddl(
+    _, cmd = delta_and_schema_from_ddl(
         ddl_stmt,
         schema=schema,
         modaliases=modaliases,
@@ -666,7 +667,7 @@ def delta_from_ddl(
     return cmd
 
 
-def _delta_from_ddl(
+def delta_and_schema_from_ddl(
     ddl_stmt: qlast.DDLCommand,
     *,
     schema: s_schema.Schema,
@@ -700,6 +701,10 @@ def _delta_from_ddl(
             context=context,
             testmode=testmode,
         )
+        if debug.flags.delta_plan:
+            debug.header('Delta Plan Input')
+            debug.dump(cmd)
+
         schema = cmd.apply(schema, context)
 
         if not stdmode:

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -113,7 +113,7 @@ def compile_and_apply_ddl_stmt(
         return compile_and_apply_ddl_stmt(ctx, cm)
 
     assert isinstance(stmt, qlast.DDLCommand)
-    delta = s_ddl.delta_from_ddl(
+    new_schema, delta = s_ddl.delta_and_schema_from_ddl(
         stmt,
         schema=schema,
         modaliases=current_tx.get_modaliases(),
@@ -121,16 +121,13 @@ def compile_and_apply_ddl_stmt(
     )
 
     if debug.flags.delta_plan:
-        debug.header('Delta Plan Input')
-        debug.dump(delta)
+        debug.header('Canonical Delta Plan')
+        debug.dump(delta, schema=schema)
 
     if mstate := current_tx.get_migration_state():
         mstate = mstate._replace(
             accepted_cmds=mstate.accepted_cmds + (stmt,),
         )
-
-        context = _new_delta_context(ctx)
-        schema = delta.apply(schema, context=context)
 
         last_proposed = mstate.last_proposed
         if last_proposed:
@@ -159,7 +156,7 @@ def compile_and_apply_ddl_stmt(
                     mstate = mstate._replace(last_proposed=None)
 
         current_tx.update_migration_state(mstate)
-        current_tx.update_schema(schema)
+        current_tx.update_schema(new_schema)
 
         return dbstate.DDLQuery(
             sql=(b'SELECT LIMIT 0',),
@@ -182,23 +179,13 @@ def compile_and_apply_ddl_stmt(
         )
         current_tx.update_migration_rewrite_state(mrstate)
 
-        context = _new_delta_context(ctx)
-        schema = delta.apply(schema, context=context)
-
-        current_tx.update_schema(schema)
+        current_tx.update_schema(new_schema)
 
         return dbstate.DDLQuery(
             sql=(b'SELECT LIMIT 0',),
             user_schema=current_tx.get_user_schema(),
             is_transactional=True,
         )
-
-    # Do a dry-run on test_schema to canonicalize
-    # the schema delta-commands.
-    test_schema = current_tx.get_schema(ctx.compiler_state.std_schema)
-    context = _new_delta_context(ctx)
-    delta.apply(test_schema, context=context)
-    delta.canonical = True
 
     # Apply and adapt delta, build native delta plan, which
     # will also update the schema.
@@ -301,7 +288,7 @@ def _new_delta_context(
 
 
 def _get_delta_context_args(ctx: compiler.CompileContext) -> dict[str, Any]:
-    """Get the args need from delta_from_ddl"""
+    """Get the args need from delta_and_schema_from_ddl"""
     return dict(
         testmode=compiler._get_config_val(ctx, '__internal_testmode'),
         allow_dml_in_functions=(
@@ -319,10 +306,6 @@ def _process_delta(
 
     current_tx = ctx.state.current_tx()
     schema = current_tx.get_schema(ctx.compiler_state.std_schema)
-
-    if debug.flags.delta_plan:
-        debug.header('Canonical Delta Plan')
-        debug.dump(delta, schema=schema)
 
     pgdelta = pg_delta.CommandMeta.adapt(delta)
     assert isinstance(pgdelta, pg_delta.DeltaRoot)


### PR DESCRIPTION
delta_from_ddl computes the new schema and canonicalizes the delta
tree already.  To print the pre-canonicalization delta, we need to do
it inside delta_from_ddl. Also, we can return and use that schema
directly.