### PR TITLE
Make expr non-Optional in irast.Set

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -85,7 +85,7 @@ def compile_cast(
 
     if (
         isinstance(ir_expr, irast.Set)
-        and isinstance(ir_expr.expr, irast.EmptySetExpr)
+        and isinstance(ir_expr.expr, irast.EmptySet)
     ):
         # For the common case of casting an empty set, we simply
         # generate a new empty set node of the requested type.

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -83,9 +83,12 @@ def compile_cast(
                  '"any" types or abstract scalars.',
             span=span)
 
-    if isinstance(ir_expr, irast.EmptySet):
+    if (
+        isinstance(ir_expr, irast.Set)
+        and isinstance(ir_expr.expr, irast.EmptySetExpr)
+    ):
         # For the common case of casting an empty set, we simply
-        # generate a new EmptySet node of the requested type.
+        # generate a new empty set node of the requested type.
         return setgen.new_empty_set(
             stype=new_stype,
             alias=ir_expr.path_id.target_name_hint.name,

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -424,7 +424,7 @@ def _compile_conflict_select(
         assert isinstance(select_ir, irast.Set)
 
     # If we have an empty set, remake it with the right type
-    if isinstance(select_ir, irast.EmptySet):
+    if isinstance(select_ir.expr, irast.EmptySetExpr):
         select_ir = setgen.new_empty_set(stype=subject_typ, ctx=ctx)
 
     return select_ir, always_check, from_parent
@@ -706,7 +706,7 @@ def _compile_inheritance_conflict_selects(
             constrs=p,
             obj_constrs=o,
             span=stmt.span, ctx=ctx)
-        if isinstance(select_ir, irast.EmptySet):
+        if isinstance(select_ir.expr, irast.EmptySetExpr):
             continue
         cnstr_ref = irast.ConstraintRef(id=cnstr.id)
         clauses.append(

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -424,7 +424,7 @@ def _compile_conflict_select(
         assert isinstance(select_ir, irast.Set)
 
     # If we have an empty set, remake it with the right type
-    if isinstance(select_ir.expr, irast.EmptySetExpr):
+    if isinstance(select_ir.expr, irast.EmptySet):
         select_ir = setgen.new_empty_set(stype=subject_typ, ctx=ctx)
 
     return select_ir, always_check, from_parent
@@ -706,7 +706,7 @@ def _compile_inheritance_conflict_selects(
             constrs=p,
             obj_constrs=o,
             span=stmt.span, ctx=ctx)
-        if isinstance(select_ir.expr, irast.EmptySetExpr):
+        if isinstance(select_ir.expr, irast.EmptySet):
             continue
         cnstr_ref = irast.ConstraintRef(id=cnstr.id)
         clauses.append(

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -473,7 +473,7 @@ def _compile_dml_ifelse(
 
         els: list[qlast.Expr] = []
 
-        if not isinstance(irutils.unwrap_set(if_ir), irast.EmptySet):
+        if not isinstance(irutils.unwrap_set(if_ir).expr, irast.EmptySetExpr):
             if_b = qlast.ForQuery(
                 iterator_alias=ctx.aliases.get('_ifelse_true_dummy'),
                 iterator=qlast.SelectQuery(
@@ -484,7 +484,7 @@ def _compile_dml_ifelse(
             )
             els.append(if_b)
 
-        if not isinstance(irutils.unwrap_set(else_ir), irast.EmptySet):
+        if not isinstance(irutils.unwrap_set(else_ir).expr, irast.EmptySetExpr):
             else_b = qlast.ForQuery(
                 iterator_alias=ctx.aliases.get('_ifelse_false_dummy'),
                 iterator=qlast.SelectQuery(

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -473,7 +473,7 @@ def _compile_dml_ifelse(
 
         els: list[qlast.Expr] = []
 
-        if not isinstance(irutils.unwrap_set(if_ir).expr, irast.EmptySetExpr):
+        if not isinstance(irutils.unwrap_set(if_ir).expr, irast.EmptySet):
             if_b = qlast.ForQuery(
                 iterator_alias=ctx.aliases.get('_ifelse_true_dummy'),
                 iterator=qlast.SelectQuery(
@@ -484,7 +484,7 @@ def _compile_dml_ifelse(
             )
             els.append(if_b)
 
-        if not isinstance(irutils.unwrap_set(else_ir).expr, irast.EmptySetExpr):
+        if not isinstance(irutils.unwrap_set(else_ir).expr, irast.EmptySet):
             else_b = qlast.ForQuery(
                 iterator_alias=ctx.aliases.get('_ifelse_false_dummy'),
                 iterator=qlast.SelectQuery(

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -303,7 +303,7 @@ def __infer_config_reset(
 
 @_infer_cardinality.register
 def __infer_empty_set(
-    ir: irast.EmptySetExpr,
+    ir: irast.EmptySet,
     *,
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -303,13 +303,12 @@ def __infer_config_reset(
 
 @_infer_cardinality.register
 def __infer_empty_set(
-    ir: irast.EmptySet,
+    ir: irast.EmptySetExpr,
     *,
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
-    return _infer_set(
-        ir, scope_tree=scope_tree, ctx=ctx)
+    return AT_MOST_ONE
 
 
 @_infer_cardinality.register
@@ -632,8 +631,6 @@ def _infer_set_inner(
 
         card = cartesian_cardinality((source_card, rptrref_card))
 
-    elif isinstance(ir, irast.EmptySet):
-        card = AT_MOST_ONE
     elif sub_expr is not None:
         card = expr_card
     else:

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -344,6 +344,16 @@ def __infer_type_root(
         return MANY
 
 
+@_infer_cardinality.register
+def __infer_cleared(
+    ir: irast.RefExpr,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Cardinality:
+    return MANY
+
+
 def _infer_pointer_cardinality(
     *,
     ptrcls: s_pointers.Pointer,

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -150,7 +150,7 @@ def __infer_config_reset(
 
 @_infer_multiplicity.register
 def __infer_empty_set(
-    ir: irast.EmptySetExpr,
+    ir: irast.EmptySet,
     *,
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -185,6 +185,16 @@ def __infer_type_root(
     return UNIQUE
 
 
+@_infer_multiplicity.register
+def __infer_cleared(
+    ir: irast.RefExpr,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    return DUPLICATE
+
+
 def _infer_shape(
     ir: irast.Set,
     *,

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -150,7 +150,7 @@ def __infer_config_reset(
 
 @_infer_multiplicity.register
 def __infer_empty_set(
-    ir: irast.EmptySet,
+    ir: irast.EmptySetExpr,
     *,
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
@@ -940,9 +940,7 @@ def infer_multiplicity(
     card = cardinality.infer_cardinality(
         ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
 
-    if isinstance(ir, irast.EmptySet):
-        result = EMPTY
-    elif isinstance(ir, irast.Set):
+    if isinstance(ir, irast.Set):
         result = _infer_set(
             ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx,
         )

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -145,6 +145,14 @@ def __infer_type_root(
 
 
 @_infer_volatility_inner.register
+def __infer_cleared_expr(
+    ir: irast.RefExpr,
+    env: context.Environment,
+) -> InferredVolatility:
+    return IMMUTABLE
+
+
+@_infer_volatility_inner.register
 def _infer_pointer(
     ir: irast.Pointer,
     env: context.Environment,
@@ -184,10 +192,8 @@ def __infer_set(
             and ir.expr.source.path_id not in env.singletons
         ):
             vol = _max_volatility((vol, STABLE))
-    elif ir.expr is not None:
-        vol = _infer_volatility(ir.expr, env)
     else:
-        vol = STABLE
+        vol = _infer_volatility(ir.expr, env)
 
     # Cache our best-known as to this point volatility, to prevent
     # infinite recursion.

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -114,7 +114,7 @@ def __infer_config_command(
 
 @_infer_volatility_inner.register
 def __infer_emptyset(
-    ir: irast.EmptySetExpr,
+    ir: irast.EmptySet,
     env: context.Environment,
 ) -> InferredVolatility:
     return IMMUTABLE

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -114,7 +114,7 @@ def __infer_config_command(
 
 @_infer_volatility_inner.register
 def __infer_emptyset(
-    ir: irast.EmptySet,
+    ir: irast.EmptySetExpr,
     env: context.Environment,
 ) -> InferredVolatility:
     return IMMUTABLE

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -145,7 +145,7 @@ def new_empty_set(
     ir_set = irast.Set(
         path_id=path_id,
         typeref=typeref,
-        expr=irast.EmptySetExpr(typeref=typeref),
+        expr=irast.EmptySet(typeref=typeref),
     )
     ctx.env.set_types[ir_set] = stype
     return ir_set
@@ -1435,7 +1435,7 @@ def ensure_set(
     if srcctx is not None:
         ir_set = new_set_from_set(ir_set, span=srcctx, ctx=ctx)
 
-    if (irutils.is_set_instance(ir_set, irast.EmptySetExpr)
+    if (irutils.is_set_instance(ir_set, irast.EmptySet)
             and (stype is None or stype.is_any(ctx.env.schema))
             and typehint is not None):
         typegen.amend_empty_set_type(ir_set, typehint, env=ctx.env)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -142,7 +142,11 @@ def new_empty_set(
 
     typeref = typegen.type_to_typeref(stype, env=ctx.env)
     path_id = pathctx.get_expression_path_id(stype, alias, ctx=ctx)
-    ir_set = irast.EmptySet(path_id=path_id, typeref=typeref)
+    ir_set = irast.Set(
+        path_id=path_id,
+        typeref=typeref,
+        expr=irast.EmptySetExpr(typeref=typeref),
+    )
     ctx.env.set_types[ir_set] = stype
     return ir_set
 
@@ -1431,7 +1435,7 @@ def ensure_set(
     if srcctx is not None:
         ir_set = new_set_from_set(ir_set, span=srcctx, ctx=ctx)
 
-    if (isinstance(ir_set, irast.EmptySet)
+    if (irutils.is_set_instance(ir_set, irast.EmptySetExpr)
             and (stype is None or stype.is_any(ctx.env.schema))
             and typehint is not None):
         typegen.amend_empty_set_type(ir_set, typehint, env=ctx.env)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1276,7 +1276,6 @@ def process_with_block(
                     had_materialized = True
                     typ = setgen.get_set_type(binding, ctx=ctx)
                     ctx.env.materialized_sets[typ] = edgeql_tree, reason
-                    assert binding.expr
                     setgen.maybe_materialize(typ, binding, ctx=ctx)
 
         else:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -255,10 +255,15 @@ def fini_expression(
 
     # Clear out exprs that we decided to omit from the IR
     for ir_set in exprs_to_clear:
+        new = (
+            irast.MaterializedExpr(typeref=ir_set.typeref)
+            if ir_set.is_materialized_ref
+            else irast.VisibleBindingExpr(typeref=ir_set.typeref)
+        )
         if isinstance(ir_set.expr, irast.Pointer):
-            ir_set.expr.expr = None
+            ir_set.expr.expr = new
         else:
-            ir_set.expr = None
+            ir_set.expr = new
 
     # Analyze GROUP statements to find aggregates that can be optimized
     group.infer_group_aggregates(all_exprs, ctx=ctx)

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -48,7 +48,7 @@ from . import setgen
 
 # XXX?
 def amend_empty_set_type(
-    es: irast.SetE[irast.EmptySetExpr],
+    es: irast.SetE[irast.EmptySet],
     t: s_types.Type,
     env: context.Environment
 ) -> None:
@@ -79,7 +79,7 @@ def infer_common_type(
 
     for i, arg in enumerate(irs):
         if (
-            isinstance(arg.expr, irast.EmptySetExpr)
+            isinstance(arg.expr, irast.EmptySet)
             and env.set_types[arg] is None
         ):
             empties.append(i)
@@ -133,7 +133,7 @@ def infer_common_type(
 
     for i in empties:
         amend_empty_set_type(
-            cast(irast.SetE[irast.EmptySetExpr], irs[i]), common_type, env)
+            cast(irast.SetE[irast.EmptySet], irs[i]), common_type, env)
 
     return common_type
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -46,7 +46,6 @@ from . import schemactx
 from . import setgen
 
 
-# XXX?
 def amend_empty_set_type(
     es: irast.SetE[irast.EmptySet],
     t: s_types.Type,

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -46,8 +46,9 @@ from . import schemactx
 from . import setgen
 
 
+# XXX?
 def amend_empty_set_type(
-    es: irast.EmptySet,
+    es: irast.SetE[irast.EmptySetExpr],
     t: s_types.Type,
     env: context.Environment
 ) -> None:
@@ -77,7 +78,10 @@ def infer_common_type(
     seen_coll = False
 
     for i, arg in enumerate(irs):
-        if isinstance(arg, irast.EmptySet) and env.set_types[arg] is None:
+        if (
+            isinstance(arg.expr, irast.EmptySetExpr)
+            and env.set_types[arg] is None
+        ):
             empties.append(i)
             continue
 
@@ -129,7 +133,7 @@ def infer_common_type(
 
     for i in empties:
         amend_empty_set_type(
-            cast(irast.EmptySet, irs[i]), common_type, env)
+            cast(irast.SetE[irast.EmptySetExpr], irs[i]), common_type, env)
 
     return common_type
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -964,7 +964,7 @@ def _compile_rewrites(
         by_type[ty] = {}
         for element in rewrites_of_type.values():
             target = element.target_set
-            assert target and target.expr
+            assert target
 
             ptrref = typegen.ptr_to_ptrref(element.ptrcls, ctx=ctx)
             actual_ptrref = irtypeutils.find_actual_ptrref(ty, ptrref)
@@ -1241,9 +1241,10 @@ def prepare_rewrite_anchors(
             namespace=ctx.path_id_namespace, env=ctx.env,
         )
         old_set = setgen.new_set(
-            stype=stype, path_id=old_path_id, ctx=ctx
+            stype=stype, path_id=old_path_id, ctx=ctx,
+            expr=irast.TriggerAnchor(
+                typeref=typegen.type_to_typeref(stype, env=ctx.env)),
         )
-        old_set.expr = irast.TriggerAnchor(typeref=old_set.typeref)
     else:
         old_set = None
 
@@ -1681,6 +1682,7 @@ def _normalize_view_ptr_expr(
                         # when compiling.
                         old_expr = irexpr.expr
                         if isinstance(old_expr, irast.Pointer):
+                            assert old_expr.expr
                             irexpr.expr = old_expr.expr
                         irexpr = dispatch.compile(cast_qlexpr, ctx=subctx)
                         if isinstance(old_expr, irast.Pointer):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -792,7 +792,7 @@ class ConstExpr(Expr):
     typeref: TypeRef
 
 
-class EmptySet(Set, ConstExpr):
+class EmptySetExpr(ConstExpr):
     pass
 
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -792,7 +792,7 @@ class ConstExpr(Expr):
     typeref: TypeRef
 
 
-class EmptySetExpr(ConstExpr):
+class EmptySet(ConstExpr):
     pass
 
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -530,14 +530,28 @@ class TypeRoot(Expr):
     skip_subtypes: bool = False
 
 
-T_co = typing.TypeVar('T_co', covariant=True, bound=typing.Optional[Expr])
+class RefExpr(Expr):
+    '''Different expressions sorts that refer to some kind of binding.'''
+    __abstract_node__ = True
+    typeref: TypeRef
+
+
+class MaterializedExpr(RefExpr):
+    pass
+
+
+class VisibleBindingExpr(RefExpr):
+    pass
+
+
+T_expr_co = typing.TypeVar('T_expr_co', covariant=True, bound=Expr)
 
 
 # SetE is the base 'Set' type, and it is parameterized over what kind
 # of expression it holds. Most code uses the Set alias below, which
-# instantiates it with Optional[Expr].
+# instantiates it with Expr.
 # irutils.is_set_instance can be used to refine the type.
-class SetE(Base, typing.Generic[T_co]):
+class SetE(Base, typing.Generic[T_expr_co]):
     '''A somewhat overloaded metadata container for expressions.
 
     Its primary purpose is to be the holder for expression metadata
@@ -553,7 +567,7 @@ class SetE(Base, typing.Generic[T_co]):
     path_id: PathId
     path_scope_id: typing.Optional[int] = None
     typeref: TypeRef
-    expr: T_co = None  # type: ignore
+    expr: T_expr_co
     shape: typing.Tuple[typing.Tuple[SetE[Pointer], qlast.ShapeOp], ...] = ()
 
     anchor: typing.Optional[str] = None
@@ -587,7 +601,7 @@ class SetE(Base, typing.Generic[T_co]):
 SetE.__name__ = 'Set'
 
 if typing.TYPE_CHECKING:
-    Set = SetE[typing.Optional[Expr]]
+    Set = SetE[Expr]
 else:
     Set = SetE
 

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -136,11 +136,7 @@ def evaluate_EmptySet(
 def evaluate_Set(
         ir_set: irast.Set,
         schema: s_schema.Schema) -> EvaluationResult:
-    if ir_set.expr is not None:
-        return evaluate(ir_set.expr, schema=schema)
-    else:
-        raise UnsupportedExpressionError(
-            'expression is not constant', span=ir_set.span)
+    return evaluate(ir_set.expr, schema=schema)
 
 
 @evaluate.register

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -125,9 +125,9 @@ def evaluate_TypeCast(
     return ir_cast
 
 
-@evaluate.register(irast.EmptySetExpr)
-def evaluate_EmptySetExpr(
-        ir_set: irast.EmptySetExpr,
+@evaluate.register(irast.EmptySet)
+def evaluate_EmptySet(
+        ir_set: irast.EmptySet,
         schema: s_schema.Schema) -> EvaluationResult:
     return ir_set
 
@@ -290,7 +290,7 @@ def _evaluate_union(
                         f'{el!r} not supported in UNION',
                         span=opcall.span)
                 elements.append(el)
-        elif isinstance(val, irast.EmptySetExpr):
+        elif isinstance(val, irast.EmptySet):
             empty_set = val
         elif isinstance(val, irast.BaseConstant):
             elements.append(val)
@@ -319,9 +319,9 @@ def const_to_python(
         f'cannot convert {ir!r} to Python value')
 
 
-@const_to_python.register(irast.EmptySetExpr)
+@const_to_python.register(irast.EmptySet)
 def empty_set_to_python(
-    ir: irast.EmptySetExpr,
+    ir: irast.EmptySet,
     schema: s_schema.Schema,
 ) -> None:
     return None

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -125,9 +125,9 @@ def evaluate_TypeCast(
     return ir_cast
 
 
-@evaluate.register(irast.EmptySet)
-def evaluate_EmptySet(
-        ir_set: irast.EmptySet,
+@evaluate.register(irast.EmptySetExpr)
+def evaluate_EmptySetExpr(
+        ir_set: irast.EmptySetExpr,
         schema: s_schema.Schema) -> EvaluationResult:
     return ir_set
 
@@ -290,7 +290,7 @@ def _evaluate_union(
                         f'{el!r} not supported in UNION',
                         span=opcall.span)
                 elements.append(el)
-        elif isinstance(val, irast.EmptySet):
+        elif isinstance(val, irast.EmptySetExpr):
             empty_set = val
         elif isinstance(val, irast.BaseConstant):
             elements.append(val)
@@ -319,9 +319,9 @@ def const_to_python(
         f'cannot convert {ir!r} to Python value')
 
 
-@const_to_python.register(irast.EmptySet)
+@const_to_python.register(irast.EmptySetExpr)
 def empty_set_to_python(
-    ir: irast.EmptySet,
+    ir: irast.EmptySetExpr,
     schema: s_schema.Schema,
 ) -> None:
     return None

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -123,7 +123,7 @@ def is_empty(ir: irast.Base) -> bool:
        or an empty array.
     """
     return (
-        isinstance(ir, irast.EmptySet) or
+        isinstance(ir, irast.EmptySetExpr) or
         (isinstance(ir, irast.Array) and not ir.elements) or
         (
             isinstance(ir, irast.Set)

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -127,7 +127,6 @@ def is_empty(ir: irast.Base) -> bool:
         (isinstance(ir, irast.Array) and not ir.elements) or
         (
             isinstance(ir, irast.Set)
-            and ir.expr is not None
             and is_empty(ir.expr)
         )
     )

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -123,7 +123,7 @@ def is_empty(ir: irast.Base) -> bool:
        or an empty array.
     """
     return (
-        isinstance(ir, irast.EmptySetExpr) or
+        isinstance(ir, irast.EmptySet) or
         (isinstance(ir, irast.Array) and not ir.elements) or
         (
             isinstance(ir, irast.Set)

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -631,7 +631,7 @@ def _compile_config_value(
             output_format = context.OutputFormat.JSONB
 
         with context.output_format(ctx, output_format):
-            if isinstance(expr.expr, irast.EmptySetExpr):
+            if isinstance(expr.expr, irast.EmptySet):
                 # Special handling for empty sets, because we want a
                 # singleton representation of the value and not an empty rel
                 # in this context.

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -631,7 +631,7 @@ def _compile_config_value(
             output_format = context.OutputFormat.JSONB
 
         with context.output_format(ctx, output_format):
-            if isinstance(expr, irast.EmptySet):
+            if isinstance(expr.expr, irast.EmptySetExpr):
                 # Special handling for empty sets, because we want a
                 # singleton representation of the value and not an empty rel
                 # in this context.

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -783,7 +783,7 @@ def _compile_shape(
 
 @dispatch.compile.register
 def compile_EmptySet(
-    expr: irast.EmptySetExpr, *, ctx: context.CompilerContextLevel
+    expr: irast.EmptySet, *, ctx: context.CompilerContextLevel
 ) -> pgast.BaseExpr:
     return pgast.NullConstant()
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -53,7 +53,8 @@ def compile_Set(
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
     if ctx.singleton_mode:
-        return _compile_set_in_singleton_mode(ir_set, ctx=ctx)
+        assert ir_set.expr is not None
+        return dispatch.compile(ir_set.expr, ctx=ctx)
 
     is_toplevel = ctx.toplevel_stmt is context.NO_STMT
 
@@ -80,7 +81,8 @@ def visit_Set(
         ctx: context.CompilerContextLevel) -> None:
 
     if ctx.singleton_mode:
-        _compile_set_in_singleton_mode(ir_set, ctx=ctx)
+        assert ir_set.expr is not None
+        dispatch.compile(ir_set.expr, ctx=ctx)
 
     _compile_set_impl(ir_set, ctx=ctx)
 
@@ -779,14 +781,11 @@ def _compile_shape(
     return result
 
 
-def _compile_set_in_singleton_mode(
-        node: irast.Set, *,
-        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
-    if isinstance(node, irast.EmptySet):
-        return pgast.NullConstant()
-    else:
-        assert node.expr is not None
-        return dispatch.compile(node.expr, ctx=ctx)
+@dispatch.compile.register
+def compile_EmptySet(
+    expr: irast.EmptySetExpr, *, ctx: context.CompilerContextLevel
+) -> pgast.BaseExpr:
+    return pgast.NullConstant()
 
 
 @dispatch.compile.register

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -53,7 +53,6 @@ def compile_Set(
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
     if ctx.singleton_mode:
-        assert ir_set.expr is not None
         return dispatch.compile(ir_set.expr, ctx=ctx)
 
     is_toplevel = ctx.toplevel_stmt is context.NO_STMT
@@ -81,7 +80,6 @@ def visit_Set(
         ctx: context.CompilerContextLevel) -> None:
 
     if ctx.singleton_mode:
-        assert ir_set.expr is not None
         dispatch.compile(ir_set.expr, ctx=ctx)
 
     _compile_set_impl(ir_set, ctx=ctx)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -423,7 +423,7 @@ def maybe_get_path_var(
 
 
 def new_empty_rvar(
-        ir_set: irast.EmptySet, *,
+        ir_set: irast.SetE[irast.EmptySetExpr], *,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
     nullrel = pgast.NullRelation(
         path_id=ir_set.path_id, type_or_ptr_ref=ir_set.typeref)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -423,7 +423,7 @@ def maybe_get_path_var(
 
 
 def new_empty_rvar(
-        ir_set: irast.SetE[irast.EmptySetExpr], *,
+        ir_set: irast.SetE[irast.EmptySet], *,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
     nullrel = pgast.NullRelation(
         path_id=ir_set.path_id, type_or_ptr_ref=ir_set.typeref)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -205,7 +205,7 @@ def get_set_rvar(
         # about it later.
         subctx.pending_query = stmt
 
-        is_empty_set = isinstance(ir_set.expr, irast.EmptySetExpr)
+        is_empty_set = isinstance(ir_set.expr, irast.EmptySet)
 
         path_scope = relctx.get_scope(ir_set, ctx=subctx)
         new_scope = path_scope or subctx.scope_tree
@@ -302,7 +302,7 @@ def _process_toplevel_query(
 
     relctx.init_toplevel_query(ir_set, ctx=ctx)
     rvars = _get_set_rvar(ir_set, ctx=ctx)
-    if isinstance(ir_set.expr, irast.EmptySetExpr):
+    if isinstance(ir_set.expr, irast.EmptySet):
         # In cases where the top-level expression is an empty set
         # as opposed to a Set wrapping some expression or path, make
         # sure the generated empty rel gets selected in the toplevel
@@ -640,11 +640,11 @@ def prepare_optional_rel(
                     empty_ir = irast.Set(
                         path_id=ir_set.path_id,
                         typeref=ir_set.typeref,
-                        expr=irast.EmptySetExpr(typeref=ir_set.typeref),
+                        expr=irast.EmptySet(typeref=ir_set.typeref),
                     )
 
                     emptyrvar = relctx.new_empty_rvar(
-                        cast('irast.SetE[irast.EmptySetExpr]', empty_ir),
+                        cast('irast.SetE[irast.EmptySet]', empty_ir),
                         ctx=scopectx)
 
                     relctx.include_rvar(
@@ -788,9 +788,9 @@ def process_set_as_root(
 register_get_rvar(irast.TypeRoot)(process_set_as_root)
 
 
-@register_get_rvar(irast.EmptySetExpr)
+@register_get_rvar(irast.EmptySet)
 def process_set_as_empty(
-    ir_set: irast.SetE[irast.EmptySetExpr], *, ctx: context.CompilerContextLevel
+    ir_set: irast.SetE[irast.EmptySet], *, ctx: context.CompilerContextLevel
 ) -> SetRVars:
 
     rvar = relctx.new_empty_rvar(ir_set, ctx=ctx)


### PR DESCRIPTION
The bulk of the work to make this happen was done in #6938
(introducing TypeRoot) and #7090 (moving Pointer into expr).

The final pieces are making EmptySet an Expr instead of a Set subclass
and getting rid of the cases where we "clear" expressions out of a
Set.

The biggest benefit here is that the meaning of a Set is much clearer
now, but there are some nice direct benefits too.

This lets have fully table dispatched set compilation in several places
now.
`_get_set_rvar`, which was 155 lines long in 2.x, is now finally completely
gone!
`_compile_set_in_singleton_mode` is also gone, replaced with simply 
compiling the set's expression.

Typechecker error messages involving SetE are also much nicer now.