### PR TITLE
Fix ISEs in constant detection for `fts::with_options`

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -498,17 +498,6 @@ def contains_set_of_op(ir: irast.Base) -> bool:
     return bool(ast.find_children(ir, irast.Call, flt, terminate_early=True))
 
 
-def as_const(ir: irast.Base) -> Optional[irast.BaseConstant]:
-    match ir:
-        case irast.BaseConstant():
-            return ir
-        case irast.TypeCast():
-            return as_const(ir.expr)
-        case irast.SetE() if ir.expr:
-            return as_const(ir.expr)
-    return None
-
-
 T = TypeVar('T')
 
 


### PR DESCRIPTION
`fts::with_options` checks `irutils.is_const` to validate whether
language and weight_category are constant, but its notion of constant
(that it doesn't access the database) is not the one we need here.

Instead, skip doing a separate check, and just try to extract the
constant directly. We could do this with `as_const`, but I decided
to delete `as_const` and use `staeval` instead.

This makes it work with simple SELECT expressions also.
(Hitting this in an experimental branch is what caused me to run into
this.)

TODO: Probably we should also get rid of `is_const` too, and do
volatility checks in the places it is used.