### PR TITLE
Refactor schema.Expression.qlast to parse()

### DIFF
--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -333,8 +333,8 @@ def _enforce_pointer_constraints(
             final_expr: Optional[s_expr.Expression] = (
                 constraint.get_finalexpr(ctx.env.schema)
             )
-            assert final_expr is not None and final_expr.qlast is not None
-            ir = dispatch.compile(final_expr.qlast, ctx=sctx)
+            assert final_expr is not None and final_expr.parse() is not None
+            ir = dispatch.compile(final_expr.parse(), ctx=sctx)
 
         result = ireval.evaluate(ir, schema=ctx.env.schema)
         assert isinstance(result, irast.BooleanConstant)

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -593,7 +593,7 @@ def compile_GlobalExpr(
     # treat it as being empty.
     if ctx.env.options.make_globals_empty:
         if default:
-            return dispatch.compile(default.qlast, ctx=ctx)
+            return dispatch.compile(default.parse(), ctx=ctx)
         else:
             return setgen.new_empty_set(
                 stype=glob.get_target(ctx.env.schema), ctx=ctx)
@@ -625,7 +625,7 @@ def compile_GlobalExpr(
             main_param = subctx.maybe_create_anchor(param_set, 'glob')
             param_set = func.compile_operator(
                 expr, op_name='std::??',
-                qlargs=[main_param, default.qlast], ctx=subctx)
+                qlargs=[main_param, default.parse()], ctx=subctx)
     elif default and present_set:
         # ... but if {} is a valid value for the global, we need to
         # stick in an extra parameter to indicate whether to use
@@ -638,7 +638,7 @@ def compile_GlobalExpr(
 
             param_set = func.compile_operator(
                 expr, op_name='std::IF',
-                qlargs=[main_param, present_param, default.qlast], ctx=subctx)
+                qlargs=[main_param, present_param, default.parse()], ctx=subctx)
     elif not isinstance(param_set, irast.Set):
         param_set = dispatch.compile(param_set, ctx=ctx)
 

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -130,13 +130,13 @@ def compile_pol(
 
     expr_field: Optional[s_expr.Expression] = pol.get_expr(schema)
     if expr_field:
-        expr = expr_field.qlast
+        expr = expr_field.parse()
     else:
         expr = qlast.Constant.boolean(True)
 
     if condition := pol.get_condition(schema):
         assert isinstance(condition, s_expr.Expression)
-        expr = qlast.BinOp(op='AND', left=condition.qlast, right=expr)
+        expr = qlast.BinOp(op='AND', left=condition.parse(), right=expr)
 
     # Find all descendants of the original subject of the rule
     subject = pol.get_original_subject(schema)

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -492,7 +492,7 @@ def try_bind_call_args(
                     )
                     assert param_default is not None
                     default = compile_arg(
-                        param_default.qlast, param_typemod, ctx=ctx)
+                        param_default.parse(), param_typemod, ctx=ctx)
 
                 empty_default = (
                     has_inlined_defaults or

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1600,7 +1600,7 @@ def computable_ptr_set(
                 raise errors.InternalServerError(
                     f'{ptrcls_sn!r} is not a computed pointer')
 
-            comp_qlexpr = comp_expr.qlast
+            comp_qlexpr = comp_expr.parse()
             assert isinstance(comp_qlexpr, qlast.Expr), 'expected qlast.Expr'
             schema_qlexpr = comp_qlexpr
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -773,7 +773,7 @@ def _declare_view_from_schema(
         subctx.expr_exposed = context.Exposure.UNEXPOSED
         view_expr: s_expr.Expression | None = viewcls.get_expr(ctx.env.schema)
         assert view_expr is not None
-        view_ql = view_expr.qlast
+        view_ql = view_expr.parse()
         viewcls_name = viewcls.get_name(ctx.env.schema)
         assert isinstance(view_ql, qlast.Expr), 'expected qlast.Expr'
         view_set = declare_view(view_ql, alias=viewcls_name,

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -102,7 +102,7 @@ def compile_trigger(
 
         trigger_expr: Optional[s_expr.Expression] = trigger.get_expr(schema)
         assert trigger_expr
-        trigger_ast = trigger_expr.qlast
+        trigger_ast = trigger_expr.parse()
 
         # A conditional trigger desugars to a FOR query that puts the
         # condition in the FILTER of a trivial SELECT.
@@ -112,7 +112,7 @@ def compile_trigger(
                 iterator_alias='__',
                 iterator=qlast.SelectQuery(
                     result=qlast.Tuple(elements=[]),
-                    where=condition.qlast,
+                    where=condition.parse(),
                 ),
                 result=trigger_ast,
             )

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -780,7 +780,7 @@ def _gen_pointers_from_defaults(
                 steps=[qlast.Ptr(name=ptrcls_sn.name)],
             ),
             compexpr=qlast.DetachedExpr(
-                expr=default_expr.qlast,
+                expr=default_expr.parse(),
                 preserve_path_prefix=True,
             ),
             origin=qlast.ShapeOrigin.DEFAULT,
@@ -1147,7 +1147,7 @@ def _compile_rewrites_for_stype(
                     steps=[qlast.Ptr(name=ptrcls_sn.name)],
                 ),
                 compexpr=qlast.DetachedExpr(
-                    expr=rewrite_expr.qlast,
+                    expr=rewrite_expr.parse(),
                     preserve_path_prefix=True,
                 ),
             )

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1229,7 +1229,7 @@ class FunctionCommand(MetaCommand):
             qlexpr = qlcompiler.astutils.ensure_ql_query(
                 ql_ast.TypeCast(
                     type=s_utils.typeref_to_ast(schema, return_type),
-                    expr=nativecode.qlast,
+                    expr=nativecode.parse(),
                 )
             )
             nativecode = self._compile_edgeql_function(
@@ -4827,7 +4827,7 @@ class PointerMetaCommand(
                 context,
                 s_expr.Expression.from_ast(
                     ql_ast.TypeCast(
-                        expr=conv_expr.qlast,
+                        expr=conv_expr.parse(),
                         type=s_utils.typeref_to_ast(schema, new_target),
                     ),
                     schema=orig_schema,

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -248,9 +248,9 @@ def compile_constraint(
     )
 
     final_expr: Optional[s_expr.Expression] = constraint.get_finalexpr(schema)
-    assert final_expr is not None and final_expr.qlast is not None
+    assert final_expr is not None and final_expr.parse() is not None
     ir = qlcompiler.compile_ast_to_ir(
-        final_expr.qlast,
+        final_expr.parse(),
         schema,
         options=options,
     )
@@ -261,7 +261,7 @@ def compile_constraint(
     if except_expr := constraint.get_except_expr(schema):
         assert isinstance(except_expr, s_expr.Expression)
         except_ir = qlcompiler.compile_ast_to_ir(
-            except_expr.qlast,
+            except_expr.parse(),
             schema,
             options=options,
         )
@@ -329,9 +329,9 @@ def compile_constraint(
         )
 
         final_expr = constraint_origin.get_finalexpr(schema)
-        assert final_expr is not None and final_expr.qlast is not None
+        assert final_expr is not None and final_expr.parse() is not None
         origin_ir = qlcompiler.compile_ast_to_ir(
-            final_expr.qlast,
+            final_expr.parse(),
             schema,
             options=origin_options,
         )
@@ -357,7 +357,7 @@ def compile_constraint(
         if except_expr := constraint_origin.get_except_expr(schema):
             assert isinstance(except_expr, s_expr.Expression)
             except_ir = qlcompiler.compile_ast_to_ir(
-                except_expr.qlast,
+                except_expr.parse(),
                 schema,
                 options=origin_options,
             )

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -284,7 +284,7 @@ class Constraint(
                 qlast.Path(steps=[qlast.ObjectRef(name=subject_name)]),
             ]
 
-            args_ql.extend(arg.qlast for arg in args)
+            args_ql.extend(arg.parse() for arg in args)
 
             constr_base: Constraint = schema.get(
                 self.get_name(schema), type=type(self))
@@ -522,7 +522,7 @@ class ConstraintCommand(
 
         except_expr: s_expr.Expression | None = parent.get_except_expr(schema)
         if except_expr:
-            except_expr_ql = except_expr.qlast
+            except_expr_ql = except_expr.parse()
         else:
             except_expr_ql = None
 
@@ -791,7 +791,7 @@ class ConstraintCommand(
             )
 
         if subjectexpr is not None:
-            subject_ql = subjectexpr.qlast
+            subject_ql = subjectexpr.parse()
             subject = subject_ql
         else:
             subject = subject_obj
@@ -830,7 +830,7 @@ class ConstraintCommand(
             args_ql: List[qlast.Base] = [
                 qlast.Path(steps=[qlast.SpecialAnchor(name='__subject__')]),
             ]
-            args_ql.extend(arg.qlast for arg in args)
+            args_ql.extend(arg.parse() for arg in args)
             args_map = qlutils.index_parameters(
                 args_ql,
                 parameters=constr_base.get_params(schema),
@@ -1340,7 +1340,7 @@ class CreateConstraint(
             assert isinstance(op.new_value, s_expr.ExpressionList)
             args = []
             for arg in op.new_value:
-                exprast = arg.qlast
+                exprast = arg.parse()
                 assert isinstance(exprast, qlast.Expr), "expected qlast.Expr"
                 args.append(exprast)
             node.args = args
@@ -1562,7 +1562,7 @@ class AlterConstraint(
             assert isinstance(name, sn.QualName), "expected qualified name"
             ast = qlast.CreateConcreteConstraint(
                 name=qlast.ObjectRef(name=name.name, module=name.module),
-                subjectexpr=subjectexpr.qlast,
+                subjectexpr=subjectexpr.parse(),
                 args=[],
             )
             quals = sn.quals_from_fullname(self.classname)
@@ -1603,7 +1603,7 @@ class DeleteConstraint(
         if op.property == 'args':
             assert isinstance(op.old_value, s_expr.ExpressionList)
             assert isinstance(node, qlast.DropConcreteConstraint)
-            node.args = [arg.qlast for arg in op.old_value]
+            node.args = [arg.parse() for arg in op.old_value]
             return
 
         super()._apply_field_ast(schema, context, node, op)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2079,7 +2079,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
 
         # say as_fragment=True as a hack to avoid renormalizing it
         out = s_expr.Expression.from_ast(
-            compiled.qlast, schema, modaliases={}, as_fragment=True)
+            compiled.parse(), schema, modaliases={}, as_fragment=True)
         return out
 
     def _propagate_if_expr_refs(
@@ -2438,14 +2438,14 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                     attr_val: Any
                     if issubclass(field.type, s_expr.Expression):
                         assert isinstance(ddl_id, s_expr.Expression)
-                        attr_val = ddl_id.qlast
+                        attr_val = ddl_id.parse()
                     elif issubclass(field.type, s_expr.ExpressionList):
                         assert isinstance(ddl_id, s_expr.ExpressionList)
-                        attr_val = [e.qlast for e in ddl_id]
+                        attr_val = [e.parse() for e in ddl_id]
                     elif issubclass(field.type, s_expr.ExpressionDict):
                         assert isinstance(ddl_id, s_expr.ExpressionDict)
                         attr_val = {
-                            name: e.qlast
+                            name: e.parse()
                             for name, e in ddl_id.items()
                         }
                     else:

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -112,8 +112,9 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             and self.origin == rhs.origin
         )
 
-    @property
-    def qlast(self) -> qlast_.Expr:
+    def parse(self) -> qlast_.Expr:
+        """Parse the expression text into an AST. Cached."""
+
         if self._qlast is None:
             self._qlast = qlparser.parse_fragment(
                 self.text, filename=f'<{self.origin}>' if self.origin else "")
@@ -216,12 +217,12 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
 
         if as_fragment:
             ir: irast_.Command = qlcompiler.compile_ast_fragment_to_ir(
-                self.qlast,
+                self.parse(),
                 schema=schema,
                 options=options,
             )
         else:
-            ql_expr = self.qlast
+            ql_expr = self.parse()
             if detached:
                 ql_expr = qlast.DetachedExpr(
                     expr=ql_expr,
@@ -242,7 +243,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         return CompiledExpression(
             text=self.text,
             refs=so.ObjectSet.create(schema, srefs),
-            _qlast=self.qlast,
+            _qlast=self.parse(),
             _irast=ir,
             origin=self.origin,
         )
@@ -277,7 +278,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         return CompiledExpression(
             text=expr.text,
             refs=so.ObjectSet.create(schema, ir.schema_refs),
-            _qlast=expr.qlast,
+            _qlast=expr.parse(),
             _irast=ir,
             origin=expr.origin,
         )
@@ -418,8 +419,7 @@ class ExpressionShell(so.Shell):
             _irast=self._irast,  # type: ignore[arg-type]
         )
 
-    @property
-    def qlast(self) -> qlast_.Expr:
+    def parse(self) -> qlast_.Expr:
         if self._qlast is None:
             self._qlast = qlparser.parse_fragment(self.text)
         return self._qlast

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -221,7 +221,7 @@ class AliasLikeCommand(
                 pschema = drop_old_types_cmd.apply(pschema, context)
 
         ir = compile_alias_expr(
-            expr.qlast,
+            expr.parse(),
             classname,
             pschema,
             context,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -485,7 +485,7 @@ class Parameter(
             type=utils.typeref_to_ast(schema, self.get_type(schema)),
             typemod=self.get_typemod(schema),
             kind=kind,
-            default=default.qlast if default else None,
+            default=default.parse() if default else None,
         )
 
 
@@ -1177,7 +1177,7 @@ class CreateCallableObject(
                 type=utils.typeref_to_ast(schema, props['type']),
                 typemod=props['typemod'],
                 kind=props['kind'],
-                default=default.qlast if default is not None else None,
+                default=default.parse() if default is not None else None,
             )
             params.append((num, param))
 
@@ -1681,7 +1681,7 @@ class FunctionCommand(
                     f'{str(spec_volatility).lower()}',
                     details=f'Actual volatility is '
                             f'{str(ir.volatility).lower()}',
-                    span=body.qlast.span,
+                    span=body.parse().span,
                 )
 
         globs = {schema.get(glob.global_name, type=s_globals.Global)
@@ -2372,7 +2372,7 @@ def get_params_symtable(
                 right=qlast.Constant.integer(0),
             ),
             if_expr=anchors[p_shortname],
-            else_expr=qlast._Optional(expr=p_default.qlast),
+            else_expr=qlast._Optional(expr=p_default.parse()),
         )
 
     return anchors
@@ -2421,7 +2421,7 @@ def compile_function(
             f'{return_type.get_verbosename(schema)}',
             details=f'Actual return type is '
                     f'{ir.stype.get_verbosename(schema)}',
-            span=body.qlast.span,
+            span=body.parse().span,
         )
 
     if (return_typemod is not ft.TypeModifier.SetOfType
@@ -2432,7 +2432,7 @@ def compile_function(
             details=(
                 f'Function may return a set with more than one element.'
             ),
-            span=body.qlast.span,
+            span=body.parse().span,
         )
     elif (return_typemod is ft.TypeModifier.SingletonType
             and ir.cardinality.can_be_zero()):
@@ -2442,7 +2442,7 @@ def compile_function(
             details=(
                 f'Function may return an empty set.'
             ),
-            span=body.qlast.span,
+            span=body.parse().span,
         )
 
     return compiled

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -360,7 +360,7 @@ class CreateGlobal(
                     self.get_attribute_value('expr')
                 )
                 if expr is not None:
-                    node.target = expr.qlast
+                    node.target = expr.parse()
                 else:
                     t = op.new_value
                     assert isinstance(t, (so.Object, so.ObjectShell))
@@ -593,7 +593,7 @@ class SetGlobalType(
             case_expr = None
             if self.cast_expr:
                 assert isinstance(self.cast_expr, s_expr.Expression)
-                case_expr = self.cast_expr.qlast
+                case_expr = self.cast_expr.parse()
 
             return qlast.SetGlobalType(
                 value=set_field.value,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -710,7 +710,7 @@ class IndexCommand(
             assert isinstance(astnode, (qlast.CreateIndex,
                                         qlast.ConcreteIndexCommand))
             astnode.kwargs = {
-                name: expr.qlast for name, expr in kwargs.items()
+                name: expr.parse() for name, expr in kwargs.items()
             }
 
         return astnode
@@ -789,13 +789,13 @@ class IndexCommand(
                     f'possibly more than one element returned by '
                     f'the index expression where only singletons '
                     f'are allowed',
-                    span=value.qlast.span,
+                    span=value.parse().span,
                 )
 
             if expr.irast.volatility != qltypes.Volatility.Immutable:
                 raise errors.SchemaDefinitionError(
                     f'index expressions must be immutable',
-                    span=value.qlast.span,
+                    span=value.parse().span,
                 )
 
             refs = irutils.get_longest_paths(expr.irast)
@@ -1000,12 +1000,12 @@ class CreateIndex(
 
         except_expr: s_expr.Expression | None = parent.get_except_expr(schema)
         if except_expr:
-            except_expr_ql = except_expr.qlast
+            except_expr_ql = except_expr.parse()
         else:
             except_expr_ql = None
 
         qlkwargs = {
-            key: val.qlast for key, val in parent.get_kwargs(schema).items()
+            key: val.parse() for key, val in parent.get_kwargs(schema).items()
         }
 
         return astnode_cls(
@@ -1332,7 +1332,7 @@ class AlterIndex(
             assert isinstance(name, sn.QualName), "expected qualified name"
             ast = qlast.CreateConcreteIndex(
                 name=qlast.ObjectRef(name=name.name, module=name.module),
-                expr=indexexpr.qlast,
+                expr=indexexpr.parse(),
             )
             quals = sn.quals_from_fullname(self.classname)
             new_name = self._classname_from_ast_and_referrer(

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -397,7 +397,7 @@ class CreateLink(
                         self.get_attribute_value('expr')
                     )
                     if expr is not None:
-                        node.target = expr.qlast
+                        node.target = expr.parse()
                     else:
                         t = op.new_value
                         assert isinstance(t, (so.Object, so.ObjectShell))

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1198,7 +1198,7 @@ class PointerCommandOrFragment(
             schema = s_types.materialize_type_in_attribute(
                 schema, context, self, 'target')
             schema, inf_target_ref = self._parse_computable(
-                expr.qlast, schema, context)
+                expr.parse(), schema, context)
         else:
             inf_target_ref = None
 
@@ -1496,7 +1496,7 @@ class PointerCommandOrFragment(
             else:
                 singletons.append(self.scls)
 
-        with errors.ensure_span(span or expr.qlast.span):
+        with errors.ensure_span(span or expr.parse().span):
             options = qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,
                 schema_object_context=self.get_schema_metaclass(),
@@ -2597,7 +2597,7 @@ class SetPointerType(
             return qlast.SetPointerType(
                 value=set_field.value,
                 cast_expr=(
-                    self.cast_expr.qlast
+                    self.cast_expr.parse()
                     if self.cast_expr is not None else None
                 )
             )
@@ -2861,7 +2861,7 @@ class AlterPointerUpperCardinality(
             return qlast.SetPointerCardinality(
                 value=set_field.value,
                 conv_expr=(
-                    self.conv_expr.qlast
+                    self.conv_expr.parse()
                     if self.conv_expr is not None else None
                 )
             )
@@ -3086,7 +3086,7 @@ class AlterPointerLowerCardinality(
             return qlast.SetPointerOptionality(
                 value=value,
                 fill_expr=(
-                    self.fill_expr.qlast
+                    self.fill_expr.parse()
                     if self.fill_expr is not None else None
                 )
             )

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -347,7 +347,7 @@ class CreateProperty(
                     self.get_attribute_value('expr')
                 )
                 if expr is not None:
-                    node.target = expr.qlast
+                    node.target = expr.parse()
                 else:
                     ref = op.new_value
                     assert isinstance(ref, (so.Object, so.ObjectShell))

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -656,7 +656,7 @@ class CreateScalarType(
                 super()._apply_field_ast(schema, context, node, op)
                 if arg_values := self.get_local_attribute_value('arg_values'):
                     frags = [
-                        s_expr.Expression(text=x).qlast for x in arg_values]
+                        s_expr.Expression(text=x).parse() for x in arg_values]
                     assert isinstance(node, qlast.BasedOnTuple)
                     node.bases[0].subtypes = [
                         qlast.TypeExprLiteral(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2001,7 +2001,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
         obj = schema.get('test::Foo')
         asdf = obj.getptr(schema, s_name.UnqualName('asdf'))
-        expr_ast = asdf.get_expr(schema).qlast
+        expr_ast = asdf.get_expr(schema).parse()
         self.assertEqual(
             expr_ast.span.name,
             f'<{asdf.id} expr>'
@@ -2013,7 +2013,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """)
         x = obj.getptr(schema, s_name.UnqualName('x'))
-        default_ast = x.get_default(schema).qlast
+        default_ast = x.get_default(schema).parse()
         self.assertEqual(
             default_ast.span.name,
             f'<{x.id} default>'


### PR DESCRIPTION
I was surprised to learn that we don't store AST within the `s_expr.Expression`, because I was used to seeing `.qlast` on exprs.

That's why I'd avoid using `@property` and have the method be named `parse()` instead, with a comment saying that it is cached.

Based on #7166