### PR TITLE
Initial implementation of the `ai` extension

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_04_04_00_00
+EDGEDB_CATALOG_VERSION = 2024_04_09_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -79,6 +79,10 @@ class Annotation(NamedObject):
     pass
 
 
+class AnnotationValue(NamedObject):
+    pass
+
+
 class Global(NamedObject):
     pass
 

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -173,7 +173,11 @@ def evaluate_Tuple(
     return irast.Tuple(
         named=ir.named,
         elements=[
-            x.replace(val=evaluate(x.val, schema)) for x in ir.elements
+            x.replace(
+                val=x.val.replace(
+                    expr=evaluate(x.val, schema)
+                ),
+            ) for x in ir.elements
         ],
         typeref=ir.typeref,
     )

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -74,6 +74,27 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         };
     };
 
+    create type ext::ai::OpenAIProviderConfig extending ext::ai::ProviderConfig {
+        alter property name {
+            set protected := true;
+            set default := 'builtin::openai';
+        };
+
+        alter property display_name {
+            set protected := true;
+            set default := 'OpenAI';
+        };
+
+        alter property api_url {
+            set default := 'https://api.openai.com/v1'
+        };
+
+        alter property api_style {
+            set protected := true;
+            set default := ext::ai::ProviderAPIStyle.OpenAI;
+        };
+    };
+
     create type ext::ai::Config extending cfg::ExtensionConfig {
         create required property indexer_naptime: std::duration {
             set default := <std::duration>'10s';
@@ -126,6 +147,76 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
     {
         create annotation
             ext::ai::text_gen_model_context_window := "<must override>";
+    };
+
+    # OpenAI models.
+
+    create abstract type ext::ai::OpenAITextEmbedding3SmallModel
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "text-embedding-3-small";
+        alter annotation
+            ext::ai::model_provider := "builtin::openai";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "8191";
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "1536";
+        alter annotation
+            ext::ai::embedding_model_supports_shortening := "true";
+    };
+
+    create abstract type ext::ai::OpenAITextEmbedding3LargeModel
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "text-embedding-3-large";
+        alter annotation
+            ext::ai::model_provider := "builtin::openai";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "8191";
+        # Note: ext::pgvector is currently limited to 2000 dimensions,
+        # so returned embeddings will be automatically truncated if
+        # pgvector is used as the index implementation.
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "3072";
+        alter annotation
+            ext::ai::embedding_model_supports_shortening := "true";
+    };
+
+    create abstract type ext::ai::OpenAITextEmbeddingAda002Model
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "text-embedding-ada-002";
+        alter annotation
+            ext::ai::model_provider := "builtin::openai";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "8191";
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "1536";
+    };
+
+    create abstract type ext::ai::OpenAIGPT_3_5_TurboModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "gpt-3.5-turbo";
+        alter annotation
+            ext::ai::model_provider := "builtin::openai";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "16385";
+    };
+
+    create abstract type ext::ai::OpenAIGPT_4_TurboModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "gpt-4-turbo-preview";
+        alter annotation
+            ext::ai::model_provider := "builtin::openai";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "128000";
     };
 
     create scalar type ext::ai::DistanceFunction

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -1,0 +1,248 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+CREATE EXTENSION PACKAGE ai VERSION '1.0' {
+    set ext_module := "ext::ai";
+    set dependencies := ["pgvector==0.5"];
+
+    create module ext::ai;
+
+    create scalar type ext::ai::ProviderAPIStyle
+        extending enum<OpenAI, Anthropic>;
+
+    create abstract type ext::ai::ProviderConfig extending cfg::ConfigObject {
+        create required property name: std::str {
+            set readonly := true;
+            create constraint exclusive;
+            create annotation std::description :=
+                "Unique provider name.";
+        };
+
+        create required property display_name: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "Human-friendly provider name.";
+        };
+
+        create required property api_url: std::str {
+            set readonly := true;
+            create annotation std::description := "Provider API URL.";
+        };
+
+        create property client_id: std::str {
+            set readonly := true;
+            create annotation std::description :=
+                "ID for client provided by model API vendor.";
+        };
+
+        create required property secret: std::str {
+            set readonly := true;
+            set secret := true;
+            create annotation std::description :=
+                "Secret provided by model API vendor.";
+        };
+
+        create required property api_style: ext::ai::ProviderAPIStyle {
+            create annotation std::description :=
+                "The API style exposed by this provider.";
+        };
+    };
+
+    create type ext::ai::CustomProviderConfig extending ext::ai::ProviderConfig {
+        alter property display_name {
+            set default := 'Custom';
+        };
+
+        alter property api_style {
+            set default := ext::ai::ProviderAPIStyle.OpenAI;
+        };
+    };
+
+    create type ext::ai::Config extending cfg::ExtensionConfig {
+        create required property indexer_naptime: std::duration {
+            set default := <std::duration>'10s';
+            create annotation std::description :=
+                "Specifies the minimum delay between deferred ext::ai::index "
+                ++ "indexer runs on any given branch.";
+        };
+
+        create multi link providers: ext::ai::ProviderConfig {
+            create annotation std::description :=
+                "AI model provider configurations.";
+        };
+    };
+
+    create abstract inheritable annotation
+        ext::ai::model_name;
+    create abstract inheritable annotation
+        ext::ai::model_provider;
+
+    create abstract type ext::ai::Model {
+        create annotation ext::ai::model_name := "<must override>";
+        create annotation ext::ai::model_provider := "<must override>";
+    };
+
+    create abstract inheritable annotation
+        ext::ai::embedding_model_max_input_tokens;
+
+    create abstract inheritable annotation
+        ext::ai::embedding_model_max_output_dimensions;
+
+    create abstract inheritable annotation
+        ext::ai::embedding_model_supports_shortening;
+
+    create abstract type ext::ai::EmbeddingModel
+        extending ext::ai::Model
+    {
+        create annotation
+            ext::ai::embedding_model_max_input_tokens := "<must override>";
+        create annotation
+            ext::ai::embedding_model_max_output_dimensions := "<must override>";
+        create annotation
+            ext::ai::embedding_model_supports_shortening := "false";
+    };
+
+    create abstract inheritable annotation
+        ext::ai::text_gen_model_context_window;
+
+    create abstract type ext::ai::TextGenerationModel
+        extending ext::ai::Model
+    {
+        create annotation
+            ext::ai::text_gen_model_context_window := "<must override>";
+    };
+
+    create scalar type ext::ai::DistanceFunction
+        extending enum<Cosine, InnerProduct, L2>;
+
+    create scalar type ext::ai::IndexType
+        extending enum<HNSW>;
+
+    create abstract inheritable annotation
+        ext::ai::embedding_dimensions;
+
+    create abstract index ext::ai::index (
+        named only embedding_model: str,
+        named only distance_function: ext::ai::DistanceFunction
+            = ext::ai::DistanceFunction.Cosine,
+        named only index_type: ext::ai::IndexType
+            = ext::ai::IndexType.HNSW,
+        named only index_parameters: tuple<m: int64, ef_construction: int64>
+            = (m := 32, ef_construction := 100),
+    ) {
+        create annotation std::description :=
+            "Semantic similarity index.";
+        create annotation ext::ai::embedding_dimensions := "";
+        set deferrability := 'Required';
+    };
+
+    create function ext::ai::to_context(
+        object: anyobject,
+    ) -> std::str
+    {
+        create annotation std::description :=
+            "Evaluate the expression of an ai::index defined on the passed "
+            ++ "object type and return it.";
+        set volatility := 'Stable';
+        using sql expression;
+    };
+
+    create function ext::ai::search(
+        object: anyobject,
+        query: array<std::float32>,
+    ) -> optional tuple<object: anyobject, distance: float64>
+    {
+        create annotation std::description := '
+            Search an object using its ext::ai::index index.
+            Returns objects that match the specified semantic query and the
+            similarity score.
+        ';
+        set volatility := 'Stable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql expression;
+    };
+
+    create scalar type ext::ai::ChatParticipantRole
+        extending enum<System, User, Assistant, Tool>;
+
+    create type ext::ai::ChatPromptMessage {
+        create required property participant_role:
+            ext::ai::ChatParticipantRole
+        {
+            create annotation std::description :=
+                'The role of the messages author.'
+        };
+
+        create property participant_name: str {
+            create annotation std::description :=
+                'Optional name for the participant.'
+        };
+
+        create required property content: str {
+            create annotation std::description :=
+                'Prompt message contenxt.'
+        };
+    };
+
+    create type ext::ai::ChatPrompt {
+        create required property name: str {
+            create constraint exclusive;
+            create annotation std::description :=
+                'Unique name for the prompt configuration';
+        };
+
+        create required multi link messages: ext::ai::ChatPromptMessage {
+            create constraint exclusive;
+            create annotation std::description :=
+                'Messages in this prompt configuration';
+        };
+    };
+
+    insert ext::ai::ChatPrompt {
+        name := 'builtin::rag-default',
+        messages := {
+            (insert ext::ai::ChatPromptMessage {
+                participant_role := ext::ai::ChatParticipantRole.System,
+                content := (
+                    "You are an expert Q&A system.\n" ++
+                    "Always answer questions based on the provided \
+                     context information. Never use prior knowledge.\n" ++
+                    "Follow these additional rules:\n\
+                     1. Never directly reference the given context in your \
+                        answer.\n\
+                     2. Never include phrases like 'Based on the context, ...' \
+                        or any similar phrases in your responses. \
+                     3. When the context does not provide information about \
+                        the question, answer with 'No information available.'."
+                ),
+            }),
+            (insert ext::ai::ChatPromptMessage {
+                participant_role := ext::ai::ChatParticipantRole.User,
+                content := (
+                    "Context information:\n{context}\n\
+                     Given the context information above and not prior \
+                     knowledge, answer the following query.\n\
+                     Query: {query}\n\
+                     Answer: "
+                ),
+            })
+        }
+    };
+};

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -230,16 +230,17 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
                      2. Never include phrases like 'Based on the context, ...' \
                         or any similar phrases in your responses. \
                      3. When the context does not provide information about \
-                        the question, answer with 'No information available.'."
+                        the question, answer with \
+                        'No information available.'.\n\
+                     Context information is below:\n{context}\n\
+                     Given the context information above and not prior \
+                     knowledge, answer the user query."
                 ),
             }),
             (insert ext::ai::ChatPromptMessage {
                 participant_role := ext::ai::ChatParticipantRole.User,
                 content := (
-                    "Context information:\n{context}\n\
-                     Given the context information above and not prior \
-                     knowledge, answer the following query.\n\
-                     Query: {query}\n\
+                    "Query: {query}\n\
                      Answer: "
                 ),
             })

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -95,6 +95,27 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         };
     };
 
+    create type ext::ai::MistralProviderConfig extending ext::ai::ProviderConfig {
+        alter property name {
+            set protected := true;
+            set default := 'builtin::mistral';
+        };
+
+        alter property display_name {
+            set protected := true;
+            set default := 'Mistral';
+        };
+
+        alter property api_url {
+            set default := 'https://api.mistral.ai/v1'
+        };
+
+        alter property api_style {
+            set protected := true;
+            set default := ext::ai::ProviderAPIStyle.OpenAI;
+        };
+    };
+
     create type ext::ai::Config extending cfg::ExtensionConfig {
         create required property indexer_naptime: std::duration {
             set default := <std::duration>'10s';
@@ -217,6 +238,53 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             ext::ai::model_provider := "builtin::openai";
         alter annotation
             ext::ai::text_gen_model_context_window := "128000";
+    };
+
+    # Mistral models.
+    create abstract type ext::ai::MistralEmbedModel
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "mistral-embed";
+        alter annotation
+            ext::ai::model_provider := "builtin::mistral";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "16384";
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "1024";
+    };
+
+    create abstract type ext::ai::MistralSmallModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "mistral-small-latest";
+        alter annotation
+            ext::ai::model_provider := "builtin::mistral";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "8192";
+    };
+
+    create abstract type ext::ai::MistralMediumModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "mistral-medium-latest";
+        alter annotation
+            ext::ai::model_provider := "builtin::mistral";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "8192";
+    };
+
+    create abstract type ext::ai::MistralLargeModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "mistral-large-latest";
+        alter annotation
+            ext::ai::model_provider := "builtin::mistral";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "8192";
     };
 
     create scalar type ext::ai::DistanceFunction

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -116,6 +116,27 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         };
     };
 
+    create type ext::ai::AnthropicProviderConfig extending ext::ai::ProviderConfig {
+        alter property name {
+            set protected := true;
+            set default := 'builtin::anthropic';
+        };
+
+        alter property display_name {
+            set protected := true;
+            set default := 'Anthropic';
+        };
+
+        alter property api_url {
+            set default := 'https://api.anthropic.com/v1'
+        };
+
+        alter property api_style {
+            set protected := true;
+            set default := ext::ai::ProviderAPIStyle.Anthropic;
+        };
+    };
+
     create type ext::ai::Config extending cfg::ExtensionConfig {
         create required property indexer_naptime: std::duration {
             set default := <std::duration>'10s';
@@ -285,6 +306,40 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             ext::ai::model_provider := "builtin::mistral";
         alter annotation
             ext::ai::text_gen_model_context_window := "8192";
+    };
+
+    # Anthropic models.
+    create abstract type ext::ai::AnthropicClaude3HaikuModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "claude-3-haiku-20240307";
+        alter annotation
+            ext::ai::model_provider := "builtin::anthropic";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "200000";
+    };
+
+    create abstract type ext::ai::AnthropicClaude3SonnetModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "claude-3-sonnet-20240229";
+        alter annotation
+            ext::ai::model_provider := "builtin::anthropic";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "200000";
+    };
+
+    create abstract type ext::ai::AnthropicClaude3OpusModel
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "claude-3-opus-20240229";
+        alter annotation
+            ext::ai::model_provider := "builtin::anthropic";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "200000";
     };
 
     create scalar type ext::ai::DistanceFunction

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -38,6 +38,7 @@ from . import clauses
 from . import context
 from . import dispatch
 from . import dml
+from . import pathctx
 
 from .context import OutputFormat as OutputFormat # NOQA
 
@@ -215,6 +216,25 @@ def new_external_rvar(
             rel.path_outputs[output_pid, aspect] = var
 
     return rvar
+
+
+def new_external_rvar_as_subquery(
+    *,
+    rel_name: tuple[str, ...],
+    path_id: irast.PathId,
+    aspects: tuple[str, ...],
+) -> pgast.SelectStmt:
+    rvar = new_external_rvar(
+        rel_name=rel_name,
+        path_id=path_id,
+        outputs={},
+    )
+    qry = pgast.SelectStmt(
+        from_clause=[rvar],
+    )
+    for aspect in aspects:
+        pathctx.put_path_rvar(qry, path_id, rvar, aspect=aspect)
+    return qry
 
 
 def new_external_rel(

--- a/edb/pgsql/dbops/ddl.py
+++ b/edb/pgsql/dbops/ddl.py
@@ -189,7 +189,7 @@ class PutSingleDBMetadata(DDLOperation):
 
 
 class SetMetadata(PutMetadata):
-    def code(self, block: base.PLBlock) -> str:
+    def creation_code(self, block: base.PLBlock) -> str:
         metadata = self.metadata
 
         object_type = self.object.get_type()
@@ -200,9 +200,12 @@ class SetMetadata(PutMetadata):
         comment = f'E{prefix} || {desc}'
 
         return textwrap.dedent(f'''\
-            EXECUTE 'COMMENT ON {object_type} {object_id} IS ' ||
-                quote_literal({comment});
+            'COMMENT ON {object_type} {object_id} IS '
+            || quote_literal({comment})
         ''')
+
+    def code(self, block: base.PLBlock) -> str:
+        return 'EXECUTE ' + self.creation_code(block) + ';'
 
 
 class SetSingleDBMetadata(PutSingleDBMetadata):

--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -74,7 +74,7 @@ class Index(tables.InheritableTableObject):
                 raise NotImplementedError()
             self._columns.add(col)
 
-    def creation_code(self, block: base.PLBlock) -> str:
+    def creation_code(self) -> str:
         if self.exprs:
             exprs = self.exprs
         else:
@@ -201,7 +201,7 @@ class CreateIndex(ddl.CreateObject):
             )
 
     def code(self, block: base.PLBlock) -> str:
-        return self.index.creation_code(block)
+        return self.index.creation_code()
 
 
 class DropIndex(ddl.DropObject):

--- a/edb/pgsql/dbops/views.py
+++ b/edb/pgsql/dbops/views.py
@@ -65,8 +65,26 @@ class CreateView(ddl.SchemaObjectOperation):
 
 class DropView(ddl.SchemaObjectOperation):
 
+    def __init__(
+        self,
+        name,
+        *,
+        conditional=False,
+        conditions=None,
+        neg_conditions=None,
+    ):
+        super().__init__(
+            name,
+            conditions=conditions,
+            neg_conditions=neg_conditions,
+        )
+        self.conditional = conditional
+
     def code(self, block: base.PLBlock) -> str:
-        return f'DROP VIEW {qn(*self.name)}'
+        if self.conditional:
+            return f'DROP VIEW IF EXISTS {qn(*self.name)}'
+        else:
+            return f'DROP VIEW {qn(*self.name)}'
 
 
 class ViewExists(base.Condition):

--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -1,0 +1,771 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Backend support for ext::ai::index
+#
+# The index adds the following hidden attribute to the object type relation
+#
+#    __ext_ai_{idx_id}_embedding__ vector(<index_embedding_dimensions>)
+#
+# The data in the attribute gets populated by an external indexing process,
+# hence the ext::ai::index is currently always deferred.  If a given object
+# record is yet unindexed, the attribute value would be NULL and the entry
+# will be picked up in the work queue view (see below).
+#
+# To invalidate embeddings on changes of data referenced in the index
+# expression changes, a simple trigger is also added, which resets the
+# value of the embedding attribute back to NULL.
+#
+# The index is currently always deferred, hence the unindexed data
+# needs to be exposed conveniently to an external indexer.  We do
+# this here by creating the following internal SQL views:
+#
+# Enumeration of embedding models currently used in ext::ai::index()
+# declarations in the current schema:
+#
+#   CREATE VIEW edgedbext.ai_active_embedding_models(
+#     id,       -- generated unique id as int64 (could be used for locking)
+#     name,     -- model name as specified in the ext::ai::model_name anno
+#     provider, -- provider name as specified in the ext::ai::provider_name
+#   )
+#
+# For each active model in the above view the following views are also
+# generated:
+#
+#   CREATE VIEW edgedbext."ai_pending_embeddings_{model_name}"(
+#     id,          -- Object ID
+#     text,        -- Indexed text document (result of index expr eval)
+#     target_rel,  -- SQL relation containing the embedding data
+#     target_attr, -- Column in the above relation containing embedding data
+#     target_dims_shortening -- If the embedding model produces more dimensions
+#                            -- than the underlying index can handle, this
+#                            -- would be the maximum dimensions supported by
+#                            -- the index.  Embedding model must support
+#                            -- vector shortening (e.g OpenAI
+#                            -- embedding-text-3- models).
+#  )
+#
+# The above view is a UNION of SELECTs over object relations, where each
+# UNION element is roughly this:
+#
+#   SELECT (
+#     Object.id,
+#     eval(get_index_expr(Object, 'ext::ai::index')),
+#   )
+#   WHERE
+#     eval(get_index_except_expr(Object, 'ext::ai::index')) IS NOT TRUE
+#     AND Object.__ext_ai_{idx_id}_embedding__  IS NULL
+#
+
+from __future__ import annotations
+from typing import (
+    Optional,
+)
+
+import collections
+import dataclasses
+import hashlib
+import struct
+import textwrap
+
+from edb.schema import expr as s_expr
+from edb.schema import indexes as s_indexes
+from edb.schema import types as s_types
+from edb.schema import schema as s_schema
+from edb.schema import delta as sd
+from edb.schema import name as sn
+from edb.schema import properties as s_props
+
+from edb.ir import ast as irast
+
+from edb.edgeql import ast as qlast
+from edb.edgeql import compiler as qlcompiler
+
+from . import codegen
+from . import common
+from . import dbops
+from . import compiler
+from . import types
+from . import ast as pgast
+
+from .common import qname as q
+from .common import quote_literal as ql
+from .common import quote_ident as qi
+from .compiler import astutils
+
+
+ai_index_base_name = sn.QualName("ext::ai", "index")
+
+
+def create_ext_ai_index(
+    index: s_indexes.Index,
+    predicate_src: Optional[str],
+    sql_kwarg_exprs: dict[str, str],
+    options: qlcompiler.CompilerOptions,
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> dbops.Command:
+    subject = index.get_subject(schema)
+    assert isinstance(subject, s_indexes.IndexableSubject)
+
+    effective, has_overridden = s_indexes.get_effective_object_index(
+        schema, subject, ai_index_base_name
+    )
+
+    if index != effective:
+        return dbops.CommandGroup()
+
+    # When creating an index on a child that already has an ext::ai index
+    # inherited from the parent, we don't need to create the index, but just
+    # update the populating expressions.
+    if has_overridden:
+        return _refresh_ai_embeddings_source_view(
+            index,
+            options,
+            schema,
+            context,
+        )
+    else:
+        return _create_ai_embeddings(
+            index,
+            predicate_src,
+            sql_kwarg_exprs,
+            options,
+            schema,
+            context,
+        )
+
+
+def delete_ext_ai_index(
+    index: s_indexes.Index,
+    drop_index: dbops.Command,
+    options: qlcompiler.CompilerOptions,
+    schema: s_schema.Schema,
+    orig_schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> tuple[dbops.Command, dbops.Command]:
+    subject = index.get_subject(orig_schema)
+    assert isinstance(subject, s_indexes.IndexableSubject)
+
+    effective, _ = s_indexes.get_effective_object_index(
+        schema, subject, ai_index_base_name
+    )
+
+    if not effective:
+        return _delete_ai_embeddings(
+            index, drop_index, schema, orig_schema, context)
+    else:
+        # effective index remains: don't drop the embeddings
+        return dbops.CommandGroup(), dbops.CommandGroup()
+
+
+def _compile_ai_embeddings_source_view_expr(
+    index: s_indexes.Index,
+    options: qlcompiler.CompilerOptions,
+    schema: s_schema.Schema,
+) -> pgast.SelectStmt:
+    # Compile a view returning a set of (id, text-to-embed) tuples
+    # roughly as the following pseudo-QL
+    #
+    # SELECT (
+    #   Object.id,
+    #   eval(get_index_expr(Object, 'ext::ai::index')),
+    # )
+    # WHERE
+    #   eval(get_index_except_expr(Object, 'ext::ai::index')) IS NOT TRUE
+    #   AND Object.embedding_column IS NULL
+    index_sexpr: Optional[s_expr.Expression] = index.get_expr(schema)
+    assert index_sexpr
+    ql = qlast.SelectQuery(
+        result=qlast.Tuple(
+            elements=[
+                qlast.Path(
+                    steps=[qlast.Ptr(name="id")],
+                    partial=True,
+                ),
+                index_sexpr.qlast,
+            ],
+        ),
+    )
+
+    my_options = dataclasses.replace(options, singletons=frozenset())
+    ir = qlcompiler.compile_ast_to_ir(
+        ql,
+        schema=schema,
+        options=my_options,
+    )
+    assert isinstance(ir, irast.Statement)
+
+    subject = index.get_subject(schema)
+    assert isinstance(subject, s_types.Type)
+    subject_id = irast.PathId.from_type(schema, subject, env=None)
+
+    idx_id = _get_index_root_id(schema, index)
+    table_name = common.get_index_table_backend_name(index, schema)
+    aspects = ("identity", "value", "source")
+    qry = compiler.new_external_rvar_as_subquery(
+        rel_name=table_name,
+        path_id=subject_id,
+        aspects=aspects,
+    )
+    qry.where_clause = astutils.extend_binop(
+        qry.where_clause,
+        pgast.NullTest(
+            arg=pgast.ColumnRef(
+                name=(f"__ext_ai_{idx_id}_embedding__",),
+            ),
+        )
+    )
+
+    except_expr = index.get_except_expr(schema)
+    if except_expr:
+        except_expr = except_expr.ensure_compiled(
+            schema=schema,
+            options=options,
+        )
+        assert except_expr.irast
+        except_res = compiler.compile_ir_to_sql_tree(
+            except_expr.irast.expr, singleton_mode=True)
+        assert isinstance(except_res.ast, pgast.BaseExpr)
+        qry.where_clause = astutils.extend_binop(
+            qry.where_clause,
+            pgast.Expr(
+                lexpr=except_res.ast,
+                name="IS NOT",
+                rexpr=pgast.BooleanConstant(val=True),
+            ),
+        )
+
+    sql_res = compiler.compile_ir_to_sql_tree(
+        ir,
+        output_format=compiler.OutputFormat.NATIVE_INTERNAL,
+        external_rels={
+            subject_id: (qry, aspects),
+        },
+    )
+    expr = sql_res.ast
+    assert isinstance(expr, pgast.SelectStmt)
+
+    return expr
+
+
+def _create_ai_embeddings(
+    index: s_indexes.Index,
+    predicate_src: Optional[str],
+    sql_kwarg_exprs: dict[str, str],
+    options: qlcompiler.CompilerOptions,
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> dbops.Command:
+    return _pg_create_ai_embeddings(
+        index,
+        options,
+        predicate_src,
+        sql_kwarg_exprs,
+        schema,
+        context,
+    )
+
+
+def _refresh_ai_embeddings_source_view(
+    index: s_indexes.Index,
+    options: qlcompiler.CompilerOptions,
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> dbops.Command:
+    return _pg_create_ai_embeddings_source_view(
+        index, options, schema, context)
+
+
+def _delete_ai_embeddings(
+    index: s_indexes.Index,
+    drop_index: dbops.Command,
+    schema: s_schema.Schema,
+    orig_schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> tuple[dbops.Command, dbops.Command]:
+    return _pg_delete_ai_embeddings(
+        index, drop_index, schema, orig_schema, context
+    )
+
+
+# --- pgvector ---
+
+
+def _pg_create_ai_embeddings(
+    index: s_indexes.Index,
+    options: qlcompiler.CompilerOptions,
+    predicate_src: Optional[str],
+    sql_kwarg_exprs: dict[str, str],
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> dbops.Command:
+    # Create:
+    # * the "__ext_ai_{idx_id}_embedding__" vector attribute;
+    # * pgvector index on the above;
+    # * the embedding attribute invalidation trigger
+    # * a component view for the "ai_pending_embeddings_{model_name}" union
+    ops = dbops.CommandGroup()
+
+    table_name = common.get_index_table_backend_name(index, schema)
+
+    with_clause = {}
+    kwargs = index.get_concrete_kwargs(schema)
+    index_params_expr = kwargs.get("index_parameters")
+    if index_params_expr is not None:
+        index_params = index_params_expr.assert_compiled().as_python_value()
+        with_clause["m"] = index_params["m"]
+        with_clause["ef_construction"] = index_params["ef_construction"]
+
+    dimensions = index.must_get_json_annotation(
+        schema,
+        sn.QualName("ext::ai", "embedding_dimensions"),
+        int,
+    )
+
+    idx_id = _get_index_root_id(schema, index)
+
+    alter_table = dbops.AlterTable(table_name)
+
+    # The attribute
+    alter_table.add_operation(
+        dbops.AlterTableAddColumn(
+            dbops.Column(
+                name=f'__ext_ai_{idx_id}_embedding__',
+                type=f'edgedb.vector({dimensions})',
+                required=False,
+            )
+        )
+    )
+
+    ops.add_command(alter_table)
+
+    # Also create a constant partial index on outdated entries
+    # so that we use an index scan and not a seq scan when
+    # picking out pending embeddings.
+    outdated_idx_name = common.get_index_table_backend_name(
+        index, schema, aspect="extaiselidx")
+
+    ops.add_command(
+        dbops.CreateIndex(
+            dbops.Index(
+                name=outdated_idx_name[1],
+                table_name=table_name,
+                exprs=["(1)"],
+                predicate=(
+                    f'__ext_ai_{idx_id}_embedding__ IS NULL'),
+                unique=False,
+                metadata={
+                    'code': '(__col__)',
+                },
+            ),
+        ),
+    )
+
+    df_expr = kwargs.get("distance_function")
+    if df_expr is not None:
+        df = df_expr.assert_compiled().as_python_value()
+    else:
+        df = "Cosine"
+
+    match df:
+        case "Cosine":
+            opclass = "vector_cosine_ops"
+        case "InnerProduct":
+            opclass = "vector_ip_ops"
+        case "L2":
+            opclass = "vector_l2_ops"
+        case _:
+            raise RuntimeError(f"unsupported distance_function: {df}")
+
+    # The main similarity (a.k.a distance) search index.
+    module_name = index.get_name(schema).module
+    index_name = common.get_index_backend_name(
+        index.id, module_name, catenate=False, aspect=f'{dimensions}_index'
+    )
+
+    pg_index = dbops.Index(
+        name=index_name[1],
+        table_name=table_name,
+        exprs=[f"__ext_ai_{idx_id}_embedding__"],
+        with_clause=with_clause,
+        unique=False,
+        predicate=predicate_src,
+        metadata={
+            'schemaname': str(index.get_name(schema)),
+            'kwargs': sql_kwarg_exprs,
+            'code': f'hnsw (__col__ {opclass})',
+            'dimensions': str(dimensions),
+            'distance_function': str(df),
+        },
+    )
+    ops.add_command(dbops.CreateIndex(pg_index))
+
+    index_expr = index.get_expr(schema)
+    assert index_expr is not None
+    dep_cols = []
+    assert index_expr.refs is not None
+    for obj in index_expr.refs.objects(schema):
+        if isinstance(obj, s_props.Property):
+            ptrinfo = types.get_pointer_storage_info(obj, schema=schema)
+            dep_cols.append(ptrinfo.column_name)
+
+    # The invalidation trigger
+    ops.add_command(
+        _pg_create_trigger(schema, index, table_name, dep_cols))
+
+    # The component view for the "ai_pending_embeddings_{model_name}" union
+    ops.add_command(
+        _pg_create_ai_embeddings_source_view(index, options, schema, context))
+
+    return ops
+
+
+def _pg_delete_ai_embeddings(
+    index: s_indexes.Index,
+    drop_index: dbops.Command,
+    schema: s_schema.Schema,
+    orig_schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> tuple[dbops.Command, dbops.Command]:
+    table_name = common.get_index_table_backend_name(index, orig_schema)
+    idx_id = _get_index_root_id(orig_schema, index)
+
+    table_ops = dbops.CommandGroup()
+
+    ops = dbops.CommandGroup()
+    ops.add_command(drop_index)
+
+    # Drop the invalidation trigger
+    ops.add_command(_pg_drop_trigger(index, table_name, orig_schema))
+    # Drop component view for the "ai_pending_embeddings_{model_name}" union
+    ops.add_command(_pg_drop_ai_embeddings_source_view(
+        index, schema, orig_schema, context))
+
+    # When the ObjectType is being deleted, we don't drop the index,
+    # as it will get dropped with the parent table.
+    # The same goes for __ext_ai_{idx_id}_embedding__.
+    source_drop = isinstance(drop_index, dbops.NoOpCommand)
+    if not source_drop:
+        table_name = common.get_index_table_backend_name(index, orig_schema)
+
+        dimensions = index.must_get_json_annotation(
+            orig_schema,
+            sn.QualName("ext::ai", "embedding_dimensions"),
+            int,
+        )
+
+        alter_table = dbops.AlterTable(table_name)
+
+        alter_table.add_operation(
+            dbops.AlterTableDropColumn(
+                dbops.Column(
+                    name=f'__ext_ai_{idx_id}_embedding__',
+                    type=('edgedb', f'vector({dimensions})'),
+                )
+            )
+        )
+
+        table_ops.add_command(alter_table)
+
+    return ops, table_ops
+
+
+def _pg_create_trigger(
+    schema: s_schema.Schema,
+    index: s_indexes.Index,
+    table_name: tuple[str, str],
+    dep_cols: list[str],
+) -> dbops.Command:
+    # Create a trigger that resets the __ext_ai_{idx_id}_embedding__ to
+    # NULL whenever data referenced in the ext::ai::index expression gets
+    # modified (TODO: the selective approach could also be used on fts::index)
+    ops = dbops.CommandGroup()
+    idx_id = _get_index_root_id(schema, index)
+
+    # create update function
+    func_name = _pg_update_func_name(table_name, idx_id)
+    function = dbops.Function(
+        name=func_name,
+        text=f"""
+        BEGIN
+            NEW."__ext_ai_{idx_id}_embedding__" := NULL;
+        END;
+        """,
+        volatility='immutable',
+        returns='trigger',
+        language='plpgsql',
+    )
+    ops.add_command(dbops.CreateFunction(function))
+
+    conditions = []
+    for dep_col in dep_cols:
+        dep_col = qi(dep_col)
+        conditions.append(f'OLD.{dep_col} IS DISTINCT FROM NEW.{dep_col}')
+
+    trigger_name = _pg_trigger_name(table_name[1], idx_id)
+    trigger = dbops.Trigger(
+        name=trigger_name,
+        table_name=table_name,
+        events=('update',),
+        timing='before',
+        procedure=func_name,
+        condition=' OR '.join(conditions),
+    )
+    ops.add_command(dbops.CreateTrigger(trigger))
+    return ops
+
+
+def _pg_drop_trigger(
+    index: s_indexes.Index,
+    table_name: tuple[str, str],
+    schema: s_schema.Schema,
+) -> dbops.Command:
+    idx_id = _get_index_root_id(schema, index)
+    ops = dbops.CommandGroup()
+
+    ops.add_command(
+        dbops.DropTrigger(
+            dbops.Trigger(
+                _pg_trigger_name(table_name[1], idx_id),
+                table_name=table_name,
+                events=(),
+                procedure='',
+            )
+        )
+    )
+
+    ops.add_command(
+        dbops.DropFunction(
+            _pg_update_func_name(table_name, idx_id),
+            (),
+        )
+    )
+    return ops
+
+
+def pg_rebuild_all_pending_embeddings_views(
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> dbops.Command:
+    ops = dbops.CommandGroup()
+
+    def flt(schema: s_schema.Schema, index: s_indexes.Index) -> bool:
+        return (
+            index.get_subject(schema) is not None
+            and s_indexes.is_ext_ai_index(schema, index)
+        )
+
+    all_ai_indexes = schema.get_objects(
+        type=s_indexes.Index,
+        extra_filters=(flt,),
+    )
+
+    all_models = s_indexes.get_defined_ext_ai_embedding_models(schema)
+
+    used_models = collections.defaultdict(list)
+    for other_index in all_ai_indexes:
+        tabname = common.get_index_table_backend_name(
+            other_index, schema, aspect="extaiview")
+        model_name = other_index.must_get_annotation(
+            schema, sn.QualName("ext::ai", "model_name"))
+        used_models[model_name].append(f"SELECT * FROM {q(*tabname)}")
+
+    model_providers = {}
+
+    for model_name, model_stype in all_models.items():
+        views = used_models.get(model_name)
+
+        if views:
+            query = " UNION ALL ".join(views)
+        else:
+            query = textwrap.dedent("""\
+                SELECT
+                    NULL::uuid AS "id",
+                    NULL::text AS "text",
+                    NULL::text AS "target_rel",
+                    NULL::text AS "target_attr",
+                    NULL::int  AS "target_dims_shortening"
+                WHERE
+                    FALSE
+            """)
+
+        view = dbops.View(
+            name=(
+                "edgedbext",
+                common.edgedb_name_to_pg_name(
+                    f"ai_pending_embeddings_{model_name}"
+                ),
+            ),
+            query=query,
+        )
+        ops.add_command(dbops.CreateView(view, or_replace=True))
+
+        provider = model_stype.must_get_annotation(
+            schema, sn.QualName("ext::ai", "model_provider"))
+        model_providers[model_name] = provider
+
+    if used_models:
+        bits = []
+        for model_name in used_models:
+            mnhash = hashlib.blake2b(model_name.encode("utf-8"), digest_size=8)
+            model_id: int = struct.unpack("q", mnhash.digest())[0]
+
+            provider = model_providers[model_name]
+            bits.append(textwrap.dedent(f"""\
+                SELECT
+                    {model_id}::bigint AS id,
+                    {ql(model_name)} AS name,
+                    {ql(provider)} AS provider
+            """))
+        used_sql = " UNION ALL ".join(bits)
+    else:
+        used_sql = textwrap.dedent("""\
+            SELECT
+                NULL::bigint AS id,
+                NULL::text AS name,
+                NULL::text AS provider
+            WHERE
+                FALSE
+        """)
+
+    ops.add_command(dbops.CreateView(
+        view=dbops.View(
+            name=("edgedbext", "ai_active_embedding_models"),
+            query=used_sql,
+        ),
+        or_replace=True,
+    ))
+
+    return ops
+
+
+def pg_drop_all_pending_embeddings_views(
+    schema: s_schema.Schema,
+) -> dbops.Command:
+    ops = dbops.CommandGroup()
+
+    all_models = s_indexes.get_defined_ext_ai_embedding_models(schema)
+    for model_name in all_models:
+        view_name = (
+            "edgedbext",
+            common.edgedb_name_to_pg_name(
+                f"ai_pending_embeddings_{model_name}"
+            ),
+        )
+        ops.add_command(dbops.DropView(view_name, conditional=True))
+
+    ops.add_command(
+        dbops.DropView(("edgedbext", "ai_active_embedding_models")))
+
+    return ops
+
+
+def _pg_create_ai_embeddings_source_view(
+    index: s_indexes.Index,
+    options: qlcompiler.CompilerOptions,
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> dbops.Command:
+    ops = dbops.CommandGroup()
+
+    expr = _compile_ai_embeddings_source_view_expr(index, options, schema)
+    view_name = common.get_index_table_backend_name(
+        index, schema, aspect="extaiview")
+
+    idx_id = _get_index_root_id(schema, index)
+    target_col = f"__ext_ai_{idx_id}_embedding__"
+    index_dimensions = index.must_get_json_annotation(
+        schema,
+        sn.QualName("ext::ai", "embedding_dimensions"),
+        int,
+    )
+    model_dimensions = index.must_get_json_annotation(
+        schema,
+        sn.QualName("ext::ai", "embedding_model_max_output_dimensions"),
+        int,
+    )
+
+    if index_dimensions < model_dimensions:
+        target_dims_shortening = str(index_dimensions)
+    else:
+        target_dims_shortening = "NULL"
+
+    table_name = common.get_index_table_backend_name(index, schema)
+    expr_sql = codegen.generate_source(expr)
+    document_sql = textwrap.dedent(f"""\
+        SELECT
+            (q.val).f1 AS "id",
+            (q.val).f2 AS "text",
+            {ql(q(*table_name))} AS "target_rel",
+            {ql(qi(target_col))} AS "target_attr",
+            {target_dims_shortening}::int AS "target_dims_shortening"
+        FROM
+            ({expr_sql}) AS q(val)
+    """)
+
+    view = dbops.View(name=view_name, query=document_sql)
+    ops.add_command(dbops.CreateView(view, or_replace=True))
+    ops.add_command(pg_rebuild_all_pending_embeddings_views(schema, context))
+
+    return ops
+
+
+def _pg_drop_ai_embeddings_source_view(
+    index: s_indexes.Index,
+    schema: s_schema.Schema,
+    orig_schema: s_schema.Schema,
+    context: sd.CommandContext,
+) -> dbops.Command:
+    ops = dbops.CommandGroup()
+
+    ops.add_command(pg_rebuild_all_pending_embeddings_views(
+        schema,
+        context,
+    ))
+
+    view_name = common.get_index_table_backend_name(
+        index, orig_schema, aspect="extaiview")
+    ops.add_command(dbops.DropView(view_name))
+
+    return ops
+
+
+def _pg_update_func_name(
+    tbl_name: tuple[str, str],
+    idx_id: str,
+) -> tuple[str, ...]:
+    return (
+        tbl_name[0],
+        common.edgedb_name_to_pg_name(tbl_name[1] + f'_extai_{idx_id}_upd'),
+    )
+
+
+def _pg_trigger_name(
+    tbl_name: str,
+    idx_id: str,
+) -> str:
+    return common.edgedb_name_to_pg_name(tbl_name + f'_extai_{idx_id}_trg')
+
+
+def _get_index_root_id(
+    schema: s_schema.Schema,
+    index: s_indexes.Index,
+) -> str:
+    return index.get_topmost_concrete_base(schema).id.hex

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -373,6 +373,12 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
 
 
 class CompiledExpression(Expression):
+    refs = struct.Field(
+        so.ObjectSet,  # type: ignore
+        coerce=True,
+        frozen=True,
+    )
+
     def __init__(
         self,
         *args: Any,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -827,7 +827,7 @@ class CallableObject(
         self: CallableObjectT,
         schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.ObjectCommand[CallableObjectT]:
+    ) -> sd.CreateObject[CallableObjectT]:
         delta = super().as_create_delta(schema, context)
 
         new_params = self.get_params(schema).objects(schema)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -943,7 +943,7 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         self,
         schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.ObjectCommand[Pointer]:
+    ) -> sd.CreateObject[Pointer]:
         delta = super().as_create_delta(schema, context)
 
         # When we are creating a new required property on an existing type,

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -508,7 +508,7 @@ class Schema(abc.ABC):
         included_items: Optional[Iterable[sn.Name]] = None,
         excluded_items: Optional[Iterable[sn.Name]] = None,
         type: Optional[Type[so.Object_T]] = None,
-        extra_filters: Iterable[Callable[[Schema, so.Object], bool]] = (),
+        extra_filters: Iterable[Callable[[Schema, so.Object_T], bool]] = (),
     ) -> SchemaIterator[so.Object_T]:
         raise NotImplementedError
 
@@ -1491,7 +1491,7 @@ class FlatSchema(Schema):
         included_items: Optional[Iterable[sn.Name]] = None,
         excluded_items: Optional[Iterable[sn.Name]] = None,
         type: Optional[Type[so.Object_T]] = None,
-        extra_filters: Iterable[Callable[[Schema, so.Object], bool]] = (),
+        extra_filters: Iterable[Callable[[Schema, so.Object_T], bool]] = (),
     ) -> SchemaIterator[so.Object_T]:
         return SchemaIterator[so.Object_T](
             self,
@@ -1577,7 +1577,7 @@ class SchemaIterator(Generic[so.Object_T]):
         included_items: Optional[Iterable[sn.Name]] = None,
         excluded_items: Optional[Iterable[sn.Name]] = None,
         type: Optional[Type[so.Object_T]] = None,
-        extra_filters: Iterable[Callable[[Schema, so.Object], bool]] = (),
+        extra_filters: Iterable[Callable[[Schema, so.Object_T], bool]] = (),
     ) -> None:
 
         filters = []
@@ -2102,7 +2102,7 @@ class ChainedSchema(Schema):
         included_items: Optional[Iterable[sn.Name]] = None,
         excluded_items: Optional[Iterable[sn.Name]] = None,
         type: Optional[Type[so.Object_T]] = None,
-        extra_filters: Iterable[Callable[[Schema, so.Object], bool]] = (),
+        extra_filters: Iterable[Callable[[Schema, so.Object_T], bool]] = (),
     ) -> SchemaIterator[so.Object_T]:
         return SchemaIterator[so.Object_T](
             self,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -955,7 +955,7 @@ class Collection(Type, s_abc.Collection):
         self: CollectionTypeT,
         schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.ObjectCommand[CollectionTypeT]:
+    ) -> sd.CreateObject[CollectionTypeT]:
         delta = super().as_create_delta(schema=schema, context=context)
         assert isinstance(delta, sd.CreateObject)
         if not isinstance(self, CollectionExprAlias):

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -45,6 +45,8 @@ from edb.server.protocol import execute
 from edb.pgsql import dbops
 from edb.server.compiler_pool import state as compiler_state_mod
 
+from edb.server.protocol import ai_ext
+
 cimport cython
 
 from edb.server.compiler cimport rpc
@@ -277,7 +279,10 @@ cdef class Database:
             self.start_stop_extensions()
 
     cpdef start_stop_extensions(self):
-        pass
+        if "ai" in self.extensions:
+            ai_ext.start_extension(self.tenant, self.name)
+        else:
+            ai_ext.stop_extension(self.tenant, self.name)
 
     cdef _observe_auth_ext_config(self):
         key = "ext::auth::AuthConfig::providers"

--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -1,0 +1,511 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import (
+    Any,
+    ClassVar,
+    NoReturn,
+    Optional,
+    TYPE_CHECKING,
+)
+
+import asyncio
+import contextvars
+import http
+import itertools
+import json
+import logging
+
+from edb import errors
+from edb.common import asyncutil
+from edb.common import debug
+from edb.common import markup
+from edb.common import uuidgen
+
+from edb.server import compiler
+from edb.server.compiler import sertypes
+from edb.server.protocol import execute
+
+if TYPE_CHECKING:
+    from edb.server import dbview
+    from edb.server import tenant as srv_tenant
+    from edb.server import pgcon
+    from edb.server.protocol import protocol
+
+
+logger = logging.getLogger("edb.server.ai_ext")
+
+
+class AIExtError(Exception):
+    http_status: ClassVar[http.HTTPStatus] = (
+        http.HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    def __init__(
+        self,
+        *args: object,
+        json: Optional[dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(*args)
+        self._json = json
+
+    def get_http_status(self) -> http.HTTPStatus:
+        return self.__class__.http_status
+
+    def json(self) -> dict[str, Any]:
+        if self._json is not None:
+            return self._json
+        else:
+            return {
+                "message": str(self.args[0]),
+                "type": self.__class__.__name__,
+            }
+
+
+class AIProviderError(AIExtError):
+    pass
+
+
+class ConfigurationError(AIExtError):
+    pass
+
+
+class InternalError(AIExtError):
+    pass
+
+
+class BadRequestError(AIExtError):
+    http_status = http.HTTPStatus.BAD_REQUEST
+
+
+def start_extension(
+    tenant: srv_tenant.Tenant,
+    dbname: str,
+) -> None:
+    task_name = _get_builder_task_name(dbname)
+    task = tenant.get_task(task_name)
+    if task is None:
+        logger.info(f"starting AI extension tasks on database {dbname!r}")
+        tenant.create_task(
+            _ext_ai_index_builder_controller_loop(tenant, dbname),
+            interruptable=True,
+            name=task_name,
+        )
+
+
+def stop_extension(
+    tenant: srv_tenant.Tenant,
+    dbname: str,
+) -> None:
+    task_name = _get_builder_task_name(dbname)
+    task = tenant.get_task(task_name)
+    if task is not None:
+        logger.info(f"stopping AI extension tasks on database {dbname!r}")
+        task.cancel()
+
+
+def _get_builder_task_name(dbname: str) -> str:
+    return f"ext::ai::index builder on database {dbname!r}"
+
+
+_task_name = contextvars.ContextVar(
+    "ext_ai_index_builder_task_name", default="-")
+
+
+async def _ext_ai_index_builder_controller_loop(
+    tenant: srv_tenant.Tenant,
+    dbname: str,
+) -> None:
+    task_name = _get_builder_task_name(dbname)
+    _task_name.set(task_name)
+    logger.info(f"started {task_name}")
+    db = tenant.get_db(dbname=dbname)
+    holding_lock = False
+
+    await db.introspection()
+    naptime_cfg = db.lookup_config("ext::ai::Config::indexer_naptime")
+    naptime = naptime_cfg.to_microseconds() / 1000000
+
+    try:
+        while True:
+            try:
+                pgconn = await tenant.acquire_pgcon(dbname)
+                models = []
+                processed = 0
+                errors = 0
+                try:
+                    models = await _ext_ai_fetch_active_models(pgconn)
+                    if models:
+                        if not holding_lock:
+                            holding_lock = await _ext_ai_lock(pgconn)
+                        if holding_lock:
+                            try:
+                                processed, errors = (
+                                    await _ext_ai_index_builder_work(
+                                        db, pgconn, models))
+                            finally:
+                                if processed == 0 or errors != 0:
+                                    await asyncutil.deferred_shield(
+                                        _ext_ai_unlock(pgconn))
+                                    holding_lock = False
+                finally:
+                    tenant.release_pgcon(dbname, pgconn)
+            except Exception:
+                logger.exception(f"caught error in {task_name}")
+
+            if processed == 0:
+                # No work, sleep for a bit.
+                logger.debug(
+                    f"{task_name} napping for {naptime:.2f} seconds: no work")
+                await asyncio.sleep(naptime)
+            elif errors != 0:
+                # No work, sleep for a bit.
+                logger.debug(
+                    f"{task_name} napping for {naptime:.2f} seconds: there "
+                    f"were {errors} error(s) during last run.")
+                await asyncio.sleep(naptime)
+    finally:
+        logger.info(f"stopped {task_name}")
+
+
+async def _ext_ai_fetch_active_models(
+    pgconn: pgcon.PGConnection,
+) -> list[tuple[int, str, str]]:
+    models = await pgconn.sql_fetch(
+        b"""
+            SELECT
+                id,
+                name,
+                provider
+            FROM
+                edgedbext.ai_active_embedding_models
+        """,
+    )
+
+    result = []
+    if models:
+        for model in models:
+            result.append((
+                int.from_bytes(model[0], byteorder="big", signed=True),
+                model[1].decode("utf-8"),
+                model[2].decode("utf-8"),
+            ))
+
+    return result
+
+
+_EXT_AI_ADVISORY_LOCK = b"3987734540"
+
+
+async def _ext_ai_lock(
+    pgconn: pgcon.PGConnection,
+) -> bool:
+    b = await pgconn.sql_fetch_val(
+        b"SELECT pg_try_advisory_lock(" + _EXT_AI_ADVISORY_LOCK + b")")
+    return b == b'\x01'
+
+
+async def _ext_ai_unlock(
+    pgconn: pgcon.PGConnection,
+) -> None:
+    await pgconn.sql_fetch_val(
+        b"SELECT pg_advisory_unlock(" + _EXT_AI_ADVISORY_LOCK + b")")
+
+
+async def _ext_ai_index_builder_work(
+    db: dbview.Database,
+    pgconn: pgcon.PGConnection,
+    models: list[tuple[int, str, str]],
+) -> tuple[int, int]:
+    task_name = _task_name.get()
+
+    models_by_provider: dict[str, list[str]] = {}
+    for entry in models:
+        model_name = entry[1]
+        provider_name = entry[2]
+        try:
+            models_by_provider[provider_name].append(model_name)
+        except KeyError:
+            m = models_by_provider[provider_name] = []
+            m.append(model_name)
+
+    submit_list: dict[str, dict[str, list[tuple[bytes, ...]]]] = {}
+
+    for provider_name, provider_models in models_by_provider.items():
+        for model_name in provider_models:
+            logger.debug(
+                f"{task_name} considering {model_name!r} "
+                f"indexes via {provider_name!r}"
+            )
+
+            entries = await pgconn.sql_fetch(
+                f"""
+                SELECT
+                    *
+                FROM
+                    (
+                        SELECT
+                            "id",
+                            "text",
+                            "target_rel",
+                            "target_attr",
+                            "target_dims_shortening"
+                        FROM
+                            edgedbext."ai_pending_embeddings_{model_name}"
+                        LIMIT
+                            500
+                    ) AS q
+                ORDER BY
+                    q."target_dims_shortening",
+                    q."target_rel"
+                """.encode()
+            )
+
+            if not entries:
+                continue
+
+            logger.debug(f"{task_name} found {len(entries)} entries to index")
+
+            try:
+                provider_list = submit_list[provider_name]
+            except KeyError:
+                provider_list = submit_list[provider_name] = {}
+
+            try:
+                model_list = provider_list[model_name]
+            except KeyError:
+                model_list = provider_list[model_name] = []
+
+            model_list.extend(entries)
+
+    errors = 0
+    if submit_list:
+        cfg = db.lookup_config("ext::ai::Config::providers")
+
+        providers_cfg = {}
+        for provider in cfg:
+            providers_cfg[provider.name] = provider
+
+        tasks = {}
+        async with asyncio.TaskGroup() as g:
+            for provider_name, provider_list in submit_list.items():
+                try:
+                    provider_cfg = _get_provider_config(
+                        db=db, provider_name=provider_name)
+                except LookupError as e:
+                    logger.error(f"{task_name}: {e}")
+                    errors += 1
+                    continue
+
+                for model_name, entries in provider_list.items():
+                    groups = itertools.groupby(entries, key=lambda e: e[4])
+                    for shortening_datum, part_iter in groups:
+                        if shortening_datum is not None:
+                            shortening = int.from_bytes(
+                                shortening_datum,
+                                byteorder="big",
+                                signed=False,
+                            )
+                        else:
+                            shortening = None
+                        part = list(part_iter)
+                        task = g.create_task(
+                            _generate_embeddings_task(
+                                provider_cfg,
+                                model_name,
+                                [entry[1].decode("utf-8") for entry in part],
+                                shortening,
+                            ),
+                        )
+                        tasks[task] = part
+
+        for task, entries in tasks.items():
+            embeddings = task.result()
+            if embeddings is None:
+                # error
+                errors += 1
+            else:
+                groups = itertools.groupby(entries, key=lambda e: e[2:])
+                offset = 0
+                for (rel, attr, *_), items in groups:
+                    ids = [item[0] for item in items]
+                    await _update_embeddings_in_db(
+                        pgconn, rel, attr, ids, embeddings, offset)
+                    offset += len(ids)
+
+    return len(submit_list), errors
+
+
+async def _update_embeddings_in_db(
+    pgconn: pgcon.PGConnection,
+    rel: bytes,
+    attr: bytes,
+    ids: list[bytes],
+    embeddings: bytes,
+    offset: int,
+) -> int:
+    id_array = '", "'.join(uuidgen.from_bytes(ub).hex for ub in ids)
+    entries = await pgconn.sql_fetch_val(
+        f"""
+        WITH upd AS (
+            UPDATE {rel.decode()} AS target
+            SET
+                {attr.decode()} = (
+                    (embeddings.data ->> 'embedding')::edgedb.vector)
+            FROM
+                (
+                    SELECT
+                        row_number() over () AS n,
+                        j.data
+                    FROM
+                        (SELECT
+                            data
+                        FROM
+                            json_array_elements(($1::json) -> 'data') AS data
+                        OFFSET
+                            $3::text::int
+                        ) AS j
+                ) AS embeddings,
+                unnest($2::text::text[]) WITH ORDINALITY AS ids(id, n)
+            WHERE
+                embeddings."n" = ids."n"
+                AND target."id" = ids."id"::uuid
+            RETURNING
+                target."id"
+        )
+        SELECT count(*)::text FROM upd
+        """.encode(),
+        args=(
+            embeddings,
+            f'{{"{id_array}"}}'.encode(),
+            str(offset).encode(),
+        ),
+    )
+
+    return int(entries.decode())
+
+
+async def _generate_embeddings_task(
+    provider,
+    model_name: str,
+    inputs: list[str],
+    shortening: Optional[int],
+) -> Optional[bytes]:
+    task_name = _task_name.get()
+
+    try:
+        return await _generate_embeddings(
+            provider, model_name, inputs, shortening,
+        )
+    except AIExtError as e:
+        logger.error(f"{task_name}: {e}")
+        return None
+    except Exception as e:
+        logger.error(
+            f"{task_name}: could not generate embeddings "
+            f"due to an internal error: {e}"
+        )
+        return None
+
+
+async def _generate_embeddings(
+    provider,
+    model_name: str,
+    inputs: list[str],
+    shortening: Optional[int],
+) -> bytes:
+    task_name = _task_name.get()
+    count = len(inputs)
+    suf = "s" if count > 1 else ""
+    logger.debug(
+        f"{task_name} generating embeddings via {model_name!r} "
+        f"of {provider.name!r} for {len(inputs)} object{suf}"
+    )
+    raise RuntimeError(f"unsupported model provider: {provider.name}")
+
+
+async def _edgeql_query_json(
+    *,
+    db: dbview.Database,
+    query: str,
+    variables: Optional[dict[str, Any]] = None,
+    globals_: Optional[dict[str, Any]] = None,
+) -> list[Any]:
+    try:
+        result = await execute.parse_execute_json(
+            db,
+            query,
+            variables=variables or {},
+            globals_=globals_,
+        )
+
+        content = json.loads(result)
+    except Exception as ex:
+        try:
+            await _db_error(db, ex)
+        except Exception as iex:
+            raise iex from None
+    else:
+        return content
+
+
+async def _db_error(
+    db: dbview.Database,
+    ex: Exception,
+    *,
+    errcls: Optional[type[AIExtError]] = None,
+    context: Optional[str] = None,
+) -> NoReturn:
+    if debug.flags.server:
+        markup.dump(ex)
+
+    iex = await execute.interpret_error(ex, db)
+
+    if context:
+        msg = f'{context}: {iex}'
+    else:
+        msg = str(iex)
+
+    err_dct = {
+        'message': msg,
+        'type': str(type(iex).__name__),
+        'code': iex.get_code(),
+    }
+
+    if errcls is None:
+        if isinstance(iex, errors.QueryError):
+            errcls = BadRequestError
+        else:
+            errcls = InternalError
+
+    raise errcls(json=err_dct) from iex
+
+
+def _get_provider_config(
+    db: dbview.Database,
+    provider_name: str,
+) -> Any:
+    cfg = db.lookup_config("ext::ai::Config::providers")
+
+    for provider in cfg:
+        if provider.name == provider_name:
+            return provider
+    else:
+        raise ConfigurationError(
+            f"provider {provider_name!r} has not been configured"
+        )

--- a/edb/server/protocol/protocol.pyi
+++ b/edb/server/protocol/protocol.pyi
@@ -17,6 +17,7 @@
 #
 
 import asyncio
+import http
 import http.cookies
 import ssl
 
@@ -39,7 +40,7 @@ class HttpRequest:
     cookies: http.cookies.SimpleCookie
 
 class HttpResponse:
-    status: str
+    status: http.HTTPStatus
     close_connection: bool
     content_type: bytes
     custom_headers: dict[str, str]

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -58,6 +58,7 @@ from . import notebook_ext
 from . import system_api
 from . import ui_ext
 from . import auth_ext
+from . import ai_ext
 
 
 HTTPStatus = http.HTTPStatus
@@ -656,6 +657,10 @@ cdef class HttpProtocol:
                     await edgeql_ext.handle_request(
                         request, response, db, args, self.tenant
                     )
+                elif extname == 'ai':
+                    await ai_ext.handle_request(
+                        self, request, response, db, args, self.tenant
+                    )
                 elif extname == 'auth':
                     netloc = (
                         f"{request_url.host.decode()}:{request_url.port}"
@@ -680,6 +685,8 @@ cdef class HttpProtocol:
                             srv_metrics.auth_api_calls.inc(
                                 1.0, self.get_tenant_label()
                             )
+                else:
+                    return self._not_found(request, response)
 
         elif route == 'auth':
             if await self._handle_cors(

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -18,8 +18,15 @@
 
 
 from __future__ import annotations
+from typing import (
+    Any,
+    Callable,
+    Optional,
+)
 
+import http.server
 import json
+import threading
 import urllib.parse
 import urllib.request
 
@@ -302,3 +309,177 @@ class GraphQLTestCase(BaseHttpExtensionTest):
         assert_data_shape.assert_data_shape(
             res, result, self.fail, message=msg)
         return res
+
+
+class MockHttpServerHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.close_connection = False
+        server, path = self.path.lstrip('/').split('/', 1)
+        server = urllib.parse.unquote(server)
+        self.server.owner.handle_request('GET', server, path, self)
+
+    def do_POST(self):
+        self.close_connection = False
+        server, path = self.path.lstrip('/').split('/', 1)
+        server = urllib.parse.unquote(server)
+        self.server.owner.handle_request('POST', server, path, self)
+
+    def log_message(self, *args):
+        pass
+
+
+ResponseType = tuple[str, int] | tuple[str, int, dict[str, str]]
+
+
+class MockHttpServer:
+    def __init__(self) -> None:
+        self.has_started = threading.Event()
+        self.routes: dict[
+            tuple[str, str, str],
+            ResponseType | Callable[[MockHttpServerHandler], ResponseType],
+        ] = {}
+        self.requests: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+        self.url: Optional[str] = None
+
+    def get_base_url(self) -> str:
+        if self.url is None:
+            raise RuntimeError("mock server is not running")
+        return self.url
+
+    def register_route_handler(
+        self,
+        method: str,
+        server: str,
+        path: str,
+    ):
+        def wrapper(
+            handler: (
+                ResponseType | Callable[[MockHttpServerHandler], ResponseType]
+            )
+        ):
+            self.routes[(method, server, path)] = handler
+            return handler
+
+        return wrapper
+
+    def handle_request(
+        self,
+        method: str,
+        server: str,
+        path: str,
+        handler: MockHttpServerHandler,
+    ):
+        # `handler` is documented here:
+        # https://docs.python.org/3/library/http.server.html#http.server.BaseHTTPRequestHandler
+        key = (method, server, path)
+        if key not in self.requests:
+            self.requests[key] = []
+
+        # Parse and save the request details
+        parsed_path = urllib.parse.urlparse(path)
+        headers = {k.lower(): v for k, v in dict(handler.headers).items()}
+        query_params = urllib.parse.parse_qs(parsed_path.query)
+        if 'content-length' in headers:
+            body = handler.rfile.read(int(headers['content-length'])).decode()
+        else:
+            body = None
+
+        request_details = {
+            'headers': headers,
+            'query_params': query_params,
+            'body': body,
+        }
+        self.requests[key].append(request_details)
+
+        if key not in self.routes:
+            handler.send_error(404)
+            return
+
+        registered_handler = self.routes[key]
+
+        if callable(registered_handler):
+            try:
+                handler_result = registered_handler(handler)
+                if len(handler_result) == 2:
+                    response, status = handler_result
+                    additional_headers = None
+                elif len(handler_result) == 3:
+                    response, status, additional_headers = handler_result
+            except Exception:
+                handler.send_error(500)
+                raise
+        else:
+            if len(registered_handler) == 2:
+                response, status = registered_handler
+                additional_headers = None
+            elif len(registered_handler) == 3:
+                response, status, additional_headers = registered_handler
+
+        if "headers" in request_details and isinstance(
+            request_details["headers"], dict
+        ):
+            accept_header = request_details["headers"].get(
+                "accept", "application/json"
+            )
+        else:
+            accept_header = "application/json"
+
+        if (
+            accept_header.startswith("application/json")
+            or (
+                accept_header.startswith("application/")
+                and "vnd." in accept_header
+                and "+json" in accept_header
+            )
+            or accept_header == "*/*"
+        ):
+            content_type = 'application/json'
+        elif accept_header.startswith("application/x-www-form-urlencoded"):
+            content_type = 'application/x-www-form-urlencoded'
+        else:
+            handler.send_error(
+                415, f"Unsupported accept header: {accept_header}"
+            )
+            return
+
+        data = response.encode()
+
+        handler.send_response(status)
+        handler.send_header('Content-Type', content_type)
+        handler.send_header('Content-Length', str(len(data)))
+        if additional_headers is not None:
+            for header, value in additional_headers.items():
+                handler.send_header(header, value)
+        handler.end_headers()
+        handler.wfile.write(data)
+
+    def start(self):
+        assert not hasattr(self, '_http_runner')
+        self._http_runner = threading.Thread(target=self._http_worker)
+        self._http_runner.start()
+        self.has_started.wait()
+        self.url = f'http://{self._address[0]}:{self._address[1]}/'
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def _http_worker(self):
+        self._http_server = http.server.HTTPServer(
+            ('localhost', 0), MockHttpServerHandler
+        )
+        self._http_server.owner = self
+        self._address = self._http_server.server_address
+        self.has_started.set()
+        self._http_server.serve_forever(poll_interval=0.01)
+        self._http_server.server_close()
+
+    def stop(self):
+        self._http_server.shutdown()
+        if self._http_runner is not None:
+            self._http_runner.join()
+            self._http_runner = None
+
+    def __exit__(self, *exc):
+        self.stop()
+        self.url = None

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1127,9 +1127,9 @@ class ConnectedTestCase(ClusterTestCase):
 
 class DatabaseTestCase(ConnectedTestCase):
 
-    SETUP: Optional[Union[str, List[str]]] = None
+    SETUP: Optional[str | pathlib.Path | list[str] | list[pathlib.Path]] = None
     TEARDOWN: Optional[str] = None
-    SCHEMA: Optional[Union[str, pathlib.Path]] = None
+    SCHEMA: Optional[str | pathlib.Path] = None
     DEFAULT_MODULE: str = 'default'
     EXTENSIONS: List[str] = []
 
@@ -1300,13 +1300,19 @@ class DatabaseTestCase(ConnectedTestCase):
             for scr in scripts:
                 has_nontrivial_script = True
 
-                if '\n' not in scr and os.path.exists(scr):
-                    with open(scr, 'rt') as f:
-                        setup = f.read()
-                else:
-                    setup = scr
+                is_path = (
+                    isinstance(scr, pathlib.Path)
+                    or '\n' not in scr and os.path.exists(scr)
+                )
 
-                script += '\n' + setup
+                if is_path:
+                    with open(scr, 'rt') as f:
+                        setup_text = f.read()
+                else:
+                    assert isinstance(scr, str)
+                    setup_text = scr
+
+                script += '\n' + setup_text
 
             # If the SETUP script did a SET MODULE, make sure it is cleared
             # (since in some modes we keep using the same connection)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     'setproctitle~=1.2',
 
     'httpx~=0.24.1',
+    'httpx-sse~=0.4.0',
     'hishel==0.0.24',
     'webauthn~=2.0.0',
     'argon2-cffi~=23.1.0',

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -1,0 +1,34 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+type TestEmbeddingModel
+    extending ext::ai::EmbeddingModel
+{
+    annotation ext::ai::model_name := "text-embedding-test";
+    annotation ext::ai::model_provider := "custom::test";
+    annotation ext::ai::embedding_model_max_input_tokens := "8191";
+    annotation ext::ai::embedding_model_max_output_dimensions := "10";
+    annotation ext::ai::embedding_model_supports_shortening := "true";
+};
+
+type Astronomy {
+    content: str;
+    deferred index ext::ai::index(embedding_model := 'text-embedding-test')
+        on (.content);
+};

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -1,0 +1,178 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import json
+import pathlib
+
+from edb.testbase import http as tb
+
+
+class TestExtAI(tb.BaseHttpExtensionTest):
+    EXTENSIONS = ['pgvector', 'ai']
+    BACKEND_SUPERUSER = True
+    TRANSACTION_ISOLATION = False
+    PARALLELISM_GRANULARITY = 'suite'
+
+    SCHEMA = pathlib.Path(__file__).parent / 'schemas' / 'ext_ai.esdl'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mock_server = tb.MockHttpServer()
+        cls.mock_server.start()
+        base_url = cls.mock_server.get_base_url().rstrip("/")
+
+        cls.mock_server.register_route_handler(
+            "POST",
+            base_url,
+            "/v1/embeddings",
+        )(cls.mock_api_embeddings)
+
+        async def _setup():
+            await cls.con.execute(
+                f"""
+                CONFIGURE CURRENT DATABASE
+                INSERT ext::ai::CustomProviderConfig {{
+                    name := 'custom::test',
+                    secret := 'very secret',
+                    api_url := '{base_url}/v1',
+                    api_style := ext::ai::ProviderAPIStyle.OpenAI,
+                }};
+
+                CONFIGURE CURRENT DATABASE
+                    SET ext::ai::Config::indexer_naptime := <duration>'100ms';
+                """,
+            )
+
+            await cls._wait_for_db_config('ext::ai::Config::providers')
+
+        cls.loop.run_until_complete(_setup())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_server.stop()
+
+    @classmethod
+    def get_setup_script(cls):
+        res = super().get_setup_script()
+
+        # HACK: As a debugging cycle hack, when RELOAD is true, we reload the
+        # extension package from the file, so we can test without a bootstrap.
+        RELOAD = False
+
+        if RELOAD:
+            root = pathlib.Path(__file__).parent.parent
+            with open(root / 'edb/lib/ext/ai.edgeql') as f:
+                contents = f.read()
+            to_add = (
+                '''
+                drop extension package ai version '1.0';
+                create extension ai;
+            '''
+                + contents
+            )
+            splice = '__internal_testmode := true;'
+            res = res.replace(splice, splice + to_add)
+
+        return res
+
+    @classmethod
+    def mock_api_embeddings(
+        cls,
+        handler: tb.MockHttpServerHandler,
+    ) -> tb.ResponseType:
+        return (
+            json.dumps({
+                "object": "list",
+                "data": [{
+                    "object": "embedding",
+                    "index": 0,
+                    "embedding": [
+                        1.0,
+                        -2.0,
+                        3.0,
+                        -4.0,
+                        5.0,
+                        -6.0,
+                        7.0,
+                        -8.0,
+                        9.0,
+                        -10.0,
+                    ],
+                }],
+            }),
+            200,
+        )
+
+    async def test_ext_ai_indexing(self):
+        await self.con.execute(
+            """
+            insert Astronomy {
+                content := 'Skies on Mars are red'
+            };
+            insert Astronomy {
+                content := 'Skies on Earth are blue'
+            };
+            """,
+        )
+
+        async for tr in self.try_until_succeeds(
+            ignore=(AssertionError,),
+            timeout=10.0,
+        ):
+            async with tr:
+                await self.assert_query_result(
+                    r'''
+                    with
+                        result := ext::ai::search(
+                            Astronomy, <array<float32>>$qv)
+                    select
+                        result.object {
+                            content,
+                            distance := result.distance,
+                        }
+                    order by
+                        result.distance asc empty last
+                        then result.object.content
+                    ''',
+                    [
+                        {
+                            'content': 'Skies on Earth are blue',
+                            'distance': 0,
+                        },
+                        {
+                            'content': 'Skies on Mars are red',
+                            'distance': 0,
+                        },
+                    ],
+                    variables={
+                        "qv": [
+                            1.0,
+                            -2.0,
+                            3.0,
+                            -4.0,
+                            5.0,
+                            -6.0,
+                            7.0,
+                            -8.0,
+                            9.0,
+                            -10.0,
+                        ],
+                    }
+                )

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -319,7 +319,8 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
     mock_provider: tb.MockHttpServer
 
     def setUp(self):
-        self.mock_provider = tb.MockHttpServer()
+        self.mock_provider = tb.MockHttpServer(
+            handler_type=tb.MultiHostMockHttpServerHandler)
         self.mock_provider.start()
         HTTP_TEST_PORT.set(self.mock_provider.get_base_url())
 


### PR DESCRIPTION
This adds the `ai` extension to EdgeDB, containing the following
functionality:

1. The new object-level `ext::ai::index` (similar to `fts::index`) that
   automatically generates and indexes embeddings from the given index
   expression.

2. A basic RAG interface via the `/ai/rag` HTTP endpoint that takes
   a query selecting from an `ai::index`-indexed type and uses it as
   context for a text generation question-answer completion.

The support for the above is implemented here for OpenAI, Mistral and
Anthropic, mostly to demonstrate multi-provider support.  Model and
provider metadata is implemented as annotated abstract types in `ext::ai`,
and the intent is that users can define models in their schemas by
extending from the appropriate base type in `ext::ai`.

To test this out:

1. Apply the following schema:

   ```edgeql
   using extension ai;

   module default {
     type Astronomy {
       content: str;
       deferred index ext::ai::index(embedding_model := 'text-embedding-3-small')
         on (.content);
     }
   };
   ```

2. Configure the OpenAI provider:

   ```edgeql
   configure current database
   insert ext::ai::OpenAIProviderConfig {
     secret := 'sk-....',
   };
   ```

3. Insert some data:

   ```edgeql
   insert Astronomy {
     content := 'Skies on Mars are red'
   };
   insert Astronomy {
     content := 'Skies on Earth are blue'
   };
   ```

4. Test RAG:

   ```shell
   $ curl --json '{
       "query": "What color is the sky on Mars?",
       "model": "gpt-4-turbo-preview",
       "context": {"query":"Astronomy"}
     }' http://127.0.0.1:5656/branch/main/ai/rag
   
   {"response": "The sky on Mars is red."}
   ```