### PR TITLE
Fix deserialization of persistent cache entries after upgrade

### DIFF
--- a/.github/scripts/patches/create-databases.py
+++ b/.github/scripts/patches/create-databases.py
@@ -37,7 +37,37 @@ try:
         POPULATE MIGRATION;
         COMMIT MIGRATION;
     ''')
+
+    # Put something in the query cache
+    db2.query(r'''
+        SELECT User {
+            name,
+            id
+        }
+        ORDER BY User.name;
+    ''')
+
     db2.close()
+
+    # Compile a query from the CLI.
+    # (At one point, having a cached query with proto version 1 caused
+    # trouble...)
+    cli_base = [
+        'edgedb',
+        'query',
+        '-H',
+        'localhost',
+        '-P',
+        '10000',
+        '-b',
+        'json',
+        '--tls-security',
+        'insecure',
+    ]
+    subprocess.run(
+        [*cli_base, 'select 1+1'],
+        check=True,
+    )
 
     # For the httpextauth database, create the proper extensions, so
     # that patching of the auth extension in place can get tested.

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -325,7 +325,7 @@ cdef class CompilationRequest:
             buf.read_len_prefixed_bytes()
         else:
             serializer = sertypes.InputShapeSerializer(
-                type_id, buf.read_len_prefixed_bytes(), self.protocol_version
+                type_id, buf.read_len_prefixed_bytes(), defines.CURRENT_PROTOCOL
             )
 
         data = buf.read_len_prefixed_bytes()


### PR DESCRIPTION
Deserialize config in rpc using current proto version always.
We always encode that way, but would decode using proto v1 if the
query was submitted with it.

And populate the query cache with the CLI in the patches test so that
this gets caught there.