### PR TITLE
Fix two GROUP bugs involving USING clauses

### DIFF
--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -510,6 +510,17 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_group_duplicate_rejected(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "used directly in the BY clause",
+        ):
+            await self.con.execute('''
+                group Card { name }
+                using element := .cost
+                by cube(.element, element)
+            ''')
+
     async def test_edgeql_group_for_01(self):
         await self.assert_query_result(
             r'''
@@ -1568,12 +1579,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             always_typenames=True,
         )
 
-    @test.xfail("""
-        Issue #4897
-
-        The link isn't having a view put on it, it's going out raw as
-        just a uuid.
-    """)
     async def test_edgeql_group_issue_4897(self):
         await self.assert_query_result(
             '''


### PR DESCRIPTION
There was a bug where we accidentally duplicated each user-written
alias in GROUP's USING clause. What's more, they were duplicated while
referring to the same AST node, which caused an incorrect cache hit on
the expr_view_cache, which led to not having a shape on the link in the output.
(I am skeptical that that cache still does anything
useful. I'll double check it.)

The other bug is that if you refer to a pointer directly but also have
a `USING` binding for that same name, the pointer reference will
actually refer to the using binding, not the pointer.

The only thing that made sense for this is to disallow this.
There's no way to distinguish them in key or grouping.

Fixes #4897.