### PR TITLE
Add a debug flag to inject the edgeql as a comment in the SQL

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -144,6 +144,9 @@ class flags(metaclass=FlagsMeta):
     server_clobber_pg_conns = Flag(
         doc="Discard Postgres connections when releasing them to the pool.")
 
+    preserve_queries = Flag(
+        doc="Include the EdgeQL query text in the SQL sent to postgres.")
+
     print_locals = Flag(
         doc="Include values of local variables in tracebacks.")
 


### PR DESCRIPTION
This should make it easier to extract information from postgres logs
in certain situations.

Right now it is a debug flag named EDGEDB_DEBUG_PRESERVE_QUERIES.
Other options would be to do it unconditionally or to have a config
value.
Taking suggestions on names.

It injects the pre-constant extraction source.