### PR TITLE
Consider database __default__ for SQL connections

### DIFF
--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -665,6 +665,16 @@ cdef class PgConnection(frontend.FrontendConnection):
         logger.debug('received pg connection request by %s to database %s',
                      user, database)
 
+        if database == '__default__':
+            database = self.tenant.default_database
+        elif (
+            database == defines.EDGEDB_OLD_DEFAULT_DB
+            and self.tenant.maybe_get_db(
+                dbname=defines.EDGEDB_OLD_DEFAULT_DB
+            ) is None
+        ):
+            database = self.tenant.default_database
+
         await self._authenticate(user, database, params)
 
         logger.debug('successfully authenticated %s in database %s',


### PR DESCRIPTION
Makes our SQL adapter use the default database branch when:
- `dbname=__default__`, or
- `dbname=edgedb` (the old default) and branch `edgedb` does not exist.

This replicates the behavior we have for the edgedb protocol.