### PR TITLE
Remove type simplification from schema.

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -396,16 +396,19 @@ def derive_view_name(
 
 
 def get_union_type(
-    types: Iterable[s_types.TypeT],
+    types: Sequence[s_types.TypeT],
     *,
     opaque: bool = False,
     preserve_derived: bool = False,
     ctx: context.ContextLevel,
 ) -> s_types.TypeT:
 
+    targets: Sequence[s_types.Type] = s_utils.simplify_union_types(
+        ctx.env.schema, types, preserve_derived
+    )
     ctx.env.schema, union, created = s_utils.ensure_union_type(
-        ctx.env.schema, types,
-        opaque=opaque, preserve_derived=preserve_derived, transient=True)
+        ctx.env.schema, targets,
+        opaque=opaque, transient=True)
 
     if created:
         ctx.env.created_schema_objects.add(union)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -403,9 +403,16 @@ def get_union_type(
     ctx: context.ContextLevel,
 ) -> s_types.TypeT:
 
-    targets: Sequence[s_types.Type] = s_utils.simplify_union_types(
-        ctx.env.schema, types, preserve_derived
-    )
+    targets: Sequence[s_types.Type]
+    if preserve_derived:
+        targets = s_utils.simplify_union_types_preserve_derived(
+            ctx.env.schema, types
+        )
+    else:
+        targets = s_utils.simplify_union_types(
+            ctx.env.schema, types
+        )
+
     ctx.env.schema, union, created = s_utils.ensure_union_type(
         ctx.env.schema, targets,
         opaque=opaque, transient=True)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -422,13 +422,15 @@ def get_union_type(
 
 
 def get_intersection_type(
-    types: Iterable[s_types.TypeT],
+    types: Sequence[s_types.TypeT],
     *,
     ctx: context.ContextLevel,
 ) -> s_types.TypeT:
 
+    targets: Sequence[s_types.Type]
+    targets = s_utils.simplify_intersection_types(ctx.env.schema, types)
     ctx.env.schema, intersection, created = s_utils.ensure_intersection_type(
-        ctx.env.schema, types, transient=True)
+        ctx.env.schema, targets, transient=True)
 
     if created:
         ctx.env.created_schema_objects.add(intersection)

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -640,7 +640,7 @@ class AlterObjectType(
                 # them in the schema to produce the correct as_alter_delta.
                 nschema = _delete_to_delist(delete, schema)
 
-                nschema, nunion = utils.get_union_type(
+                nschema, nunion, _ = utils.ensure_union_type(
                     nschema,
                     types=union.get_union_of(schema).objects(schema),
                     opaque=union.get_is_opaque_union(schema),

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -641,7 +641,7 @@ class AlterObjectType(
                 nschema = _delete_to_delist(delete, schema)
 
                 types = utils.simplify_union_types(
-                    schema, union.get_union_of(schema).objects(schema), False
+                    schema, union.get_union_of(schema).objects(schema)
                 )
                 nschema, nunion, _ = utils.ensure_union_type(
                     nschema,

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -640,9 +640,12 @@ class AlterObjectType(
                 # them in the schema to produce the correct as_alter_delta.
                 nschema = _delete_to_delist(delete, schema)
 
+                types = utils.simplify_union_types(
+                    schema, union.get_union_of(schema).objects(schema), False
+                )
                 nschema, nunion, _ = utils.ensure_union_type(
                     nschema,
-                    types=union.get_union_of(schema).objects(schema),
+                    types=types,
                     opaque=union.get_is_opaque_union(schema),
                     module=union.get_name(schema).module,
                 )

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -640,12 +640,9 @@ class AlterObjectType(
                 # them in the schema to produce the correct as_alter_delta.
                 nschema = _delete_to_delist(delete, schema)
 
-                types = utils.simplify_union_types(
-                    schema, union.get_union_of(schema).objects(schema)
-                )
                 nschema, nunion, _ = utils.ensure_union_type(
                     nschema,
-                    types=types,
+                    types=union.get_union_of(schema).objects(schema),
                     opaque=union.get_is_opaque_union(schema),
                     module=union.get_name(schema).module,
                 )

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3141,7 +3141,7 @@ def get_or_create_union_pointer(
                      for p in components]
     targets: Sequence[s_types.Type] = [p for p in far_endpoints
                                    if isinstance(p, s_types.Type)]
-    targets = utils.simplify_union_types(schema, targets, False)
+    targets = utils.simplify_union_types(schema, targets)
 
     target: s_types.Type
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3139,8 +3139,9 @@ def get_or_create_union_pointer(
 
     far_endpoints = [p.get_far_endpoint(schema, direction)
                      for p in components]
-    targets: List[s_types.Type] = [p for p in far_endpoints
+    targets: Sequence[s_types.Type] = [p for p in far_endpoints
                                    if isinstance(p, s_types.Type)]
+    targets = utils.simplify_union_types(schema, targets, False)
 
     target: s_types.Type
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3220,7 +3220,7 @@ def get_or_create_intersection_pointer(
         return schema, components[0]
 
     targets = list(filter(None, [p.get_target(schema) for p in components]))
-    schema, target = utils.get_intersection_type(
+    schema, target, _ = utils.ensure_intersection_type(
         schema, targets, module=modname)
 
     cardinality = qltypes.SchemaCardinality.One

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3137,10 +3137,14 @@ def get_or_create_union_pointer(
     if len(components) == 1 and direction is PointerDirection.Outbound:
         return schema, components[0]
 
-    far_endpoints = [p.get_far_endpoint(schema, direction)
-                     for p in components]
-    targets: Sequence[s_types.Type] = [p for p in far_endpoints
-                                   if isinstance(p, s_types.Type)]
+    far_endpoints = [
+        p.get_far_endpoint(schema, direction)
+        for p in components
+    ]
+    targets: Sequence[s_types.Type] = [
+        p for p in far_endpoints
+        if isinstance(p, s_types.Type)
+    ]
     targets = utils.simplify_union_types(schema, targets)
 
     target: s_types.Type

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3219,7 +3219,9 @@ def get_or_create_intersection_pointer(
     if len(components) == 1:
         return schema, components[0]
 
+    targets: Sequence[s_types.Type]
     targets = list(filter(None, [p.get_target(schema) for p in components]))
+    targets = utils.simplify_intersection_types(schema, targets)
     schema, target, _ = utils.ensure_intersection_type(
         schema, targets, module=modname)
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -882,7 +882,7 @@ class CreateUnionType(sd.CreateObject[InheritingType], CompoundTypeCommand):
                 for c in self.get_attribute_value('components')
             ]
 
-            new_schema, union_type = utils.get_union_type(
+            new_schema, union_type, _ = utils.ensure_union_type(
                 schema,
                 components,
                 opaque=self.get_attribute_value('is_opaque_union') or False,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -876,11 +876,14 @@ class CreateUnionType(sd.CreateObject[InheritingType], CompoundTypeCommand):
         context: sd.CommandContext,
     ) -> s_schema.Schema:
 
+        from edb.schema import types as s_types
+
         if not context.canonical:
-            components = [
+            components: Sequence[s_types.Type] = [
                 c.resolve(schema)
                 for c in self.get_attribute_value('components')
             ]
+            components = utils.simplify_union_types(schema, components, False)
 
             new_schema, union_type, _ = utils.ensure_union_type(
                 schema,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -883,7 +883,7 @@ class CreateUnionType(sd.CreateObject[InheritingType], CompoundTypeCommand):
                 c.resolve(schema)
                 for c in self.get_attribute_value('components')
             ]
-            components = utils.simplify_union_types(schema, components, False)
+            components = utils.simplify_union_types(schema, components)
 
             new_schema, union_type, _ = utils.ensure_union_type(
                 schema,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -883,21 +883,21 @@ class CreateUnionType(sd.CreateObject[InheritingType], CompoundTypeCommand):
                 c.resolve(schema)
                 for c in self.get_attribute_value('components')
             ]
-            components = utils.simplify_union_types(schema, components)
 
-            new_schema, union_type, _ = utils.ensure_union_type(
+            new_schema, union_type, created = utils.ensure_union_type(
                 schema,
                 components,
                 opaque=self.get_attribute_value('is_opaque_union') or False,
                 module=self.classname.module,
             )
 
-            delta = union_type.as_create_delta(
-                schema=new_schema,
-                context=so.ComparisonContext(),
-            )
+            if created:
+                delta = union_type.as_create_delta(
+                    schema=new_schema,
+                    context=so.ComparisonContext(),
+                )
 
-            self.add(delta)
+                self.add(delta)
 
         for cmd in self.get_subcommands():
             schema = cmd.apply(schema, context)

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -1078,6 +1078,11 @@ def simplify_union_types(
     schema: s_schema.Schema,
     types: Sequence[s_types.Type],
 ) -> Sequence[s_types.Type]:
+    """Minimize the types used to create a union of types.
+
+    Any unions types are unwrapped. Then, any unnecessary subclasses are
+    removed.
+    """
 
     from edb.schema import types as s_types
 
@@ -1102,6 +1107,14 @@ def simplify_union_types_preserve_derived(
     schema: s_schema.Schema,
     types: Sequence[s_types.Type],
 ) -> Sequence[s_types.Type]:
+    """Minimize the types used to create a union of types.
+
+    Any unions types are unwrapped. Then, any unnecessary subclasses are
+    removed.
+    
+    Derived types are always preserved for 'std::UNION', 'std::IF', and
+    'std::??'.
+    """
 
     from edb.schema import types as s_types
 
@@ -1203,6 +1216,11 @@ def simplify_intersection_types(
     schema: s_schema.Schema,
     types: Sequence[s_types.Type],
 ) -> Sequence[s_types.Type]:
+    """Minimize the types used to create an intersection of types.
+
+    Any intersection types are unwrapped. Then, any unnecessary superclasses are
+    removed.
+    """
 
     from edb.schema import types as s_types
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -1109,20 +1109,6 @@ def ensure_union_type(
     return schema, uniontype, created
 
 
-def get_union_type(
-    schema: s_schema.Schema,
-    types: Iterable[s_types.Type],
-    *,
-    opaque: bool = False,
-    module: Optional[str] = None,
-) -> Tuple[s_schema.Schema, s_types.Type]:
-
-    schema, union, _ = ensure_union_type(
-        schema, types, opaque=opaque, module=module)
-
-    return schema, union
-
-
 def get_non_overlapping_union(
     schema: s_schema.Schema,
     objects: Iterable[so.InheritingObjectT],
@@ -1204,19 +1190,6 @@ def ensure_intersection_type(
             module=module,
             transient=transient,
         )
-
-
-def get_intersection_type(
-    schema: s_schema.Schema,
-    types: Iterable[s_types.Type],
-    *,
-    module: Optional[str] = None,
-) -> Tuple[s_schema.Schema, s_types.Type]:
-
-    schema, intersection, _ = ensure_intersection_type(
-        schema, types, module=module)
-
-    return schema, intersection
 
 
 def _intersection_error(

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -1111,7 +1111,7 @@ def simplify_union_types_preserve_derived(
 
     Any unions types are unwrapped. Then, any unnecessary subclasses are
     removed.
-    
+
     Derived types are always preserved for 'std::UNION', 'std::IF', and
     'std::??'.
     """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4029,6 +4029,18 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_get_migration_union_ptrs_02(self):
+        schema = r'''
+        type A;
+        type A_ extending A;
+        type B;
+        type C {
+            link foo -> A | A_ | B;
+        };
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_except_01(self):
         schema = r'''
         type ExceptTest {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4029,18 +4029,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
-    def test_schema_get_migration_union_ptrs_02(self):
-        schema = r'''
-        type A;
-        type A_ extending A;
-        type B;
-        type C {
-            link foo -> A | A_ | B;
-        };
-        '''
-
-        self._assert_migration_consistency(schema)
-
     def test_schema_get_migration_except_01(self):
         schema = r'''
         type ExceptTest {
@@ -8870,6 +8858,40 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             alias Z := Y;
             """,
         ])
+
+    def test_schema_migrations_union_ptrs_01(self):
+        self._assert_migration_equivalence([
+            r"""
+            type A;
+            type A_ extending A;
+            type B;
+            type C {
+                # link of type and base type
+                link foo -> A | A_;
+            };
+            """,
+            r"""
+            type A;
+            type A_ extending A;
+            type B;
+            type C {
+                # link of type, base type, and other type
+                link foo -> A | A_ | B;
+            };
+            """,
+            r"""
+            type A;
+            type A_ extending A;
+            type B;
+            type C {
+                # remove link
+            };
+            """,
+        ])
+        schema = r'''
+        '''
+
+        self._assert_migration_consistency(schema)
 
 
 class TestDescribe(tb.BaseSchemaLoadTest):


### PR DESCRIPTION
close #7221

Make type simplification for schema utils `ensure_union_type` and `ensure_intersection_type` explicit. Remove the type simplification when generating types from a user schema.

When creating types from a schema, the implicit simplification can cause an error when the name of the simplified type differs from the non-simplified type. This can occur if the type of a link is the union of a type and a base type (eg. `type A; type A_ extending A;` `link foo -> A | A_`).