### PR TITLE
Handle index kwarg defaults properly

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3644,25 +3644,8 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
             root_code = root.get_code(schema)
 
             kwargs = index.get_concrete_kwargs(schema)
-            # Get all the concrete kwargs compiled (they are expected to be
-            # constants)
-            # These are expected to be constants, so we don't have anchors,
-            # path prefixes, etc.
-            kw_options = qlcompiler.CompilerOptions(
-                modaliases=context.modaliases,
-                schema_object_context=cls.get_schema_metaclass(),
-                apply_query_rewrites=False,
-            )
             for name, expr in kwargs.items():
-                # XXX: origin messes up compilation, but by this point we
-                # shouldn't care about the expression's origin.
-                expr.origin = None
-                kw_expr = expr.ensure_compiled(
-                    schema=schema,
-                    options=kw_options,
-                    as_fragment=True,
-                )
-                kw_ir = kw_expr.irast
+                kw_ir = expr.assert_compiled().irast
                 kw_sql_res = compiler.compile_ir_to_sql_tree(
                     kw_ir.expr, singleton_mode=True)
                 kw_sql_tree = kw_sql_res.ast

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2704,6 +2704,16 @@ class ObjectCommand(Command, Generic[so.Object_T]):
 
             if id := self.get_attribute_value('id'):
                 value.set_origin(id, attr_name)
+        elif isinstance(value, s_expr.ExpressionDict):
+            compiled = {}
+            obj_id = self.get_attribute_value('id')
+            for k, v in value.items():
+                if not v.is_compiled():
+                    v = self.compile_expr_field(schema, context, field, v)
+                    if obj_id:
+                        v.set_origin(obj_id, attr_name)
+                compiled[k] = v
+            value = compiled
 
         return value
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -166,10 +166,18 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                 if (
                     inherited
                     and not context.transient_derivation
-                    and isinstance(result, s_expr.Expression)
                 ):
-                    result = self.compile_expr_field(
-                        schema, context, field=field, value=result)
+                    if isinstance(result, s_expr.Expression):
+                        result = self.compile_expr_field(
+                            schema, context, field=field, value=result)
+                    elif isinstance(result, s_expr.ExpressionDict):
+                        compiled = {}
+                        for k, v in result.items():
+                            if not v.is_compiled():
+                                v = self.compile_expr_field(
+                                    schema, context, field, v)
+                            compiled[k] = v
+                        result = compiled
                 sav = self.set_attribute_value(
                     field_name, result, inherited=inherited)
                 if isinstance(sav, sd.AlterObjectProperty):


### PR DESCRIPTION
Index kwargs are supposed to be compiled in `compile_expr_field` of the
`IndexCommand` and not in the guts of `pgsql.delta`.
