### PR TITLE
Add cfg::Config._query_cache_mode

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_03_06_00_00
+EDGEDB_CATALOG_VERSION = 2024_03_26_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import builtins
 import contextlib
-import platform
 import os
 import sys
 import time
@@ -177,19 +176,6 @@ class flags(metaclass=FlagsMeta):
     )
 
     zombodb = Flag(doc="Enabled zombodb and disables postgres FTS")
-
-    disable_persistent_cache = Flag(
-        doc="Don't use persistent cache",
-        # Persistent cache disabled for now by default on arm64 linux
-        # because of observed problems in CI test runs.
-        default=(
-            platform.system() == 'Linux'
-            and platform.machine() == 'arm64'
-        ),
-    )
-
-    # Function cache is an experimental feature that may not fully work
-    func_cache = Flag(doc="Use stored functions for persistent cache")
 
 
 @contextlib.contextmanager

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -40,6 +40,8 @@ CREATE SCALAR TYPE cfg::memory EXTENDING std::anyscalar;
 CREATE SCALAR TYPE cfg::AllowBareDDL EXTENDING enum<AlwaysAllow, NeverAllow>;
 CREATE SCALAR TYPE cfg::ConnectionTransport EXTENDING enum<
     TCP, TCP_PG, HTTP, SIMPLE_HTTP, HTTP_METRICS, HTTP_HEALTH>;
+CREATE SCALAR TYPE cfg::QueryCacheMode EXTENDING enum<
+    InMemory, RegInline, PgFunc, Default>;
 
 CREATE ABSTRACT TYPE cfg::ConfigObject EXTENDING std::BaseObject;
 
@@ -190,6 +192,14 @@ ALTER TYPE cfg::AbstractConfig {
         SET default := true;
         CREATE ANNOTATION std::description :=
             'Recompile all cached queries on DDL if enabled.';
+    };
+
+    CREATE PROPERTY _query_cache_mode -> cfg::QueryCacheMode {
+        SET default := cfg::QueryCacheMode.Default;
+        CREATE ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::requires_restart := 'true';
+        CREATE ANNOTATION std::description :=
+            'Where the query cache is finally stored';
     };
 
     # Exposed backend settings follow.

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Dict, NamedTuple, TYPE_CHECKING
+from typing import Any, Dict, NamedTuple
 
 import asyncio
 import collections
@@ -41,6 +41,7 @@ from edb.common import debug
 from edb.pgsql import params as pgparams
 
 from edb.server import args as srvargs
+from edb.server import dbview
 from edb.server import defines
 from edb.server import metrics
 
@@ -48,8 +49,6 @@ from . import amsg
 from . import queue
 from . import state
 
-if TYPE_CHECKING:
-    from edb.server import dbview
 
 PROCESS_INITIAL_RESPONSE_TIMEOUT: float = 60.0
 KILL_TIMEOUT: float = 10.0
@@ -734,7 +733,7 @@ class BaseLocalPool(
         if debug.flags.server:
             env = {'EDGEDB_DEBUG_SERVER': '1', **_ENV}
         if self._query_cache_mode:
-            env = {'EDGEDB_COMPILER_QUERY_CACHE_MODE': self._query_cache_mode}
+            env['EDGEDB_COMPILER_QUERY_CACHE_MODE'] = self._query_cache_mode
 
         cmdline = [sys.executable]
         if sys.flags.isolated:

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from typing import Any, TypeVar, TYPE_CHECKING, TypeGuard
 
+import enum
+
 from edb import errors
 from edb.common import typeutils
 from edb.common import typing_inspect
@@ -251,3 +253,10 @@ class CompositeConfigType(ConfigType, statypes.CompositeType):
     ) -> errors.ConfigurationError:
         return errors.ConfigurationError(
             f'invalid {tspec.name.lower()!r} value: {msg}')
+
+
+class QueryCacheMode(enum.StrEnum):
+    InMemory = "InMemory"
+    RegInline = "RegInline"
+    PgFunc = "PgFunc"
+    Default = "Default"

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -149,7 +149,9 @@ cdef class Database:
 
         self._cache_worker_task = self._cache_queue = None
         self._cache_notify_task = self._cache_notify_queue = None
-        if not debug.flags.disable_persistent_cache:
+        if self.tenant.query_cache_mode in (
+            config.QueryCacheMode.RegInline, config.QueryCacheMode.PgFunc
+        ):
             self._cache_queue = asyncio.Queue()
             self._cache_worker_task = asyncio.create_task(
                 self.monitor(self.cache_worker, 'cache_worker'))
@@ -377,7 +379,10 @@ cdef class Database:
                 if self.user_schema_pickle is None:
                     await self.tenant.introspect_db(
                         self.name,
-                        hydrate_cache=not debug.flags.disable_persistent_cache,
+                        hydrate_cache=self.tenant.query_cache_mode in (
+                            config.QueryCacheMode.RegInline,
+                            config.QueryCacheMode.PgFunc,
+                        ),
                     )
 
 

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -360,6 +360,9 @@ class MultiTenantServer(server.BaseServer):
     def _get_compiler_args(self) -> dict[str, Any]:
         args = super()._get_compiler_args()
         args["cache_size"] = self._compiler_pool_tenant_cache_size
+        args["query_cache_mode"] = config.get_query_cache_mode(
+            self._sys_config, self._config_settings
+        ).value
         return args
 
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1678,6 +1678,7 @@ class Server(BaseServer):
     def _get_compiler_args(self) -> dict[str, Any]:
         rv = super()._get_compiler_args()
         rv.update(self._tenant.get_compiler_args())
+        rv["query_cache_mode"] = self._tenant.query_cache_mode.value
         return rv
 
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -2087,6 +2087,7 @@ class TestStaticServerConfig(tb.TestCase):
             "EDGEDB_SERVER_CONFIG_cfg::session_idle_timeout": "1m22s",
             "EDGEDB_SERVER_CONFIG_cfg::query_execution_timeout": "403",
             "EDGEDB_SERVER_CONFIG_cfg::apply_access_policies": "false",
+            "EDGEDB_SERVER_CONFIG_cfg::allow_user_specified_id": "true",
         }
         async with tb.start_edgedb_server(env=env) as sd:
             conn = await sd.connect()
@@ -2114,6 +2115,17 @@ class TestStaticServerConfig(tb.TestCase):
                     await conn.query_single("""\
                         select assert_single(cfg::Config.apply_access_policies)
                     """)
+                )
+                await conn.execute("create type Foo")
+                self.assertEqual(
+                    str(await conn.query_single(
+                        """
+                        select (insert Foo {
+                            id := <uuid>'8c425e34-d1c3-11ee-8c78-8f34556d1111'
+                        }).id
+                        """
+                    )),
+                    "8c425e34-d1c3-11ee-8c78-8f34556d1111",
                 )
             finally:
                 await conn.aclose()


### PR DESCRIPTION
Query cache mode is a system config. Changes are only effective after server restart. If changed, the persistent query cache will be reset on server start.

Fixes #7102