### PR TITLE
Move extension casts into `__ext_casts__` module

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_04_01_00_00
+EDGEDB_CATALOG_VERSION = 2024_04_01_00_01
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -184,7 +184,7 @@ def get_cast_fullname_from_names(
             and sn.UnqualName(to_type.module) not in s_schema.STD_MODULES
         )
     )
-    module = 'std' if std else '__derived__'
+    module = 'std' if std else '__ext_casts__'
 
     quals = [str(from_type), str(to_type)]
     shortname = sn.QualName(module, 'cast')

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -484,9 +484,14 @@ class DeleteExtension(
                 or name == module_name
             )
 
-        # Clean up the casts separately for annoying reasons
+        # Clean up the casts separately because we can't keep them in
+        # our own module, so we keep them in __ext_casts__. (Cast
+        # names are derived solely from the names of their from and to
+        # types, which means that if we have a cast between ext::a::T
+        # and ext::b::S, we wouldn't have a way to distinguish which
+        # is should be.)
         for obj in schema.get_objects(
-            included_modules=(sn.UnqualName('__derived__'),),
+            included_modules=(sn.UnqualName('__ext_casts__'),),
             type=s_casts.Cast,
         ):
             if (

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -90,6 +90,11 @@ STD_MODULES = (
     sn.UnqualName('std::enc'),
 )
 
+SPECIAL_MODULES = (
+    sn.UnqualName('__derived__'),
+    sn.UnqualName('__ext_casts__'),
+)
+
 # Specifies the order of processing of files and directories in lib/
 STD_SOURCES = (
     sn.UnqualName('std'),
@@ -644,7 +649,7 @@ class FlatSchema(Schema):
                 assert isinstance(new_name, sn.QualName)
                 if (
                     not self.has_module(new_name.module)
-                    and new_name.module != '__derived__'
+                    and new_name.get_module_name() not in SPECIAL_MODULES
                 ):
                     raise errors.UnknownModuleError(
                         f'module {new_name.module!r} is not in this schema')
@@ -989,7 +994,7 @@ class FlatSchema(Schema):
         if (
             issubclass(sclass, so.QualifiedObject)
             and not self.has_module(name.module)
-            and name.module != '__derived__'
+            and name.get_module_name() not in SPECIAL_MODULES
         ):
             raise errors.UnknownModuleError(
                 f'module {name.module!r} is not in this schema')

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1204,11 +1204,12 @@ async def _make_stdlib(
         s_schema.EMPTY_SCHEMA,
         s_schema.EMPTY_SCHEMA,
     )
-    schema, _ = s_mod.Module.create_in_schema(
-        schema,
-        name=sn.UnqualName('__derived__'),
-        stable_ids=True,
-    )
+    for special_mod in s_schema.SPECIAL_MODULES:
+        schema, _ = s_mod.Module.create_in_schema(
+            schema,
+            name=special_mod,
+            stable_ids=True,
+        )
 
     current_block = dbops.PLTopBlock()
 


### PR DESCRIPTION
Currently they are stored in `__derived__`, which is questionable and
requires some fiddly handling (see #7139).

I had originally wanted to place the casts in one of the modules that
the type is declared in, so that we can get rid of all the special
case cast deletions for extensions (and just delete everything in the
module), but I realized that won't work if we have an extension that
declares casts between a new type and a type in one of its
dependencies.