### PR TITLE
Fix doing a no-op update to an exclusive multi pointer with children

### DIFF
--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -528,6 +528,7 @@ class SchemaTableConstraint:
             except_data=pg_c.except_data,
             scope=pg_c.scope,
             type=pg_c.type,
+            table_type=pg_c.table_type,
             schema=constr.schema,
         )
 

--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -279,6 +279,7 @@ type PropertyContainer {
         constraint exclusive
     }
 }
+type PropertyContainerChild extending PropertyContainer;
 
 type Pair {
     required property x -> str;

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -408,6 +408,13 @@ class TestConstraintsSchema(tb.QueryTestCase):
             };
         """)
 
+        # Update to same values should be fine
+        await self.con.execute("""
+            UPDATE PropertyContainer SET {
+                tags := {"one", "two"}
+            };
+        """)
+
         async with self.assertRaisesRegexTx(
             edgedb.ConstraintViolationError,
             "tags violates exclusivity constraint",
@@ -427,6 +434,12 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     tags := {"four", "four"}
                 };
             """)
+
+        await self.con.execute("""
+            UPDATE PropertyContainer SET {
+                tags := "one"
+            };
+        """)
 
     async def test_constraints_objects(self):
         async with self._run_and_rollback():


### PR DESCRIPTION
Currently, if a type has children and has a multi pointer with an
exclusive constraint, updating the pointer to the value it already has
will produce a ConstraintError. This is because while `UPDATE`
triggers check if the row has actually changed, updates on link tables
are done using deletes and inserts, and so the trigger function is
called unconditionally.

Fix this by checking for source in the trigger function.

--

I'm not sure what the best way to backport this to 5.x is, though.
Options are.

1. Do nothing special to upgrade. Upgraded databases that have
   existing such constraints will have the wrong behavior. Document in
   the changelog that the constraints can be repaired by dropping and
   recreating them.
2. Add a custom patch that runs for each database, finds all the
   relevant constraints, and fixes up the trigger functions directly.
   We did something kind of similar in 5.0.
3. Add an `ADMINISTER` command that takes a `Object.pointer` argument
   and repairs any constraints.

The advantages of option #1 is that it is easy (no work at all) and
pretty safe seeming. The big disadvantage is that it doesn't always
fix the bug and the workaround is slow. This bug has been present
*forever*, though, and never got reported, so probably not many people
will have to do the workaround anyway.

The advantage of option #2 is that it is the only *truly* correct one,
and updating the trigger functions is fast. Disadvantage is that it is
somewhat complex, slows down minor version upgrades, and the patch
system is kind of terrifying.

Option #3 allows doing fast trigger function repair without needing to
involve the patch system.

I think my inclination here is to go with option #1, and cherry-pick it
without a patch. I don't think option #3 is really worth the hassle,
so if we care about a faster way to fix it than DROP/CREATE, we should
do the patch.