### PR TITLE
workflows: Use `macos-13` runner to build and test x86_64 builds

### DIFF
--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -136,7 +136,7 @@ targets:
           platform: macos
           platform_version: x86_64
           family: generic
-          runs_on: [macos-14]
+          runs_on: [macos-13]
         - name: macos-aarch64
           arch: aarch64
           platform: macos

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -848,7 +848,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
     needs: prep
 
     if: needs.prep.outputs.if_macos_x86_64 == 'true'
@@ -1385,7 +1385,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -853,7 +853,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
     needs: prep
 
     if: needs.prep.outputs.if_macos_x86_64 == 'true'
@@ -1390,7 +1390,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,7 +469,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
     needs: prep
 
 
@@ -982,7 +982,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -489,7 +489,7 @@ jobs:
         path: artifacts/linuxmusl-aarch64
 
   build-macos-x86_64:
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
     needs: prep
 
 
@@ -1024,7 +1024,7 @@ jobs:
 
   test-macos-x86_64:
     needs: [build-macos-x86_64]
-    runs-on: ['macos-14']
+    runs-on: ['macos-13']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
`macos-14` runs on Applie Silicon, and that causes the build and test
phase to be quite slow.
