### PR TITLE
Fix restoring dumps that use ai extension

### DIFF
--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -113,6 +113,18 @@ from .compiler import astutils
 ai_index_base_name = sn.QualName("ext::ai", "index")
 
 
+def get_ext_ai_pre_restore_script(
+    schema: s_schema.Schema,
+) -> str:
+    # We helpfully populate ext::ai::ChatPrompt with a starter prompt
+    # in the extension setup script.
+    # Unfortunately, this means that before user data is restored, we need
+    # to delete those objects, or there will be a constraint error.
+    return '''
+        delete {ext::ai::ChatPrompt, ext::ai::ChatPromptMessage}
+    '''
+
+
 def create_ext_ai_index(
     index: s_indexes.Index,
     predicate_src: Optional[str],

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1304,6 +1304,14 @@ class Compiler:
         schema = ctx.state.current_tx().get_schema(
             ctx.compiler_state.std_schema)
 
+        # The AI extension needs to run some code before restoring data.
+        # TODO: Generalize this mechanism.
+        if schema.get_global(s_ext.Extension, 'ai', default=None):
+            from edb.pgsql import delta_ext_ai
+            ddl_source = edgeql.Source.from_string(
+                delta_ext_ai.get_ext_ai_pre_restore_script(schema))
+            units += compile(ctx=ctx, source=ddl_source).units
+
         if allow_dml_in_functions:
             # Check if any functions actually contained DML.
             for func in schema.get_objects(

--- a/tests/schemas/dump_v5_default.esdl
+++ b/tests/schemas/dump_v5_default.esdl
@@ -23,3 +23,19 @@ type L2 {
     required vec: v3;
     index ext::pgvector::hnsw_cosine(m := 2, ef_construction := 4) on (.vec);
 }
+
+type TestEmbeddingModel
+    extending ext::ai::EmbeddingModel
+{
+    annotation ext::ai::model_name := "text-embedding-test";
+    annotation ext::ai::model_provider := "custom::test";
+    annotation ext::ai::embedding_model_max_input_tokens := "8191";
+    annotation ext::ai::embedding_model_max_output_dimensions := "10";
+    annotation ext::ai::embedding_model_supports_shortening := "true";
+};
+
+type Astronomy {
+    content: str;
+    deferred index ext::ai::index(embedding_model := 'text-embedding-test')
+        on (.content);
+};

--- a/tests/schemas/dump_v5_setup.edgeql
+++ b/tests/schemas/dump_v5_setup.edgeql
@@ -26,3 +26,10 @@ insert L2 {vec := [x % 10, math::ln(x), x / 7 % 13]};
 # set the ef_search extension config value
 configure current database set
 ext::pgvector::Config::ef_search := 5;
+
+insert Astronomy {
+    content := 'Skies on Mars are red'
+};
+insert Astronomy {
+    content := 'Skies on Earth are blue'
+};

--- a/tests/test_dump_v5.py
+++ b/tests/test_dump_v5.py
@@ -80,7 +80,7 @@ class DumpTestCaseMixin:
 
 
 class TestDumpV5(tb.StableDumpTestCase, DumpTestCaseMixin):
-    EXTENSIONS = ["pgvector"]
+    EXTENSIONS = ["pgvector", "ai"]
     BACKEND_SUPERUSER = True
 
     SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',


### PR DESCRIPTION
We helpfully populate ext::ai::ChatPrompt with a starter prompt
in the extension setup script.
Unfortunately, this means that when we try to restore a dump
that still has that prompt in it, we'll get a constraint error.

Delete the objects before restoring the data.