### PR TITLE
Undo `NULL`-filtering embedding columns

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3984,9 +3984,7 @@ def _ext_ai_search_inner_pgvector(
         ],
     )
 
-    valid = pgast.NullTest(arg=embedding, negated=True)
-
-    return similarity, valid
+    return similarity, None
 
 
 def _process_set_as_object_search(


### PR DESCRIPTION
This forces expensive seqscans and we don't want that.
