### PR TITLE
Add rudimentary support for inline function calls

### DIFF
--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -220,6 +220,15 @@ def __infer_func_call(
     ir: irast.FunctionCall,
     env: context.Environment,
 ) -> InferredVolatility:
+    if ir.body is not None:
+        body_volatility = infer_volatility(ir.body, env=env)
+        if body_volatility > ir.volatility:
+            raise errors.QueryError(
+                f'inline function body expression is {body_volatility} '
+                f'while the function is declared as {ir.volatility}',
+                span=ir.span,
+            )
+
     if ir.args:
         return _max_volatility([
             _common_volatility((arg.expr for arg in ir.args), env),

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -935,6 +935,8 @@ class Call(ImmutableExpr):
     """Operator or a function call."""
     __abstract_node__ = True
 
+    __ast_mutable_fields__ = frozenset(('extras', 'body'))
+
     # Bound callable has polymorphic parameters and
     # a polymorphic return type.
     func_polymorphic: bool
@@ -980,6 +982,12 @@ class Call(ImmutableExpr):
     # to this function as a subquery-as-an-expression.
     # See comment in schema/functions.py for more discussion.
     prefer_subquery_args: bool = False
+
+    # Any extra information useful for compilation of special-case callables.
+    extras: typing.Optional[dict[str, typing.Any]] = None
+
+    # Inline body of the callable.
+    body: typing.Optional[Set] = None
 
 
 class FunctionCall(Call):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -935,8 +935,6 @@ class Call(ImmutableExpr):
     """Operator or a function call."""
     __abstract_node__ = True
 
-    __ast_mutable_fields__ = frozenset(('extras', 'body'))
-
     # Bound callable has polymorphic parameters and
     # a polymorphic return type.
     func_polymorphic: bool
@@ -983,14 +981,10 @@ class Call(ImmutableExpr):
     # See comment in schema/functions.py for more discussion.
     prefer_subquery_args: bool = False
 
-    # Any extra information useful for compilation of special-case callables.
-    extras: typing.Optional[dict[str, typing.Any]] = None
-
-    # Inline body of the callable.
-    body: typing.Optional[Set] = None
-
 
 class FunctionCall(Call):
+
+    __ast_mutable_fields__ = frozenset(('extras', 'body'))
 
     # If the bound callable is a "USING SQL" callable, this
     # attribute will be set to the name of the SQL function.
@@ -1027,6 +1021,12 @@ class FunctionCall(Call):
 
     # Additional arguments representing global variables
     global_args: typing.Optional[typing.List[Set]] = None
+
+    # Any extra information useful for compilation of special-case callables.
+    extras: typing.Optional[dict[str, typing.Any]] = None
+
+    # Inline body of the callable.
+    body: typing.Optional[Set] = None
 
 
 class OperatorCall(Call):

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -433,6 +433,10 @@ def compile_operator(
     lexpr = rexpr = None
     result: Optional[pgast.BaseExpr] = None
 
+    if expr.body is not None:
+        raise NotImplementedError(
+            "support for generic inline operator calls is not implemented")
+
     if expr.operator_kind is ql_ft.OperatorKind.Infix:
         lexpr, rexpr = args
     elif expr.operator_kind is ql_ft.OperatorKind.Prefix:

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -433,10 +433,6 @@ def compile_operator(
     lexpr = rexpr = None
     result: Optional[pgast.BaseExpr] = None
 
-    if expr.body is not None:
-        raise NotImplementedError(
-            "support for generic inline operator calls is not implemented")
-
     if expr.operator_kind is ql_ft.OperatorKind.Infix:
         lexpr, rexpr = args
     elif expr.operator_kind is ql_ft.OperatorKind.Prefix:

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3351,13 +3351,17 @@ def process_set_as_func_expr(
     with ctx.subrel() as newctx:
         newctx.expr_exposed = False
         args = _compile_call_args(ir_set, ctx=newctx)
-        name = get_func_call_backend_name(expr, ctx=newctx)
 
-        if expr.typemod is qltypes.TypeModifier.SetOfType:
-            set_expr = _process_set_func(
-                ir_set, func_name=name, args=args, ctx=newctx)
+        if expr.body is not None:
+            set_expr = dispatch.compile(expr.body, ctx=newctx)
         else:
-            set_expr = pgast.FuncCall(name=name, args=args)
+            name = get_func_call_backend_name(expr, ctx=newctx)
+
+            if expr.typemod is qltypes.TypeModifier.SetOfType:
+                set_expr = _process_set_func(
+                    ir_set, func_name=name, args=args, ctx=newctx)
+            else:
+                set_expr = pgast.FuncCall(name=name, args=args)
 
         if expr.error_on_null_result:
             set_expr = pgast.FuncCall(


### PR DESCRIPTION
If the IR produces a `FunctionCall` with non-empty `body` attribute, we
use that instead of compiling an SQL function call.  It is currently the
responsibility of the IR producer to make sure that any arguments are
wired properly via anchors.
