### PR TITLE
Make pyright shut up about schema field getters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,3 +240,7 @@ exclude = ["postgres", ".github"]
 lint.flake8-bugbear.extend-immutable-calls = [
     "immutables.Map"
 ]
+
+[tool.pyright]
+# Pyright has no idea about metaclass-generated getters for schema fields.
+reportAttributeAccessIssue = false


### PR DESCRIPTION
Pyright has no idea about metaclass-generated getters for schema fields.
