### PR TITLE
Skip rebuilding query string if normalization didn't extract variables

### DIFF
--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -187,10 +187,12 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
     }
 
     all_variables.push(variables);
-    let processed_source = if !all_variables.is_empty() {
-        serialize_tokens(&rewritten_tokens[..])
-    } else {
+    let processed_source = if counter <= var_idx {
+        // Just use the original text when there is no literal to extract,
+        // in order to save the time calling `serialize_tokens()`
         text.to_string()
+    } else {
+        serialize_tokens(&rewritten_tokens[..])
     };
     Ok(Entry {
         hash: hash(&processed_source),

--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -159,10 +159,9 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
                 matches!(kw, "configure"|"create"|"alter"|"drop"|"start"|"analyze")
                 || (last_was_set && kw == "global")
             ) => {
-                let processed_source = serialize_tokens(&tokens);
                 return Ok(Entry {
-                    hash: hash(&processed_source),
-                    processed_source,
+                    hash: hash(text),
+                    processed_source: text.to_string(),
                     tokens,
                     variables: Vec::new(),
                     named_args: false,
@@ -188,7 +187,11 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
     }
 
     all_variables.push(variables);
-    let processed_source = serialize_tokens(&rewritten_tokens[..]);
+    let processed_source = if !all_variables.is_empty() {
+        serialize_tokens(&rewritten_tokens[..])
+    } else {
+        text.to_string()
+    };
     Ok(Entry {
         hash: hash(&processed_source),
         processed_source,

--- a/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
@@ -7,8 +7,8 @@ use num_bigint::BigInt;
 fn test_verbatim() {
     let entry = normalize(r###"
         SELECT $1 + $2
-    "###).unwrap();
-    assert_eq!(entry.processed_source, "SELECT$1+$2");
+    "###.trim()).unwrap();
+    assert_eq!(entry.processed_source, "SELECT $1 + $2");
     assert_eq!(entry.variables, vec![vec![]]);
 }
 

--- a/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
@@ -16,8 +16,8 @@ fn test_verbatim() {
 fn test_configure() {
     let entry = normalize(r###"
         CONFIGURE INSTANCE SET some_setting := 7
-    "###).unwrap();
-    assert_eq!(entry.processed_source, "CONFIGURE INSTANCE SET some_setting:=7");
+    "###.trim()).unwrap();
+    assert_eq!(entry.processed_source, "CONFIGURE INSTANCE SET some_setting := 7");
     assert_eq!(entry.variables, vec![] as Vec<Vec<Variable>>);
 }
 


### PR DESCRIPTION
Hope I get @elprans's idea correctly