### PR TITLE
Generalize some aspects of handling object-only indexes

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -284,8 +284,12 @@ def get_objtype_backend_name(
 ):
     if aspect is None:
         aspect = 'table'
-    if aspect not in {'table', 'inhview', 'dummy'} and not re.match(
-            r'(source|target)-del-(def|imm)-(inl|otl)-(f|t)', aspect):
+    if (
+        aspect not in {'table', 'inhview', 'dummy'}
+        and not re.match(
+            r'(source|target)-del-(def|imm)-(inl|otl)-(f|t)', aspect)
+        and not aspect.startswith("ext")
+    ):
         raise ValueError(
             f'unexpected aspect for object type backend name: {aspect!r}')
 
@@ -401,6 +405,17 @@ def get_index_backend_name(id, module_name, catenate=True, *, aspect=None):
         aspect = 'index'
     name = s_name.QualName(module=module_name, name=str(id))
     return convert_name(name, aspect, catenate)
+
+
+def get_index_table_backend_name(
+    index: s_indexes.Index,
+    schema: s_schema.Schema,
+    *,
+    aspect: Optional[str] = None,
+) -> Tuple[str, str]:
+    subject = index.get_subject(schema)
+    assert isinstance(subject, s_types.Type)
+    return get_backend_name(schema, subject, aspect=aspect, catenate=False)
 
 
 def get_tuple_backend_name(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3585,7 +3585,9 @@ def get_reindex_sql(
     "Generate SQL statement that repopulates the index after a restore."
     "Currently this only applies to FTS indexes."
 
-    (fts_index, _) = s_indexes.get_effective_fts_index(obj, schema)
+    (fts_index, _) = s_indexes.get_effective_object_index(
+        schema, obj, sn.QualName("fts", "index")
+    )
     if fts_index:
         options = get_index_compile_options(fts_index, schema, {}, None)
         cmd = deltafts.update_fts_document(fts_index, options, schema)
@@ -3737,8 +3739,14 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
         with errors.ensure_span(self.span):
             self.pgops.add(self.create_index(index, schema, context))
 
+        # XXX: the below hardcode should be replaced by an index scope
+        #      field instead.
         # FTS
-        if index.has_base_with_name(schema, sn.QualName('fts', 'index')):
+        object_scoped_indexes = (
+            sn.QualName('fts', 'index'),
+        )
+        # FTS
+        if index.has_base_with_name(schema, object_scoped_indexes):
             # update inhviews
 
             subject = index.get_subject(schema)

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -1108,13 +1108,20 @@ class CreateIndex(
         subject = referrer_ctx.scls
         assert isinstance(subject, (s_types.Type, s_pointers.Pointer))
 
+        # XXX: the below hardcode should be replaced by an index scope
+        #      field instead.
         # FTS
-        if self.scls.has_base_with_name(schema, sn.QualName('fts', 'index')):
-
-            if isinstance(subject, s_pointers.Pointer):
+        object_scoped_indexes = (
+            sn.QualName('fts', 'index'),
+        )
+        for idx_base in object_scoped_indexes:
+            if (
+                self.scls.has_base_with_name(schema, idx_base)
+                and isinstance(subject, s_pointers.Pointer)
+            ):
                 raise errors.SchemaDefinitionError(
-                    "fts::index cannot be declared on links",
-                    span=self.span
+                    f"{idx_base} cannot be declared on links",
+                    span=self.span,
                 )
 
         # Ensure that the name of the index (if given) matches an existing
@@ -1349,8 +1356,10 @@ class RebaseIndex(
     pass
 
 
-def get_effective_fts_index(
-    subject: IndexableSubject, schema: s_schema.Schema
+def get_effective_object_index(
+    schema: s_schema.Schema,
+    subject: IndexableSubject,
+    base_idx_name: sn.QualName,
 ) -> Tuple[Optional[Index], bool]:
     """
     Returns the effective index of a subject and a boolean indicating
@@ -1358,41 +1367,41 @@ def get_effective_fts_index(
     """
     indexes: so.ObjectIndexByFullname[Index] = subject.get_indexes(schema)
 
-    fts_name = sn.QualName('fts', 'index')
-    fts_indexes = [
+    object_indexes = [
         ind
         for ind in indexes.objects(schema)
-        if ind.has_base_with_name(schema, fts_name)
+        if ind.has_base_with_name(schema, base_idx_name)
     ]
-    if len(fts_indexes) == 0:
+    if len(object_indexes) == 0:
         return (None, False)
 
-    fts_indexes_defined_here = [
-        ind for ind in fts_indexes if ind.is_defined_here(schema)
+    object_indexes_defined_here = [
+        ind for ind in object_indexes if ind.is_defined_here(schema)
     ]
 
-    if len(fts_indexes_defined_here) > 0:
+    if len(object_indexes_defined_here) > 0:
         # indexes defined here have priority
 
-        if len(fts_indexes_defined_here) > 1:
+        if len(object_indexes_defined_here) > 1:
             subject_name = subject.get_displayname(schema)
             raise errors.SchemaDefinitionError(
-                f'multiple {fts_name} indexes defined for {subject_name}'
+                f'multiple {base_idx_name} indexes defined for {subject_name}'
             )
-        effective = fts_indexes_defined_here[0]
-        has_overridden = len(fts_indexes) >= 2
+        effective = object_indexes_defined_here[0]
+        has_overridden = len(object_indexes) >= 2
 
     else:
-        # there are no fts indexes defined on the subject
+        # there are no object-scoped indexes defined on the subject
         # the inherited indexes take effect
 
-        if len(fts_indexes) > 1:
+        if len(object_indexes) > 1:
             subject_name = subject.get_displayname(schema)
             raise errors.SchemaDefinitionError(
-                f'multiple {fts_name} indexes inherited for {subject_name}'
+                f'multiple {base_idx_name} indexes '
+                f'inherited for {subject_name}'
             )
 
-        effective = fts_indexes[0]
+        effective = object_indexes[0]
         has_overridden = False
 
     return (effective, has_overridden)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -3391,12 +3391,15 @@ class InheritingObject(SubclassableObject):
         return similarity
 
     def has_base_with_name(
-        self, schema: s_schema.Schema, name: sn.Name | str
+        self,
+        schema: s_schema.Schema,
+        name: sn.Name | str | tuple[sn.Name | str, ...],
     ) -> bool:
-        base = schema.get(name, None)
-        return isinstance(base, SubclassableObject) and self.issubclass(
-            schema, base
-        )
+        if not isinstance(name, (sn.Name, str)):
+            bases = tuple(schema.get(n, type=SubclassableObject) for n in name)
+        else:
+            bases = (schema.get(name, type=SubclassableObject),)
+        return self.issubclass(schema, bases)
 
 
 DerivableInheritingObjectT = TypeVar(

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -179,7 +179,9 @@ class Source(
         from edb.common import debug
 
         if not debug.flags.zombodb:
-            (fts_index, _) = indexes.get_effective_fts_index(self, schema)
+            fts_index, _ = indexes.get_effective_object_index(
+                schema, self, sn.QualName("fts", "index")
+            )
 
             if fts_index:
                 res.append(

--- a/tests/test_edgeql_fts.py
+++ b/tests/test_edgeql_fts.py
@@ -415,7 +415,7 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
     async def test_edgeql_fts_inheritance_07(self):
         async with self.assertRaisesRegexTx(
             edgedb.InvalidReferenceError,
-            r'fts::search requires an fts::index index',
+            r'fts::search\(\) requires an fts::index index',
         ):
             await self.con.execute(
                 '''

--- a/tests/test_edgeql_fts_schema.py
+++ b/tests/test_edgeql_fts_schema.py
@@ -257,7 +257,7 @@ class TestEdgeQLFTSSchema(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidReferenceError,
-            r'fts::search requires an fts::index index',
+            r'fts::search\(\) requires an fts::index index',
         ):
             await self.con.execute(
                 r'''


### PR DESCRIPTION
There are bits of code that are hardcoded to handle `fts::index`,
which is currently the only supported object-level index.  In
preparation for adding another such index, generalize the
infrastructure somewhat to avoid naming weirdness and/or code
duplication.
