### PR TITLE
schema: Add some helper methods on `Expression`

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -411,6 +411,26 @@ def evaluate_to_python_val(
     return evaluate_ast_to_python_val(tree, schema, modaliases=modaliases)
 
 
+def evaluate_ir_statement_to_python_val(
+    ir: irast.Statement,
+) -> Any:
+    """Evaluate the given EdgeQL IR AST as a constant expression.
+
+    Args:
+        ir:
+            EdgeQL IR Statement AST.
+
+    Returns:
+        The result of the evaluation as a Python value and the associated IR.
+
+    Raises:
+        If the expression is not constant, or is otherwise not supported by
+        the const evaluator, the function will raise
+        :exc:`ir.staeval.UnsupportedExpressionError`.
+    """
+    return ireval.evaluate_to_python_val(ir.expr, schema=ir.schema)
+
+
 def evaluate_ast_to_python_val_and_ir(
     tree: qlast.Base,
     schema: s_schema.Schema,

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -260,6 +260,13 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             return self.compiled(
                 schema, options=options, as_fragment=as_fragment)
 
+    def assert_compiled(self) -> CompiledExpression:
+        if self._irast:
+            return self  # type: ignore
+        else:
+            raise AssertionError(
+                f"uncompiled expression {self.text!r} (origin: {self.origin})")
+
     @classmethod
     def from_ir(
         cls: Type[Expression],
@@ -379,6 +386,9 @@ class CompiledExpression(Expression):
     def irast(self) -> irast_.Statement:
         assert self._irast
         return self._irast
+
+    def as_python_value(self) -> Any:
+        return qlcompiler.evaluate_ir_statement_to_python_val(self.irast)
 
 
 class ExpressionShell(so.Shell):


### PR DESCRIPTION
The new `Expression.assert_compiled()` method is like
`ensure_compiled()` but does not actually attempt to compile an
uncompiled `Expression` raising an `AssertionError` instead.

The new `CompiledExpression.as_python_value()` method is a convenience
function to convert constant expression to Python values.
