### PR TITLE
Provide infrastructure for long-running extension tasks

### DIFF
--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -104,7 +104,9 @@ cdef class Database:
         reflection_cache=?,
         backend_ids=?,
         db_config=?,
+        start_stop_extensions=?,
     )
+    cpdef start_stop_extensions(self)
     cdef get_state_serializer(self, protocol_version)
     cpdef set_state_serializer(self, protocol_version, serializer)
 

--- a/edb/server/dbview/dbview.pyi
+++ b/edb/server/dbview/dbview.pyi
@@ -75,6 +75,9 @@ class Database:
     async def cache_notifier(self) -> None:
         ...
 
+    def start_stop_extensions(self) -> None:
+        ...
+
     def cache_compiled_sql(
         self,
         key: Hashable,
@@ -178,6 +181,7 @@ class DatabaseIndex:
         backend_ids: Optional[Mapping[str, int]],
         extensions: Optional[set[str]],
         ext_config_settings: Optional[list[config.Setting]],
+        early: bool = False,
     ) -> Database:
         ...
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -253,6 +253,7 @@ cdef class Database:
         reflection_cache=None,
         backend_ids=None,
         db_config=None,
+        start_stop_extensions=True,
     ):
         if new_schema_pickle is None:
             raise AssertionError('new_schema is not supposed to be None')
@@ -272,6 +273,11 @@ cdef class Database:
             self.db_config = db_config
             self._observe_auth_ext_config()
         self._invalidate_caches()
+        if start_stop_extensions:
+            self.start_stop_extensions()
+
+    cpdef start_stop_extensions(self):
+        pass
 
     cdef _observe_auth_ext_config(self):
         key = "ext::auth::AuthConfig::providers"
@@ -1453,6 +1459,7 @@ cdef class DatabaseIndex:
         backend_ids,
         extensions,
         ext_config_settings,
+        early=False,
     ):
         cdef Database db
         db = self._dbs.get(dbname)
@@ -1465,6 +1472,7 @@ cdef class DatabaseIndex:
                 reflection_cache,
                 backend_ids,
                 db_config,
+                not early,
             )
         else:
             db = Database(
@@ -1479,6 +1487,8 @@ cdef class DatabaseIndex:
                 ext_config_settings=ext_config_settings,
             )
             self._dbs[dbname] = db
+            if not early:
+                db.start_stop_extensions()
         self.set_current_branches()
         return db
 


### PR DESCRIPTION
Some extensions might benefit from the ability to run an async task
whenever the extension is present in a branch.  Add a
`start_stop_extensions()` hook which is called whenever the set of
enabled extensions in a branch changes.

Additionally, make it possible to create named tasks associated with
the server tenant.
