### PR TITLE
Prevent dump hangups from leaving stray postgres queries

### DIFF
--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -531,6 +531,10 @@ cdef class FrontendConnection(AbstractFrontendConnection):
             # after all the client has already disconnected.
             self._cancelled = True
 
+            # Make sure nothing is blocked on flow control.
+            # (Currently only dump uses this.)
+            self.resume_writing()
+
             if not self.authed:
                 # We must be still authenticating. We can abort that.
                 self._main_task.cancel()


### PR DESCRIPTION
When a dump connection disconnected uncleanly (without sending a
message, I think), it often left one of the COPY queries still
running. This could cause problems, including potential deadlocks.
This can be reproduced by killing `edgedb dump` with ^\ or with
a signal (on ^C it hangs up nicely).

There were two components to the problem:
 * dump and restore went around the normal method for a frontend
   connection to acquire a pgcon, which mean that the hangup code did
   not know about it, and would not attempt to cancel the pgcon.
 * dump might be blocked waiting on a flow control future that
   would never be signalled or cancelled

In my testing, it actually worked to just fix the second issue,
but I think we prefer to cancel the pgcon, not just disconnect it,
and also only unblocking the flow control led to some tasks dying
with weird exceptions.

We also can't just abort the pgcon, because that would leave the dump
tasks blocked forever leaking memory.

I tested manually by killing a bunch of `edgedb dump` commands and
then checking `pg_stat_activity`. It should be possibly to write an
automated test if we think it's important, but it will be pretty
hacky.