### PR TITLE
Refactor QL AST

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -174,7 +174,7 @@ class ObjectRef(BaseObjectRef):
 
 
 class PseudoObjectRef(BaseObjectRef):
-    ''' anytype, anytuple or anyobject '''
+    '''anytype, anytuple or anyobject'''
     name: str
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -224,10 +224,6 @@ class BinOp(Expr):
     rebalanced: bool = False
 
 
-class SetConstructorOp(BinOp):
-    op: str = 'UNION'
-
-
 class WindowSpec(Base):
     orderby: typing.List[SortExpr]
     partition: typing.List[Expr]
@@ -477,7 +473,7 @@ class ShapeOrigin(s_enum.StrEnum):
     MATERIALIZATION = 'MATERIALIZATION'
 
 
-class ShapeElement(Expr):
+class ShapeElement(Base):
     expr: Path
     elements: typing.Optional[typing.List[ShapeElement]] = None
     compexpr: typing.Optional[Expr] = None

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -240,42 +240,33 @@ class BaseConstant(Expr):
     __abstract_node__ = True
     value: str
 
-    @classmethod
-    def from_python(cls, val: typing.Any) -> BaseConstant:
-        raise NotImplementedError
-
 
 class StringConstant(BaseConstant):
     @classmethod
     def from_python(cls, s: str) -> StringConstant:
-        return cls(value=s)
+        return StringConstant(value=s)
 
 
-class BaseRealConstant(BaseConstant):
-    __abstract_node__ = True
-    is_negative: bool = False
-
-
-class IntegerConstant(BaseRealConstant):
+class IntegerConstant(BaseConstant):
     pass
 
 
-class FloatConstant(BaseRealConstant):
+class FloatConstant(BaseConstant):
     pass
 
 
-class BigintConstant(BaseRealConstant):
+class BigintConstant(BaseConstant):
     pass
 
 
-class DecimalConstant(BaseRealConstant):
+class DecimalConstant(BaseConstant):
     pass
 
 
 class BooleanConstant(BaseConstant):
     @classmethod
     def from_python(cls, b: bool) -> BooleanConstant:
-        return cls(value=str(b).lower())
+        return BooleanConstant(value=str(b).lower())
 
 
 class BytesConstant(BaseConstant):
@@ -284,7 +275,7 @@ class BytesConstant(BaseConstant):
 
     @classmethod
     def from_python(cls, s: bytes) -> BytesConstant:
-        return cls(value=s)
+        return BytesConstant(value=s)
 
 
 class Parameter(Expr):

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -173,11 +173,15 @@ class ObjectRef(BaseObjectRef):
 
 
 class PseudoObjectRef(BaseObjectRef):
-    # anytype, anytuple or anyobject
+    ''' anytype, anytuple or anyobject '''
     name: str
 
 
 class Anchor(Expr):
+    '''Identifier that resolves to some pre-compiled expression.
+       For example in shapes, the anchor __subject__ refers to object that the
+       shape is defined on.
+    '''
     __abstract_node__ = True
     name: str
 
@@ -188,14 +192,6 @@ class IRAnchor(Anchor):
 
 class SpecialAnchor(Anchor):
     pass
-
-
-class Source(SpecialAnchor):  # __source__
-    name: str = '__source__'
-
-
-class Subject(SpecialAnchor):  # __subject__
-    name: str = '__subject__'
 
 
 class DetachedExpr(Expr):  # DETACHED Expr

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -288,6 +288,8 @@ class UnaryOp(Expr):
 
 
 class TypeExpr(Base):
+    __abstract_node__ = True
+
     name: typing.Optional[str] = None  # name is used for types in named tuples
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -222,7 +222,9 @@ class BinOp(Expr):
     left: Expr
     op: str
     right: Expr
+
     rebalanced: bool = False
+    set_constructor: bool = False
 
 
 class WindowSpec(Base):
@@ -465,7 +467,7 @@ class ShapeOrigin(s_enum.StrEnum):
     MATERIALIZATION = 'MATERIALIZATION'
 
 
-class ShapeElement(Base):
+class ShapeElement(Expr):
     expr: Path
     elements: typing.Optional[typing.List[ShapeElement]] = None
     compexpr: typing.Optional[Expr] = None

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -498,9 +498,9 @@ class Query(Expr):
 Statement = Query | Command
 
 
-class PipelinedQuery(Query):
-    __abstract_node__ = True
-    implicit: bool = False
+class SelectQuery(Query):
+    result_alias: typing.Optional[str] = None
+    result: Expr
 
     where: typing.Optional[Expr] = None
 
@@ -514,11 +514,7 @@ class PipelinedQuery(Query):
     # not interfere with linkprops.
     rptr_passthrough: bool = False
 
-
-class SelectQuery(PipelinedQuery):
-
-    result_alias: typing.Optional[str] = None
-    result: Expr
+    implicit: bool = False
 
 
 class GroupingIdentList(Base):
@@ -582,8 +578,15 @@ class UpdateQuery(Query):
     where: typing.Optional[Expr] = None
 
 
-class DeleteQuery(PipelinedQuery):
+class DeleteQuery(Query):
     subject: Expr
+
+    where: typing.Optional[Expr] = None
+
+    orderby: typing.Optional[typing.List[SortExpr]] = None
+
+    offset: typing.Optional[Expr] = None
+    limit: typing.Optional[Expr] = None
 
 
 class ForQuery(Query):
@@ -1606,13 +1609,15 @@ def has_ddl_subcommand(
 ReturningQuery = SelectQuery | ForQuery | InternalGroupQuery
 
 
-FilteringQuery = PipelinedQuery | ShapeElement | UpdateQuery | ConfigReset
+FilteringQuery = (
+    SelectQuery | DeleteQuery | ShapeElement | UpdateQuery | ConfigReset
+)
 
 
 SubjectQuery = DeleteQuery | UpdateQuery | GroupQuery
 
 
-OffsetLimitQuery = PipelinedQuery | ShapeElement
+OffsetLimitQuery = SelectQuery | DeleteQuery | ShapeElement
 
 
 BasedOn = (

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -687,33 +687,21 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.write(node.name)
         self.write(')')
 
-    def visit_StringConstant(self, node: qlast.StringConstant) -> None:
-        if not _NON_PRINTABLE_RE.search(node.value):
-            for d in ("'", '"', '$$'):
-                if d not in node.value:
-                    if '\\' in node.value and d != '$$':
-                        self.write('r', d, node.value, d)
-                    else:
-                        self.write(d, node.value, d)
-                    return
-            self.write(edgeql_quote.dollar_quote_literal(node.value))
-            return
-        self.write(repr(node.value))
-
-    def visit_IntegerConstant(self, node: qlast.IntegerConstant) -> None:
-        self.write(node.value)
-
-    def visit_FloatConstant(self, node: qlast.FloatConstant) -> None:
-        self.write(node.value)
-
-    def visit_DecimalConstant(self, node: qlast.DecimalConstant) -> None:
-        self.write(node.value)
-
-    def visit_BigintConstant(self, node: qlast.BigintConstant) -> None:
-        self.write(node.value)
-
-    def visit_BooleanConstant(self, node: qlast.BooleanConstant) -> None:
-        self.write(node.value)
+    def visit_Constant(self, node: qlast.Constant) -> None:
+        if node.kind == qlast.ConstantKind.STRING:
+            if not _NON_PRINTABLE_RE.search(node.value):
+                for d in ("'", '"', '$$'):
+                    if d not in node.value:
+                        if '\\' in node.value and d != '$$':
+                            self.write('r', d, node.value, d)
+                        else:
+                            self.write(d, node.value, d)
+                        return
+                self.write(edgeql_quote.dollar_quote_literal(node.value))
+                return
+            self.write(repr(node.value))
+        else:
+            self.write(node.value)
 
     def visit_BytesConstant(self, node: qlast.BytesConstant) -> None:
         val = _BYTES_ESCAPE_RE.sub(_bytes_escape, node.value)
@@ -1341,7 +1329,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self,
         expr: Union[qlast.Expr, qlast.TypeExpr],
     ) -> bool:
-        if not isinstance(expr, qlast.BooleanConstant):
+        if (not isinstance(expr, qlast.Constant)
+            or expr.kind != qlast.ConstantKind.BOOLEAN
+        ):
             raise AssertionError(f'expected BooleanConstant, got {expr!r}')
         return expr.value == 'true'
 
@@ -1350,7 +1340,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         expr: Union[qlast.Expr, qlast.TypeExpr],
         enum_type: Type[Enum_T],
     ) -> Enum_T:
-        if not isinstance(expr, qlast.StringConstant):
+        if (
+            not isinstance(expr, qlast.Constant)
+            or expr.kind != qlast.ConstantKind.STRING
+        ):
             raise AssertionError(f'expected StringConstant, got {expr!r}')
         return enum_type(expr.value)
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -811,19 +811,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write('::')
         self.write(ident_to_str(node.name))
 
-    def visit_Anchor(self, node: qlast.Anchor) -> None:
-        self.write(node.name)
-
-    def visit_IRAnchor(self, node: qlast.IRAnchor) -> None:
-        self.write(node.name)
-
-    def visit_SpecialAnchor(self, node: qlast.SpecialAnchor) -> None:
-        self.write(node.name)
-
-    def visit_Subject(self, node: qlast.Subject) -> None:
-        self.write(node.name)
-
-    def visit_Source(self, node: qlast.Source) -> None:
+    def visit_SpecialAnchor(self, node: qlast.Anchor) -> None:
         self.write(node.name)
 
     def visit_TypeExprLiteral(self, node: qlast.TypeExprLiteral) -> None:

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -701,23 +701,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.write(repr(node.value))
 
     def visit_IntegerConstant(self, node: qlast.IntegerConstant) -> None:
-        if node.is_negative:
-            self.write('-')
         self.write(node.value)
 
     def visit_FloatConstant(self, node: qlast.FloatConstant) -> None:
-        if node.is_negative:
-            self.write('-')
         self.write(node.value)
 
     def visit_DecimalConstant(self, node: qlast.DecimalConstant) -> None:
-        if node.is_negative:
-            self.write('-')
         self.write(node.value)
 
     def visit_BigintConstant(self, node: qlast.BigintConstant) -> None:
-        if node.is_negative:
-            self.write('-')
         self.write(node.value)
 
     def visit_BooleanConstant(self, node: qlast.BooleanConstant) -> None:

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -93,7 +93,9 @@ def is_ql_path(qlexpr: qlast.Expr) -> bool:
 
     start = qlexpr.steps[0]
 
-    return isinstance(start, (qlast.Source, qlast.ObjectRef, qlast.Ptr))
+    return isinstance(start, (qlast.ObjectRef, qlast.Ptr)) or (
+        isinstance(start, qlast.Anchor) and start.name == '__source__'
+    )
 
 
 def is_nontrivial_shape_element(shape_el: qlast.ShapeElement) -> bool:

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -83,21 +83,6 @@ def is_ql_empty_array(expr: qlast.Expr) -> bool:
     return isinstance(expr, qlast.Array) and len(expr.elements) == 0
 
 
-def is_ql_path(qlexpr: qlast.Expr) -> bool:
-    if isinstance(qlexpr, qlast.Shape):
-        if qlexpr.expr:
-            qlexpr = qlexpr.expr
-
-    if not isinstance(qlexpr, qlast.Path):
-        return False
-
-    start = qlexpr.steps[0]
-
-    return isinstance(start, (qlast.ObjectRef, qlast.Ptr)) or (
-        isinstance(start, qlast.Anchor) and start.name == '__source__'
-    )
-
-
 def is_nontrivial_shape_element(shape_el: qlast.ShapeElement) -> bool:
     return bool(
         shape_el.where

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -641,7 +641,7 @@ def _cast_json_to_tuple(
                 where=qlast.BinOp(
                     left=check,
                     op='!=',
-                    right=qlast.StringConstant(value='null'),
+                    right=qlast.Constant.string('null'),
                 )
             )
             filtered_ir = dispatch.compile(filtered, ctx=subctx)
@@ -655,7 +655,7 @@ def _cast_json_to_tuple(
                 func=('__std__', 'json_get'),
                 args=[
                     source_path,
-                    qlast.StringConstant(value=new_el_name),
+                    qlast.Constant.string(new_el_name),
                 ],
             )
 
@@ -941,7 +941,7 @@ def _cast_json_to_range(
                         func=('__std__', 'json_get'),
                         args=[
                             source_path,
-                            qlast.StringConstant(value='lower'),
+                            qlast.Constant.string('lower'),
                         ],
                     ),
                     type=ql_range_el_t,
@@ -951,7 +951,7 @@ def _cast_json_to_range(
                         func=('__std__', 'json_get'),
                         args=[
                             source_path,
-                            qlast.StringConstant(value='upper'),
+                            qlast.Constant.string('upper'),
                         ],
                     ),
                     type=ql_range_el_t,
@@ -969,12 +969,12 @@ def _cast_json_to_range(
                         func=('__std__', 'json_get'),
                         args=[
                             source_path,
-                            qlast.StringConstant(value='inc_lower'),
+                            qlast.Constant.string('inc_lower'),
                         ],
                         kwargs={
                             'default': qlast.FunctionCall(
                                 func=('__std__', 'to_json'),
-                                args=[qlast.StringConstant(value="true")],
+                                args=[qlast.Constant.string("true")],
                             ),
                         },
                     ),
@@ -985,12 +985,12 @@ def _cast_json_to_range(
                         func=('__std__', 'json_get'),
                         args=[
                             source_path,
-                            qlast.StringConstant(value='inc_upper'),
+                            qlast.Constant.string('inc_upper'),
                         ],
                         kwargs={
                             'default': qlast.FunctionCall(
                                 func=('__std__', 'to_json'),
-                                args=[qlast.StringConstant(value="false")],
+                                args=[qlast.Constant.string("false")],
                             ),
                         },
                     ),
@@ -1001,12 +1001,12 @@ def _cast_json_to_range(
                         func=('__std__', 'json_get'),
                         args=[
                             source_path,
-                            qlast.StringConstant(value='empty'),
+                            qlast.Constant.string('empty'),
                         ],
                         kwargs={
                             'default': qlast.FunctionCall(
                                 func=('__std__', 'to_json'),
-                                args=[qlast.StringConstant(value="false")],
+                                args=[qlast.Constant.string("false")],
                             ),
                         },
                     ),
@@ -1303,7 +1303,7 @@ def _find_object_by_id(
         )
 
         error_message = qlast.BinOp(
-            left=qlast.StringConstant(
+            left=qlast.Constant.string(
                 value=(
                     repr(new_stype.get_displayname(ctx.env.schema))
                     + ' with id \''
@@ -1316,7 +1316,7 @@ def _find_object_by_id(
                     type=qlast.TypeName(maintype=qlast.ObjectRef(name='str')),
                 ),
                 op='++',
-                right=qlast.StringConstant(value='\' does not exist'),
+                right=qlast.Constant.string('\' does not exist'),
             ),
         )
 

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -102,7 +102,7 @@ def compile_ConfigSet(
     else:
         if isinstance(val, statypes.ScalarType) and info.backend_setting:
             backend_expr = dispatch.compile(
-                qlast.StringConstant.from_python(val.to_backend_str()),
+                qlast.Constant.string(val.to_backend_str()),
                 ctx=ctx,
             )
         else:

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -327,7 +327,7 @@ def _enforce_pointer_constraints(
         with ctx.detached() as sctx:
             sctx.partial_path_prefix = expr
             sctx.anchors = ctx.anchors.copy()
-            sctx.anchors[qlast.Subject().name] = expr
+            sctx.anchors['__subject__'] = expr
 
             final_expr = constraint.get_finalexpr(ctx.env.schema)
             assert final_expr is not None and final_expr.qlast is not None

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -246,7 +246,7 @@ def _compile_conflict_select_for_obj_type(
             e_rhs = qlutils.subject_substitute(
                 except_expr.qlast, insert_subject)
 
-            true_ast = qlast.BooleanConstant(value='true')
+            true_ast = qlast.Constant.boolean(True)
             on = qlast.BinOp(
                 op='AND',
                 left=qlast.BinOp(op='?!=', left=e_lhs, right=true_ast),

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -132,10 +132,9 @@ def compile_BinOp(expr: qlast.BinOp, *, ctx: context.ContextLevel) -> irast.Set:
     if expr.op == '??' and utils.contains_dml(expr.right):
         return _compile_dml_coalesce(expr, ctx=ctx)
 
-    op_node = func.compile_operator(
-        expr, op_name=expr.op, qlargs=[expr.left, expr.right], ctx=ctx)
-
-    return op_node
+    return func.compile_operator(
+        expr, op_name=expr.op, qlargs=[expr.left, expr.right], ctx=ctx
+    )
 
 
 @dispatch.compile.register(qlast.IsOp)
@@ -182,7 +181,8 @@ def compile_Set(expr: qlast.Set, *, ctx: context.ContextLevel) -> irast.Set:
             bigunion = _balance(
                 elements,
                 lambda l, r, s: qlast.BinOp(
-                    left=l, op='UNION', right=r, rebalanced=True, span=s
+                    left=l, op='UNION', right=r,
+                    rebalanced=True, set_constructor=True, span=s
                 ),
                 expr.span
             )

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -113,7 +113,6 @@ REBALANCED_OPS = {'UNION'}
 REBALANCE_THRESHOLD = 10
 
 
-@dispatch.compile.register(qlast.SetConstructorOp)
 @dispatch.compile.register(qlast.BinOp)
 def compile_BinOp(expr: qlast.BinOp, *, ctx: context.ContextLevel) -> irast.Set:
     # Rebalance some associative operations to avoid deeply nested ASTs
@@ -182,8 +181,9 @@ def compile_Set(expr: qlast.Set, *, ctx: context.ContextLevel) -> irast.Set:
             # TODO: Introduce an N-ary operation that handles the whole thing?
             bigunion = _balance(
                 elements,
-                lambda l, r, c: qlast.SetConstructorOp(
-                    left=l, right=r, rebalanced=True, span=c),
+                lambda l, r, s: qlast.BinOp(
+                    left=l, op='UNION', right=r, rebalanced=True, span=s
+                ),
                 expr.span
             )
             res = dispatch.compile(bigunion, ctx=ctx)

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -211,31 +211,20 @@ def compile_BaseConstant(
         node_cls = irast.StringConstant
     elif isinstance(expr, qlast.IntegerConstant):
         value = value.replace("_", "")
-        int_value = int(value)
-        if expr.is_negative:
-            int_value = -int_value
-            value = f'-{value}'
-        # If integer value is out of int64 bounds, use decimal
         std_type = sn.QualName('std', 'int64')
         node_cls = irast.IntegerConstant
     elif isinstance(expr, qlast.FloatConstant):
         value = value.replace("_", "")
-        if expr.is_negative:
-            value = f'-{value}'
         std_type = sn.QualName('std', 'float64')
         node_cls = irast.FloatConstant
     elif isinstance(expr, qlast.DecimalConstant):
         assert value[-1] == 'n'
         value = value[:-1].replace("_", "")
-        if expr.is_negative:
-            value = f'-{value}'
         std_type = sn.QualName('std', 'decimal')
         node_cls = irast.DecimalConstant
     elif isinstance(expr, qlast.BigintConstant):
         assert value[-1] == 'n'
         value = value[:-1].replace("_", "")
-        if expr.is_negative:
-            value = f'-{value}'
         std_type = sn.QualName('std', 'bigint')
         node_cls = irast.BigintConstant
     elif isinstance(expr, qlast.BooleanConstant):

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -902,7 +902,7 @@ def finalize_args(
                 and not ctx.inhibit_implicit_limit
             ):
                 arg.expr.limit = dispatch.compile(
-                    qlast.IntegerConstant(value=str(ctx.implicit_limit)),
+                    qlast.Constant.integer(ctx.implicit_limit),
                     ctx=ctx,
                 )
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -541,7 +541,7 @@ def compile_operator(
                 ):
                     hint = 'Consider using the "++" operator for concatenation'
 
-            if isinstance(qlexpr, qlast.SetConstructorOp):
+            if isinstance(qlexpr, qlast.BinOp) and qlexpr.op == 'UNION':
                 msg = (
                     f'set constructor has arguments of incompatible types '
                     f'{types}'

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -352,7 +352,7 @@ def _special_case(name: str) -> Callable[[_SpecialCaseFunc], _SpecialCaseFunc]:
 
 
 def compile_operator(
-    qlexpr: qlast.Base,
+    qlexpr: qlast.Expr,
     op_name: str,
     qlargs: List[qlast.Expr],
     *,
@@ -541,7 +541,7 @@ def compile_operator(
                 ):
                     hint = 'Consider using the "++" operator for concatenation'
 
-            if isinstance(qlexpr, qlast.BinOp) and qlexpr.op == 'UNION':
+            if isinstance(qlexpr, qlast.BinOp) and qlexpr.set_constructor:
                 msg = (
                     f'set constructor has arguments of incompatible types '
                     f'{types}'

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -336,7 +336,7 @@ def try_type_rewrite(
                 from . import clauses
 
                 filtered_stmt = irast.SelectStmt(result=base_set)
-                subctx.anchors[qlast.Subject().name] = base_set
+                subctx.anchors['__subject__'] = base_set
                 subctx.partial_path_prefix = base_set
                 subctx.path_scope = subctx.env.path_scope.root.attach_fence()
 
@@ -466,5 +466,5 @@ def _prepare_dml_policy_context(
         stype, path_id=result.path_id, skip_subtypes=skip_subtypes, ctx=ctx
     )
 
-    ctx.anchors[qlast.Subject().name] = result
+    ctx.anchors['__subject__'] = result
     ctx.partial_path_prefix = result

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -131,7 +131,7 @@ def compile_pol(
     if expr_field:
         expr = expr_field.qlast
     else:
-        expr = qlast.BooleanConstant(value='true')
+        expr = qlast.Constant.boolean(True)
 
     if condition := pol.get_condition(schema):
         expr = qlast.BinOp(op='AND', left=condition.qlast, right=expr)
@@ -167,11 +167,11 @@ def get_extra_function_rewrite_filter(ctx: context.ContextLevel) -> qlast.Expr:
         func=('__std__', 'json_get'),
         args=[
             ctx.create_anchor(glob_set, 'a'),
-            qlast.StringConstant(value="__disable_access_policies"),
+            qlast.Constant.string(value="__disable_access_policies"),
         ],
         kwargs={
             'default': qlast.TypeCast(
-                expr=qlast.BooleanConstant(value="false"),
+                expr=qlast.Constant.boolean(False),
                 type=json_type,
             )
         },
@@ -216,7 +216,7 @@ def get_rewrite_filter(
     if allow:
         filter_expr = astutils.extend_binop(None, *allow, op='OR')
     else:
-        filter_expr = qlast.BooleanConstant(value='false')
+        filter_expr = qlast.Constant.boolean(False)
 
     if deny:
         deny_expr = qlast.UnaryOp(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1570,7 +1570,7 @@ def computable_ptr_set(
                 # the assert_exists.
                 # TODO: do something less bad
                 arg = qlast.SelectQuery(
-                    result=path, where=qlast.BooleanConstant(value='true'))
+                    result=path, where=qlast.Constant.boolean(True))
                 vname = ptrcls.get_verbosename(
                     ctx.env.schema, with_parent=True)
                 msg = f'required {vname} is hidden by access policy'
@@ -1583,7 +1583,7 @@ def computable_ptr_set(
                 schema_qlexpr = qlast.FunctionCall(
                     func=('__std__', 'assert_exists'),
                     args=[arg],
-                    kwargs={'message': qlast.StringConstant(value=msg)},
+                    kwargs={'message': qlast.Constant.string(value=msg)},
                 )
 
             # Is this is a view, we want to shadow the underlying
@@ -2071,7 +2071,7 @@ def get_func_global_param_sets(
             func=('__std__', 'json_get'),
             args=[
                 subctx.create_anchor(glob_set, 'a'),
-                qlast.StringConstant(value=str(name)),
+                qlast.Constant.string(value=str(name)),
             ],
         )
 
@@ -2127,7 +2127,7 @@ def get_globals_as_json(
 
     null_expr = qlast.FunctionCall(
         func=('__std__', 'to_json'),
-        args=[qlast.StringConstant(value="null")],
+        args=[qlast.Constant.string(value="null")],
     )
 
     with ctx.new() as subctx:
@@ -2174,7 +2174,7 @@ def get_globals_as_json(
                     if_expr=tup,
                     else_expr=qlast.FunctionCall(
                         func=('__std__', 'to_json'),
-                        args=[qlast.StringConstant(value="{}")],
+                        args=[qlast.Constant.string(value="{}")],
                     )
                 ))
 
@@ -2188,7 +2188,7 @@ def get_globals_as_json(
         ) and not is_constraint_like:
             full_objs.append(qlast.FunctionCall(
                 func=('__std__', 'to_json'),
-                args=[qlast.StringConstant(
+                args=[qlast.Constant.string(
                     value='{"__disable_access_policies": true}'
                 )],
             ))

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1543,7 +1543,7 @@ def computable_ptr_set(
             ptrcls_n = ptrcls.get_shortname(ctx.env.schema).name
             path = qlast.Path(
                 steps=[
-                    qlast.Source(),
+                    qlast.SpecialAnchor(name='__source__'),
                     qlast.Ptr(
                         name=ptrcls_n,
                         direction=s_pointers.PointerDirection.Outbound,
@@ -1655,7 +1655,7 @@ def computable_ptr_set(
             subctx.view_scls = result_stype
         subctx.view_rptr = context.ViewRPtr(
             source=source_scls, ptrcls=ptrcls)
-        subctx.anchors[qlast.Source().name] = source_set
+        subctx.anchors['__source__'] = source_set
         subctx.empty_result_type_hint = ptrcls.get_target(ctx.env.schema)
         subctx.partial_path_prefix = source_set
         # On a mutation, make the expr_exposed. This corresponds with

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -133,7 +133,7 @@ def compile_SelectQuery(
             and expr.limit is None
             and not ctx.inhibit_implicit_limit
         ):
-            expr.limit = qlast.IntegerConstant(value=str(ctx.implicit_limit))
+            expr.limit = qlast.Constant.integer(ctx.implicit_limit)
 
         stmt.result = compile_result_clause(
             expr.result,
@@ -259,7 +259,7 @@ def compile_ForQuery(
         if ((ctx.expr_exposed or sctx.stmt is ctx.toplevel_stmt)
                 and ctx.implicit_limit):
             stmt.limit = dispatch.compile(
-                qlast.IntegerConstant(value=str(ctx.implicit_limit)),
+                qlast.Constant.integer(ctx.implicit_limit),
                 ctx=sctx,
             )
 

--- a/edb/edgeql/compiler/tuple_args.py
+++ b/edb/edgeql/compiler/tuple_args.py
@@ -218,7 +218,7 @@ def _plus_const(expr: qlast.Expr, val: int) -> qlast.Expr:
     return qlast.BinOp(
         left=expr,
         op='+',
-        right=qlast.IntegerConstant(value=str(val)),
+        right=qlast.Constant.integer(val),
     )
 
 
@@ -279,7 +279,7 @@ def make_decoder(
             lo: qlast.Expr
             hi: qlast.Expr
             if idx is None:
-                lo = qlast.IntegerConstant(value='0')
+                lo = qlast.Constant.integer(0)
                 hi = qlast.FunctionCall(
                     func=('__std__', 'len'), args=[params[typ.idx]])
                 # If the leftmost element inside a toplevel array is

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1452,9 +1452,7 @@ def _normalize_view_ptr_expr(
                 and not base_is_singleton
             ):
                 qlexpr = qlast.SelectQuery(result=qlexpr, implicit=True)
-                qlexpr.limit = qlast.IntegerConstant(
-                    value=str(ctx.implicit_limit),
-                )
+                qlexpr.limit = qlast.Constant.integer(ctx.implicit_limit)
 
         if target_typexpr is not None:
             assert isinstance(target_typexpr, qlast.TypeName)
@@ -1580,7 +1578,7 @@ def _normalize_view_ptr_expr(
             and not qlexpr.limit
         ):
             qlexpr = qlast.SelectQuery(result=qlexpr, implicit=True)
-            qlexpr.limit = qlast.IntegerConstant(value=str(ctx.implicit_limit))
+            qlexpr.limit = qlast.Constant.integer(ctx.implicit_limit)
 
         irexpr, sub_view_rptr = _compile_qlexpr(
             ir_source,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1574,7 +1574,9 @@ def _normalize_view_ptr_expr(
         if (
             (ctx.expr_exposed or ctx.stmt is ctx.toplevel_stmt)
             and ctx.implicit_limit
-            and isinstance(qlexpr, (qlast.PipelinedQuery, qlast.ShapeElement))
+            and isinstance(qlexpr, (
+                qlast.SelectQuery, qlast.DeleteQuery, qlast.ShapeElement
+            ))
             and not qlexpr.limit
         ):
             qlexpr = qlast.SelectQuery(result=qlexpr, implicit=True)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2142,7 +2142,7 @@ def _inline_type_computable(
             ),
             compexpr=qlast.Path(
                 steps=[
-                    qlast.Source(),
+                    qlast.SpecialAnchor(name='__source__'),
                     qlast.Ptr(
                         name='__type__',
                         direction=s_pointers.PointerDirection.Outbound,
@@ -2167,7 +2167,7 @@ def _inline_type_computable(
             base_ir_set = setgen.ensure_set(
                 ir_set, type_override=base_stype, ctx=scopectx)
 
-            scopectx.anchors[qlast.Source().name] = base_ir_set
+            scopectx.anchors['__source__'] = base_ir_set
             ptr, ptr_set = _normalize_view_ptr_expr(
                 base_ir_set,
                 ql_desc,

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -528,7 +528,7 @@ class AlterAnnotationValueStmt(Nonterm):
         )
         self.val.commands = [qlast.SetField(
             name='owned',
-            value=qlast.BooleanConstant(value='false'),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )]
 
@@ -572,21 +572,21 @@ class AlterAbstract(Nonterm):
         # TODO: Raise a DeprecationWarning once we have facility for that.
         self.val = qlast.SetField(
             name='abstract',
-            value=qlast.BooleanConstant.from_python(False),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )
 
     def reduce_SET_NOT_ABSTRACT(self, *kids):
         self.val = qlast.SetField(
             name='abstract',
-            value=qlast.BooleanConstant.from_python(False),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )
 
     def reduce_SET_ABSTRACT(self, *kids):
         self.val = qlast.SetField(
             name='abstract',
-            value=qlast.BooleanConstant.from_python(True),
+            value=qlast.Constant.boolean(True),
             special_syntax=True,
         )
 
@@ -648,14 +648,14 @@ class AlterOwnedStmt(Nonterm):
     def reduce_DROP_OWNED(self, *kids):
         self.val = qlast.SetField(
             name='owned',
-            value=qlast.BooleanConstant(value='false'),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )
 
     def reduce_SET_OWNED(self, *kids):
         self.val = qlast.SetField(
             name='owned',
-            value=qlast.BooleanConstant(value='true'),
+            value=qlast.Constant.boolean(True),
             special_syntax=True,
         )
 
@@ -1231,14 +1231,14 @@ class SetDelegatedStmt(Nonterm):
     def reduce_SET_DELEGATED(self, *kids):
         self.val = qlast.SetField(
             name='delegated',
-            value=qlast.BooleanConstant.from_python(True),
+            value=qlast.Constant.boolean(True),
             special_syntax=True,
         )
 
     def reduce_SET_NOT_DELEGATED(self, *kids):
         self.val = qlast.SetField(
             name='delegated',
-            value=qlast.BooleanConstant.from_python(False),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )
 
@@ -1583,14 +1583,14 @@ class AlterDeferredStmt(Nonterm):
     def reduce_DROP_DEFERRED(self, *kids):
         self.val = qlast.SetField(
             name='deferred',
-            value=qlast.BooleanConstant(value='false'),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )
 
     def reduce_SET_DEFERRED(self, *kids):
         self.val = qlast.SetField(
             name='deferred',
-            value=qlast.BooleanConstant(value='true'),
+            value=qlast.Constant.boolean(True),
             special_syntax=True,
         )
 
@@ -1808,7 +1808,7 @@ class SetRequiredInCreateStmt(Nonterm):
     def reduce_SET_REQUIRED_OptAlterUsingClause(self, *kids):
         self.val = qlast.SetPointerOptionality(
             name='required',
-            value=qlast.BooleanConstant.from_python(True),
+            value=qlast.Constant.boolean(True),
             special_syntax=True,
             fill_expr=kids[2].val,
         )
@@ -1924,7 +1924,7 @@ class SetCardinalityStmt(Nonterm):
     def reduce_SET_SINGLE_OptAlterUsingClause(self, *kids):
         self.val = qlast.SetPointerCardinality(
             name='cardinality',
-            value=qlast.StringConstant.from_python(
+            value=qlast.Constant.string(
                 qltypes.SchemaCardinality.One),
             special_syntax=True,
             conv_expr=kids[2].val,
@@ -1933,7 +1933,7 @@ class SetCardinalityStmt(Nonterm):
     def reduce_SET_MULTI(self, *kids):
         self.val = qlast.SetPointerCardinality(
             name='cardinality',
-            value=qlast.StringConstant.from_python(
+            value=qlast.Constant.string(
                 qltypes.SchemaCardinality.Many),
             special_syntax=True,
         )
@@ -1952,7 +1952,7 @@ class SetRequiredStmt(Nonterm):
     def reduce_SET_REQUIRED_OptAlterUsingClause(self, *kids):
         self.val = qlast.SetPointerOptionality(
             name='required',
-            value=qlast.BooleanConstant.from_python(True),
+            value=qlast.Constant.boolean(True),
             special_syntax=True,
             fill_expr=kids[2].val,
         )
@@ -1960,7 +1960,7 @@ class SetRequiredStmt(Nonterm):
     def reduce_SET_OPTIONAL(self, *kids):
         self.val = qlast.SetPointerOptionality(
             name='required',
-            value=qlast.BooleanConstant.from_python(False),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )
 
@@ -1968,7 +1968,7 @@ class SetRequiredStmt(Nonterm):
         # TODO: Raise a DeprecationWarning once we have facility for that.
         self.val = qlast.SetPointerOptionality(
             name='required',
-            value=qlast.BooleanConstant.from_python(False),
+            value=qlast.Constant.boolean(False),
             special_syntax=True,
         )
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1265,11 +1265,13 @@ class Expr(Nonterm):
     @parsing.precedence(precedence.P_UMINUS)
     def reduce_MINUS_Expr(self, *kids):
         arg = kids[1].val
-        if isinstance(arg, qlast.BaseRealConstant):
-            # Special case for -<real_const> so that type inference based
-            # on literal size works correctly in the case of INT_MIN and
-            # friends.
-            self.val = type(arg)(value=arg.value, is_negative=True)
+        if isinstance(arg, (
+            qlast.IntegerConstant,
+            qlast.FloatConstant,
+            qlast.BigintConstant,
+            qlast.DecimalConstant,
+        )):
+            self.val = type(arg)(value=f'-{arg.value}')
         else:
             self.val = qlast.UnaryOp(op=kids[0].val, operand=arg)
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1265,13 +1265,13 @@ class Expr(Nonterm):
     @parsing.precedence(precedence.P_UMINUS)
     def reduce_MINUS_Expr(self, *kids):
         arg = kids[1].val
-        if isinstance(arg, (
-            qlast.IntegerConstant,
-            qlast.FloatConstant,
-            qlast.BigintConstant,
-            qlast.DecimalConstant,
-        )):
-            self.val = type(arg)(value=f'-{arg.value}')
+        if isinstance(arg, qlast.Constant) and arg.kind in {
+            qlast.ConstantKind.INTEGER,
+            qlast.ConstantKind.FLOAT,
+            qlast.ConstantKind.BIGINT,
+            qlast.ConstantKind.DECIMAL,
+        }:
+            self.val = type(arg)(value=f'-{arg.value}', kind=arg.kind)
         else:
             self.val = qlast.UnaryOp(op=kids[0].val, operand=arg)
 
@@ -1566,22 +1566,30 @@ class Constant(Nonterm):
 
 class BaseNumberConstant(Nonterm):
     def reduce_ICONST(self, *kids):
-        self.val = qlast.IntegerConstant(value=kids[0].val)
+        self.val = qlast.Constant(
+            value=kids[0].val, kind=qlast.ConstantKind.INTEGER
+        )
 
     def reduce_FCONST(self, *kids):
-        self.val = qlast.FloatConstant(value=kids[0].val)
+        self.val = qlast.Constant(
+            value=kids[0].val, kind=qlast.ConstantKind.FLOAT
+        )
 
     def reduce_NICONST(self, *kids):
-        self.val = qlast.BigintConstant(value=kids[0].val)
+        self.val = qlast.Constant(
+            value=kids[0].val, kind=qlast.ConstantKind.BIGINT
+        )
 
     def reduce_NFCONST(self, *kids):
-        self.val = qlast.DecimalConstant(value=kids[0].val)
+        self.val = qlast.Constant(
+            value=kids[0].val, kind=qlast.ConstantKind.DECIMAL
+        )
 
 
 class BaseStringConstant(Nonterm):
 
     def reduce_SCONST(self, token):
-        self.val = qlast.StringConstant(value=token.clean_value)
+        self.val = qlast.Constant.string(value=token.clean_value)
 
 
 class BaseBytesConstant(Nonterm):
@@ -1592,10 +1600,10 @@ class BaseBytesConstant(Nonterm):
 
 class BaseBooleanConstant(Nonterm):
     def reduce_TRUE(self, *kids):
-        self.val = qlast.BooleanConstant(value='true')
+        self.val = qlast.Constant.boolean(True)
 
     def reduce_FALSE(self, *kids):
-        self.val = qlast.BooleanConstant(value='false')
+        self.val = qlast.Constant.boolean(False)
 
 
 def ensure_path(expr):

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1145,10 +1145,10 @@ class BaseAtomicExpr(Nonterm):
         pass
 
     def reduce_DUNDERSOURCE(self, *kids):
-        self.val = qlast.Path(steps=[qlast.Source()])
+        self.val = qlast.Path(steps=[qlast.SpecialAnchor(name='__source__')])
 
     def reduce_DUNDERSUBJECT(self, *kids):
-        self.val = qlast.Path(steps=[qlast.Subject()])
+        self.val = qlast.Path(steps=[qlast.SpecialAnchor(name='__subject__')])
 
     def reduce_DUNDERNEW(self, *kids):
         self.val = qlast.Path(steps=[qlast.SpecialAnchor(name='__new__')])

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -153,7 +153,7 @@ def find_subject_ptrs(ast: qlast.Base) -> Set[str]:
     for path in find_paths(ast):
         if path.partial:
             p = path.steps[0]
-        elif isinstance(path.steps[0], qlast.Subject) and len(path.steps) > 1:
+        elif is_anchor(path.steps[0], '__subject__') and len(path.steps) > 1:
             p = path.steps[1]
         else:
             continue
@@ -161,6 +161,10 @@ def find_subject_ptrs(ast: qlast.Base) -> Set[str]:
         if isinstance(p, qlast.Ptr):
             ptrs.add(p.name)
     return ptrs
+
+
+def is_anchor(expr: qlast.PathElement, name: str):
+    return isinstance(expr, qlast.Anchor) and expr.name == name
 
 
 def subject_paths_substitute(
@@ -175,7 +179,7 @@ def subject_paths_substitute(
                 subject_ptrs,
             )
         elif (
-            isinstance(path.steps[0], qlast.Subject)
+            is_anchor(path.steps[0], '__subject__')
             and len(path.steps)
             and isinstance(path.steps[1], qlast.Ptr)
         ):
@@ -191,7 +195,7 @@ def subject_substitute(
 ) -> qlast.Base_T:
     ast = copy.deepcopy(ast)
     for path in find_paths(ast):
-        if isinstance(path.steps[0], qlast.Subject):
+        if is_anchor(path.steps[0], '__subject__'):
             path.steps[0] = new_subject
     return ast
 

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -176,9 +176,9 @@ def _process_op_result(
 ) -> irast.ConstExpr:
     qlconst: qlast.BaseConstant
     if isinstance(value, str):
-        qlconst = qlast.StringConstant.from_python(value)
+        qlconst = qlast.Constant.string(value)
     elif isinstance(value, bool):
-        qlconst = qlast.BooleanConstant.from_python(value)
+        qlconst = qlast.Constant.boolean(value)
     else:
         raise UnsupportedExpressionError(
             f"unsupported result type: {type(value)}", span=span

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3568,15 +3568,12 @@ def get_index_compile_options(
     subject = index.get_subject(schema)
     assert isinstance(subject, (s_types.Type, s_pointers.Pointer))
 
-    singletons = [subject]
-    path_prefix_anchor = ql_ast.Subject().name
-
     return qlcompiler.CompilerOptions(
         modaliases=modaliases,
         schema_object_context=schema_object_context,
-        anchors={ql_ast.Subject().name: subject},
-        path_prefix_anchor=path_prefix_anchor,
-        singletons=singletons,
+        anchors={'__subject__': subject},
+        path_prefix_anchor='__subject__',
+        singletons=[subject],
         apply_query_rewrites=False,
     )
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -243,8 +243,8 @@ def compile_constraint(
         {(subject, is_optional)}
     )
     options = qlcompiler.CompilerOptions(
-        anchors={qlast.Subject().name: subject},
-        path_prefix_anchor=qlast.Subject().name,
+        anchors={'__subject__': subject},
+        path_prefix_anchor='__subject__',
         apply_query_rewrites=False,
         singletons=singletons,
         schema_object_context=type(constraint),
@@ -326,11 +326,11 @@ def compile_constraint(
         assert isinstance(sub, (s_types.Type, s_pointers.Pointer))
         origin_subject: s_types.Type | s_pointers.Pointer = sub
 
-        origin_path_prefix_anchor = qlast.Subject().name
+        origin_path_prefix_anchor = '__subject__'
         singletons = frozenset({(origin_subject, is_optional)})
 
         origin_options = qlcompiler.CompilerOptions(
-            anchors={qlast.Subject().name: origin_subject},
+            anchors={'__subject__': origin_subject},
             path_prefix_anchor=origin_path_prefix_anchor,
             apply_query_rewrites=False,
             singletons=singletons,

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -345,7 +345,7 @@ class CreateAnnotationValue(
             assert isinstance(op.new_value, str)
             assert isinstance(node, (
                 qlast.CreateAnnotationValue, qlast.AlterAnnotationValue))
-            node.value = qlast.StringConstant.from_python(op.new_value)
+            node.value = qlast.Constant.string(op.new_value)
         else:
             super()._apply_field_ast(schema, context, node, op)
 
@@ -436,7 +436,7 @@ class AlterAnnotationValue(
 
         if op.property == 'value':
             assert isinstance(op.new_value, str)
-            node.value = qlast.StringConstant.from_python(op.new_value)
+            node.value = qlast.Constant.string(op.new_value)
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -572,8 +572,8 @@ class ConstraintCommand(
                     schema=schema,
                     options=qlcompiler.CompilerOptions(
                         modaliases=context.modaliases,
-                        anchors={qlast.Subject().name: base},
-                        path_prefix_anchor=qlast.Subject().name,
+                        anchors={'__subject__': base},
+                        path_prefix_anchor='__subject__',
                         singletons=frozenset([base]),
                         allow_generic_type_output=True,
                         schema_object_context=self.get_schema_metaclass(),
@@ -822,12 +822,12 @@ class ConstraintCommand(
             # subject has been redefined
             assert isinstance(subject, qlast.Base)
             qlutils.inline_anchors(
-                expr_ql, anchors={qlast.Subject().name: subject})
+                expr_ql, anchors={'__subject__': subject})
             subject = orig_subject
 
         if args:
             args_ql: List[qlast.Base] = [
-                qlast.Path(steps=[qlast.Subject()]),
+                qlast.Path(steps=[qlast.SpecialAnchor(name='__subject__')]),
             ]
             args_ql.extend(arg.qlast for arg in args)
             args_map = qlutils.index_parameters(
@@ -849,8 +849,8 @@ class ConstraintCommand(
         final_expr = s_expr.Expression.from_ast(expr_ql, schema, {}).compiled(
             schema=schema,
             options=qlcompiler.CompilerOptions(
-                anchors={qlast.Subject().name: subject},
-                path_prefix_anchor=qlast.Subject().name,
+                anchors={'__subject__': subject},
+                path_prefix_anchor='__subject__',
                 singletons=singletons,
                 apply_query_rewrites=False,
                 schema_object_context=self.get_schema_metaclass(),
@@ -879,8 +879,8 @@ class ConstraintCommand(
 
         if subjectexpr is not None:
             options = qlcompiler.CompilerOptions(
-                anchors={qlast.Subject().name: subject},
-                path_prefix_anchor=qlast.Subject().name,
+                anchors={'__subject__': subject},
+                path_prefix_anchor='__subject__',
                 singletons=singletons,
                 apply_query_rewrites=False,
                 schema_object_context=self.get_schema_metaclass(),

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -568,7 +568,7 @@ def apply_sdl(
                 process_ext(
                     qlast.CreateExtension(
                         name=qlast.ObjectRef(name=dep),
-                        version=qlast.StringConstant(value=dep_version),
+                        version=qlast.Constant.string(value=dep_version),
                     )
                 )
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -4346,7 +4346,7 @@ class AlterObjectProperty(Command):
             ])
         elif isinstance(value, uuid.UUID):
             value = qlast.TypeCast(
-                expr=qlast.StringConstant.from_python(str(value)),
+                expr=qlast.Constant.string(str(value)),
                 type=qlast.TypeName(
                     maintype=qlast.ObjectRef(
                         name='uuid',

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -277,7 +277,7 @@ class CreateExtensionPackage(
                     qlparser.parse_block(op.new_value)),
             )
         elif op.property == 'version':
-            node.version = qlast.StringConstant(
+            node.version = qlast.Constant.string(
                 value=str(op.new_value),
             )
         else:
@@ -449,7 +449,7 @@ class CreateExtension(
         # restoring the dump. We also have no mechanism of installing a specific
         # extension version, yet.
         if context.include_ext_version:
-            node.version = qlast.StringConstant(
+            node.version = qlast.Constant.string(
                 value=str(pkg.get_version(schema))
             )
         return node

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -2366,10 +2366,10 @@ def get_params_symtable(
                     func=('std', 'bytes_get_bit'),
                     args=[
                         defaults_mask,
-                        qlast.IntegerConstant(value=str(pi)),
+                        qlast.Constant.integer(pi),
                     ]),
                 op='=',
-                right=qlast.IntegerConstant(value='0'),
+                right=qlast.Constant.integer(0),
             ),
             if_expr=anchors[p_shortname],
             else_expr=qlast._Optional(expr=p_default.qlast),

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -765,8 +765,8 @@ class IndexCommand(
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,
                     schema_object_context=self.get_schema_metaclass(),
-                    anchors={qlast.Subject().name: subject},
-                    path_prefix_anchor=qlast.Subject().name,
+                    anchors={'__subject__': subject},
+                    path_prefix_anchor='__subject__',
                     singletons=frozenset([subject]),
                     apply_query_rewrites=False,
                     track_schema_ref_exprs=track_schema_ref_exprs,
@@ -1178,8 +1178,8 @@ class CreateIndex(
                 context=context,
             )
             options = qlcompiler.CompilerOptions(
-                anchors={qlast.Subject().name: subject},
-                path_prefix_anchor=qlast.Subject().name,
+                anchors={'__subject__': subject},
+                path_prefix_anchor='__subject__',
                 singletons=frozenset([subject]),
                 apply_query_rewrites=False,
                 schema_object_context=self.get_schema_metaclass(),

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1946,7 +1946,7 @@ class PointerCommand(
                 assert handler is not None
                 set_field = qlast.SetField(
                     name='cardinality',
-                    value=qlast.StringConstant.from_python(
+                    value=qlast.Constant.string(
                         str(astnode.cardinality),
                     ),
                     special_syntax=True,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1499,9 +1499,9 @@ class PointerCommandOrFragment(
             options = qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,
                 schema_object_context=self.get_schema_metaclass(),
-                anchors={qlast.Source().name: source},
+                anchors={'__source__': source},
                 path_prefix_anchor=(
-                    qlast.Source().name
+                    '__source__'
                     if should_set_path_prefix_anchor
                     else None),
                 singletons=singletons,
@@ -2224,8 +2224,8 @@ class AlterPointer(
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,
-                anchors={qlast.Source().name: source},
-                path_prefix_anchor=qlast.Source().name,
+                anchors={'__source__': source},
+                path_prefix_anchor='__source__',
                 singletons=frozenset([source]),
                 apply_query_rewrites=not context.stdmode,
             ),

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -222,8 +222,8 @@ class AccessPolicyCommand(
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,
                     schema_object_context=self.get_schema_metaclass(),
-                    anchors={qlast.Subject().name: source},
-                    path_prefix_anchor=qlast.Subject().name,
+                    anchors={'__subject__': source},
+                    path_prefix_anchor='__subject__',
                     singletons=frozenset({source}),
                     apply_query_rewrites=not context.stdmode,
                     track_schema_ref_exprs=track_schema_ref_exprs,

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -589,7 +589,8 @@ class CreateScalarType(
                     for x in (base.extra_args or ()):
                         if (
                             not isinstance(x, qlast.TypeExprLiteral)
-                            or not isinstance(x.val, qlast.IntegerConstant)
+                            or not isinstance(x.val, qlast.Constant)
+                            or x.val.kind != qlast.ConstantKind.INTEGER
                         ):
                             raise errors.SchemaDefinitionError(
                                 'invalid scalar type argument',
@@ -659,7 +660,7 @@ class CreateScalarType(
                     assert isinstance(node, qlast.BasedOnTuple)
                     node.bases[0].subtypes = [
                         qlast.TypeExprLiteral(
-                            val=downcast(qlast.BaseConstant, frag)
+                            val=downcast(qlast.Constant, frag)
                         )
                         for frag in frags
                     ]

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -1231,26 +1231,26 @@ MIN_INT64 = -2 ** 63
 
 def const_ast_from_python(val: Any) -> qlast.Expr:
     if isinstance(val, str):
-        return qlast.StringConstant.from_python(val)
+        return qlast.Constant.string(val)
     elif isinstance(val, bool):
-        return qlast.BooleanConstant(value='true' if val else 'false')
+        return qlast.Constant.boolean(val)
     elif isinstance(val, int):
         if MIN_INT64 <= val <= MAX_INT64:
-            return qlast.IntegerConstant(value=str(val))
+            return qlast.Constant.integer(val)
         else:
             raise ValueError(f'int64 value out of range: {val}')
     elif isinstance(val, decimal.Decimal):
-        return qlast.DecimalConstant(value=f'{val}n')
+        return qlast.Constant(value=f'{val}n', kind=qlast.ConstantKind.DECIMAL)
     elif isinstance(val, float):
-        return qlast.FloatConstant(value=str(val))
+        return qlast.Constant(value=str(val), kind=qlast.ConstantKind.FLOAT)
     elif isinstance(val, bytes):
-        return qlast.BytesConstant.from_python(val)
+        return qlast.BytesConstant(value=val)
     elif isinstance(val, statypes.Duration):
         return qlast.TypeCast(
             type=qlast.TypeName(
                 maintype=qlast.ObjectRef(module='__std__', name='duration'),
             ),
-            expr=qlast.StringConstant(value=val.to_iso8601()),
+            expr=qlast.Constant.string(value=val.to_iso8601()),
         )
     elif isinstance(val, statypes.CompositeType):
         return qlast.InsertQuery(

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1404,7 +1404,10 @@ def administer_vacuum(
                 f'unrecognized keyword argument {name!r} for vacuum()',
                 span=val.span,
             )
-        elif not isinstance(val, qlast.BooleanConstant):
+        elif (
+            not isinstance(val, qlast.Constant)
+            or val.kind != qlast.ConstantKind.BOOLEAN
+        ):
             raise errors.QueryError(
                 f'argument {name!r} for vacuum() must be a boolean literal',
                 span=val.span,

--- a/edb/tools/ast_inheritance_graph.py
+++ b/edb/tools/ast_inheritance_graph.py
@@ -1,0 +1,78 @@
+# Generates an inheritance graph of Python classes.
+#
+# Usage:
+# $ edb ast-inheritance-graph | fdp -T svg -o ast-fdp.svg
+#
+# Requirements:
+# - graphviz
+
+import typing
+import dataclasses
+import enum
+
+import click
+
+from edb.edgeql import ast as qlast
+from edb.ir import ast as irast
+from edb.pgsql import ast as pgast
+from edb.tools.edb import edbcommands
+
+
+class ASTModule(str, enum.Enum):
+    ql = "ql"
+    ir = "ir"
+    pg = "pg"
+
+
+@dataclasses.dataclass()
+class ASTClass:
+    name: str
+    typ: typing.Type
+
+
+@edbcommands.command("ast-inheritance-graph")
+@click.argument('ast', type=click.Choice(ASTModule))  # type: ignore
+def main(ast: ASTModule) -> None:
+    print('digraph G {')
+
+    ast_mod: typing.Any
+    if ast == ASTModule.ql:
+        ast_mod = qlast
+    elif ast == ASTModule.ir:
+        ast_mod = irast
+    elif ast == ASTModule.pg:
+        ast_mod = pgast
+    else:
+        raise AssertionError()
+
+    # discover all nodes
+    ast_classes: typing.Dict[str, ASTClass] = {}
+    for name, typ in ast_mod.__dict__.items():
+        if not isinstance(typ, type):
+            continue
+
+        if not issubclass(typ, ast_mod.Base) or name in {
+            'Base',
+            'ImmutableBase',
+        }:
+            continue
+
+        if typ.__abstract_node__:  # type: ignore
+            print(f'  {name} [color = red];')
+
+        if typ.__rust_ignore__:  # type: ignore
+            continue
+
+        # re-run field collection to correctly handle forward-references
+        typ = typ._collect_direct_fields()  # type: ignore
+
+        ast_classes[typ.__name__] = ASTClass(name=name, typ=typ)
+
+    # build inheritance graph
+    for ast_class in ast_classes.values():
+        for base in ast_class.typ.__bases__:
+            if base.__name__ not in ast_classes:
+                continue
+            print(f'  {ast_class.name} -> {base.__name__};')
+
+    print('}')

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -74,5 +74,6 @@ from . import wipe  # noqa
 from . import gen_test_dumps  # noqa
 from . import gen_sql_introspection  # noqa
 from . import gen_rust_ast  # noqa
+from . import ast_inheritance_graph  # noqa
 from . import parser_demo  # noqa
 from .profiling import cli as prof_cli  # noqa

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -990,27 +990,16 @@ def eval_Indirection(node: qlast.Indirection, ctx: EvalContext) -> Result:
 
 
 @_eval.register
-def eval_StringConstant(node: qlast.StringConstant, ctx: EvalContext) -> Result:
-    return [node.value]
-
-
-@_eval.register
-def eval_IntegerConstant(
-    node: qlast.IntegerConstant, ctx: EvalContext
-) -> Result:
-    return [int(node.value)]
-
-
-@_eval.register
-def eval_BooleanConstant(
-    node: qlast.BooleanConstant, ctx: EvalContext
-) -> Result:
-    return [node.value == 'true']
-
-
-@_eval.register
-def eval_FloatConstant(node: qlast.FloatConstant, ctx: EvalContext) -> Result:
-    return [float(node.value)]
+def eval_Constant(node: qlast.Constant, ctx: EvalContext) -> Result:
+    if node.kind == qlast.ConstantKind.STRING:
+        return [node.value]
+    elif node.kind == qlast.ConstantKind.INTEGER:
+        return [int(node.value)]
+    elif node.kind == qlast.ConstantKind.BOOLEAN:
+        return [node.value == 'true']
+    elif node.kind == qlast.ConstantKind.FLOAT:
+        return [float(node.value)]
+    raise AssertionError('unimplemented')
 
 
 @_eval.register

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -998,7 +998,7 @@ def eval_StringConstant(node: qlast.StringConstant, ctx: EvalContext) -> Result:
 def eval_IntegerConstant(
     node: qlast.IntegerConstant, ctx: EvalContext
 ) -> Result:
-    return [int(node.value) * (-1 if node.is_negative else 1)]
+    return [int(node.value)]
 
 
 @_eval.register
@@ -1010,7 +1010,7 @@ def eval_BooleanConstant(
 
 @_eval.register
 def eval_FloatConstant(node: qlast.FloatConstant, ctx: EvalContext) -> Result:
-    return [float(node.value) * (-1 if node.is_negative else 1)]
+    return [float(node.value)]
 
 
 @_eval.register


### PR DESCRIPTION
This PR refactors QL AST to make it more "flat": such that there each node is either inheriting from an abstract node, or is abstract itself.

This is fully accomplished from the "expression" part of the AST. The "DDL" and "SDL" part is still left to do.

- Refactor qlast.SpecialAnchor to also include subject and source
- Refactor out SetConstructorOp
- Refactor our qlast.BaseRealConstant
- Refactor out PipelinedQuery
- Mark TypeExpr abstract
- gen-ast-inheritance
