### PR TITLE
[6.x forward port] Fix several bugs in the AI extension

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_04_09_00_00
+EDGEDB_CATALOG_VERSION = 2024_04_18_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -1006,7 +1006,7 @@ def compile_ext_ai_search(
         )[0]
 
         index_metadata[typeref] = {
-            "id": index.id,
+            "id": s_indexes.get_ai_index_id(schema, index),
             "dimensions": dimensions,
             "distance_function": (
                 distance_func.get_shortname(schema),

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3954,7 +3954,7 @@ def _ext_ai_search_inner_pgvector(
     query, = args_pg
     el_name = sn.QualName(
         '__object__',
-        f'__ext_ai_{index_id.hex}_embedding__',
+        f'__ext_ai_{index_id}_embedding__',
     )
     embedding_ptrref = irast.SpecialPointerRef(
         name=el_name,
@@ -3984,7 +3984,9 @@ def _ext_ai_search_inner_pgvector(
         ],
     )
 
-    return similarity, None
+    valid = pgast.NullTest(arg=embedding, negated=True)
+
+    return similarity, valid
 
 
 def _process_set_as_object_search(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -7541,7 +7541,6 @@ class CreateExtension(ExtensionCommand, adapts=s_exts.CreateExtension):
             self.pgops.add(
                 delta_ext_ai.pg_rebuild_all_pending_embeddings_views(
                     schema,
-                    context,
                 ),
             )
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -458,6 +458,14 @@ class Index(
 
         return kwargs
 
+    def get_ddl_identity(
+        self,
+        schema: s_schema.Schema,
+    ) -> Optional[Dict[str, Any]]:
+        v = super().get_ddl_identity(schema) or {}
+        v['kwargs'] = self.get_all_kwargs(schema)
+        return v
+
     def get_root(
         self,
         schema: s_schema.Schema,
@@ -1694,6 +1702,14 @@ def is_fts_index(
 ) -> bool:
     fts_index = schema.get(sn.QualName("fts", "index"), type=Index)
     return index.issubclass(schema, fts_index)
+
+
+def get_ai_index_id(
+    schema: s_schema.Schema,
+    index: Index,
+) -> str:
+    # TODO: Use the model name?
+    return f'base'
 
 
 def is_ext_ai_index(

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1592,7 +1592,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
     def get_ddl_identity(
         self,
         schema: s_schema.Schema,
-    ) -> Optional[Dict[str, str]]:
+    ) -> Optional[Dict[str, Any]]:
         ddl_id_fields = [
             fn for fn, f in type(self).get_fields().items() if f.ddl_identity
         ]

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -200,7 +200,7 @@ class Source(
             schema, self, sn.QualName("ext::ai", "index")
         )
         if ext_ai_index:
-            root_idx_id = ext_ai_index.get_topmost_concrete_base(schema).id.hex
+            idx_id = indexes.get_ai_index_id(schema, ext_ai_index)
             dimensions = ext_ai_index.must_get_json_annotation(
                 schema,
                 sn.QualName(
@@ -209,9 +209,8 @@ class Source(
             )
             res.append(
                 (
-                    f'__ext_ai_{root_idx_id}_embedding__',
-                    f'__ext_ai_{root_idx_id}_embedding__',
-
+                    f'__ext_ai_{idx_id}_embedding__',
+                    f'__ext_ai_{idx_id}_embedding__',
                     (
                         'edgedb',
                         f'vector({dimensions})',

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1048,6 +1048,11 @@ def prepare_patch(
         sys_updates = (patch,) + sys_updates
     else:
         regular_updates = spatches + (update,)
+        # FIXME: This is a hack to make the is_user_ext_update cases
+        # work (by ensuring we can always read their current state),
+        # but this is actually a pretty dumb approach and we can do
+        # better.
+        regular_updates += sys_updates
 
     return regular_updates, sys_updates, updates, False
 

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -32,3 +32,13 @@ type Astronomy {
     deferred index ext::ai::index(embedding_model := 'text-embedding-test')
         on (.content);
 };
+
+type Stuff extending Astronomy {
+    content2: str;
+    deferred index ext::ai::index(embedding_model := 'text-embedding-test')
+        on (.content ++ .content2);
+};
+
+type Star extending Astronomy;
+
+type Supernova extending Star;

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12416,6 +12416,106 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             };
         ''', explicit_modules=True)
 
+    async def test_edgeql_migration_ai_07(self):
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Astronomy {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Astronomy {
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+            };
+        ''', explicit_modules=True)
+
+    async def test_edgeql_migration_ai_08(self):
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Base {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Base {
+                    # deferred index ext::ai::index(
+                    #     embedding_model := 'text-embedding-3-small'
+                    # ) on (.content ++ '!');
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        await self.con.query('''
+            select {
+                base := ext::ai::search(Base, <array<float32>>[1]),
+                sub := ext::ai::search(Sub, <array<float32>>[1]),
+            }
+        ''')
+
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Base {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Base {
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content ++ '!');
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        await self.con.query('''
+            select {
+                base := ext::ai::search(Base, <array<float32>>[1]),
+                sub := ext::ai::search(Sub, <array<float32>>[1]),
+            }
+        ''')
+
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Base {
+                    content: str;
+                };
+
+                type Sub extending Base {
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content ++ '!');
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        # Base lost the index, just select Sub
+        await self.con.query('''
+            select {
+                sub := ext::ai::search(Sub, <array<float32>>[1]),
+            }
+        ''')
+
 
 class EdgeQLMigrationRewriteTestCase(EdgeQLDataMigrationTestCase):
     DEFAULT_MODULE = 'default'


### PR DESCRIPTION
This is a forward port of #7220 that drops all the patching mechanisms.

 * Fix trivial index overriding by tweaking ddl_identity.
 * Make UPDATE triggers not always ISE
 * Filter out rows with NULL embeddings in fts::search
 * Update the triggers when overriding an index
 * Fix nontrivial index overriding.

The last one is the most impactful thing here.

The issue was that indexes in children were expected to have the same name as in the parent, but did not. The "effective object index" in a child, if the child defined the index itself, won't actually be a child of the parent index, which was how the name was found.  It would not be hard to do this computation right (and I had that part working), but this approach has a major downside: *adding* an index to a parent can require the column name to be changed in the child. Additionally, it can't work if there are multiple independent base types with ai indexes.

Another approach would be to always use the indexes *own* id as the name.  I started along this path too, and had it much of the way. The main downside (which I hadn't started on) is that handling the EXPLAIN mode where inhviews are not used would be a pain.  This is *almost* compatible with the existing database layouts (since nontrivial inheritance doesn't work anyway) but differs when there is trivial inheritance of indexes (where the child has no index specified). So we would need to apply a patch to rename columns and whatnot.

Instead I went with a simplifying approach of making everything use the same name. It's generalized in a way were it would be very easy to use the model_name in the name instead, though.

This did also require some very custom patching code to rename all of the generated columns, refresh the triggers, and refresh some views. Refreshing the triggers was also necessary on is own, since they never worked.