### PR TITLE
Proposal: eliminate `id` on `FreeObject`

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_04_01_00_01
+EDGEDB_CATALOG_VERSION = 2024_04_02_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -664,7 +664,8 @@ def compile_operator(
 # so we ban them
 INVALID_FREE_SHAPE_OPS: Final = {
     sn.QualName('std', x) for x in [
-        'DISTINCT', '=', '!=', '?=', '?!=', 'IN', 'NOT IN'
+        'DISTINCT', '=', '!=', '?=', '?!=', 'IN', 'NOT IN',
+        'assert_distinct',
     ]
 }
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -432,6 +432,13 @@ ALTER TYPE std::BaseObject {
         SET protected := True;
     };
 };
+ALTER TYPE std::FreeObject {
+    # N.B: See above.
+    CREATE REQUIRED LINK __type__ -> schema::ObjectType {
+        SET readonly := True;
+        SET protected := True;
+    };
+};
 
 
 ALTER TYPE schema::ObjectType {

--- a/edb/lib/std/60-baseobject.edgeql
+++ b/edb/lib/std/60-baseobject.edgeql
@@ -44,7 +44,8 @@ CREATE ABSTRACT TYPE std::Object EXTENDING std::BaseObject {
         'Root object type for user-defined types';
 };
 
-CREATE TYPE std::FreeObject EXTENDING std::BaseObject {
+# N.B: This does *not* derive from std::BaseObject!
+CREATE TYPE std::FreeObject {
     CREATE ANNOTATION std::description :=
         'Object type for free shapes';
 };
@@ -145,6 +146,10 @@ std::`<` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
 
 # The only possible Object cast is into json.
 CREATE CAST FROM std::BaseObject TO std::json {
+    SET volatility := 'Immutable';
+    USING SQL EXPRESSION;
+};
+CREATE CAST FROM std::FreeObject TO std::json {
     SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1406,7 +1406,9 @@ def process_set_as_subquery(
                 # understanding of when to do semi-joins. Using that
                 # naively here doesn't work, but perhaps it could be
                 # adapted?
-                semi_join = True
+                # Don't semi-join on free objects, since they are all unique
+                # (but don't *actually* have unique ids...)
+                semi_join = not irtyputils.is_free_object(ir_set.typeref)
 
                 # We need to compile the source and include it in,
                 # since we need to do the semi-join deduplication here

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -114,7 +114,7 @@ def compile_shape(
             assert isinstance(tuple_el, pgast.TupleElement)
             elements.append(tuple_el)
 
-        # OH HO HO
+        # If there wasn't an id (because its a FreeObject), add a fake one.
         if ctx.materializing and not has_id:
             elements.append(pgast.TupleElement(
                 path_id=ir_set.path_id,

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -76,12 +76,14 @@ def compile_shape(
             if iterator:
                 shapectx.path_scope[iterator.path_id] = ctx.rel
 
+        has_id = False
         for el, op in shape:
             if op == qlast.ShapeOp.MATERIALIZE and not ctx.materializing:
                 continue
 
             rptr = el.expr
             ptrref = rptr.ptrref
+            has_id |= ptrref.shortname.name == 'id'
             # As an implementation expedient, we currently represent
             # AT_MOST_ONE materialized values with arrays
             card = rptr.dir_cardinality
@@ -111,5 +113,12 @@ def compile_shape(
 
             assert isinstance(tuple_el, pgast.TupleElement)
             elements.append(tuple_el)
+
+        # OH HO HO
+        if ctx.materializing and not has_id:
+            elements.append(pgast.TupleElement(
+                path_id=ir_set.path_id,
+                val=var,
+            ))
 
     return pgast.TupleVar(elements=elements, named=True)

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -198,12 +198,12 @@ class ObjectType(
 
         for obj in (self,) + ancestor_objects:
             ptrs.update(
-                lnk for lnk in schema.get_referrers(obj, scls_type=links.Link,
-                                                    field_name='target')
+                lnk for lnk in schema.get_referrers(
+                    obj, scls_type=links.Link, field_name='target')
                 if (
                     lnk.get_shortname(schema).name == name
-                    and not lnk.get_source_type(schema).is_view(schema)
-                    and not lnk.get_source_type(schema).is_union_type(schema)
+                    and lnk.get_source_type(schema).is_material_object_type(
+                        schema)
                     # Only grab the "base" pointers
                     and all(
                         b.is_non_concrete(schema)
@@ -264,6 +264,7 @@ class ObjectType(
         return (
             sn.QualName(module='std', name='BaseObject'),
             sn.QualName(module='std', name='Object'),
+            sn.QualName(module='std', name='FreeObject'),
         )
 
     @classmethod

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -151,12 +151,8 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                 "plan_rows": 1,
                 "actual_rows": 1,
                 "actual_loops": 1,
-                "plan_type": "SubqueryScan",
-                "properties": [{
-                    "title": "filter",
-                    "type": "expr",
-                    "important": False,
-                }],
+                "plan_type": "Result",
+                "properties": [],
                 # Just validating that these fields appear. This was part of
                 # the early tests and these fields are something the users may
                 # rely on and should be part of stable API.

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -9150,6 +9150,10 @@ aa \
         )
         await self.assert_query_result(
             'select {x := 1} is (typeof Issue.references | BaseObject);',
+            {False}
+        )
+        await self.assert_query_result(
+            'select {x := 1} is (typeof Issue.references | FreeObject);',
             {True}
         )
 

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -475,7 +475,6 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             chunks = [f'{name} := global {name}' for name in globs]
             res = await scon.query_single(f'select {{ {", ".join(chunks)} }}')
             dres = dataclasses.asdict(res)
-            del dres['id']
             self.assertEqual(dres, globs)
         finally:
             await con.aclose()

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -959,18 +959,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             ])
         )
 
-    async def test_edgeql_group_agg_with_free_ref_01(self):
-        out = await self.con.query(r'''
-            with module cards
-            select (group Card by .element) {
-                id, els := array_agg((.id, .elements.name))
-            };
-        ''')
-
-        for obj in out:
-            for el in obj.els:
-                self.assertEqual(obj.id, el[0])
-
     async def test_edgeql_group_agg_multi_01(self):
         await self.assert_query_result(
             '''

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -8076,16 +8076,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_free_object_distinct_01(self):
-        foo, bar = await self.con.query_single('''
-            select ({foo := "test"}, {bar := 1000})
+        foo = await self.con.query_single('''
+            select {foo := "test"}
         ''')
-        self.assertNotEqual(foo.id, bar.id)
-
-    async def test_edgeql_select_free_object_distinct_02(self):
-        vals = await self.con.query('''
-            for x in {1,2,3} union { asdf := 10*x };
-        ''')
-        self.assertEqual(len(vals), len({v.id for v in vals}))
+        self.assertFalse(hasattr(foo, 'id'))
 
     async def test_edgeql_select_shadow_computable_01(self):
         # The thing this is testing for
@@ -8099,13 +8093,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 {"is_elvis": True, "name": "Elvis"}
             ]
         )
-
-    async def test_edgeql_select_free_object_distinct_03(self):
-        vals = await self.con.query('''
-            with w := {x := 10}
-            for x in {1,2,3} union w
-        ''')
-        self.assertEqual(1, len({v.id for v in vals}))
 
     async def test_edgeql_select_card_blowup_01(self):
         # This used to really blow up cardinality inference


### PR DESCRIPTION
We do this by making FreeObject not extend BaseObject.

FreeObject ids are currently generated; this is not particularly
useful and requires some machinations to make work correctly.

Having FreeObject not have ids makes them more sensible, I think,
especially once we are going to support taking them as input.

This breaks compatibility but probably not in a way many people depend
on.

It might require some fixes to bindings. I fixed the python bindings a
while ago in prep for
this. (https://github.com/edgedb/edgedb-python/pull/464)