### PR TITLE
Fix dropping AI indexes in a parent and child at the same time

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -7540,7 +7540,7 @@ class CreateExtension(ExtensionCommand, adapts=s_exts.CreateExtension):
         if str(self.classname) == "ai":
             self.pgops.add(
                 delta_ext_ai.pg_rebuild_all_pending_embeddings_views(
-                    schema,
+                    schema, context
                 ),
             )
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12416,7 +12416,7 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             };
         ''', explicit_modules=True)
 
-    async def test_edgeql_migration_ai_07(self):
+    async def test_edgeql_migration_ai_07a(self):
         await self.migrate('''
             using extension ai;
 
@@ -12435,6 +12435,90 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
                 };
 
             };
+        ''', explicit_modules=True)
+
+        await self.migrate('''
+            using extension ai;
+        ''', explicit_modules=True)
+
+    async def test_edgeql_migration_ai_07b(self):
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Astronomy {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Astronomy;
+
+            };
+        ''', explicit_modules=True)
+
+        await self.migrate('''
+            using extension ai;
+        ''', explicit_modules=True)
+
+    async def test_edgeql_migration_ai_07c(self):
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Astronomy {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Astronomy {
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Astronomy {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Astronomy {
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        await self.migrate('''
+            using extension ai;
+
+            module default {
+                type Astronomy {
+                    content: str;
+                    deferred index ext::ai::index(
+                        embedding_model := 'text-embedding-3-small'
+                    ) on (.content);
+                };
+
+                type Sub extending Astronomy {
+                };
+
+            };
+        ''', explicit_modules=True)
+
+        await self.migrate('''
+            using extension ai;
         ''', explicit_modules=True)
 
     async def test_edgeql_migration_ai_08(self):


### PR DESCRIPTION
We need to skip putting objects that are in the process of being deleted
into the views, since the annotations may already be gone.

Also, the annotations that get copied are always marked OWNED, and we
need to preserve that when DROP OWNED.

Annoyingly, this requires passing context back in as an argument to
several functions that I just *removed* it as an argument from. When I
backport this, I'll need to make it optional.