### PR TITLE
Cache encoded compilation config

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -411,7 +411,9 @@ class CompilerState:
         )
 
     @functools.cached_property
-    def compilation_config_serializer(self) -> sertypes.InputShapeSerializer:
+    def compilation_config_serializer(
+        self
+    ) -> sertypes.CompilationConfigSerializer:
         return (
             self.state_serializer_factory.make_compilation_config_serializer()
         )
@@ -1132,7 +1134,7 @@ class Compiler:
 
     def make_compilation_config_serializer(
         self,
-    ) -> sertypes.InputShapeSerializer:
+    ) -> sertypes.CompilationConfigSerializer:
         return self.state.compilation_config_serializer
 
     def describe_database_dump(

--- a/edb/server/compiler/rpc.pyi
+++ b/edb/server/compiler/rpc.pyi
@@ -40,7 +40,8 @@ class CompilationRequest:
     session_config: immutables.Map[str, config.SettingValue] | None
 
     def __init__(
-        self, compilation_config_serializer: sertypes.InputShapeSerializer
+        self,
+        compilation_config_serializer: sertypes.CompilationConfigSerializer,
     ):
         ...
 

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -1856,7 +1856,7 @@ class CompilationConfigSerializer(InputShapeSerializer):
     def encode_configs(
         self, *configs: immutables.Map[str, config.SettingValue] | None
     ) -> bytes:
-        state = {}
+        state: dict[str, Any] = {}
         for conf in configs:
             if conf is not None:
                 state.update((k, v.value) for k, v in conf.items())

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -1771,7 +1771,7 @@ class StateSerializerFactory:
             type_id, type_data, global_reps, protocol_version
         )
 
-    def make_compilation_config_serializer(self) -> InputShapeSerializer:
+    def make_compilation_config_serializer(self) -> CompilationConfigSerializer:
         ctx = Context(
             schema=self._schema,
             protocol_version=edbdef.CURRENT_PROTOCOL,
@@ -1782,7 +1782,7 @@ class StateSerializerFactory:
             ctx=ctx
         )
         type_data = b''.join(ctx.buffer)
-        return InputShapeSerializer(
+        return CompilationConfigSerializer(
             type_id,
             type_data,
             edbdef.CURRENT_PROTOCOL
@@ -1849,6 +1849,18 @@ class StateSerializer(InputShapeSerializer):
         global_name: str,
     ) -> Optional[object]:
         return self._global_reps.get(global_name)
+
+
+class CompilationConfigSerializer(InputShapeSerializer):
+    @functools.lru_cache(64)
+    def encode_configs(
+        self, *configs: immutables.Map[str, config.SettingValue] | None
+    ) -> bytes:
+        state = {}
+        for conf in configs:
+            if conf is not None:
+                state.update((k, v.value) for k, v in conf.items())
+        return self.encode(state)
 
 
 def derive_alias(

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -128,7 +128,7 @@ class BaseServer:
     _stmt_cache_size: int | None = None
 
     _compiler_pool: compiler_pool.AbstractPool | None
-    compilation_config_serializer: sertypes.InputShapeSerializer
+    compilation_config_serializer: sertypes.CompilationConfigSerializer
     _http_request_logger: asyncio.Task | None
     _auth_gc: asyncio.Task | None
 


### PR DESCRIPTION
This change adds an in-memory LRU cache for compilation config serialization, which is used to compute the query cache key.

Benchmarks before this PR:

```
/home/fantix/imdbench/bench.py
============ JS ============
concurrency:	1
warmup time:	5 seconds
duration:	30 seconds
queries:	get_movie, get_user, insert_movie
benchmarks:	edgedb_js

Running benchmark...
/home/fantix/imdbench/jsbench.js --concurrency 1 --duration 30 --timeout 2 --warmup-time 5 --output-format json --host 127.0.0.1 --nsamples 10 --number-of-ids 250 --query get_movie --port 5656 edgedb_js
== edgedb_js : get_movie ==
queries:	83016
qps:		2767 q/s
min latency:	0.29ms
avg latency:	0.36ms
max latency:	1.28ms

Running benchmark...
/home/fantix/imdbench/jsbench.js --concurrency 1 --duration 30 --timeout 2 --warmup-time 5 --output-format json --host 127.0.0.1 --nsamples 10 --number-of-ids 250 --query get_user --port 5656 edgedb_js
== edgedb_js : get_user ==
queries:	135734
qps:		4524 q/s
min latency:	0.20ms
avg latency:	0.22ms
max latency:	0.83ms

Running benchmark...
/home/fantix/imdbench/jsbench.js --concurrency 1 --duration 30 --timeout 2 --warmup-time 5 --output-format json --host 127.0.0.1 --nsamples 10 --number-of-ids 250 --query insert_movie --port 5656 edgedb_js
== edgedb_js : insert_movie ==
queries:	4292
qps:		143 q/s
min latency:	6.40ms
avg latency:	6.99ms
max latency:	44.72ms
```

And after this PR:

```
/home/fantix/imdbench/bench.py
============ JS ============
concurrency:	1
warmup time:	5 seconds
duration:	30 seconds
queries:	get_movie, get_user, insert_movie
benchmarks:	edgedb_js

Running benchmark...
/home/fantix/imdbench/jsbench.js --concurrency 1 --duration 30 --timeout 2 --warmup-time 5 --output-format json --host 127.0.0.1 --nsamples 10 --number-of-ids 250 --query get_movie --port 5656 edgedb_js
== edgedb_js : get_movie ==
queries:	84094
qps:		2803 q/s
min latency:	0.28ms
avg latency:	0.36ms
max latency:	1.10ms

Running benchmark...
/home/fantix/imdbench/jsbench.js --concurrency 1 --duration 30 --timeout 2 --warmup-time 5 --output-format json --host 127.0.0.1 --nsamples 10 --number-of-ids 250 --query get_user --port 5656 edgedb_js
== edgedb_js : get_user ==
queries:	140581
qps:		4686 q/s
min latency:	0.20ms
avg latency:	0.21ms
max latency:	0.63ms

Running benchmark...
/home/fantix/imdbench/jsbench.js --concurrency 1 --duration 30 --timeout 2 --warmup-time 5 --output-format json --host 127.0.0.1 --nsamples 10 --number-of-ids 250 --query insert_movie --port 5656 edgedb_js
== edgedb_js : insert_movie ==
queries:	4255
qps:		141 q/s
min latency:	6.45ms
avg latency:	7.05ms
max latency:	19.96ms
```