### PR TITLE
Pin ruff and silence an error

### DIFF
--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -722,11 +722,11 @@ def get_ref_storage_info(
                 src = src.get_bases(schema).first(schema)
         elif ptr.is_tuple_indirection():
             assert rptr
-            refs.append(rptr.source)
+            refs.append(rptr.source)  # noqa: B909
             continue
         elif ptr.is_type_intersection():
             assert rptr
-            refs.append(rptr.source)
+            refs.append(rptr.source)  # noqa: B909
             continue
         else:
             schema, src = irtyputils.ir_typeref_to_type(schema, source_typeref)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ edgedb = "edb.cli:rustcli"
 test = [
     'black~=24.2.0',
     'coverage~=7.4',
-    'ruff~=0.3.4',
+    'ruff==0.3.7',
     'asyncpg~=0.29.0',
 
     # Needed for testing asyncutil


### PR DESCRIPTION
It started complaining in 0.3.7 about some (intentional) mutations to
a loop iterable we were doing. Pin ruff so we don't get surprise
errors on new versions, and also suppress those.