### PR TITLE
Fix AI columns to not appear in SQL introspection tables

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_04_18_00_00
+EDGEDB_CATALOG_VERSION = 2024_04_18_00_01
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5834,8 +5834,8 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
 
         LEFT JOIN edgedb."_SchemaPointer" sp ON sp.id::text = isc.column_name
         LEFT JOIN edgedb."_SchemaLink" sl ON sl.id::text = isc.column_name
-        WHERE isc.column_name <> '__fts_document__'
         ) t
+        WHERE v_column_name IS NOT NULL
             '''
             ),
         ),
@@ -6058,7 +6058,7 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
         # attnum_internal column.
         dbops.View(
             name=("edgedbsql", "pg_attribute_ext"),
-            query="""
+            query=r"""
         SELECT attrelid,
             attname,
             atttypid,
@@ -6160,7 +6160,8 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
 
         LEFT JOIN edgedb."_SchemaPointer" sp ON sp.id::text = pa.attname
         LEFT JOIN edgedb."_SchemaLink" sl ON sl.id::text = pa.attname
-        WHERE pa.attname <> '__fts_document__'
+        -- Filter out internal columns
+        WHERE pa.attname NOT LIKE '\_\_%\_\_' OR pa.attname = '__type__'
         ) t
         """,
         ),

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -172,10 +172,6 @@ class Source(
         Returns a list of columns that are present in the backing table of
         this source, apart from the columns for pointers.
         """
-        # Beware: when adding columns here, make sure to update SQL
-        # introspection views. If you do not, these new addon columns will
-        # appear in pg_attribute and information_schema.column, but will not
-        # be queryable.
         res = []
         from edb.common import debug
 


### PR DESCRIPTION
I noticed a comment in get_addon_columns indicating that we
needed to update the SQL introspection views to know about
any new columns we inject. Oops.

Instead I updated the views to try to figure it out more generally,
and removed the comment.