### PR TITLE
Add a server helper returning a parsed type descriptor from a query string

### DIFF
--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -396,3 +396,4 @@ async def _execute(db, tenant, query, operation_name, variables, globals):
         )
     finally:
         tenant.release_pgcon(db.name, pgcon)
+        tenant.remove_dbview(dbv)

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -44,6 +44,7 @@ class Capability(enum.IntFlag):
 
     ALL               = 0xFFFF_FFFF_FFFF_FFFF  # noqa
     WRITE             = (MODIFICATIONS | DDL | PERSISTENT_CONFIG)  # noqa
+    NONE              = 0  # noqa
 
     def make_error(
         self,

--- a/edb/server/protocol/execute.pyi
+++ b/edb/server/protocol/execute.pyi
@@ -23,8 +23,20 @@ from typing import (
 )
 import immutables
 
+from edb import errors
 from edb.server import compiler
+from edb.server.compiler import sertypes
 from edb.server.dbview import dbview
+
+async def describe(
+    db: dbview.Database,
+    query: str,
+    *,
+    query_cache_enabled: Optional[bool] = None,
+    allow_capabilities: compiler.Capability = (
+        compiler.Capability.MODIFICATIONS),
+) -> sertypes.TypeDesc:
+    ...
 
 async def parse_execute_json(
     db: dbview.Database,
@@ -46,5 +58,5 @@ async def interpret_error(
     global_schema_pickle: object=None,
     user_schema_pickle: object=None,
     from_graphql: bool=False,
-) -> Exception:
+) -> errors.EdgeDBError:
     ...

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -45,6 +45,7 @@ from edb.server import defines as edbdef
 from edb.server import metrics
 from edb.server.compiler import errormech
 from edb.server.compiler cimport rpc
+from edb.server.compiler import sertypes
 from edb.server.dbview cimport dbview
 from edb.server.protocol cimport args_ser
 from edb.server.protocol cimport frontend
@@ -150,6 +151,73 @@ cpdef ExecutionGroup build_cache_persistence_units(
             )),
         )
     return group
+
+
+async def describe(
+    db: dbview.Database,
+    query: str,
+    *,
+    query_cache_enabled: Optional[bool] = None,
+    allow_capabilities: compiler.Capability = compiler.Capability.MODIFICATIONS,
+) -> sertypes.TypeDesc:
+    compiled, _ = await _parse(
+        db,
+        query,
+        query_cache_enabled=query_cache_enabled,
+        allow_capabilities=allow_capabilities,
+    )
+
+    desc = sertypes.parse(
+        compiled.query_unit_group.out_type_data,
+        edbdef.CURRENT_PROTOCOL,
+    )
+
+    return desc
+
+
+async def _parse(
+    db: dbview.Database,
+    query: str,
+    *,
+    input_format: compiler.InputFormat = compiler.InputFormat.BINARY,
+    output_format: compiler.OutputFormat = compiler.OutputFormat.BINARY,
+    allow_capabilities: compiler.Capability = compiler.Capability.MODIFICATIONS,
+    use_metrics: bool = True,
+    cached_globally: bool = False,
+    query_cache_enabled: Optional[bool] = None,
+) -> tuple[dbview.CompiledQuery, dbview.DatabaseConnectionView]:
+    if query_cache_enabled is None:
+        query_cache_enabled = not (
+            debug.flags.disable_qcache or debug.flags.edgeql_compile)
+
+    tenant = db.tenant
+    dbv = await tenant.new_dbview(
+        dbname=db.name,
+        query_cache=query_cache_enabled,
+        protocol_version=edbdef.CURRENT_PROTOCOL,
+    )
+    if use_metrics:
+        metrics.query_size.observe(
+            len(query.encode('utf-8')), tenant.get_instance_name(), 'edgeql'
+        )
+
+    query_req = rpc.CompilationRequest(
+        db.server.compilation_config_serializer
+    ).update(
+        edgeql.Source.from_string(query),
+        protocol_version=edbdef.CURRENT_PROTOCOL,
+        input_format=input_format,
+        output_format=output_format,
+    ).set_schema_version(dbv.schema_version)
+
+    compiled = await dbv.parse(
+        query_req,
+        cached_globally=cached_globally,
+        use_metrics=use_metrics,
+        allow_capabilities=allow_capabilities,
+    )
+
+    return compiled, dbv
 
 
 # TODO: can we merge execute and execute_script?
@@ -617,38 +685,18 @@ async def parse_execute_json(
     # or anything from std schema, for example:
     #     YES:  select ext::auth::UIConfig { ... }
     #     NO:   select default::User { ... }
-
-    if query_cache_enabled is None:
-        query_cache_enabled = not (
-            debug.flags.disable_qcache or debug.flags.edgeql_compile)
-
-    tenant = db.tenant
-    dbv = await tenant.new_dbview(
-        dbname=db.name,
-        query_cache=query_cache_enabled,
-        protocol_version=edbdef.CURRENT_PROTOCOL,
-    )
-    if use_metrics:
-        metrics.query_size.observe(
-            len(query.encode('utf-8')), tenant.get_instance_name(), 'edgeql'
-        )
-
-    query_req = rpc.CompilationRequest(
-        db.server.compilation_config_serializer
-    ).update(
-        edgeql.Source.from_string(query),
-        protocol_version=edbdef.CURRENT_PROTOCOL,
+    compiled, dbv = await _parse(
+        db,
+        query,
         input_format=compiler.InputFormat.JSON,
         output_format=output_format,
-    ).set_schema_version(dbv.schema_version)
-
-    compiled = await dbv.parse(
-        query_req,
-        cached_globally=cached_globally,
-        use_metrics=use_metrics,
         allow_capabilities=compiler.Capability.MODIFICATIONS,
+        use_metrics=use_metrics,
+        cached_globally=cached_globally,
+        query_cache_enabled=query_cache_enabled,
     )
 
+    tenant = db.tenant
     pgcon = await tenant.acquire_pgcon(db.name)
     try:
         return await execute_json(

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -246,5 +246,6 @@ async def execute(db, tenant, queries: list):
             await pgcon.sql_execute(b'ROLLBACK;')
         finally:
             tenant.release_pgcon(db.name, pgcon)
+            tenant.remove_dbview(dbv)
 
     return json.dumps(result).encode()


### PR DESCRIPTION
The new `execute.describe(query) -> TypeDesc` helper is useful for
situations when the server (or its extension) needs to reason about what
a given query returns.  This is essentially a nicely packaged
`DatabaseConnectionView.parse`.
