### PR TITLE
[5.x] Allow either b1/b2 catver or b3 catver

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,15 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
+#
+# N.B: DO NOT INCREMENT THIS WHEN BACKPORTING CHANGES TO A RELEASE BRANCH.
+# The merge conflict there is a nice reminder that you probably need
+# to write a patch in edb/pgsql/patches.py, and then you should preserve
+# the old value.
 EDGEDB_CATALOG_VERSION = 2024_04_04_00_00
+# We accidentally bumped the catalog version in 5.0b3. For subsequent
+# versions, allow either catalog version.
+EDGEDB_CATALOG_VERSIONS = (EDGEDB_CATALOG_VERSION, 2024_02_27_13_20)
 EDGEDB_MAJOR_VERSION = 5
 
 

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -63,7 +63,8 @@ from edb.common import verutils
 EDGEDB_CATALOG_VERSION = 2024_04_04_00_00
 # We accidentally bumped the catalog version in 5.0b3. For subsequent
 # versions, allow either catalog version.
-EDGEDB_CATALOG_VERSIONS = (EDGEDB_CATALOG_VERSION, 2024_02_27_13_20)
+EDGEDB_OLD_CATALOG_VERSION = 2024_02_27_13_20
+EDGEDB_CATALOG_VERSIONS = (EDGEDB_CATALOG_VERSION, EDGEDB_OLD_CATALOG_VERSION)
 EDGEDB_MAJOR_VERSION = 5
 
 
@@ -587,9 +588,12 @@ def get_cache_src_dirs():
     )
 
 
-def get_default_tenant_id() -> str:
-    catver = EDGEDB_CATALOG_VERSION
+def get_default_tenant_id_from_catver(catver: int) -> str:
     return f'V{catver:x}'
+
+
+def get_default_tenant_id() -> str:
+    return get_default_tenant_id_from_catver(EDGEDB_CATALOG_VERSION)
 
 
 def get_version_line() -> str:

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -2227,7 +2227,7 @@ async def _check_catalog_compatibility(
                 )
             )
 
-        if datadir_catver != expected_catver:
+        if datadir_catver not in edbdef.EDGEDB_CATALOG_VERSIONS:
             for status_sink in ctx.args.status_sinks:
                 status_sink(f'INCOMPATIBLE={json.dumps(status)}')
             raise errors.ConfigurationError(

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -2153,6 +2153,7 @@ async def _check_catalog_compatibility(
                 tenant_id.encode("utf-8"),
             ],
         )
+        is_default_tenant = False
     else:
         is_default_tenant = tenant_id == buildmeta.get_default_tenant_id()
 
@@ -2243,6 +2244,17 @@ async def _check_catalog_compatibility(
                     f'using dump/restore.'
                 )
             )
+
+        # HACK: If we are trying to use the default tenant but the database
+        # has the old catalog version (from b1/b2), update the tenant_id
+        # to be based on that version.
+        if (
+            datadir_catver == buildmeta.EDGEDB_OLD_CATALOG_VERSION
+            and is_default_tenant
+        ):
+            ctx.cluster.overwrite_tenant_id(
+                buildmeta.get_default_tenant_id_from_catver(datadir_catver))
+
     except Exception:
         conn.terminate()
         raise

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -38,6 +38,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = s_def.EDGEDB_SPECIAL_DBS
 
 EDGEDB_CATALOG_VERSION = buildmeta.EDGEDB_CATALOG_VERSION
+EDGEDB_CATALOG_VERSIONS = buildmeta.EDGEDB_CATALOG_VERSIONS
 MIN_POSTGRES_VERSION = (14, 0)
 
 # Resource limit on open FDs for the server process.

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -105,6 +105,9 @@ class BaseCluster:
         else:
             self._instance_params = instance_params
 
+    def _clear_caches(self) -> None:
+        pass
+
     def get_db_name(self, db_name: str) -> str:
         if (
             not self._instance_params.capabilities
@@ -190,6 +193,14 @@ class BaseCluster:
         self._instance_params = self._instance_params._replace(
             capabilities=caps
         )
+
+    def overwrite_tenant_id(
+        self, tenant_id: str
+    ) -> None:
+        self._instance_params = self._instance_params._replace(
+            tenant_id=tenant_id
+        )
+        self._clear_caches()
 
     def get_connection_addr(self) -> Optional[Tuple[str, int]]:
         return self._get_connection_addr()
@@ -853,6 +864,10 @@ class RemoteCluster(BaseCluster):
         self._connection_addr = addr
         self._connection_params = params
         self._ha_backend = ha_backend
+
+    def _clear_caches(self) -> None:
+        super()._clear_caches()
+        self.get_client_id.cache_clear()
 
     def _get_connection_addr(self) -> Optional[Tuple[str, int]]:
         if self._ha_backend is not None:


### PR DESCRIPTION
EDGEDB_CATALOG_VERSION got spuriously bumped in b890bd79, which prevents
b3 from reading b1/b2 databases.

Make sure the next version can upgrade from either.