### PR TITLE
Add support for marking indexes as `deferred`

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_03_27_00_01
+EDGEDB_CATALOG_VERSION = 2024_03_28_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1281,6 +1281,7 @@ class ConcreteIndexCommand(IndexCommand):
     kwargs: typing.Dict[str, Expr] = ast.field(factory=dict)
     expr: Expr
     except_expr: typing.Optional[Expr] = None
+    deferred: typing.Optional[bool] = None
 
 
 class CreateConcreteIndex(ConcreteIndexCommand, CreateObject):

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -184,6 +184,14 @@ class OptOnExpr(Nonterm):
         pass
 
 
+class OptDeferred(Nonterm):
+    def reduce_empty(self):
+        self.val = None
+
+    def reduce_DEFERRED(self, _):
+        self.val = True
+
+
 class OptExceptExpr(Nonterm):
     def reduce_empty(self):
         self.val = None

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -659,13 +659,28 @@ sdl_commands_block(
 
 
 class ConcreteIndexDeclarationBlock(Nonterm, commondl.ProcessIndexMixin):
-    def reduce_INDEX_OnExpr_OptExceptExpr_CreateConcreteIndexSDLCommandsBlock(
-            self, *kids):
+    def reduce_CreateConcreteAnonymousIndex(self, *kids):
+        r"""%reduce INDEX OnExpr OptExceptExpr
+                    CreateConcreteIndexSDLCommandsBlock
+        """
         _, on_expr, except_expr, commands = kids
         self.val = qlast.CreateConcreteIndex(
             name=qlast.ObjectRef(module='__', name='idx'),
             expr=on_expr.val,
             except_expr=except_expr.val,
+            commands=commands.val,
+        )
+
+    def reduce_CreateConcreteAnonymousDeferredIndex(self, *kids):
+        r"""%reduce DEFERRED INDEX OnExpr OptExceptExpr
+                    CreateConcreteIndexSDLCommandsBlock
+        """
+        _, _, on_expr, except_expr, commands = kids
+        self.val = qlast.CreateConcreteIndex(
+            name=qlast.ObjectRef(module='__', name='idx'),
+            expr=on_expr.val,
+            except_expr=except_expr.val,
+            deferred=True,
             commands=commands.val,
         )
 
@@ -679,6 +694,20 @@ class ConcreteIndexDeclarationBlock(Nonterm, commondl.ProcessIndexMixin):
             name=name.val,
             expr=on_expr.val,
             except_expr=except_expr.val,
+            commands=commands.val,
+        )
+
+    def reduce_CreateConcreteDeferredIndex(self, *kids):
+        r"""%reduce DEFERRED INDEX NodeName \
+                    OnExpr OptExceptExpr \
+                    CreateConcreteIndexSDLCommandsBlock \
+        """
+        _, _, name, on_expr, except_expr, commands = kids
+        self.val = qlast.CreateConcreteIndex(
+            name=name.val,
+            expr=on_expr.val,
+            except_expr=except_expr.val,
+            deferred=True,
             commands=commands.val,
         )
 
@@ -697,6 +726,22 @@ class ConcreteIndexDeclarationBlock(Nonterm, commondl.ProcessIndexMixin):
             commands=commands.val,
         )
 
+    def reduce_CreateConcreteDeferredIndexWithArgs(self, *kids):
+        r"""%reduce DEFERRED INDEX NodeName IndexExtArgList \
+                    OnExpr OptExceptExpr \
+                    CreateConcreteIndexSDLCommandsBlock \
+        """
+        _, _, name, arg_list, on_expr, except_expr, commands = kids
+        kwargs = self._process_arguments(arg_list.val)
+        self.val = qlast.CreateConcreteIndex(
+            name=name.val,
+            kwargs=kwargs,
+            expr=on_expr.val,
+            except_expr=except_expr.val,
+            deferred=True,
+            commands=commands.val,
+        )
+
 
 class ConcreteIndexDeclarationShort(Nonterm, commondl.ProcessIndexMixin):
     def reduce_INDEX_OnExpr_OptExceptExpr(self, *kids):
@@ -707,15 +752,34 @@ class ConcreteIndexDeclarationShort(Nonterm, commondl.ProcessIndexMixin):
             except_expr=except_expr.val,
         )
 
+    def reduce_DEFERRED_INDEX_OnExpr_OptExceptExpr(self, *kids):
+        _, _, on_expr, except_expr = kids
+        self.val = qlast.CreateConcreteIndex(
+            name=qlast.ObjectRef(module='__', name='idx'),
+            expr=on_expr.val,
+            except_expr=except_expr.val,
+            deferred=True,
+        )
+
     def reduce_CreateConcreteIndex(self, *kids):
-        r"""%reduce INDEX NodeName \
-                    OnExpr OptExceptExpr \
+        r"""%reduce INDEX NodeName OnExpr OptExceptExpr
         """
         _, name, on_expr, except_expr = kids
         self.val = qlast.CreateConcreteIndex(
             name=name.val,
             expr=on_expr.val,
             except_expr=except_expr.val,
+        )
+
+    def reduce_CreateConcreteDeferredIndex(self, *kids):
+        r"""%reduce DEFERRED INDEX NodeName OnExpr OptExceptExpr
+        """
+        _, _, name, on_expr, except_expr = kids
+        self.val = qlast.CreateConcreteIndex(
+            name=name.val,
+            expr=on_expr.val,
+            except_expr=except_expr.val,
+            deferred=True,
         )
 
     def reduce_CreateConcreteIndexWithArgs(self, *kids):
@@ -729,6 +793,20 @@ class ConcreteIndexDeclarationShort(Nonterm, commondl.ProcessIndexMixin):
             kwargs=kwargs,
             expr=on_expr.val,
             except_expr=except_expr.val,
+        )
+
+    def reduce_CreateConcreteDeferredIndexWithArgs(self, *kids):
+        r"""%reduce DEFERRED INDEX NodeName IndexExtArgList
+                    OnExpr OptExceptExpr
+        """
+        _, _, name, arg_list, on_expr, except_expr = kids
+        kwargs = self._process_arguments(arg_list.val)
+        self.val = qlast.CreateConcreteIndex(
+            name=name.val,
+            kwargs=kwargs,
+            expr=on_expr.val,
+            except_expr=except_expr.val,
+            deferred=True,
         )
 
 

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -190,6 +190,18 @@ class Multiplicity(s_enum.OrderedEnumMixin, s_enum.StrEnum):
         return self is Multiplicity.DUPLICATE
 
 
+class IndexDeferrability(s_enum.OrderedEnumMixin, s_enum.StrEnum):
+    Prohibited = 'Prohibited'
+    Permitted = 'Permitted'
+    Required = 'Required'
+
+    def is_deferrable(self) -> bool:
+        return (
+            self is IndexDeferrability.Required
+            or self is IndexDeferrability.Permitted
+        )
+
+
 class AccessPolicyAction(s_enum.StrEnum):
     Allow = 'Allow'
     Deny = 'Deny'

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -64,6 +64,9 @@ CREATE SCALAR TYPE schema::RewriteKind
 CREATE SCALAR TYPE schema::MigrationGeneratedBy
     EXTENDING enum<DevMode, DDLStatement>;
 
+CREATE SCALAR TYPE schema::IndexDeferrability
+    EXTENDING enum<Prohibited, Permitted, `Required`>;
+
 # Base type for all schema entities.
 CREATE ABSTRACT TYPE schema::Object EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str;
@@ -267,6 +270,8 @@ CREATE TYPE schema::Index
 {
     CREATE PROPERTY expr -> std::str;
     CREATE PROPERTY except_expr -> std::str;
+    CREATE PROPERTY deferrability -> schema::IndexDeferrability;
+    CREATE PROPERTY deferred -> std::bool;
     CREATE MULTI LINK params EXTENDING schema::ordered -> schema::Parameter {
         ON TARGET DELETE ALLOW;
     };

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2413,6 +2413,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                         not fop.new_inherited
                         or context.descriptive_mode
                         or self.ast_ignore_ownership()
+                        or self.ast_ignore_field_ownership(fop.property)
                     )
                     and (
                         fop.old_value != new_value
@@ -2903,6 +2904,10 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         self.annotations[name] = value
 
     def ast_ignore_ownership(self) -> bool:
+        """Whether to force generating an AST even though it isn't owned"""
+        return False
+
+    def ast_ignore_field_ownership(self, field: str) -> bool:
         """Whether to force generating an AST even though it isn't owned"""
         return False
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -34,6 +34,7 @@ from typing import (
 import collections.abc
 import enum
 import json
+import operator
 
 from edb import errors
 
@@ -211,7 +212,7 @@ def merge_required(
             field_name=field_name,
             ignore_local=ignore_local,
             schema=schema,
-            f=max,
+            f=operator.or_,
             type=bool,
         )
     elif local_required:

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12946,6 +12946,130 @@ type default::Foo {
                 drop abstract index test;
             ''')
 
+    async def test_edgeql_ddl_deferred_index_01(self):
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            r"cannot be declared as deferred",
+            _line=8, _col=21
+        ):
+            await self.con.execute('''
+                create abstract index test() {
+                    set code := ' ((__col__) NULLS FIRST)';
+                };
+
+                create type Foo {
+                    create property bar -> str;
+                    create deferred index test on (.bar);
+                };
+            ''')
+
+    async def test_edgeql_ddl_deferred_index_02(self):
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            r"must be declared as deferred",
+        ):
+            await self.con.execute('''
+                create abstract index test() {
+                    set code := ' ((__col__) NULLS FIRST)';
+                    set deferrability := 'Required';
+                };
+
+                create type Foo {
+                    create property bar -> str;
+                    create index test on (.bar);
+                };
+            ''')
+
+    async def test_edgeql_ddl_deferred_index_03(self):
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            r"cannot be declared as deferred",
+            _line=12,
+            _col=59,
+        ):
+            await self.con.execute('''
+                create abstract index test() {
+                    set code := ' ((__col__) NULLS FIRST)';
+                    set deferrability := 'Prohibited';
+                };
+
+                create type Foo {
+                    create property bar -> str;
+                    create index test on (.bar);
+                };
+
+                alter type Foo alter index test on (.bar) set deferred;
+            ''')
+
+    async def test_edgeql_ddl_deferred_index_04(self):
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            r"must be declared as deferred",
+            _line=12,
+            _col=59,
+        ):
+            await self.con.execute('''
+                create abstract index test() {
+                    set code := ' ((__col__) NULLS FIRST)';
+                    set deferrability := 'Required';
+                };
+
+                create type Foo {
+                    create property bar -> str;
+                    create deferred index test on (.bar);
+                };
+
+                alter type Foo alter index test on (.bar) drop deferred;
+            ''')
+
+    async def test_edgeql_ddl_deferred_index_05(self):
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            r"deferrability can only be specified on abstract indexes",
+            _line=5,
+            _col=25,
+        ):
+            await self.con.execute('''
+                create type Foo {
+                    create property bar -> str;
+                    create index on (.bar) {
+                        set deferrability := 'Permitted';
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_deferred_index_06(self):
+        await self.con.execute('''
+            create abstract index test() {
+                set code := ' ((__col__) NULLS FIRST)';
+                set deferrability := 'Permitted';
+            };
+
+            create type Foo {
+                create property bar -> str;
+                create deferred index test on (.bar);
+            };
+        ''')
+
+        await self.assert_query_result(
+            '''
+            SELECT schema::ObjectType {
+                name,
+                indexes: {
+                    deferred,
+                    deferrability,
+                }
+            } FILTER .name = 'default::Foo'
+            ''',
+            [{
+                'name': 'default::Foo',
+                'indexes': [{
+                    'deferred': True,
+                    'deferrability': 'Permitted',
+                }]
+            }]
+        )
+
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
             CREATE TYPE Err1 {

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -5944,6 +5944,29 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_index_12(self):
+        """
+        CREATE TYPE Foo {
+            CREATE DEFERRED INDEX myindex0 ON (.bar);
+
+            CREATE DEFERRED INDEX
+                myindex1(a := 13, b := 'ab', conf := [4, 3, 2]) ON (.baz);
+
+            CREATE DEFERRED INDEX myindex2(num := 13, val := 'ab')
+                ON (.foo);
+
+            CREATE DEFERRED INDEX ON (.bar);
+        };
+        """
+
+    def test_edgeql_syntax_ddl_index_13(self):
+        """
+        ALTER TYPE Foo {
+            ALTER INDEX myindex0 ON (.bar) SET DEFERRED;
+            ALTER INDEX ON (.bar) DROP DEFERRED;
+        };
+        """
+
     def test_edgeql_syntax_ddl_global_01(self):
         """
         CREATE GLOBAL Foo := (SELECT User);

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7812,6 +7812,29 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
+    def test_schema_migrations_deferred_index_01(self):
+        self._assert_migration_equivalence([r"""
+            abstract index test() {
+                code := ' ((__col__) NULLS FIRST)';
+                deferrability := 'Permitted';
+            };
+
+            type Foo {
+                property bar -> str;
+                deferred index test on (.bar);
+            };
+        """, r"""
+            abstract index test() {
+                code := ' ((__col__) NULLS FIRST)';
+                deferrability := 'Permitted';
+            };
+
+            type Foo {
+                property bar -> str;
+                index test on (.bar);
+            };
+        """])
+
     def test_schema_migrations_drop_parent_01(self):
         self._assert_migration_equivalence([r"""
             type Parent {

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -443,6 +443,9 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
                 };
                 constraint exclusive on (.asdf) except (.baz);
                 index on (.asdf) except (.baz);
+                deferred index on (.asdf) except (.baz);
+                deferred index bar on (.foo);
+                deferred index bar on (.foo) except (.bar);
             };
         };
         """


### PR DESCRIPTION
A deferred index is a kind of index that gets created and updated in a
background process and not immediately.  This is required for indexes
that are slow and/or require calling out to external services.

To implement this we add the ability to specify `deferrability` on an
abstract index as one of three enum values:

* `Required`: concrete indexes of this type must be declared as
  `deferred`
* `Prohibited`: concrete indexes of this type must NOT be declared
  as `deferred`
* `Permitted`: either way is OK.

All current index types are marked as `Prohibited`.
