### PR TITLE
Fix initialization of defaults in patches

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1555,8 +1555,8 @@ def upgrade_schema(schema: FlatSchema) -> FlatSchema:
         exp_len = len(tfields)
         if len(data) < exp_len:
             ldata = list(data)
-            for i in range(len(ldata), exp_len):
-                ldata.append(tfields[i].get_default())
+            for _ in range(len(ldata), exp_len):
+                ldata.append(None)
 
             fixes[id] = tuple(ldata)
 


### PR DESCRIPTION
In upgrade_schema, when we fix up schemas loaded from older versions,
we were filling new fields in with the defaults. That's not how the
schema is supposed to work, though, so fill them in with None instead.
(Defaults are resolved on the read side, not the write side.)

The particular issue being fixed here is with ObjectList, which is not
pickleable.

This was also probably the cause of the schema mismatch that required
a repair when we introduced pgvector. I don't think that fixing this
means we can skip the repair for the ai index changes, though, because
those also involve the `inherited` flag.