### PR TITLE
Dunder default

### DIFF
--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -155,6 +155,7 @@ pub const CURRENT_RESERVED_KEYWORDS: phf::Set<&str> = phf_set!(
     "__new__",
     "__old__",
     "__specified__",
+    "__default__",
     "administer",
     "alter",
     "analyze",

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -407,10 +407,10 @@ def _process_view(
     for shape_el_desc in shape_desc:
         with ctx.new() as scopectx:
             if (
-                s_ctx.exprtype.is_insert()
+                (s_ctx.exprtype.is_insert() or s_ctx.exprtype.is_update())
                 and shape_el_desc.ql.compexpr is not None
             ):
-                # insert statement, ptrcls guaranteed to exist
+                # mutating statement, ptrcls guaranteed to exist
                 ptrcls = setgen.resolve_ptr(
                     shape_el_desc.source,
                     shape_el_desc.ptr_name,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -406,9 +406,14 @@ def _process_view(
 
     for shape_el_desc in shape_desc:
         with ctx.new() as scopectx:
+            # when doing insert or update with a compexpr, generate the
+            # the anchor for __default__
             if (
                 (s_ctx.exprtype.is_insert() or s_ctx.exprtype.is_update())
                 and shape_el_desc.ql.compexpr is not None
+                and shape_el_desc.ptr_name not in (
+                    ctx.special_computables_in_mutation_shape
+                )
             ):
                 # mutating statement, ptrcls guaranteed to exist
                 ptrcls = setgen.resolve_ptr(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -406,6 +406,94 @@ def _process_view(
 
     for shape_el_desc in shape_desc:
         with ctx.new() as scopectx:
+            if (
+                s_ctx.exprtype.is_insert()
+                and shape_el_desc.ql.compexpr is not None
+            ):
+                # insert statement, ptrcls guaranteed to exist
+                ptrcls = setgen.resolve_ptr(
+                    shape_el_desc.source,
+                    shape_el_desc.ptr_name,
+                    track_ref=shape_el_desc.ptr_ql,
+                    ctx=scopectx
+                )
+
+                compexpr_uses_default = False
+                compexpr_default_span: Optional[parsing.Span] = None
+                for path_node in ast.find_children(
+                    shape_el_desc.ql.compexpr, qlast.Path
+                ):
+                    for step in path_node.steps:
+                        if not isinstance(step, qlast.SpecialAnchor):
+                            continue
+                        if step.name != '__default__':
+                            continue
+
+                        compexpr_uses_default = True
+                        compexpr_default_span = step.span
+                        break
+
+                    if compexpr_uses_default:
+                        break
+
+                if compexpr_uses_default and compexpr_default_span is not None:
+                    def make_error(
+                            span: parsing.Span, hint: str
+                        ) -> errors.InvalidReferenceError:
+                        return errors.InvalidReferenceError(
+                            f'__default__ cannot be used in this expression',
+                            span=span,
+                            hint=hint,
+                        )
+
+                    default_expr: Optional[s_expr.Expression] = (
+                        ptrcls.get_default(scopectx.env.schema)
+                    )
+                    if default_expr is None or default_expr.qlast is None:
+                        raise make_error(
+                            compexpr_default_span,
+                            'No default expression exists',
+                        )
+
+                    if any(
+                        any(
+                            (
+                                isinstance(step, qlast.SpecialAnchor)
+                                and step.name == '__source__'
+                            )
+                            for step in path_node.steps
+                        )
+                        for path_node in ast.find_children(
+                            default_expr.qlast, qlast.Path
+                        )
+                    ):
+                        raise make_error(
+                            compexpr_default_span,
+                            'Default expression uses __source__',
+                        )
+
+                    if len(
+                        ast.find_children(default_expr.qlast, qlast.InsertQuery)
+                    ) > 0:
+                        raise make_error(
+                            compexpr_default_span,
+                            'Default expression uses INSERT',
+                        )
+
+                    if len(
+                        ast.find_children(default_expr.qlast, qlast.UpdateQuery)
+                    ) > 0:
+                        raise make_error(
+                            compexpr_default_span,
+                            'Default expression uses UPDATE',
+                        )
+
+                    default_set = dispatch.compile(
+                        default_expr.qlast, ctx=scopectx
+                    )
+
+                    scopectx.anchors['__default__'] = default_set
+
             pointer, ptr_set = _normalize_view_ptr_expr(
                 ir_set,
                 shape_el_desc,
@@ -1535,69 +1623,6 @@ def _normalize_view_ptr_expr(
                 module='__',
                 name=ptrcls.get_shortname(ctx.env.schema).name,
             )
-
-            if s_ctx.exprtype.is_insert():
-                compexpr_uses_default = False
-                compexpr_default_span: Optional[parsing.Span] = None
-                for path_node in ast.find_children(
-                    compexpr, qlast.Path
-                ):
-                    for step in path_node.steps:
-                        if not isinstance(step, qlast.SpecialAnchor):
-                            continue
-                        if step.name != '__default__':
-                            continue
-
-                        compexpr_uses_default = True
-                        compexpr_default_span = step.span
-                        break
-
-                    if compexpr_uses_default:
-                        break
-
-                if compexpr_uses_default:
-                    def make_error(hint):
-                        return errors.InvalidReferenceError(
-                            f'__default__ cannot be used in this expression',
-                            span=compexpr_default_span,
-                            hint=hint,
-                        )
-
-                    default_expr: Optional[s_expr.Expression] = (
-                        ptrcls.get_default(ctx.env.schema)
-                    )
-                    if default_expr is None or default_expr.qlast is None:
-                        raise make_error('No default expression exists')
-
-                    if any(
-                        any(
-                            (
-                                isinstance(step, qlast.SpecialAnchor)
-                                and step.name == '__source__'
-                            )
-                            for step in path_node.steps
-                        )
-                        for path_node in ast.find_children(
-                            default_expr.qlast, qlast.Path
-                        )
-                    ):
-                        raise make_error('Default expression uses __source__')
-
-                    if len(
-                        ast.find_children(default_expr.qlast, qlast.InsertQuery)
-                    ) > 0:
-                        raise make_error('Default expression uses INSERT')
-
-                    if len(
-                        ast.find_children(default_expr.qlast, qlast.UpdateQuery)
-                    ) > 0:
-                        raise make_error('Default expression uses UPDATE')
-
-                    default_set = dispatch.compile(
-                        default_expr.qlast, ctx=ctx
-                    )
-
-                    ctx.anchors['__default__'] = default_set
 
         else:
             ptr_name = sn.QualName(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -454,11 +454,13 @@ def _process_view(
                     default_expr: Optional[s_expr.Expression] = (
                         ptrcls.get_default(scopectx.env.schema)
                     )
-                    if default_expr is None or default_expr.qlast is None:
+                    if default_expr is None:
                         raise make_error(
                             compexpr_default_span,
                             'No default expression exists',
                         )
+
+                    default_ast_expr = default_expr.parse()
 
                     if any(
                         any(
@@ -469,7 +471,7 @@ def _process_view(
                             for step in path_node.steps
                         )
                         for path_node in ast.find_children(
-                            default_expr.qlast, qlast.Path
+                            default_ast_expr, qlast.Path
                         )
                     ):
                         raise make_error(
@@ -478,7 +480,7 @@ def _process_view(
                         )
 
                     if len(
-                        ast.find_children(default_expr.qlast, qlast.InsertQuery)
+                        ast.find_children(default_ast_expr, qlast.InsertQuery)
                     ) > 0:
                         raise make_error(
                             compexpr_default_span,
@@ -486,7 +488,7 @@ def _process_view(
                         )
 
                     if len(
-                        ast.find_children(default_expr.qlast, qlast.UpdateQuery)
+                        ast.find_children(default_ast_expr, qlast.UpdateQuery)
                     ) > 0:
                         raise make_error(
                             compexpr_default_span,
@@ -494,7 +496,7 @@ def _process_view(
                         )
 
                     default_set = dispatch.compile(
-                        default_expr.qlast, ctx=scopectx
+                        default_ast_expr, ctx=scopectx
                     )
 
                     scopectx.anchors['__default__'] = default_set

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -64,6 +64,7 @@ from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
+from edb.edgeql import utils as qlutils
 
 from . import astutils
 from . import context
@@ -479,20 +480,10 @@ def _process_view(
                             'Default expression uses __source__',
                         )
 
-                    if len(
-                        ast.find_children(default_ast_expr, qlast.InsertQuery)
-                    ) > 0:
+                    if qlutils.contains_dml(default_ast_expr):
                         raise make_error(
                             compexpr_default_span,
-                            'Default expression uses INSERT',
-                        )
-
-                    if len(
-                        ast.find_children(default_ast_expr, qlast.UpdateQuery)
-                    ) > 0:
-                        raise make_error(
-                            compexpr_default_span,
-                            'Default expression uses UPDATE',
+                            'Default expression uses DML',
                         )
 
                     default_set = dispatch.compile(

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1133,7 +1133,7 @@ class BaseAtomicExpr(Nonterm):
     # { ... } | Constant | '(' Expr ')' | FuncExpr
     # | Tuple | NamedTuple | Collection | Set
     # | '__source__' | '__subject__'
-    # | '__new__' | '__old__' | '__specified__'
+    # | '__new__' | '__old__' | '__specified__' | '__default__'
     # | NodeName | PathStep
 
     @parsing.inline(0)
@@ -1160,6 +1160,9 @@ class BaseAtomicExpr(Nonterm):
         self.val = qlast.Path(
             steps=[qlast.SpecialAnchor(name='__specified__')]
         )
+
+    def reduce_DUNDERDEFAULT(self, *kids):
+        self.val = qlast.Path(steps=[qlast.SpecialAnchor(name='__default__')])
 
     @parsing.precedence(precedence.P_UMINUS)
     @parsing.inline(0)

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -179,6 +179,30 @@ type DefaultTest8 {
     }
 }
 
+type DunderDefaultTest01 {
+    required a: int64;
+    required b: int64 {
+        default := __source__.a+1
+    };
+    required c: int64 {
+        default := 1
+    }
+}
+
+type DunderDefaultTest02_A {
+    required a: int64 {
+        default := 1
+    };
+}
+
+type DunderDefaultTest02_B {
+    required a: DunderDefaultTest02_A {
+        default := (insert DunderDefaultTest02_A {
+            a := 1
+        })
+    };
+}
+
 # types to test some inheritance issues
 type InputValue {
     property val -> str;

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -196,10 +196,33 @@ type DunderDefaultTest02_A {
 }
 
 type DunderDefaultTest02_B {
-    required a: DunderDefaultTest02_A {
-        default := (insert DunderDefaultTest02_A {
-            a := 1
-        })
+    multi default_with_insert: DunderDefaultTest02_A {
+        default := (
+            insert DunderDefaultTest02_A {
+                a := 1
+            }
+        )
+    };
+    multi default_with_update: DunderDefaultTest02_A {
+        default := (
+            update DunderDefaultTest02_A
+            filter DunderDefaultTest02_A.a = 2
+            set {
+                a := 22
+            }
+        )
+    };
+    multi default_with_delete: DunderDefaultTest02_A {
+        default := (
+            delete DunderDefaultTest02_A
+            filter DunderDefaultTest02_A.a = 3
+        )
+    };
+    multi default_with_select: DunderDefaultTest02_A {
+        default := (
+            select DunderDefaultTest02_A
+            filter DunderDefaultTest02_A.a = 4
+        )
     };
 }
 

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -111,9 +111,32 @@ type DunderDefaultTest02_A {
 }
 
 type DunderDefaultTest02_B {
-    required a: DunderDefaultTest02_A {
-        default := (insert DunderDefaultTest02_A {
-            a := 1
-        })
+    multi default_with_insert: DunderDefaultTest02_A {
+        default := (
+            insert DunderDefaultTest02_A {
+                a := 1
+            }
+        )
+    };
+    multi default_with_update: DunderDefaultTest02_A {
+        default := (
+            update DunderDefaultTest02_A
+            filter DunderDefaultTest02_A.a = 2
+            set {
+                a := 22
+            }
+        )
+    };
+    multi default_with_delete: DunderDefaultTest02_A {
+        default := (
+            delete DunderDefaultTest02_A
+            filter DunderDefaultTest02_A.a = 3
+        )
+    };
+    multi default_with_select: DunderDefaultTest02_A {
+        default := (
+            select DunderDefaultTest02_A
+            filter DunderDefaultTest02_A.a = 4
+        )
     };
 }

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -93,3 +93,27 @@ type MultiRequiredTest {
     required multi property prop -> str;
     required multi link tags -> Tag;
 }
+
+type DunderDefaultTest01 {
+    required a: int64;
+    required b: int64 {
+        default := __source__.a+1
+    };
+    required c: int64 {
+        default := 1
+    }
+}
+
+type DunderDefaultTest02_A {
+    required a: int64 {
+        default := 1
+    };
+}
+
+type DunderDefaultTest02_B {
+    required a: DunderDefaultTest02_A {
+        default := (insert DunderDefaultTest02_A {
+            a := 1
+        })
+    };
+}

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2103,10 +2103,6 @@ class TestInsert(tb.QueryTestCase):
             ''')
 
     async def test_edgeql_insert_dunder_default_02(self):
-        await self.con.execute(r'''
-            INSERT DunderDefaultTest02_B;
-        ''')
-
         async with self.assertRaisesRegexTx(
             edgedb.InvalidReferenceError,
             r"__default__ cannot be used in this expression",

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -3834,14 +3834,77 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_dunder_default_02(self):
         await self.con.execute(r'''
-            INSERT DunderDefaultTest02_B;
+            INSERT DunderDefaultTest02_A { a := 1 };
+            INSERT DunderDefaultTest02_A { a := 2 };
+            INSERT DunderDefaultTest02_A { a := 3 };
+            INSERT DunderDefaultTest02_A { a := 4 };
+            INSERT DunderDefaultTest02_A { a := 5 };
+            INSERT DunderDefaultTest02_B {
+                default_with_insert := (
+                    select DunderDefaultTest02_A
+                    filter DunderDefaultTest02_A.a = 1
+                ),
+                default_with_update := (
+                    select DunderDefaultTest02_A
+                    filter DunderDefaultTest02_A.a = 2
+                ),
+                default_with_delete := (
+                    select DunderDefaultTest02_A
+                    filter DunderDefaultTest02_A.a = 3
+                ),
+                default_with_select := (
+                    select DunderDefaultTest02_A
+                    filter DunderDefaultTest02_A.a = 5
+                ),
+            };
         ''')
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidReferenceError,
             r"__default__ cannot be used in this expression",
-            _hint='Default expression uses INSERT',
+            _hint='Default expression uses DML',
         ):
             await self.con.execute(r'''
-                UPDATE DunderDefaultTest02_B set { a := __default__ };
+                UPDATE DunderDefaultTest02_B set {
+                    default_with_insert := __default__
+                };
             ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidReferenceError,
+            r"__default__ cannot be used in this expression",
+            _hint='Default expression uses DML',
+        ):
+            await self.con.execute(r'''
+                UPDATE DunderDefaultTest02_B set {
+                    default_with_update := __default__
+                };
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidReferenceError,
+            r"__default__ cannot be used in this expression",
+            _hint='Default expression uses DML',
+        ):
+            await self.con.execute(r'''
+                UPDATE DunderDefaultTest02_B set {
+                    default_with_delete := __default__
+                };
+            ''')
+
+        await self.con.execute(r'''
+            UPDATE DunderDefaultTest02_B set {
+                default_with_select := __default__
+            };
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                SELECT DunderDefaultTest02_B {
+                    a := .default_with_select.a
+                };
+            ''',
+            [
+                {'a': [4]},
+            ]
+        )


### PR DESCRIPTION
Adding `__default__` as a way of accessing default statements in `insert` and `update` statements.

Given:
```
type Foo {
    a: int64 { default := 1 }
};
```

The query `insert Foo { a := __default__ * 2 }` creates `Foo { a := 2 }`.

Then later, `update Foo set { a := __default__ + 2 }` updates it to `Foo { a := 3 }`.

For `insert` statements, this may be a cleaner way to deal with #4803.