### PR TITLE
Accept session changes in transactions

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -956,6 +956,18 @@ class Compiler:
         )
         request.deserialize(serialized_request, original_query)
 
+        # Apply session differences if any
+        if (
+            request.modaliases is not None
+            and state.current_tx().get_modaliases() != request.modaliases
+        ):
+            state.current_tx().update_modaliases(request.modaliases)
+        if (
+            (session_config := request.session_config) is not None
+            and state.current_tx().get_session_config() != session_config
+        ):
+            state.current_tx().update_session_config(session_config)
+
         units, cstate = self.compile_in_tx(
             state,
             txid,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -679,6 +679,46 @@ class TestProtocol(ProtocolTestCase):
             transaction_state=protocol.TransactionState.NOT_IN_TRANSACTION,
         )
 
+    async def test_proto_state_change_in_tx(self):
+        await self.con.connect()
+
+        # Fixture
+        await self._execute('CREATE TYPE StateChangeInTx')
+        await self.con.recv_match(
+            protocol.CommandComplete,
+            status='CREATE TYPE'
+        )
+        await self.con.recv_match(protocol.ReadyForCommand)
+
+        # Collect states
+        await self._execute('''
+            CONFIGURE SESSION SET allow_user_specified_id := true
+        ''')
+        cc_true = await self.con.recv_match(protocol.CommandComplete)
+        await self.con.recv_match(protocol.ReadyForCommand)
+        await self._execute('''
+            CONFIGURE SESSION SET allow_user_specified_id := false
+        ''')
+        cc_false = await self.con.recv_match(protocol.CommandComplete)
+        await self.con.recv_match(protocol.ReadyForCommand)
+
+        # Start a transaction that doesn't allow_user_specified_id
+        await self._execute('START TRANSACTION', cc=cc_false)
+        await self.con.recv_match(protocol.CommandComplete)
+        await self.con.recv_match(protocol.ReadyForCommand)
+
+        # But insert with session that does allow_user_specified_id
+        await self._execute('''
+            INSERT StateChangeInTx {
+                id := <uuid>'a768e9d5-d908-4072-b370-865b450216ff'
+            };
+        ''', cc=cc_true)
+        await self.con.recv_match(
+            protocol.CommandComplete,
+            status='INSERT'
+        )
+        await self.con.recv_match(protocol.ReadyForCommand)
+
 
 class TestServerCancellation(tb.TestCase):
     @contextlib.asynccontextmanager


### PR DESCRIPTION
This is a leftover from the protocol 1.0 upgrade when we moved the session state to the protocol level in an HTTP-cookie style. Specifically, any custom session state from the client was not synchronized into the compiler if the command was issued in a transaction. This wasn't an issue because we don't have the `tx.with_config()` API in client bindings.

This PR fixes so that session states (config and module aliases) are also synchronized in the compiler state even in transactions.

For 5.0 users, please run the following commands to clear the query cache (assuming this config `query_cache_mode` was never touched):

```
configure current database set query_cache_mode := <cfg::QueryCacheMode>'InMemory';
configure current database reset query_cache_mode;
```

- [x] Add a test

Fixes #7138 