### PR TITLE
[5.x] Fix several bugs in the AI extension

### DIFF
--- a/.github/scripts/patches/create-databases.py
+++ b/.github/scripts/patches/create-databases.py
@@ -17,7 +17,7 @@ try:
     )
     for name in [
         'json', 'functions', 'expressions', 'casts', 'policies', 'vector',
-        'scope', 'httpextauth', 'extai',
+        'scope', 'httpextauth', 'extairc1',
     ]:
         db.execute(f'create database {name};')
 
@@ -47,6 +47,24 @@ try:
         ORDER BY User.name;
     ''')
 
+    db2.close()
+
+    db2 = edgedb.create_client(
+        host='localhost', port=10000, tls_security='insecure',
+        database='extairc1'
+    )
+    with open("tests/schemas/ext_ai_rc1.esdl") as f:
+        body = f.read()
+    db2.execute(f'''
+        START MIGRATION TO {{
+            using extension ai;
+            module default {{
+                {body}
+            }}
+        }};
+        POPULATE MIGRATION;
+        COMMIT MIGRATION;
+    ''')
     db2.close()
 
     # Compile a query from the CLI.

--- a/.github/scripts/patches/create-databases.py
+++ b/.github/scripts/patches/create-databases.py
@@ -55,16 +55,19 @@ try:
     )
     with open("tests/schemas/ext_ai_rc1.esdl") as f:
         body = f.read()
-    db2.execute(f'''
-        START MIGRATION TO {{
-            using extension ai;
-            module default {{
-                {body}
-            }}
-        }};
-        POPULATE MIGRATION;
-        COMMIT MIGRATION;
-    ''')
+    try:
+        db2.execute(f'''
+            START MIGRATION TO {{
+                using extension ai;
+                module default {{
+                    {body}
+                }}
+            }};
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        ''')
+    except edgedb.EdgeQLSyntaxError:
+        pass
     db2.close()
 
     # Compile a query from the CLI.

--- a/.github/workflows.src/tests-patches.tpl.yml
+++ b/.github/workflows.src/tests-patches.tpl.yml
@@ -67,7 +67,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py tests/test_ext_ai_rc1.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -510,7 +510,7 @@ jobs:
         # has timeouts.
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
-        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py
+        edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py tests/test_ext_ai_rc1.py
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -987,7 +987,7 @@ def compile_ext_ai_search(
         )[0]
 
         index_metadata[typeref] = {
-            "id": s_indexes.get_fts_index_id(schema, index),
+            "id": s_indexes.get_ai_index_id(schema, index),
             "dimensions": dimensions,
             "distance_function": (
                 distance_func.get_shortname(schema),

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -987,7 +987,7 @@ def compile_ext_ai_search(
         )[0]
 
         index_metadata[typeref] = {
-            "id": index.id,
+            "id": s_indexes.get_fts_index_id(schema, index),
             "dimensions": dimensions,
             "distance_function": (
                 distance_func.get_shortname(schema),

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3991,7 +3991,9 @@ def _ext_ai_search_inner_pgvector(
         ],
     )
 
-    return similarity, None
+    valid = pgast.NullTest(arg=embedding, negated=True)
+
+    return similarity, valid
 
 
 def _process_set_as_object_search(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3961,7 +3961,7 @@ def _ext_ai_search_inner_pgvector(
     query, = args_pg
     el_name = sn.QualName(
         '__object__',
-        f'__ext_ai_{index_id.hex}_embedding__',
+        f'__ext_ai_{index_id}_embedding__',
     )
     embedding_ptrref = irast.SpecialPointerRef(
         name=el_name,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -7544,7 +7544,6 @@ class CreateExtension(ExtensionCommand, adapts=s_exts.CreateExtension):
             self.pgops.add(
                 delta_ext_ai.pg_rebuild_all_pending_embeddings_views(
                     schema,
-                    context,
                 ),
             )
 

--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -61,9 +61,6 @@
 #                            -- embedding-text-3- models).
 #  )
 #
-# TODO: We could probably drop target_attr since the names should be
-# predictable now.
-#
 # The above view is a UNION of SELECTs over object relations, where each
 # UNION element is roughly this:
 #
@@ -796,7 +793,7 @@ def _get_index_root_id(
     schema: s_schema.Schema,
     index: s_indexes.Index,
 ) -> str:
-    return s_indexes.get_fts_index_id(schema, index)
+    return s_indexes.get_ai_index_id(schema, index)
 
 
 def patch_fix_ai_indexes(

--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -768,4 +768,4 @@ def _get_index_root_id(
     schema: s_schema.Schema,
     index: s_indexes.Index,
 ) -> str:
-    return index.get_topmost_concrete_base(schema).id.hex
+    return s_indexes.get_fts_index_id(schema, index)

--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -135,7 +135,7 @@ def create_ext_ai_index(
     # inherited from the parent, we don't need to create the index, but just
     # update the populating expressions.
     if has_overridden:
-        return _refresh_ai_embeddings_source_view(
+        return _refresh_ai_embeddings(
             index,
             options,
             schema,
@@ -283,14 +283,30 @@ def _create_ai_embeddings(
     )
 
 
-def _refresh_ai_embeddings_source_view(
+def _refresh_ai_embeddings(
     index: s_indexes.Index,
     options: qlcompiler.CompilerOptions,
     schema: s_schema.Schema,
     context: sd.CommandContext,
 ) -> dbops.Command:
-    return _pg_create_ai_embeddings_source_view(
-        index, options, schema, context)
+    ops = dbops.CommandGroup()
+    table_name = common.get_index_table_backend_name(index, schema)
+    ops.add_command(
+        _pg_drop_trigger(index, table_name, schema))
+
+    idx_id = _get_index_root_id(schema, index)
+    ops.add_command(dbops.Query(textwrap.dedent(f"""\
+        UPDATE {common.qname(*table_name)}
+        SET __ext_ai_{idx_id}_embedding__ = NULL
+        WHERE __ext_ai_{idx_id}_embedding__ IS NOT NULL
+    """)))
+
+    ops.add_command(
+        _pg_create_trigger(index, table_name, schema))
+    ops.add_command(
+        _pg_create_ai_embeddings_source_view(
+            index, options, schema, context))
+    return ops
 
 
 def _delete_ai_embeddings(
@@ -417,6 +433,20 @@ def _pg_create_ai_embeddings(
     )
     ops.add_command(dbops.CreateIndex(pg_index))
 
+    # The invalidation trigger
+    ops.add_command(_pg_create_trigger(index, table_name, schema))
+
+    # The component view for the "ai_pending_embeddings_{model_name}" union
+    ops.add_command(
+        _pg_create_ai_embeddings_source_view(index, options, schema, context))
+
+    return ops
+
+
+def _get_dep_cols(
+    index: s_indexes.Index,
+    schema: s_schema.Schema,
+) -> list[str]:
     index_expr = index.get_expr(schema)
     assert index_expr is not None
     dep_cols = []
@@ -426,15 +456,7 @@ def _pg_create_ai_embeddings(
             ptrinfo = types.get_pointer_storage_info(obj, schema=schema)
             dep_cols.append(ptrinfo.column_name)
 
-    # The invalidation trigger
-    ops.add_command(
-        _pg_create_trigger(schema, index, table_name, dep_cols))
-
-    # The component view for the "ai_pending_embeddings_{model_name}" union
-    ops.add_command(
-        _pg_create_ai_embeddings_source_view(index, options, schema, context))
-
-    return ops
+    return dep_cols
 
 
 def _pg_delete_ai_embeddings(
@@ -488,11 +510,12 @@ def _pg_delete_ai_embeddings(
 
 
 def _pg_create_trigger(
-    schema: s_schema.Schema,
     index: s_indexes.Index,
     table_name: tuple[str, str],
-    dep_cols: list[str],
+    schema: s_schema.Schema,
 ) -> dbops.Command:
+    dep_cols = _get_dep_cols(index, schema)
+
     # Create a trigger that resets the __ext_ai_{idx_id}_embedding__ to
     # NULL whenever data referenced in the ext::ai::index expression gets
     # modified (TODO: the selective approach could also be used on fts::index)
@@ -537,8 +560,9 @@ def _pg_drop_trigger(
     index: s_indexes.Index,
     table_name: tuple[str, str],
     schema: s_schema.Schema,
+    override_id: Optional[str] = None,
 ) -> dbops.Command:
-    idx_id = _get_index_root_id(schema, index)
+    idx_id = override_id or _get_index_root_id(schema, index)
     ops = dbops.CommandGroup()
 
     ops.add_command(

--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -506,6 +506,7 @@ def _pg_create_trigger(
         text=f"""
         BEGIN
             NEW."__ext_ai_{idx_id}_embedding__" := NULL;
+            RETURN NEW;
         END;
         """,
         volatility='immutable',

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -129,4 +129,6 @@ ALTER TYPE cfg::AbstractConfig {
     # FIXME: It would be nice to have a lighter weight mechanism.
     ('repair', ''),
     ('ext-pkg', 'ai'),
+    # === 5.0rc2
+    ('edgeql+user_ext+fix-ai-indexes|ai', ''),
 ])

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -1702,6 +1702,14 @@ def is_fts_index(
     return index.issubclass(schema, fts_index)
 
 
+def get_fts_index_id(
+    schema: s_schema.Schema,
+    index: Index,
+) -> str:
+    # TODO: Use the model name?
+    return f'base'
+
+
 def is_ext_ai_index(
     schema: s_schema.Schema,
     index: Index,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -1702,7 +1702,7 @@ def is_fts_index(
     return index.issubclass(schema, fts_index)
 
 
-def get_fts_index_id(
+def get_ai_index_id(
     schema: s_schema.Schema,
     index: Index,
 ) -> str:

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -460,6 +460,14 @@ class Index(
 
         return kwargs
 
+    def get_ddl_identity(
+        self,
+        schema: s_schema.Schema,
+    ) -> Optional[Dict[str, Any]]:
+        v = super().get_ddl_identity(schema) or {}
+        v['kwargs'] = self.get_all_kwargs(schema)
+        return v
+
     def get_root(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1592,7 +1592,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
     def get_ddl_identity(
         self,
         schema: s_schema.Schema,
-    ) -> Optional[Dict[str, str]]:
+    ) -> Optional[Dict[str, Any]]:
         ddl_id_fields = [
             fn for fn, f in type(self).get_fields().items() if f.ddl_identity
         ]

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -200,7 +200,7 @@ class Source(
             schema, self, sn.QualName("ext::ai", "index")
         )
         if ext_ai_index:
-            idx_id = indexes.get_fts_index_id(schema, ext_ai_index)
+            idx_id = indexes.get_ai_index_id(schema, ext_ai_index)
             dimensions = ext_ai_index.must_get_json_annotation(
                 schema,
                 sn.QualName(

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -200,7 +200,7 @@ class Source(
             schema, self, sn.QualName("ext::ai", "index")
         )
         if ext_ai_index:
-            root_idx_id = ext_ai_index.get_topmost_concrete_base(schema).id.hex
+            idx_id = indexes.get_fts_index_id(schema, ext_ai_index)
             dimensions = ext_ai_index.must_get_json_annotation(
                 schema,
                 sn.QualName(
@@ -209,9 +209,8 @@ class Source(
             )
             res.append(
                 (
-                    f'__ext_ai_{root_idx_id}_embedding__',
-                    f'__ext_ai_{root_idx_id}_embedding__',
-
+                    f'__ext_ai_{idx_id}_embedding__',
+                    f'__ext_ai_{idx_id}_embedding__',
                     (
                         'edgedb',
                         f'vector({dimensions})',

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -864,6 +864,11 @@ def prepare_patch(
             std_plans.append(delta_command)
             plan.generate(subblock)
 
+        if '+fix-ai-indexes' in kind:
+            from edb.pgsql import delta_ext_ai
+            ai_fixes = delta_ext_ai.patch_fix_ai_indexes(cschema)
+            ai_fixes.generate(subblock)
+
         if '+config' in kind:
             views = metaschema.get_config_views(cschema, existing_view_columns)
             views.generate(subblock)

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1053,6 +1053,11 @@ def prepare_patch(
         sys_updates = (patch,) + sys_updates
     else:
         regular_updates = spatches + (update,)
+        # FIXME: This is a hack to make the is_user_ext_update cases
+        # work (by ensuring we can always read their current state),
+        # but this is actually a pretty dumb approach and we can do
+        # better.
+        regular_updates += sys_updates
 
     return regular_updates, sys_updates, updates, False
 

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -32,3 +32,13 @@ type Astronomy {
     deferred index ext::ai::index(embedding_model := 'text-embedding-test')
         on (.content);
 };
+
+type Stuff extending Astronomy {
+    content2: str;
+    deferred index ext::ai::index(embedding_model := 'text-embedding-test')
+        on (.content ++ .content2);
+};
+
+type Star extending Astronomy;
+
+type Supernova extending Star;

--- a/tests/schemas/ext_ai_rc1.esdl
+++ b/tests/schemas/ext_ai_rc1.esdl
@@ -1,0 +1,34 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+type TestEmbeddingModel
+    extending ext::ai::EmbeddingModel
+{
+    annotation ext::ai::model_name := "text-embedding-test";
+    annotation ext::ai::model_provider := "custom::test";
+    annotation ext::ai::embedding_model_max_input_tokens := "8191";
+    annotation ext::ai::embedding_model_max_output_dimensions := "10";
+    annotation ext::ai::embedding_model_supports_shortening := "true";
+};
+
+type Astronomy {
+    content: str;
+    deferred index ext::ai::index(embedding_model := 'text-embedding-test')
+        on (.content);
+};

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12416,6 +12416,27 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             };
         ''', explicit_modules=True)
 
+    async def test_edgeql_migration_ai_07(self):
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Astronomy {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Astronomy {
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+            };
+        ''', explicit_modules=True)
+
 
 class EdgeQLMigrationRewriteTestCase(EdgeQLDataMigrationTestCase):
     DEFAULT_MODULE = 'default'

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12437,6 +12437,85 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             };
         ''', explicit_modules=True)
 
+    async def test_edgeql_migration_ai_08(self):
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Base {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Base {
+                    # deferred index ext::ai::index(
+                    #     embedding_model := 'text-embedding-3-small'
+                    # ) on (.content ++ '!');
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        await self.con.query('''
+            select {
+                base := ext::ai::search(Base, <array<float32>>[1]),
+                sub := ext::ai::search(Sub, <array<float32>>[1]),
+            }
+        ''')
+
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Base {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Base {
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content ++ '!');
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        await self.con.query('''
+            select {
+                base := ext::ai::search(Base, <array<float32>>[1]),
+                sub := ext::ai::search(Sub, <array<float32>>[1]),
+            }
+        ''')
+
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Base {
+                    content: str;
+                };
+
+                type Sub extending Base {
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content ++ '!');
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        # Base lost the index, just select Sub
+        await self.con.query('''
+            select {
+                sub := ext::ai::search(Sub, <array<float32>>[1]),
+            }
+        ''')
+
 
 class EdgeQLMigrationRewriteTestCase(EdgeQLDataMigrationTestCase):
     DEFAULT_MODULE = 'default'

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -178,7 +178,23 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                 )
 
     async def test_ext_ai_indexing_02(self):
-        await self.con.execute(
+        qry = '''
+            with
+                result := ext::ai::search(
+                    Stuff, <array<float32>>$qv)
+            select
+                result.object {
+                    content,
+                    content2,
+                    distance := result.distance,
+                }
+            order by
+                result.distance asc empty last
+                then result.object.content;
+        '''
+        qv = [1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0]
+
+        await self.assert_query_result(
             """
             insert Stuff {
                 content := 'Skies on Mars',
@@ -188,7 +204,9 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                 content := 'Skies on Earth',
                 content2 := ' are blue',
             };
-            """,
+            """ + qry,
+            [],
+            variables=dict(qv=qv),
         )
 
         async for tr in self.try_until_succeeds(
@@ -197,20 +215,7 @@ class TestExtAI(tb.BaseHttpExtensionTest):
         ):
             async with tr:
                 await self.assert_query_result(
-                    r'''
-                    with
-                        result := ext::ai::search(
-                            Stuff, <array<float32>>$qv)
-                    select
-                        result.object {
-                            content,
-                            content2,
-                            distance := result.distance,
-                        }
-                    order by
-                        result.distance asc empty last
-                        then result.object.content
-                    ''',
+                    qry,
                     [
                         {
                             'content': 'Skies on Earth',
@@ -223,21 +228,26 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                             'distance': 0,
                         },
                     ],
-                    variables={
-                        "qv": [
-                            1.0,
-                            -2.0,
-                            3.0,
-                            -4.0,
-                            5.0,
-                            -6.0,
-                            7.0,
-                            -8.0,
-                            9.0,
-                            -10.0,
-                        ],
-                    }
+                    variables=dict(qv=qv),
                 )
+
+        # updating an object should make it disappear from results.
+        # (the read is done in the same tx, so there is no possible
+        # race where the worker picks it up before the read)
+        await self.assert_query_result(
+            """
+            update Stuff filter .content like '%Earth'
+            set { content2 := ' are often grey' };
+            """ + qry,
+            [
+                {
+                    'content': 'Skies on Mars',
+                    'content2': ' are red',
+                    'distance': 0,
+                },
+            ],
+            variables=dict(qv=qv),
+        )
 
     async def test_ext_ai_indexing_03(self):
         await self.con.execute(

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -120,7 +120,7 @@ class TestExtAI(tb.BaseHttpExtensionTest):
             200,
         )
 
-    async def test_ext_ai_indexing(self):
+    async def test_ext_ai_indexing_01(self):
         await self.con.execute(
             """
             insert Astronomy {
@@ -142,6 +142,125 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                     with
                         result := ext::ai::search(
                             Astronomy, <array<float32>>$qv)
+                    select
+                        result.object {
+                            content,
+                            distance := result.distance,
+                        }
+                    order by
+                        result.distance asc empty last
+                        then result.object.content
+                    ''',
+                    [
+                        {
+                            'content': 'Skies on Earth are blue',
+                            'distance': 0,
+                        },
+                        {
+                            'content': 'Skies on Mars are red',
+                            'distance': 0,
+                        },
+                    ],
+                    variables={
+                        "qv": [
+                            1.0,
+                            -2.0,
+                            3.0,
+                            -4.0,
+                            5.0,
+                            -6.0,
+                            7.0,
+                            -8.0,
+                            9.0,
+                            -10.0,
+                        ],
+                    }
+                )
+
+    async def test_ext_ai_indexing_02(self):
+        await self.con.execute(
+            """
+            insert Stuff {
+                content := 'Skies on Mars',
+                content2 := ' are red',
+            };
+            insert Stuff {
+                content := 'Skies on Earth',
+                content2 := ' are blue',
+            };
+            """,
+        )
+
+        async for tr in self.try_until_succeeds(
+            ignore=(AssertionError,),
+            timeout=10.0,
+        ):
+            async with tr:
+                await self.assert_query_result(
+                    r'''
+                    with
+                        result := ext::ai::search(
+                            Stuff, <array<float32>>$qv)
+                    select
+                        result.object {
+                            content,
+                            content2,
+                            distance := result.distance,
+                        }
+                    order by
+                        result.distance asc empty last
+                        then result.object.content
+                    ''',
+                    [
+                        {
+                            'content': 'Skies on Earth',
+                            'content2': ' are blue',
+                            'distance': 0,
+                        },
+                        {
+                            'content': 'Skies on Mars',
+                            'content2': ' are red',
+                            'distance': 0,
+                        },
+                    ],
+                    variables={
+                        "qv": [
+                            1.0,
+                            -2.0,
+                            3.0,
+                            -4.0,
+                            5.0,
+                            -6.0,
+                            7.0,
+                            -8.0,
+                            9.0,
+                            -10.0,
+                        ],
+                    }
+                )
+
+    async def test_ext_ai_indexing_03(self):
+        await self.con.execute(
+            """
+            insert Star {
+                content := 'Skies on Mars are red'
+            };
+            insert Supernova {
+                content := 'Skies on Earth are blue'
+            };
+            """,
+        )
+
+        async for tr in self.try_until_succeeds(
+            ignore=(AssertionError,),
+            timeout=10.0,
+        ):
+            async with tr:
+                await self.assert_query_result(
+                    r'''
+                    with
+                        result := ext::ai::search(
+                            Star, <array<float32>>$qv)
                     select
                         result.object {
                             content,

--- a/tests/test_ext_ai_rc1.py
+++ b/tests/test_ext_ai_rc1.py
@@ -1,0 +1,179 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2023-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import json
+import pathlib
+
+from edb.testbase import http as tb
+
+# A copy of the ext_ai tests released with RC1, for the purposes of
+# patch testing
+class TestExtAIRC1(tb.BaseHttpExtensionTest):
+    EXTENSIONS = ['pgvector', 'ai']
+    BACKEND_SUPERUSER = True
+    TRANSACTION_ISOLATION = False
+    PARALLELISM_GRANULARITY = 'suite'
+
+    SCHEMA = pathlib.Path(__file__).parent / 'schemas' / 'ext_ai_rc1.esdl'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mock_server = tb.MockHttpServer()
+        cls.mock_server.start()
+        base_url = cls.mock_server.get_base_url().rstrip("/")
+
+        cls.mock_server.register_route_handler(
+            "POST",
+            base_url,
+            "/v1/embeddings",
+        )(cls.mock_api_embeddings)
+
+        async def _setup():
+            await cls.con.execute(
+                f"""
+                CONFIGURE CURRENT DATABASE
+                INSERT ext::ai::CustomProviderConfig {{
+                    name := 'custom::test',
+                    secret := 'very secret',
+                    api_url := '{base_url}/v1',
+                    api_style := ext::ai::ProviderAPIStyle.OpenAI,
+                }};
+
+                CONFIGURE CURRENT DATABASE
+                    SET ext::ai::Config::indexer_naptime := <duration>'100ms';
+                """,
+            )
+
+            await cls._wait_for_db_config('ext::ai::Config::providers')
+
+        cls.loop.run_until_complete(_setup())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_server.stop()
+
+    @classmethod
+    def get_setup_script(cls):
+        res = super().get_setup_script()
+
+        # HACK: As a debugging cycle hack, when RELOAD is true, we reload the
+        # extension package from the file, so we can test without a bootstrap.
+        RELOAD = False
+
+        if RELOAD:
+            root = pathlib.Path(__file__).parent.parent
+            with open(root / 'edb/lib/ext/ai.edgeql') as f:
+                contents = f.read()
+            to_add = (
+                '''
+                drop extension package ai version '1.0';
+                create extension ai;
+            '''
+                + contents
+            )
+            splice = '__internal_testmode := true;'
+            res = res.replace(splice, splice + to_add)
+
+        return res
+
+    @classmethod
+    def mock_api_embeddings(
+        cls,
+        handler: tb.MockHttpServerHandler,
+    ) -> tb.ResponseType:
+        return (
+            json.dumps({
+                "object": "list",
+                "data": [{
+                    "object": "embedding",
+                    "index": 0,
+                    "embedding": [
+                        1.0,
+                        -2.0,
+                        3.0,
+                        -4.0,
+                        5.0,
+                        -6.0,
+                        7.0,
+                        -8.0,
+                        9.0,
+                        -10.0,
+                    ],
+                }],
+            }),
+            200,
+        )
+
+    async def test_ext_ai_rc1_indexing(self):
+        await self.con.execute(
+            """
+            insert Astronomy {
+                content := 'Skies on Mars are red'
+            };
+            insert Astronomy {
+                content := 'Skies on Earth are blue'
+            };
+            """,
+        )
+
+        async for tr in self.try_until_succeeds(
+            ignore=(AssertionError,),
+            timeout=10.0,
+        ):
+            async with tr:
+                await self.assert_query_result(
+                    r'''
+                    with
+                        result := ext::ai::search(
+                            Astronomy, <array<float32>>$qv)
+                    select
+                        result.object {
+                            content,
+                            distance := result.distance,
+                        }
+                    order by
+                        result.distance asc empty last
+                        then result.object.content
+                    ''',
+                    [
+                        {
+                            'content': 'Skies on Earth are blue',
+                            'distance': 0,
+                        },
+                        {
+                            'content': 'Skies on Mars are red',
+                            'distance': 0,
+                        },
+                    ],
+                    variables={
+                        "qv": [
+                            1.0,
+                            -2.0,
+                            3.0,
+                            -4.0,
+                            5.0,
+                            -6.0,
+                            7.0,
+                            -8.0,
+                            9.0,
+                            -10.0,
+                        ],
+                    }
+                )


### PR DESCRIPTION
I'm making these changes on 5.x first and will forward port to
master. This is because I think that the patch mechanism is a critical
component.

 * Fix trivial index overriding by tweaking ddl_identity.
 * Make UPDATE triggers not always ISE
 * Filter out rows with NULL embeddings in fts::search
 * Update the triggers when overriding an index
 * Fix nontrivial index overriding.

The last one is the most impactful thing here.

The issue was that indexes in children were expected to have the same
name as in the parent, but did not. The "effective object index" in a
child, if the child defined the index itself, won't actually be a
child of the parent index, which was how the name was found.  It would
not be hard to do this computation right (and I had that part
working), but this approach has a major downside: *adding* an index to
a parent can require the column name to be changed in the child.
Additionally, it can't work if there are multiple independent base types
with ai indexes.

Another approach would be to always use the indexes *own* id as the
name.  I started along this path too, and had it much of the way. The
main downside (which I hadn't started on) is that handling the EXPLAIN
mode where inhviews are not used would be a pain.  This is *almost*
compatible with the existing database layouts (since nontrivial
inheritance doesn't work anyway) but differs when there is trivial
inheritance of indexes (where the child has no index specified).
So we would need to apply a patch to rename columns and whatnot.

Instead I went with a simplifying approach of making everything
use the same name. It's generalized in a way were it would be
very easy to use the model_name in the name instead, though.

This did also require some very custom patching code to rename all of
the generated columns, refresh the triggers, and refresh some views.
Refreshing the triggers was also necessary on is own, since they never
worked.