### PR TITLE
Don't pretty print SQL text by default

### DIFF
--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -86,7 +86,7 @@ def generate_source(
     *,
     indent_with: str = ' ' * 4,
     add_line_information: bool = False,
-    pretty: bool = True,
+    pretty: bool = False,
     reordered: bool = False,
 ) -> str:
     # Simplified entrypoint


### PR DESCRIPTION
Only do it during the debug endpoints. I think this changed by
accident at some point.  This shouldn't matter *too* much, but will
reduce the size of the SQL sent to postgres.