### PR TITLE
Allow multiple authentication methods per transport in `--default-auth-method`

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -543,7 +543,7 @@ def _validate_default_auth_method(
                     f"invalid connection transport: {transport_name}, "
                     f"supported values are: {', '.join(transport_names)})"
                 )
-
+            transport_methods = []
             for method_name in method_names.split('/'):
                 method = names.get(method_name)
                 if not method:
@@ -551,10 +551,8 @@ def _validate_default_auth_method(
                         f"invalid authentication method: {method_name}, "
                         f"supported values are: {', '.join(names)})"
                     )
-                try:
-                    methods[transport].append(method)
-                except KeyError:
-                    methods[transport] = [method]
+                transport_methods.append(method)
+            methods[transport] = transport_methods
 
     return ServerAuthMethods(methods)
 

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -167,29 +167,31 @@ class ServerAuthMethods:
 
     def __init__(
         self,
-        methods: Mapping[ServerConnTransport, ServerAuthMethod],
+        methods: Mapping[ServerConnTransport, list[ServerAuthMethod]],
     ) -> None:
         self._methods = dict(methods)
 
-    def get(self, transport: ServerConnTransport) -> ServerAuthMethod:
+    def get(self, transport: ServerConnTransport) -> list[ServerAuthMethod]:
         return self._methods[transport]
 
-    def items(self) -> ItemsView[ServerConnTransport, ServerAuthMethod]:
+    def items(self) -> ItemsView[ServerConnTransport, list[ServerAuthMethod]]:
         return self._methods.items()
 
     def __str__(self):
         return ','.join(
-            f'{t.lower()}:{m.lower()}' for t, m in self._methods.items()
+            f'{t.lower()}:{'/'.join(m.lower() for m in mm)}'
+            for t, mm in self._methods.items()
         )
 
 
 DEFAULT_AUTH_METHODS = ServerAuthMethods({
-    ServerConnTransport.TCP: ServerAuthMethod.Scram,
-    ServerConnTransport.TCP_PG: ServerAuthMethod.Scram,
-    ServerConnTransport.HTTP: ServerAuthMethod.JWT,
-    ServerConnTransport.SIMPLE_HTTP: ServerAuthMethod.Password,
-    ServerConnTransport.HTTP_METRICS: ServerAuthMethod.Auto,
-    ServerConnTransport.HTTP_HEALTH: ServerAuthMethod.Auto,
+    ServerConnTransport.TCP: [ServerAuthMethod.Scram],
+    ServerConnTransport.TCP_PG: [ServerAuthMethod.Scram],
+    ServerConnTransport.HTTP: [ServerAuthMethod.JWT],
+    ServerConnTransport.SIMPLE_HTTP: [
+        ServerAuthMethod.Password, ServerAuthMethod.JWT],
+    ServerConnTransport.HTTP_METRICS: [ServerAuthMethod.Auto],
+    ServerConnTransport.HTTP_HEALTH: [ServerAuthMethod.Auto],
 })
 
 
@@ -516,7 +518,7 @@ def _validate_default_auth_method(
                     ):
                         continue
 
-                methods[t] = method
+                methods[t] = [method]
     elif "," not in value and ":" not in value:
         raise click.BadParameter(
             f"invalid authentication method: {value}, "
@@ -531,23 +533,28 @@ def _validate_default_auth_method(
         }
         for transport_spec in transport_specs:
             transport_spec = transport_spec.strip()
-            transport_name, _, method_name = transport_spec.partition(':')
-            if not method_name:
+            transport_name, _, method_names = transport_spec.partition(':')
+            if not method_names:
                 raise click.BadParameter(
-                    "format is <transport>:<method>[,...]")
+                    "format is <transport>:<method>[/method...][,...]")
             transport = transport_names.get(transport_name.lower())
             if not transport:
                 raise click.BadParameter(
                     f"invalid connection transport: {transport_name}, "
                     f"supported values are: {', '.join(transport_names)})"
                 )
-            method = names.get(method_name)
-            if not method:
-                raise click.BadParameter(
-                    f"invalid authentication method: {method_name}, "
-                    f"supported values are: {', '.join(names)})"
-                )
-            methods[transport] = method
+
+            for method_name in method_names.split('/'):
+                method = names.get(method_name)
+                if not method:
+                    raise click.BadParameter(
+                        f"invalid authentication method: {method_name}, "
+                        f"supported values are: {', '.join(names)})"
+                    )
+                try:
+                    methods[transport].append(method)
+                except KeyError:
+                    methods[transport] = [method]
 
     return ServerAuthMethods(methods)
 
@@ -1201,7 +1208,7 @@ def parse_args(**kwargs: Any):
             kwargs['http_endpoint_security'] = 'optional'
         if not kwargs['default_auth_method']:
             kwargs['default_auth_method'] = ServerAuthMethods({
-                t: ServerAuthMethod.Trust
+                t: [ServerAuthMethod.Trust]
                 for t in ServerConnTransport.__members__.values()
             })
         if kwargs['tls_cert_mode'] == 'default':
@@ -1210,10 +1217,11 @@ def parse_args(**kwargs: Any):
     elif not kwargs['default_auth_method']:
         kwargs['default_auth_method'] = DEFAULT_AUTH_METHODS
 
-    methods = dict(kwargs['default_auth_method'].items())
+    transport_methods = dict(kwargs['default_auth_method'].items())
     for transport in ServerConnTransport.__members__.values():
-        method = methods[transport]
-        if method is ServerAuthMethod.Auto:
+        methods = transport_methods[transport]
+        if ServerAuthMethod.Auto in methods:
+            pos = methods.index(ServerAuthMethod.Auto)
             if transport in (
                 ServerConnTransport.HTTP_METRICS,
                 ServerConnTransport.HTTP_HEALTH,
@@ -1222,24 +1230,33 @@ def parse_args(**kwargs: Any):
                     method = ServerAuthMethod.Trust
                 else:
                     method = ServerAuthMethod.mTLS
+                methods[pos] = method
             else:
-                method = DEFAULT_AUTH_METHODS.get(transport)
-            methods[transport] = method
+                methods = (
+                    methods[:pos]
+                    + DEFAULT_AUTH_METHODS.get(transport)
+                    + methods[pos + 1:]
+                )
+            transport_methods[transport] = [method]
         elif transport in (
             ServerConnTransport.HTTP_METRICS,
             ServerConnTransport.HTTP_HEALTH,
         ):
-            if method is ServerAuthMethod.mTLS:
+            if ServerAuthMethod.mTLS in methods:
                 if kwargs['tls_client_ca_file'] is None:
                     abort('--tls-client-ca-file is required '
                           'for mTLS authentication')
-            elif method is not ServerAuthMethod.Trust:
+
+            if not all(
+                m is ServerAuthMethod.Trust or m is ServerAuthMethod.mTLS
+                for m in methods
+            ):
                 abort(
                     f'--default-auth-method of {transport} can only be one '
                     f'of: {ServerAuthMethod.Trust}, {ServerAuthMethod.mTLS} '
                     f'or {ServerAuthMethod.Auto}'
                 )
-    kwargs['default_auth_method'] = ServerAuthMethods(methods)
+    kwargs['default_auth_method'] = ServerAuthMethods(transport_methods)
 
     if kwargs['binary_endpoint_security'] == 'default':
         kwargs['binary_endpoint_security'] = 'tls'

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -596,29 +596,49 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         # The user has already been authenticated by other means
         # (such as the ability to write to a protected socket).
         if self._external_auth:
-            authmethod_name = 'Trust'
+            authmethods = [
+                self.server.config_settings.get_type_by_name('cfg::Trust')
+            ]
         else:
-            authmethod = await self.tenant.get_auth_method(
+            authmethods = await self.tenant.get_auth_methods(
                 user, self._transport_proto)
+
+        auth_errors = {}
+
+        for authmethod in authmethods:
             authmethod_name = authmethod._tspec.name.split('::')[1]
 
-        if authmethod_name == 'SCRAM':
-            await self._auth_scram(user)
-        elif authmethod_name == 'JWT':
-            self._auth_jwt(user, database, params)
-        elif authmethod_name == 'Trust':
-            self._auth_trust(user)
-        elif authmethod_name == 'Password':
-            raise errors.AuthenticationError(
-                'authentication failed: '
-                'Simple password authentication required but it is only '
-                'supported for HTTP endpoints'
-            )
-        elif authmethod_name == 'mTLS':
-            auth_helpers.auth_mtls_with_user(self._transport, user)
-        else:
-            raise errors.InternalServerError(
-                f'unimplemented auth method: {authmethod_name}')
+            try:
+                if authmethod_name == 'SCRAM':
+                    await self._auth_scram(user)
+                elif authmethod_name == 'JWT':
+                    self._auth_jwt(user, database, params)
+                elif authmethod_name == 'Trust':
+                    self._auth_trust(user)
+                elif authmethod_name == 'Password':
+                    raise errors.AuthenticationError(
+                        'authentication failed: '
+                        'Simple password authentication required but it is '
+                        'only supported for HTTP endpoints'
+                    )
+                elif authmethod_name == 'mTLS':
+                    auth_helpers.auth_mtls_with_user(self._transport, user)
+                else:
+                    raise errors.InternalServerError(
+                        f'unimplemented auth method: {authmethod_name}')
+            except errors.AuthenticationError as e:
+                auth_errors[authmethod_name] = e
+            else:
+                break
+
+        if len(auth_errors) == len(authmethods):
+            if len(auth_errors) > 1:
+                desc = ", ".join(
+                    f"{k}: {e.args[0]};" for k, e in auth_errors.items())
+                raise errors.AuthenticationError(
+                    f"all authentication methods failed: {desc}")
+            else:
+                raise next(iter(auth_errors.values()))
 
     cdef WriteBuffer _make_authentication_sasl_initial(self, list methods):
         raise NotImplementedError

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -633,8 +633,8 @@ cdef class FrontendConnection(AbstractFrontendConnection):
 
         if len(auth_errors) == len(authmethods):
             if len(auth_errors) > 1:
-                desc = ", ".join(
-                    f"{k}: {e.args[0]};" for k, e in auth_errors.items())
+                desc = "; ".join(
+                    f"{k}: {e.args[0]}" for k, e in auth_errors.items())
                 raise errors.AuthenticationError(
                     f"all authentication methods failed: {desc}")
             else:

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -597,7 +597,7 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         # (such as the ability to write to a protected socket).
         if self._external_auth:
             authmethods = [
-                self.server.config_settings.get_type_by_name('cfg::Trust')
+                self.server.config_settings.get_type_by_name('cfg::Trust')()
             ]
         else:
             authmethods = await self.tenant.get_auth_methods(

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -918,8 +918,8 @@ cdef class HttpProtocol:
 
             if len(auth_errors) == len(authmethods):
                 if len(auth_errors) > 1:
-                    desc = ", ".join(
-                        f"{k}: {e.args[0]};" for k, e in auth_errors.items())
+                    desc = "; ".join(
+                        f"{k}: {e.args[0]}" for k, e in auth_errors.items())
                     raise errors.AuthenticationError(
                         f"all authentication methods failed: {desc}")
                 else:
@@ -975,8 +975,8 @@ cdef class HttpProtocol:
 
             if len(auth_errors) == len(auth_methods):
                 if len(auth_errors) > 1:
-                    desc = ", ".join(
-                        f"{k}: {e.args[0]};" for k, e in auth_errors.items())
+                    desc = "; ".join(
+                        f"{k}: {e.args[0]}" for k, e in auth_errors.items())
                     raise errors.AuthenticationError(
                         f"all authentication methods failed: {desc}")
                 else:

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -234,7 +234,8 @@ class BaseServer:
         self._jws_key: jwk.JWK | None = None
         self._jws_keys_newly_generated = False
 
-        self._default_auth_method = default_auth_method
+        self._default_auth_methods = self._get_auth_method_types(
+            default_auth_method)
         self._binary_endpoint_security = binary_endpoint_security
         self._http_endpoint_security = http_endpoint_security
 
@@ -247,6 +248,22 @@ class BaseServer:
 
         self._disable_dynamic_system_config = disable_dynamic_system_config
         self._report_config_typedesc = {}
+
+    def _get_auth_method_types(
+        self,
+        auth_methods_spec: srvargs.ServerAuthMethods,
+    ) -> dict[srvargs.ServerConnTransport, list[config.CompositeConfigType]]:
+        mapping = {}
+        for transport, methods in auth_methods_spec.items():
+            result = []
+            for method in methods:
+                auth_type = self.config_settings.get_type_by_name(
+                    f'cfg::{method.value}'
+                )
+                result.append(auth_type())
+            mapping[transport] = result
+
+        return mapping
 
     async def _request_stats_logger(self):
         last_seen = -1
@@ -1081,10 +1098,10 @@ class BaseServer:
     ) -> dict[defines.ProtocolVersion, bytes]:
         return self._report_config_typedesc
 
-    def get_default_auth_method(
+    def get_default_auth_methods(
         self, transport: srvargs.ServerConnTransport
-    ) -> srvargs.ServerAuthMethod:
-        return self._default_auth_method.get(transport)
+    ) -> list[config.CompositeConfigType]:
+        return self._default_auth_methods.get(transport, [])
 
     def get_std_schema(self) -> s_schema.Schema:
         return self._std_schema

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -234,6 +234,7 @@ class BaseServer:
         self._jws_key: jwk.JWK | None = None
         self._jws_keys_newly_generated = False
 
+        self._default_auth_method_spec = default_auth_method
         self._default_auth_methods = self._get_auth_method_types(
             default_auth_method)
         self._binary_endpoint_security = binary_endpoint_security
@@ -1080,7 +1081,7 @@ class BaseServer:
             params=dict(
                 dev_mode=self._devmode,
                 test_mode=self._testmode,
-                default_auth_method=str(self._default_auth_method),
+                default_auth_methods=str(self._default_auth_method_spec),
                 listen_hosts=self._listen_hosts,
                 listen_port=self._listen_port,
             ),

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1090,12 +1090,13 @@ class Tenant(ha_base.ClusterProtocol):
             assert database is not None
             return database
 
-    async def get_auth_method(
+    async def get_auth_methods(
         self,
         user: str,
         transport: srvargs.ServerConnTransport,
-    ) -> Any:
+    ) -> list[config.CompositeConfigType]:
         authlist = self._sys_auth
+        methods = []
 
         if authlist:
             for auth in authlist:
@@ -1105,13 +1106,11 @@ class Tenant(ha_base.ClusterProtocol):
                 )
 
                 if match:
-                    return auth.method
+                    methods.append(auth.method)
+        else:
+            methods = self._server.get_default_auth_methods(transport)
 
-        default_method = self._server.get_default_auth_method(transport)
-        auth_type = self._server.config_settings.get_type_by_name(
-            f'cfg::{default_method.value}'
-        )
-        return auth_type()
+        return methods
 
     async def new_dbview(
         self,

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1107,7 +1107,9 @@ class Tenant(ha_base.ClusterProtocol):
 
                 if match:
                     methods.append(auth.method)
-        else:
+                    break
+
+        if not methods:
             methods = self._server.get_default_auth_methods(transport)
 
         return methods


### PR DESCRIPTION
Currently, `--default-auth-method` only allows one default method per transport.  This isn't very flexible and so allow multiple authentication methods to be tried in sequence (according to the
specified order in `--default-auth-method`).

Technically, this infrastructure also allows trying multiple configured `cfg::Auth` methods in order of `.priority`, but that is a bigger (and breaking) change so I left it out.
