### PR TITLE
[5.x] Skip *all* the start_edgedb_server tests on x86 MacOS

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -47,6 +47,7 @@ import inspect
 import json
 import os
 import pathlib
+import platform
 import random
 import re
 import secrets
@@ -2459,6 +2460,12 @@ def start_edgedb_server(
     extra_args: Optional[List[str]] = None,
     default_branch: Optional[str] = None,
 ):
+    if platform.system() == "Darwin" and platform.machine() == 'x86_64':
+        raise unittest.SkipTest(
+            "Postgres is not getting getting enough shared memory on macos-14 "
+            "GitHub runner by default"
+        )
+
     if not devmode.is_in_dev_mode() and not runstate_dir:
         if backend_dsn or adjacent_to:
             # We don't want to implicitly "fix the issue" for the test author

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -19,7 +19,6 @@
 import asyncio
 import os
 import pathlib
-import platform
 import signal
 import ssl
 import tempfile
@@ -582,11 +581,6 @@ class TestServerAuth(tb.ConnectedTestCase):
                 DROP ROLE foo;
             ''')
 
-    @unittest.skipIf(
-        platform.system() == "Darwin" and platform.machine() == 'x86_64',
-        "Postgres is not getting getting enough shared memory on macos-14 "
-        "GitHub runner by default"
-    )
     @unittest.skipIf(
         "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" in os.environ,
         "cannot use CONFIGURE INSTANCE in multi-tenant mode",


### PR DESCRIPTION
They are failing due to shared memory errors on the crappy
github runner we are using in tests.