### PR TITLE
Fix missing span when overloading fields with mismatch type

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -141,7 +141,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                     ignore_local=ignore_local_field,
                     schema=schema,
                 )
-            except errors.SchemaDefinitionError as e:
+            except (errors.SchemaDefinitionError, errors.SchemaError) as e:
                 if (span := self.get_attribute_span(field_name)):
                     e.set_span(span)
                 raise

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -206,6 +206,21 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """
 
+    @tb.must_fail(errors.SchemaError,
+                  "cannot redefine property 'name' of object type "
+                  "'test::UniqueName_2' as scalar type 'std::bytes'",
+                  position=196)
+    def test_schema_overloaded_prop_11(self):
+        """
+            type UniqueName {
+                property name -> str;
+            };
+
+            type UniqueName_2 extending UniqueName {
+                overloaded property name -> bytes;
+            };
+        """
+
     @tb.must_fail(errors.SchemaDefinitionError,
                   "it is illegal for the computed link 'foo' "
                   "of object type 'test::UniqueName_2' to overload "


### PR DESCRIPTION
An overloaded field may raise either `SchemaDefinitionError` or `SchemaError` when the cardinality or target type mismatches its base. In case of type mismatch, the `SchemaError` is not patched with the corresponding span with error, leading to an error without source indication, like:

```
$ edgedb migration create
edgedb error: SchemaError: cannot redefine property 'v' of object type 'default::B' as scalar type 'std::bool'
  Detail: property 'v' is defined as scalar type 'std::str' in parent object type 'default::A'
edgedb error: cannot proceed until .esdl files are fixed
```

For schema:

```esdl
type A {
  required v: str;
}

type B extending A {
  overloaded v: bool;  # added this line
}
```

With this PR:

```
error: cannot redefine property 'v' of object type 'default::B' as scalar type 'std::bool'
  ┌─ dbschema/default.esdl:6:17
  │
8 │   overloaded v: bool;
  │                 ^^^^ error
  │
  = property 'v' is defined as scalar type 'std::str' in parent object type 'default::A'

edgedb error: cannot proceed until .esdl files are fixed
```

The added test covers this fix with the `position` assertion.