### PR TITLE
Add hint when calling a type or casting to function.

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -35,6 +35,7 @@ from edb.ir import utils as irutils
 
 from edb.schema import abc as s_abc
 from edb.schema import constraints as s_constr
+from edb.schema import functions as s_func
 from edb.schema import globals as s_globals
 from edb.schema import indexes as s_indexes
 from edb.schema import name as sn
@@ -646,7 +647,34 @@ def compile_GlobalExpr(
 def compile_TypeCast(
     expr: qlast.TypeCast, *, ctx: context.ContextLevel
 ) -> irast.Set:
-    target_stype = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
+    try:
+        target_stype = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
+    except errors.InvalidReferenceError as e:
+        if (
+            e.hint is None
+            and isinstance(expr.type, qlast.TypeName)
+            and isinstance(expr.type.maintype, qlast.ObjectRef)
+        ):
+            type_name: str = expr.type.maintype.name
+            type_module: Optional[str] = expr.type.maintype.module
+
+            name: sn.Name
+            if type_module is not None:
+                name = sn.QualName(type_module, type_name)
+            else:
+                name = sn.UnqualName(type_name)
+
+            s_utils.enrich_schema_lookup_error(
+                e,
+                name,
+                modaliases=ctx.modaliases,
+                schema=ctx.env.schema,
+                suggestion_limit=1,
+                item_type=s_func.Function,
+                hint_text='did you mean to call'
+            )
+        raise
+
     ir_expr: Union[irast.Set, irast.Expr]
 
     if isinstance(expr.expr, qlast.Parameter):

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -655,18 +655,9 @@ def compile_TypeCast(
             and isinstance(expr.type, qlast.TypeName)
             and isinstance(expr.type.maintype, qlast.ObjectRef)
         ):
-            type_name: str = expr.type.maintype.name
-            type_module: Optional[str] = expr.type.maintype.module
-
-            name: sn.Name
-            if type_module is not None:
-                name = sn.QualName(type_module, type_name)
-            else:
-                name = sn.UnqualName(type_name)
-
             s_utils.enrich_schema_lookup_error(
                 e,
-                name,
+                s_utils.ast_ref_to_name(expr.type.maintype),
                 modaliases=ctx.modaliases,
                 schema=ctx.env.schema,
                 suggestion_limit=1,

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -53,6 +53,7 @@ from edb.schema import scalars as s_scalars
 from edb.schema import types as s_types
 from edb.schema import indexes as s_indexes
 from edb.schema import schema as s_schema
+from edb.schema import utils as s_utils
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
@@ -95,7 +96,23 @@ def compile_FunctionCall(
     else:
         funcname = sn.QualName(*expr.func)
 
-    funcs = env.schema.get_functions(funcname, module_aliases=ctx.modaliases)
+    try:
+        funcs = env.schema.get_functions(
+            funcname,
+            module_aliases=ctx.modaliases,
+        )
+    except errors.InvalidReferenceError as e:
+        s_utils.enrich_schema_lookup_error(
+            e,
+            funcname,
+            modaliases=ctx.modaliases,
+            schema=env.schema,
+            suggestion_limit=1,
+            span=expr.span,
+            hint_text='did you mean to cast to'
+        )
+        raise
+
     prefer_subquery_args = any(
         func.get_prefer_subquery_args(env.schema) for func in funcs
     )

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -108,6 +108,7 @@ def compile_FunctionCall(
             modaliases=ctx.modaliases,
             schema=env.schema,
             suggestion_limit=1,
+            item_type=s_types.Type,
             span=expr.span,
             hint_text='did you mean to cast to'
         )

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -986,6 +986,7 @@ def enrich_schema_lookup_error(
     condition: Optional[Callable[[so.Object], bool]] = None,
     span: Optional[parsing.Span] = None,
     pointer_parent: Optional[so.Object] = None,
+    hint_text: str = 'did you mean'
 ) -> None:
 
     all_suggestions = itertools.chain(
@@ -1007,9 +1008,9 @@ def enrich_schema_lookup_error(
         names = [name for _, name in suggestions]
 
         if len(names) > 1:
-            hint = f'did you mean one of these: {", ".join(names)}?'
+            hint = f'{hint_text} one of these: {", ".join(names)}?'
         else:
-            hint = f'did you mean {names[0]!r}?'
+            hint = f'{hint_text} {names[0]!r}?'
 
         error.set_hint_and_details(hint=hint)
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -9798,3 +9798,14 @@ aa \
             await self.con.query(f'''
                 with x := 1337, select {body}
             ''')
+
+
+    async def test_edgeql_cast_to_function_01(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidReferenceError,
+            "does not exist",
+            _hint="did you mean to call 'to_str'?"
+        ):
+            await self.con.execute(f"""
+                select <to_str>1;
+            """)

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -9799,7 +9799,6 @@ aa \
                 with x := 1337, select {body}
             ''')
 
-
     async def test_edgeql_cast_to_function_01(self):
         async with self.assertRaisesRegexTx(
             edgedb.errors.InvalidReferenceError,
@@ -9808,4 +9807,22 @@ aa \
         ):
             await self.con.execute(f"""
                 select <to_str>1;
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidReferenceError,
+            "does not exist",
+            _hint="did you mean to call 'round'?"
+        ):
+            await self.con.execute(f"""
+                select <round>1;
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidReferenceError,
+            "does not exist",
+            _hint="did you mean to call 'cal::to_local_date'?"
+        ):
+            await self.con.execute(f"""
+                select <cal::to_local_date>1;
             """)

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -7914,3 +7914,13 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             await self.con.execute(
                 'select std::enc::base64_decode("AA")'
             )
+
+    async def test_edgeql_call_type_as_function_01(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidReferenceError,
+            "does not exist",
+            _hint="did you mean to cast to 'str'?",
+        ):
+            await self.con.execute(f"""
+                select str(1);
+            """)

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -7924,3 +7924,21 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             await self.con.execute(f"""
                 select str(1);
             """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidReferenceError,
+            "does not exist",
+            _hint="did you mean to cast to 'int32'?",
+        ):
+            await self.con.execute(f"""
+                select int32(1);
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidReferenceError,
+            "does not exist",
+            _hint="did you mean to cast to 'cal::local_date'?",
+        ):
+            await self.con.execute(f"""
+                select cal::local_date(1);
+            """)


### PR DESCRIPTION
Given `select <to_str>(1);`, the following error is produced:
```
error: InvalidReferenceError: type 'to_str' does not exist
  ┌─ <query>:1:9
  │
1 │ select <to_str>(1);
  │         ^^^^^^ did you mean to call 'to_str'?
```

Given `select str(1);`, the following error is produced:
```
error: InvalidReferenceError: function 'default::str' does not exist
  ┌─ <query>:1:8
  │
1 │ select str(1);
  │        ^^^^^^ did you mean to cast to 'str'?
```

close #1601 