### PR TITLE
Add some migration tests for AI extension, fix some of them

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -961,10 +961,12 @@ def trace_Index(
     deps = set()
     if node.kwargs:
         for kwarg in node.kwargs:
+            # HACK: Search all objects and depend on any ext::ai annotations.
+            # FIXME: Can we make this more general and less slow?
             if kwarg == "embedding_model":
                 for n, v in ctx.objects.items():
                     if (
-                        n.name.endswith("@ext::ai::model_name")
+                        "@ext::ai::" in n.name
                         and isinstance(v, qltracer.AnnotationValue)
                     ):
                         deps.add(n)

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -1383,8 +1383,8 @@ class CreateIndex(
             value = model_anno.get_value(schema)
             if value is None or value == "<must override>":
                 raise errors.SchemaDefinitionError(
-                    f"{model_stype_vn!r} is missing a value for the "
-                    f"{anno_name!r} annotation"
+                    f"{model_stype_vn} is missing a value for the "
+                    f"'{anno_name}' annotation"
                 )
             anno_sname = sn.get_specialized_name(
                 anno_name,
@@ -1432,17 +1432,18 @@ class CreateIndex(
             bool,
         )
 
-        if dimensions > 2000:  # pgvector limit
+        MAX_DIM = 2000  # pgvector limit
+        if dimensions > MAX_DIM:
             if not supports_shortening:
                 raise errors.SchemaDefinitionError(
-                    f"{model_stype_vn!r} returns embeddings with over "
-                    f"2000 dimensions, does not support embedding "
+                    f"{model_stype_vn} returns embeddings with over "
+                    f"{MAX_DIM} dimensions, does not support embedding "
                     f"shortening, and thus cannot be used with "
                     f"this index",
                     span=self.span,
                 )
             else:
-                dimensions = 2000
+                dimensions = MAX_DIM
 
         dims_anno_sname = sn.get_specialized_name(
             sn.QualName("ext::ai", "embedding_dimensions"),


### PR DESCRIPTION
The fixes I made:
 * Remove some uglifying `!r`s in some messages (one of them was
   causing QualName to get printed)
 * Make declarative depend on *all* the annotations, not just
   model_name, or else it doesn't work when the EmbeddingModel
   comes after the index.

The worst of the xfailed bugs is test_edgeql_migration_ai_02, where
changing `embedding_model` only works if the new model is *later*
alphabetically than the current model. Otherwise it fails with
"test_edgeql_migration_ai_02".

The other bugs I found all had to do with modifying custom
`EmbeddingModel`s.