### PR TITLE
Add link properties to GroupingIdent

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -120,6 +120,18 @@ class GroupingIdent(Nonterm):
             steps=[qlast.Ptr(name=kids[1].val)],
         )
 
+    def reduce_AT_Identifier(self, *kids):
+        self.val = qlast.Path(
+            partial=True,
+            steps=[
+                qlast.Ptr(
+                    name=kids[1].val,
+                    type='property',
+                    span=kids[1].span,
+                )
+            ]
+        )
+
 
 class GroupingIdentList(ListNonterm, element=GroupingIdent,
                         separator=tokens.T_COMMA):

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -54,6 +54,7 @@ type Bot extending User;
 type Card extending Named {
     required element: str;
     required cost: int64;
+    optional text: str;
     multi owners := .<deck[IS User];
     # computable property
     elemental_cost := <str>.cost ++ ' ' ++ .element;

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -510,7 +510,7 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             ]
         )
 
-    async def test_edgeql_group_duplicate_rejected(self):
+    async def test_edgeql_group_duplicate_rejected_01(self):
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "used directly in the BY clause",
@@ -519,6 +519,37 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                 group Card { name }
                 using element := .cost
                 by cube(.element, element)
+            ''')
+
+    async def test_edgeql_group_duplicate_rejected_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "BY clause cannot refer to link property and object property with "
+            "the same name",
+        ):
+            await self.con.execute('''
+                WITH MODULE cards
+                SELECT Card {
+                    invalid := (
+                        GROUP .avatar
+                        BY @text, .text
+                    )
+                }
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "BY clause cannot refer to link property and object property with "
+            "the same name",
+        ):
+            await self.con.execute('''
+                WITH MODULE cards
+                SELECT Card {
+                    invalid := (
+                        GROUP .avatar
+                        BY .text, @text
+                    )
+                }
             ''')
 
     async def test_edgeql_group_for_01(self):
@@ -1388,6 +1419,39 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             with module cards
             select User {
               cards_by_count := (group .deck by @count) {
+                key : {count},
+                elements: {name},
+              }
+            }
+            filter .name = 'Alice';
+            ''',
+            [
+                {
+                    "cards_by_count": [
+                        {
+                            "key": {"count": 2},
+                            "elements": [
+                                {"name": "Imp"},
+                                {"name": "Dragon"}
+                            ]
+                        },
+                        {
+                            "key": {"count": 3},
+                            "elements": [
+                                {"name": "Bog monster"},
+                                {"name": "Giant turtle"}
+                            ]
+                        }
+                    ]
+                }
+            ],
+        )
+
+        await self.assert_query_result(
+            r'''
+            with module cards
+            select User {
+              cards_by_count := (group .deck by (@count, @count)) {
                 key : {count},
                 elements: {name},
               }

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -1382,6 +1382,40 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             [{"a": {}}, {"a": {}}],
         )
 
+    async def test_edgeql_group_link_property_01(self):
+        await self.assert_query_result(
+            r'''
+            with module cards
+            select User {
+              cards_by_count := (group .deck by @count) {
+                key : {count},
+                elements: {name},
+              }
+            }
+            filter .name = 'Alice';
+            ''',
+            [
+                {
+                    "cards_by_count": [
+                        {
+                            "key": {"count": 2},
+                            "elements": [
+                                {"name": "Imp"},
+                                {"name": "Dragon"}
+                            ]
+                        },
+                        {
+                            "key": {"count": 3},
+                            "elements": [
+                                {"name": "Bog monster"},
+                                {"name": "Giant turtle"}
+                            ]
+                        }
+                    ]
+                }
+            ],
+        )
+
     async def test_edgeql_group_destruct_immediately_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
Allow link properties to be included in the `by` clause of grouping statements.

Given a schema:
```
  type User {
    required name: str;
  }

  type Post {
    multi user_reactions: User {
      emoji: str;
    };
  }
```

It allows the following query:
```
select Post {
    blah := (
        with grouped := (
            group .user_reactions
            by @emoji
        )
        select grouped {**}
    )
};
```

close #7013 