### PR TITLE
Allow extensions to control when and how HTTP responses are sent

### DIFF
--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -46,6 +46,7 @@ cdef class HttpResponse:
         public bytes content_type
         public dict custom_headers
         public bytes body
+        public bint sent
 
 
 cdef class HttpProtocol:
@@ -82,10 +83,10 @@ cdef class HttpProtocol:
                 bytes content_type, dict custom_headers, bytes body,
                 bint close_connection)
 
-    cdef write(self, HttpRequest request, HttpResponse response)
+    cpdef write(self, HttpRequest request, HttpResponse response)
 
     cdef unhandled_exception(self, bytes status, ex)
     cdef resume(self)
-    cdef close(self)
+    cpdef close(self)
     cdef inline _schedule_handle_request(self, request)
     cdef inline _close_with_error(self, bytes status, bytes message)

--- a/edb/server/protocol/protocol.pyi
+++ b/edb/server/protocol/protocol.pyi
@@ -1,0 +1,69 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import asyncio
+import http.cookies
+import ssl
+
+from edb.server import args as srvargs
+from edb.server import server
+
+class HttpRequest:
+    url: str
+    version: bytes
+    should_keep_alive: bool
+    content_type: bytes
+    method: bytes
+    accept: bytes
+    body: bytes
+    host: bytes
+    origin: bytes
+    authorization: bytes
+    params: dict[bytes, bytes]
+    forwarded: dict[bytes, bytes]
+    cookies: http.cookies.SimpleCookie
+
+class HttpResponse:
+    status: str
+    close_connection: bool
+    content_type: bytes
+    custom_headers: dict[str, str]
+    body: bytes
+    sent: bool
+
+class HttpProtocol(asyncio.Protocol):
+    def __init__(
+        self,
+        server: server.BaseServer,
+        sslctx: ssl.SSLContext,
+        sslctx_pgext: ssl.SSLContext,
+        *,
+        external_auth: bool = False,
+        binary_endpoint_security: srvargs.ServerEndpointSecurityMode,
+        http_endpoint_security: srvargs.ServerEndpointSecurityMode,
+    ) -> None:
+        ...
+
+    def write_raw(self, data: bytes) -> None:
+        ...
+
+    def write(self, request: HttpRequest, response: HttpResponse) -> None:
+        ...
+
+    def close(self) -> None:
+        ...


### PR DESCRIPTION
Extensions currently don't have much control over when the HTTP response
is sent.  Change this by allowing the `HttpResponse` to be written out
by an extension along with any subsequent output via `write_raw()` on
the protocol.  This allows extensions to support server-sent events,
a.k.a response streaming.
