### PR TITLE
Backport force return cast on range get upper and lower functions.

### DIFF
--- a/edb/lib/std/31-rangefuncs.edgeql
+++ b/edb/lib/std/31-rangefuncs.edgeql
@@ -265,6 +265,7 @@ CREATE FUNCTION std::range_get_upper(r: range<anypoint>) -> optional anypoint
 {
     SET volatility := 'Immutable';
     USING SQL FUNCTION 'upper';
+    SET force_return_cast := true;
 };
 
 
@@ -272,6 +273,7 @@ CREATE FUNCTION std::range_get_lower(r: range<anypoint>) -> optional anypoint
 {
     SET volatility := 'Immutable';
     USING SQL FUNCTION 'lower';
+    SET force_return_cast := true;
 };
 
 
@@ -295,6 +297,7 @@ CREATE FUNCTION std::range_get_upper(
 {
     SET volatility := 'Immutable';
     USING SQL FUNCTION 'upper';
+    SET force_return_cast := true;
 };
 
 
@@ -304,6 +307,7 @@ CREATE FUNCTION std::range_get_lower(
 {
     SET volatility := 'Immutable';
     USING SQL FUNCTION 'lower';
+    SET force_return_cast := true;
 };
 
 

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -132,4 +132,27 @@ ALTER TYPE cfg::AbstractConfig {
     # === 5.0
     ('edgeql+user_ext+fix-ai-indexes|ai', ''),
     ('edgeql+schema', ''),  # for SQL introspection schema updates
+    # === 5.3
+    ('edgeql', '''
+ALTER FUNCTION 
+std::range_get_upper(r: range<anypoint>) -> optional anypoint
+{
+    SET force_return_cast := true;
+};
+ALTER FUNCTION 
+std::range_get_lower(r: range<anypoint>) -> optional anypoint
+{
+    SET force_return_cast := true;
+};
+ALTER FUNCTION 
+std::range_get_upper(r: multirange<anypoint>) -> optional anypoint
+{
+    SET force_return_cast := true;
+};
+ALTER FUNCTION 
+std::range_get_lower(r: multirange<anypoint>) -> optional anypoint
+{
+    SET force_return_cast := true;
+};
+'''),
 ])

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -5425,6 +5425,48 @@ aa \
             [],
         )
 
+        # check that return type of sql is correct
+        # https://github.com/edgedb/edgedb/issues/6786
+        await self.assert_query_result(
+            f'''select <str>(range_get_upper(
+                    range(
+                        <cal::local_datetime>'2024-01-11T00:00:00',
+                        <cal::local_datetime>'2025-01-11T00:00:00'
+                    )
+                ) - <cal::date_duration>"1 day");''',
+            ['2025-01-10T00:00:00'],
+        )
+
+        await self.assert_query_result(
+            f'''select <str>(range_get_lower(
+                    range(
+                        <cal::local_datetime>'2024-01-11T00:00:00',
+                        <cal::local_datetime>'2025-01-11T00:00:00'
+                    )
+                ) - <cal::date_duration>"1 day");''',
+            ['2024-01-10T00:00:00'],
+        )
+
+        await self.assert_query_result(
+            f'''select <str>(range_get_upper(
+                    multirange([range(
+                        <cal::local_datetime>'2024-01-11T00:00:00',
+                        <cal::local_datetime>'2025-01-11T00:00:00'
+                    )])
+                ) - <cal::date_duration>"1 day");''',
+            ['2025-01-10T00:00:00'],
+        )
+
+        await self.assert_query_result(
+            f'''select <str>(range_get_lower(
+                    multirange([range(
+                        <cal::local_datetime>'2024-01-11T00:00:00',
+                        <cal::local_datetime>'2025-01-11T00:00:00'
+                    )])
+                ) - <cal::date_duration>"1 day");''',
+            ['2024-01-10T00:00:00'],
+        )
+
     async def test_edgeql_expr_range_18(self):
         # Test bound for datetime ranges and multiranges.
         await self.assert_query_result(
@@ -5885,6 +5927,48 @@ aa \
                     range(<cal::local_date>{{}},
                           <cal::local_date>'2022-06-15')]));''',
             [],
+        )
+
+        # check that return type of sql is correct
+        # https://github.com/edgedb/edgedb/issues/6786
+        await self.assert_query_result(
+            f'''select <str>(range_get_upper(
+                    range(
+                        <cal::local_date>'2024-01-11',
+                        <cal::local_date>'2025-01-11'
+                    )
+                ) - <cal::date_duration>"1 day");''',
+            ['2025-01-10'],
+        )
+
+        await self.assert_query_result(
+            f'''select <str>(range_get_lower(
+                    range(
+                        <cal::local_date>'2024-01-11',
+                        <cal::local_date>'2025-01-11'
+                    )
+                ) - <cal::date_duration>"1 day");''',
+            ['2024-01-10'],
+        )
+
+        await self.assert_query_result(
+            f'''select <str>(range_get_upper(
+                    multirange([range(
+                        <cal::local_date>'2024-01-11',
+                        <cal::local_date>'2025-01-11'
+                    )])
+                ) - <cal::date_duration>"1 day");''',
+            ['2025-01-10'],
+        )
+
+        await self.assert_query_result(
+            f'''select <str>(range_get_lower(
+                    multirange([range(
+                        <cal::local_date>'2024-01-11',
+                        <cal::local_date>'2025-01-11'
+                    )])
+                ) - <cal::date_duration>"1 day");''',
+            ['2024-01-10'],
         )
 
     async def test_edgeql_expr_range_25(self):


### PR DESCRIPTION
From PR: #7251
Issue: #6786