### PR TITLE
Refactor to add type annotations for s_expr.Expression

### DIFF
--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -42,6 +42,7 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
 from edb.schema import utils as s_utils
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 
@@ -329,7 +330,9 @@ def _enforce_pointer_constraints(
             sctx.anchors = ctx.anchors.copy()
             sctx.anchors[qlast.Subject().name] = expr
 
-            final_expr = constraint.get_finalexpr(ctx.env.schema)
+            final_expr: Optional[s_expr.Expression] = (
+                constraint.get_finalexpr(ctx.env.schema)
+            )
             assert final_expr is not None and final_expr.qlast is not None
             ir = dispatch.compile(final_expr.qlast, ctx=sctx)
 

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -44,6 +44,7 @@ from edb.schema import pseudo as s_pseudo
 from edb.schema import scalars as s_scalars
 from edb.schema import types as s_types
 from edb.schema import utils as s_utils
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import utils
@@ -585,7 +586,7 @@ def compile_GlobalExpr(
 
         return target
 
-    default = glob.get_default(ctx.env.schema)
+    default: Optional[s_expr.Expression] = glob.get_default(ctx.env.schema)
 
     # If we are compiling with globals suppressed but still allowed, always
     # treat it as being empty.

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -31,6 +31,7 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import policies as s_policies
 from edb.schema import schema as s_schema
 from edb.schema import types as s_types
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -127,13 +128,14 @@ def compile_pol(
     """
     schema = ctx.env.schema
 
-    expr_field = pol.get_expr(schema)
+    expr_field: Optional[s_expr.Expression] = pol.get_expr(schema)
     if expr_field:
         expr = expr_field.qlast
     else:
         expr = qlast.BooleanConstant(value='true')
 
     if condition := pol.get_condition(schema):
+        assert isinstance(condition, s_expr.Expression)
         expr = qlast.BinOp(op='AND', left=condition.qlast, right=expr)
 
     # Find all descendants of the original subject of the rule

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -46,6 +46,7 @@ from edb.schema import functions as s_func
 from edb.schema import name as sn
 from edb.schema import types as s_types
 from edb.schema import pseudo as s_pseudo
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
@@ -486,7 +487,9 @@ def try_bind_call_args(
                 defaults_mask |= 1 << i
 
                 if not has_inlined_defaults:
-                    param_default = param.get_default(schema)
+                    param_default: Optional[s_expr.Expression] = (
+                        param.get_default(schema)
+                    )
                     assert param_default is not None
                     default = compile_arg(
                         param_default.qlast, param_typemod, ctx=ctx)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -65,6 +65,7 @@ from edb.schema import scalars as s_scalars
 from edb.schema import sources as s_sources
 from edb.schema import types as s_types
 from edb.schema import utils as s_utils
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -1536,7 +1537,7 @@ def computable_ptr_set(
         inner_source_path_id = comp_info.path_id
         path_id_ns = comp_info.path_id_ns
     except KeyError:
-        comp_expr = ptrcls.get_expr(ctx.env.schema)
+        comp_expr: Optional[s_expr.Expression] = ptrcls.get_expr(ctx.env.schema)
         schema_qlexpr: Optional[qlast.Expr] = None
         if comp_expr is None and ctx.env.options.apply_query_rewrites:
             assert isinstance(ptrcls, s_pointers.Pointer)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -49,6 +49,7 @@ from edb.schema import rewrites as s_rewrites
 from edb.schema import schema as s_schema
 from edb.schema import sources as s_sources
 from edb.schema import types as s_types
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 
@@ -770,7 +771,7 @@ def _declare_view_from_schema(
     with ctx.detached() as subctx:
         subctx.current_schema_views += (viewcls,)
         subctx.expr_exposed = context.Exposure.UNEXPOSED
-        view_expr = viewcls.get_expr(ctx.env.schema)
+        view_expr: s_expr.Expression | None = viewcls.get_expr(ctx.env.schema)
         assert view_expr is not None
         view_ql = view_expr.qlast
         viewcls_name = viewcls.get_name(ctx.env.schema)

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -32,6 +32,7 @@ from edb.schema import name as sn
 from edb.schema import objtypes as s_objtypes
 from edb.schema import triggers as s_triggers
 from edb.schema import types as s_types
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -99,11 +100,13 @@ def compile_trigger(
                 sctx.iterator_path_ids |= {ir.path_id}
             sctx.anchors[name] = ir
 
-        trigger_ast = trigger.get_expr(schema).qlast
+        trigger_expr: Optional[s_expr.Expression] = trigger.get_expr(schema)
+        assert trigger_expr
+        trigger_ast = trigger_expr.qlast
 
         # A conditional trigger desugars to a FOR query that puts the
         # condition in the FILTER of a trivial SELECT.
-        condition = trigger.get_condition(schema)
+        condition: Optional[s_expr.Expression] = trigger.get_condition(schema)
         if condition:
             trigger_ast = qlast.ForQuery(
                 iterator_alias='__',

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -60,6 +60,7 @@ from edb.schema import objects as s_objects
 from edb.schema import pointers as s_pointers
 from edb.schema import properties as s_props
 from edb.schema import types as s_types
+from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -767,7 +768,9 @@ def _gen_pointers_from_defaults(
         ):
             continue
 
-        default_expr = ptrcls.get_default(ctx.env.schema)
+        default_expr: Optional[s_expr.Expression] = (
+            ptrcls.get_default(ctx.env.schema)
+        )
         if not default_expr:
             continue
 
@@ -1105,7 +1108,9 @@ def _compile_rewrites_for_stype(
 
         anchors = get_anchors(stype)
 
-        rewrite_expr = rewrite.get_expr(ctx.env.schema)
+        rewrite_expr: Optional[s_expr.Expression] = (
+            rewrite.get_expr(ctx.env.schema)
+        )
         assert rewrite_expr
 
         with ctx.newscope(fenced=True) as scopectx:

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -42,6 +42,7 @@ from edb.schema import types as s_types
 from edb.schema import constraints as s_constraints
 from edb.schema import schema as s_schema
 from edb.schema import sources as s_sources
+from edb.schema import expr as s_expr
 
 from edb.common import ast
 from edb.common import parsing
@@ -257,7 +258,7 @@ def compile_constraint(
         type_remaps={first_subject: subject},
     )
 
-    final_expr = constraint.get_finalexpr(schema)
+    final_expr: Optional[s_expr.Expression] = constraint.get_finalexpr(schema)
     assert final_expr is not None and final_expr.qlast is not None
     ir = qlcompiler.compile_ast_to_ir(
         final_expr.qlast,
@@ -269,6 +270,7 @@ def compile_constraint(
 
     except_data = None
     if except_expr := constraint.get_except_expr(schema):
+        assert isinstance(except_expr, s_expr.Expression)
         except_ir = qlcompiler.compile_ast_to_ir(
             except_expr.qlast,
             schema,
@@ -364,6 +366,7 @@ def compile_constraint(
 
         origin_except_data = None
         if except_expr := constraint_origin.get_except_expr(schema):
+            assert isinstance(except_expr, s_expr.Expression)
             except_ir = qlcompiler.compile_ast_to_ir(
                 except_expr.qlast,
                 schema,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2435,13 +2435,19 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                     )
                 ):
                     ddl_id = self.get_ddl_identity(field.name)
+                    attr_val: Any
                     if issubclass(field.type, s_expr.Expression):
+                        assert isinstance(ddl_id, s_expr.Expression)
                         attr_val = ddl_id.qlast
                     elif issubclass(field.type, s_expr.ExpressionList):
+                        assert isinstance(ddl_id, s_expr.ExpressionList)
                         attr_val = [e.qlast for e in ddl_id]
                     elif issubclass(field.type, s_expr.ExpressionDict):
-                        attr_val = {name: e.qlast
-                                    for name, e in ddl_id.items()}
+                        assert isinstance(ddl_id, s_expr.ExpressionDict)
+                        attr_val = {
+                            name: e.qlast
+                            for name, e in ddl_id.items()
+                        }
                     else:
                         raise AssertionError(
                             f'unexpected type of ddl_identity'

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1171,7 +1171,7 @@ class CreateCallableObject(
                 continue
 
             num: int = props['num']
-            default = props.get('default')
+            default: Optional[s_expr.Expression] = props.get('default')
             param = make_func_param(
                 name=Parameter.paramname_from_fullname(props['name']),
                 type=utils.typeref_to_ast(schema, props['type']),

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -589,12 +589,15 @@ class SetGlobalType(
         else:
             assert isinstance(set_field, qlast.SetField)
             assert not isinstance(set_field.value, qlast.Expr)
+
+            case_expr = None
+            if self.cast_expr:
+                assert isinstance(self.cast_expr, s_expr.Expression)
+                case_expr = self.cast_expr.qlast
+
             return qlast.SetGlobalType(
                 value=set_field.value,
-                cast_expr=(
-                    cast(s_expr.Expression, self.cast_expr).qlast
-                    if self.cast_expr is not None else None
-                ),
+                cast_expr=case_expr,
                 reset_value=self.reset_value,
             )
 

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -356,7 +356,9 @@ class CreateGlobal(
         assert isinstance(node, qlast.CreateGlobal)
         if op.property == 'target':
             if not node.target:
-                expr = self.get_attribute_value('expr')
+                expr: Optional[s_expr.Expression] = (
+                    self.get_attribute_value('expr')
+                )
                 if expr is not None:
                     node.target = expr.qlast
                 else:
@@ -587,6 +589,7 @@ class SetGlobalType(
         else:
             assert isinstance(set_field, qlast.SetField)
             assert not isinstance(set_field.value, qlast.Expr)
+            assert isinstance(self.cast_expr, s_expr.Expression)
             return qlast.SetGlobalType(
                 value=set_field.value,
                 cast_expr=(

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Optional, Type, TYPE_CHECKING, cast
+from typing import Any, Optional, Type, TYPE_CHECKING
 
 from edb import errors
 

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Optional, Type, TYPE_CHECKING
+from typing import Any, Optional, Type, TYPE_CHECKING, cast
 
 from edb import errors
 
@@ -589,11 +589,10 @@ class SetGlobalType(
         else:
             assert isinstance(set_field, qlast.SetField)
             assert not isinstance(set_field.value, qlast.Expr)
-            assert isinstance(self.cast_expr, s_expr.Expression)
             return qlast.SetGlobalType(
                 value=set_field.value,
                 cast_expr=(
-                    self.cast_expr.qlast
+                    cast(s_expr.Expression, self.cast_expr).qlast
                     if self.cast_expr is not None else None
                 ),
                 reset_value=self.reset_value,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -25,6 +25,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    Mapping,
     Dict,
     List,
     cast,
@@ -692,10 +693,12 @@ class IndexCommand(
     ) -> Optional[qlast.DDLOperation]:
         astnode = super()._get_ast(schema, context, parent_node=parent_node)
 
-        kwargs = self.get_resolved_attribute_value(
-            'kwargs',
-            schema=schema,
-            context=context,
+        kwargs: Optional[Mapping[str, s_expr.Expression]] = (
+            self.get_resolved_attribute_value(
+                'kwargs',
+                schema=schema,
+                context=context,
+            )
         )
         if kwargs:
             assert isinstance(astnode, (qlast.CreateIndex,
@@ -965,7 +968,7 @@ class CreateIndex(
         assert expr is not None
         expr_ql = edgeql.parse_fragment(expr.text)
 
-        except_expr = parent.get_except_expr(schema)
+        except_expr: s_expr.Expression | None = parent.get_except_expr(schema)
         if except_expr:
             except_expr_ql = except_expr.qlast
         else:
@@ -1283,6 +1286,8 @@ class AlterIndex(
             not self.get_attribute_value('abstract')
             and (indexexpr := self.get_attribute_value('expr')) is not None
         ):
+            assert isinstance(indexexpr, s_expr.Expression)
+
             # To compute the new name, we construct an AST of the
             # index, since that is the infrastructure we have for
             # computing the classname.

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -40,6 +40,7 @@ from . import sources
 from . import types as s_types
 from . import unknown_pointers
 from . import utils
+from . import expr as s_expr
 
 if TYPE_CHECKING:
     from . import objtypes as s_objtypes
@@ -392,7 +393,9 @@ class CreateLink(
             # AlterConcreteLink, which requires different handling.
             if isinstance(node, qlast.CreateConcreteLink):
                 if not node.target:
-                    expr = self.get_attribute_value('expr')
+                    expr: Optional[s_expr.Expression] = (
+                        self.get_attribute_value('expr')
+                    )
                     if expr is not None:
                         node.target = expr.qlast
                     else:

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1194,6 +1194,7 @@ class PointerCommandOrFragment(
             schema, inf_target_ref = self._parse_computable(
                 target_ref.expr, schema, context)
         elif (expr := self.get_local_attribute_value('expr')) is not None:
+            assert isinstance(expr, s_expr.Expression)
             schema = s_types.materialize_type_in_attribute(
                 schema, context, self, 'target')
             schema, inf_target_ref = self._parse_computable(

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -38,6 +38,7 @@ from . import rewrites as s_rewrites
 from . import sources
 from . import types as s_types
 from . import utils
+from . import expr as s_expr
 
 if TYPE_CHECKING:
     from . import schema as s_schema
@@ -342,7 +343,9 @@ class CreateProperty(
 
         if op.property == 'target' and link:
             if isinstance(node, qlast.CreateConcreteProperty):
-                expr = self.get_attribute_value('expr')
+                expr: Optional[s_expr.Expression] = (
+                    self.get_attribute_value('expr')
+                )
                 if expr is not None:
                     node.target = expr.qlast
                 else:


### PR DESCRIPTION
In cases where we use field getter on schema objects, we have a custom mypy extension that figures out the type of the field. This does not work with Pylance unfortunately, so I went around and added type annotations.

```diff
- expr = pointer.get_expr(schema)
+ expr: Optional[s_expr.Expression] = pointer.get_expr(schema)
```