### PR TITLE
Fix two bugs affecting unions in computed links

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -1033,6 +1033,8 @@ def _update_path_prefix(tip: Optional[ObjectLike], ctx: TracerContext) -> None:
         tip_name = tip.get_name(ctx.schema)
         assert isinstance(tip_name, sn.QualName)
         ctx.path_prefix = tip_name
+    else:
+        ctx.path_prefix = None
 
 
 @trace.register

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -43,6 +43,7 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import declarative as s_decl
 from edb.server import defines
 
+from . import casts as s_casts
 from . import delta as sd
 from . import expr as s_expr
 from . import extensions as s_ext
@@ -228,8 +229,24 @@ def delta_schemas(
         schema_a_filters.append(_filter)
         schema_b_filters.append(_filter)
 
-    # __derived__ is ephemeral and should never be included
-    excluded_modules.add(sn.UnqualName('__derived__'))
+    # In theory, __derived__ is ephemeral and should not need to be included.
+    # In practice, unions created by computed links and casts of extension
+    # types both put persistent things into __derived__. The unions
+    # need to be included in diffs, and the casts need to not be.
+    # TODO: This is being fixed here because it is backportable,
+    # but we should fix both of those cases to not put persistent things
+    # into __derived__.
+    if not include_derived_types:
+        excluded_modules.add(sn.UnqualName('__derived__'))
+
+    def _cast_filter(schema: s_schema.Schema, obj: so.Object) -> bool:
+        return not (
+            isinstance(obj, s_casts.Cast)
+            and obj.get_name(schema).module == '__derived__'
+        )
+
+    schema_a_filters.append(_cast_filter)
+    schema_b_filters.append(_cast_filter)
 
     # Don't analyze the objects from extensions.
     if not include_extensions and isinstance(schema_b, s_schema.ChainedSchema):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1036,6 +1036,25 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
        """
 
+    def test_schema_hard_sorting_05(self):
+        """
+            type T {
+                multi as: A;
+                multi bs: B;
+                sections := (
+                    select (.as union .bs)
+                    filter .index > 0
+                );
+            }
+
+            abstract type I {
+                required index: int16;
+            }
+
+            type A extending I;
+            type B extending I;
+       """
+
     def test_schema_refs_01(self):
         schema = self.load_schema("""
             type Object1;


### PR DESCRIPTION
* Support computed union target types in migrations. They worked
   when using DDL directly, but broke in migrations, because
   the computed union target type was placed in the `__derived__` module,
   which is not considered when comparing schemas.
   This is probably wrong, but I don't want to change where they are placed
   in something we want to backport.
   (I'll address this and a related issue in followups.)

 * Clear the `path_prefix` in tracer when entering a context where we
   don't know it. Previously, if the new path_prefix's type was unknown,
   we preserved the existing one, which caused us to think we knew the
   type even though it was wrong. This prevented the weak dependency
   based pointer ordering from kicking in.