### PR TITLE
Refactor to make rewrites use object's id for id of __subject__ 

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1087,7 +1087,6 @@ def _compile_rewrites(
         return None
 
     return irast.Rewrites(
-        subject_path_id=anc.subject_set.path_id,
         old_path_id=anc.old_set.path_id if anc.old_set else None,
         by_type=by_type,
     )

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1278,10 +1278,8 @@ def prepare_rewrite_anchors(
     schema = ctx.env.schema
 
     # init set for __subject__
-    # TODO: Do we really need a separate path id for __subject__?
-    subject_name = sn.QualName("__derived__", "__subject__")
     subject_path_id = irast.PathId.from_type(
-        schema, stype, typename=subject_name,
+        schema, stype,
         namespace=ctx.path_id_namespace, env=ctx.env,
     )
     subject_set = setgen.class_set(

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1277,10 +1277,8 @@ class InsertStmt(MutatingStmt):
 RewritesOfType = typing.Dict[str, typing.Tuple[SetE[Pointer], BasePointerRef]]
 
 
-@dataclasses.dataclass(kw_only=True, frozen=True)
+@dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
 class Rewrites:
-    subject_path_id: PathId
-
     old_path_id: typing.Optional[PathId]
 
     by_type: typing.Dict[TypeRef, RewritesOfType]

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -2787,7 +2787,7 @@ def process_link_update(
                 ]
             )
 
-    updcte = pgast.CommonTableExpr(
+    update = pgast.CommonTableExpr(
         name=ctx.env.aliases.get(hint='i'),
         query=pgast.InsertStmt(
             relation=target_rvar,
@@ -2805,7 +2805,7 @@ def process_link_update(
         )
     )
 
-    pathctx.put_path_value_rvar(updcte.query, path_id.ptr_path(), target_rvar)
+    pathctx.put_path_value_rvar(update.query, path_id.ptr_path(), target_rvar)
 
     def register_overlays(
         overlay_cte: pgast.CommonTableExpr, octx: context.CompilerContextLevel
@@ -2832,9 +2832,9 @@ def process_link_update(
         policy_ctx.rel_overlays = policy_ctx.rel_overlays.copy()
         register_overlays(data_cte, policy_ctx)
 
-    register_overlays(updcte, ctx)
+    register_overlays(update, ctx)
 
-    return updcte, None
+    return update, None
 
 
 def process_link_values(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -600,8 +600,8 @@ def new_pointer_rvar(
     if ptr_info and ptr_info.table_type == 'ObjectType':
         # Inline link
         return _new_inline_pointer_rvar(
-            ir_set, ptr_info=ptr_info,
-            src_rvar=src_rvar, ctx=ctx)
+            ir_set, src_rvar=src_rvar, ctx=ctx
+        )
     else:
         return _new_mapped_pointer_rvar(ir_set, ctx=ctx)
 
@@ -609,7 +609,6 @@ def new_pointer_rvar(
 def _new_inline_pointer_rvar(
         ir_set: irast.SetE[irast.Pointer], *,
         lateral: bool=True,
-        ptr_info: pg_types.PointerStorageInfo,
         src_rvar: pgast.PathRangeVar,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
     ir_ptr = ir_set.expr


### PR DESCRIPTION
Before we were creating a separate path id with name `__derived__::__subject__`.