### PR TITLE
Add cfg::Config._query_cache_mode

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_04_02_00_00
+EDGEDB_CATALOG_VERSION = 2024_04_04_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import builtins
 import contextlib
-import platform
 import os
 import sys
 import time
@@ -180,19 +179,6 @@ class flags(metaclass=FlagsMeta):
     )
 
     zombodb = Flag(doc="Enabled zombodb and disables postgres FTS")
-
-    disable_persistent_cache = Flag(
-        doc="Don't use persistent cache",
-        # Persistent cache disabled for now by default on arm64 linux
-        # because of observed problems in CI test runs.
-        default=(
-            platform.system() == 'Linux'
-            and platform.machine() == 'arm64'
-        ),
-    )
-
-    # Function cache is an experimental feature that may not fully work
-    func_cache = Flag(doc="Use stored functions for persistent cache")
 
 
 @contextlib.contextmanager

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -194,7 +194,7 @@ ALTER TYPE cfg::AbstractConfig {
             'Recompile all cached queries on DDL if enabled.';
     };
 
-    CREATE PROPERTY _query_cache_mode -> cfg::QueryCacheMode {
+    CREATE PROPERTY query_cache_mode -> cfg::QueryCacheMode {
         SET default := cfg::QueryCacheMode.Default;
         CREATE ANNOTATION cfg::affects_compilation := 'true';
         CREATE ANNOTATION std::description :=

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -40,6 +40,8 @@ CREATE SCALAR TYPE cfg::memory EXTENDING std::anyscalar;
 CREATE SCALAR TYPE cfg::AllowBareDDL EXTENDING enum<AlwaysAllow, NeverAllow>;
 CREATE SCALAR TYPE cfg::ConnectionTransport EXTENDING enum<
     TCP, TCP_PG, HTTP, SIMPLE_HTTP, HTTP_METRICS, HTTP_HEALTH>;
+CREATE SCALAR TYPE cfg::QueryCacheMode EXTENDING enum<
+    InMemory, RegInline, PgFunc, Default>;
 
 CREATE ABSTRACT TYPE cfg::ConfigObject EXTENDING std::BaseObject;
 
@@ -190,6 +192,13 @@ ALTER TYPE cfg::AbstractConfig {
         SET default := true;
         CREATE ANNOTATION std::description :=
             'Recompile all cached queries on DDL if enabled.';
+    };
+
+    CREATE PROPERTY _query_cache_mode -> cfg::QueryCacheMode {
+        SET default := cfg::QueryCacheMode.Default;
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION std::description :=
+            'Where the query cache is finally stored';
     };
 
     # Exposed backend settings follow.

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -141,8 +141,12 @@ class CompileContext:
     log_ddl_as_migrations: bool = True
     dump_restore_mode: bool = False
     notebook: bool = False
-    persistent_cache: bool = False
     cache_key: Optional[uuid.UUID] = None
+
+    def get_cache_mode(self) -> config.QueryCacheMode:
+        return config.QueryCacheMode.effective(
+            _get_config_val(self, '_query_cache_mode')
+        )
 
     def _assert_not_in_migration_block(self, ql: qlast.Base) -> None:
         """Check that a START MIGRATION block is *not* active."""
@@ -862,7 +866,6 @@ class Compiler:
             request.protocol_version,
             request.inline_objectids,
             request.json_parameters,
-            persistent_cache=not debug.flags.disable_persistent_cache,
             cache_key=request.get_cache_key(),
         )
         return units, cstate
@@ -885,7 +888,6 @@ class Compiler:
         protocol_version: defines.ProtocolVersion,
         inline_objectids: bool = True,
         json_parameters: bool = False,
-        persistent_cache: bool = False,
         cache_key: Optional[uuid.UUID] = None,
     ) -> Tuple[dbstate.QueryUnitGroup,
                Optional[dbstate.CompilerConnectionState]]:
@@ -924,7 +926,6 @@ class Compiler:
             json_parameters=json_parameters,
             source=source,
             protocol_version=protocol_version,
-            persistent_cache=persistent_cache,
             cache_key=cache_key,
         )
 
@@ -968,7 +969,6 @@ class Compiler:
             request.inline_objectids,
             request.json_parameters,
             expect_rollback=expect_rollback,
-            persistent_cache=not debug.flags.disable_persistent_cache,
             cache_key=request.get_cache_key(),
         )
         return units, cstate
@@ -987,7 +987,6 @@ class Compiler:
         inline_objectids: bool = True,
         json_parameters: bool = False,
         expect_rollback: bool = False,
-        persistent_cache: bool = False,
         cache_key: Optional[uuid.UUID] = None,
     ) -> Tuple[dbstate.QueryUnitGroup, dbstate.CompilerConnectionState]:
         if (
@@ -1014,7 +1013,6 @@ class Compiler:
             protocol_version=protocol_version,
             json_parameters=json_parameters,
             expect_rollback=expect_rollback,
-            persistent_cache=persistent_cache,
             cache_key=cache_key,
         )
 
@@ -1835,12 +1833,12 @@ def _compile_ql_query(
     # This low-hanging-fruit is temporary; persistent cache should cover all
     # cacheable cases properly in future changes.
     use_persistent_cache = (
-        ctx.persistent_cache
-        and cacheable
+        cacheable
         and not ctx.bootstrap_mode
         and script_info is None
         and ctx.cache_key is not None
     )
+    cache_mode = ctx.get_cache_mode()
 
     sql_res = pg_compiler.compile_ir_to_sql_tree(
         ir,
@@ -1848,17 +1846,19 @@ def _compile_ql_query(
         output_format=_convert_format(ctx.output_format),
         backend_runtime_params=ctx.backend_runtime_params,
         expand_inhviews=options.expand_inhviews,
-        detach_params=bool(use_persistent_cache and debug.flags.func_cache),
+        detach_params=(use_persistent_cache
+                       and cache_mode is config.QueryCacheMode.PgFunc),
     )
 
     pg_debug.dump_ast_and_query(sql_res.ast, ir)
 
-    if use_persistent_cache:
-        if debug.flags.func_cache:
-            cache_sql, sql_ast = _build_cache_function(ctx, ir, sql_res)
-        else:
-            sql_ast = sql_res.ast
-            cache_sql = (b"", b"")
+    if use_persistent_cache and cache_mode is config.QueryCacheMode.PgFunc:
+        cache_sql, sql_ast = _build_cache_function(ctx, ir, sql_res)
+    elif (
+        use_persistent_cache and cache_mode is config.QueryCacheMode.RegInline
+    ):
+        sql_ast = sql_res.ast
+        cache_sql = (b"", b"")
     else:
         sql_ast = sql_res.ast
         cache_sql = None

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -145,7 +145,7 @@ class CompileContext:
 
     def get_cache_mode(self) -> config.QueryCacheMode:
         return config.QueryCacheMode.effective(
-            _get_config_val(self, '_query_cache_mode')
+            _get_config_val(self, 'query_cache_mode')
         )
 
     def _assert_not_in_migration_block(self, ql: qlast.Base) -> None:

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -34,6 +34,7 @@ from .spec import (
     load_ext_settings_from_schema,
 )
 from .types import ConfigType, CompositeConfigType
+from .types import QueryCacheMode
 
 
 __all__ = (
@@ -47,6 +48,7 @@ __all__ = (
     'load_ext_settings_from_schema',
     'get_compilation_config',
     'coerce_single_value',
+    'QueryCacheMode',
 )
 
 

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -869,9 +869,9 @@ class Tenant(ha_base.ClusterProtocol):
 
         assert self._dbindex is not None
         if db := self._dbindex.maybe_get_db(dbname):
-            cache_mode_val = db.lookup_config('_query_cache_mode')
+            cache_mode_val = db.lookup_config('query_cache_mode')
         else:
-            cache_mode_val = self._dbindex.lookup_config('_query_cache_mode')
+            cache_mode_val = self._dbindex.lookup_config('query_cache_mode')
         old_cache_mode = config.QueryCacheMode.effective(cache_mode_val)
 
         conn = await self._acquire_intro_pgcon(dbname)
@@ -948,7 +948,7 @@ class Tenant(ha_base.ClusterProtocol):
             parsed_db.state_serializer,
         )
         cache_mode = config.QueryCacheMode.effective(
-            db.lookup_config('_query_cache_mode')
+            db.lookup_config('query_cache_mode')
         )
         if query_cache and cache_mode is not config.QueryCacheMode.InMemory:
             db.hydrate_cache(query_cache)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -848,9 +848,7 @@ class Tenant(ha_base.ClusterProtocol):
 
         return extensions
 
-    async def introspect_db(
-        self, dbname: str, hydrate_cache: bool = False
-    ) -> None:
+    async def introspect_db(self, dbname: str) -> bool:
         """Use this method to (re-)introspect a DB.
 
         If the DB is already registered in self._dbindex, its
@@ -864,12 +862,21 @@ class Tenant(ha_base.ClusterProtocol):
         dropped and recreated again. It's safer to refresh the entire state
         than refreshing individual components of it. Besides, DDL and
         database-level config modifications are supposed to be rare events.
+
+        Returns True if the query cache mode changed.
         """
         logger.info("introspecting database '%s'", dbname)
 
+        assert self._dbindex is not None
+        if db := self._dbindex.maybe_get_db(dbname):
+            cache_mode_val = db.lookup_config('_query_cache_mode')
+        else:
+            cache_mode_val = self._dbindex.lookup_config('_query_cache_mode')
+        old_cache_mode = config.QueryCacheMode.effective(cache_mode_val)
+
         conn = await self._acquire_intro_pgcon(dbname)
         if not conn:
-            return
+            return False
 
         try:
             user_schema_json = (
@@ -917,7 +924,7 @@ class Tenant(ha_base.ClusterProtocol):
             extensions = await self._introspect_extensions(conn)
 
             query_cache: list[tuple[bytes, ...]] | None = None
-            if hydrate_cache:
+            if old_cache_mode is not config.QueryCacheMode.InMemory:
                 query_cache = await self._load_query_cache(conn)
         finally:
             self.release_pgcon(dbname, conn)
@@ -926,7 +933,6 @@ class Tenant(ha_base.ClusterProtocol):
         parsed_db = await compiler_pool.parse_user_schema_db_config(
             user_schema_json, db_config_json, self.get_global_schema_pickle()
         )
-        assert self._dbindex is not None
         db = self._dbindex.register_db(
             dbname,
             user_schema_pickle=parsed_db.user_schema_pickle,
@@ -941,8 +947,12 @@ class Tenant(ha_base.ClusterProtocol):
             parsed_db.protocol_version,
             parsed_db.state_serializer,
         )
-        if query_cache:
+        cache_mode = config.QueryCacheMode.effective(
+            db.lookup_config('_query_cache_mode')
+        )
+        if query_cache and cache_mode is not config.QueryCacheMode.InMemory:
             db.hydrate_cache(query_cache)
+        return old_cache_mode is not cache_mode
 
     async def _early_introspect_db(self, dbname: str) -> None:
         """We need to always introspect the extensions for each database.
@@ -1436,7 +1446,16 @@ class Tenant(ha_base.ClusterProtocol):
         # of the DB and update all components of it.
         async def task():
             try:
-                await self.introspect_db(dbname)
+                if await self.introspect_db(dbname):
+                    logger.info(
+                        "clearing query cache for database '%s'", dbname)
+                    conn = await self.acquire_pgcon(dbname)
+                    try:
+                        await conn.sql_execute(
+                            b'SELECT edgedb._clear_query_cache()')
+                        self._dbindex.get_db(dbname).clear_query_cache()
+                    finally:
+                        self.release_pgcon(dbname, conn)
             except Exception:
                 metrics.background_errors.inc(
                     1.0, self._instance_name, "on_local_database_config_change"


### PR DESCRIPTION
Now users may control the cache mode per statement or database. Changing the effective mode on a database will clear its cache registration table.

Fixes #7102, replaces #7122