### PR TITLE
Add a debug flag to spew the DDL commands in apply_sdl

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -122,6 +122,9 @@ class flags(metaclass=FlagsMeta):
     graphql_compile = Flag(
         doc="Debug GraphQL compiler.")
 
+    sdl_loading = Flag(
+        doc="Print applied DDL when loading SDL.")
+
     delta_plan = Flag(
         doc="Print expanded delta command tree prior to processing.")
 

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -581,8 +581,14 @@ def apply_sdl(
     # Now, sort the main body of SDL and apply it.
     ddl_stmts = s_decl.sdl_to_ddl(target_schema, documents)
 
-    chained = itertools.chain(futures.values(), ddl_stmts)
-    for ddl_stmt in chained:
+    if debug.flags.sdl_loading:
+        debug.header('SDL loading script')
+        for ddl_stmt in itertools.chain(
+            extensions.values(), futures.values(), ddl_stmts
+        ):
+            ddl_stmt.dump_edgeql()
+
+    for ddl_stmt in itertools.chain(futures.values(), ddl_stmts):
         process(ddl_stmt)
 
     return target_schema


### PR DESCRIPTION
Super useful for debugging declarative stuff. Not sure why it took me
this long to add it, since I've added dumps like this tens of times.