### PR TITLE
Make ai::search have integrated sort and hit indexes

### DIFF
--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -42,3 +42,9 @@ type Stuff extending Astronomy {
 type Star extending Astronomy;
 
 type Supernova extending Star;
+
+function _set_seqscan(val: std::str) -> std::str {
+    using sql $$
+      select set_config('enable_seqscan', val, true)
+    $$;
+};

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12542,12 +12542,13 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             };
         ''', explicit_modules=True)
 
+        arg = [0.0] * 1536
         await self.con.query('''
             select {
-                base := ext::ai::search(Base, <array<float32>>[1]),
-                sub := ext::ai::search(Sub, <array<float32>>[1]),
+                base := ext::ai::search(Base, <array<float32>>$0),
+                sub := ext::ai::search(Sub, <array<float32>>$0),
             }
-        ''')
+        ''', arg)
 
         await self.migrate('''
             using extension ai;
@@ -12571,10 +12572,10 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
 
         await self.con.query('''
             select {
-                base := ext::ai::search(Base, <array<float32>>[1]),
-                sub := ext::ai::search(Sub, <array<float32>>[1]),
+                base := ext::ai::search(Base, <array<float32>>$0),
+                sub := ext::ai::search(Sub, <array<float32>>$0),
             }
-        ''')
+        ''', arg)
 
         await self.migrate('''
             using extension ai;
@@ -12596,9 +12597,9 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
         # Base lost the index, just select Sub
         await self.con.query('''
             select {
-                sub := ext::ai::search(Sub, <array<float32>>[1]),
+                sub := ext::ai::search(Sub, <array<float32>>$0),
             }
-        ''')
+        ''', arg)
 
     async def test_edgeql_migration_ai_09(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
Tweak ai::search codegen to make it hit the index reliably even with
filtering NULLs out. It seems that postgres *can* sometimes manage to
use an ORDER BY index even when the function call isn't directly in
the ORDER BY, but it is much more fragile (broken by adding the NULL
check in #7223, for one).

Making ai::search return sorted output makes it easy to hit the
indexes and improves ergonomics.

Also:
 * Compile the arguments in the enclosing scope, which helps us hit the
   index in more complex scenarios (like a cast from json)
 * Make sure to export a source rvar for `.object`