### PR TITLE
Fix stray loop variable use in _propagate_if_expr_refs

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -631,7 +631,7 @@ class ConstraintCommand(
         field: so.Field[Any],
         value: Any,
     ) -> Optional[s_expr.Expression]:
-        if field.name in {'expr', 'subjectexpr', 'finalexpr'}:
+        if field.name in {'expr', 'subjectexpr', 'finalexpr', 'except_expr'}:
             return s_expr.Expression(text='SELECT false')
         else:
             raise NotImplementedError(f'unhandled field {field.name!r}')


### PR DESCRIPTION
We were computing the "dummy" value based on whatever was left over in
the `fn` variable in an earlier loop, instead of doing it for the
field actually being considered. Sink that down into the loop.

This doesn't typically matter, but it's cleaner and it has an impact
for some experimental work I'm doing.