### PR TITLE
Make changing fts and ai indexes work consistently in migrations

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12193,13 +12193,6 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             using extension ai;
         ''', explicit_modules=True)
 
-    @test.xerror('''
-        "multiple ext::ai::index indexes defined for default::Astronomy"
-
-        The first step, going from -small to -large works, but going
-        the other way fails. The different is probably alphabet
-        related.
-    ''')
     async def test_edgeql_migration_ai_02(self):
         await self.migrate('''
             using extension ai;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -675,7 +675,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         errors.InvalidDefinitionError,
         "index 'fts::index' of object type 'test::Foo' " "was already declared",
     )
-    def test_schema_bad_type_17(self):
+    def test_schema_bad_type_17a(self):
         """
         type Foo {
             property val -> str;
@@ -687,6 +687,23 @@ class TestSchema(tb.BaseSchemaLoadTest):
             );
             index fts::index on (
                 fts::with_options(.val, language := fts::Language.eng)
+            );
+        };
+        """
+
+    @tb.must_fail(
+        errors.InvalidDefinitionError,
+        "multiple fts::index indexes defined for test::Foo",
+    )
+    def test_schema_bad_type_17b(self):
+        """
+        type Foo {
+            property val -> str;
+            index fts::index on (
+                fts::with_options(.val, language := fts::Language.eng)
+            );
+            index fts::index on (
+                fts::with_options(.val, language := fts::Language.ita)
             );
         };
         """


### PR DESCRIPTION
Since only one of each kind is allowed, we need to make sure to drop
the old one before creating the new.

Also, reject having multiple fts/ai indexes at migration creation,
not just at migration application.