### PR TITLE
Fix qlast references after bad merge

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -1037,7 +1037,7 @@ def compile_ext_ai_to_str(
     with ctx.detached() as subctx:
         subctx.partial_path_prefix = call.args[0].expr
         subctx.anchors["__subject__"] = call.args[0].expr
-        call.body = dispatch.compile(index_expr.qlast, ctx=subctx)
+        call.body = dispatch.compile(index_expr.parse(), ctx=subctx)
 
     return call
 

--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -199,7 +199,7 @@ def _compile_ai_embeddings_source_view_expr(
                     steps=[qlast.Ptr(name="id")],
                     partial=True,
                 ),
-                index_sexpr.qlast,
+                index_sexpr.parse(),
             ],
         ),
     )


### PR DESCRIPTION
The qlast refactor PR (#7167) removed qlast while #7183 added more
references. Fix them.