### PR TITLE
Refactor converting type expressions to typerefs and ranges

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -151,15 +151,16 @@ class TypeRef(ImmutableBase):
     # A set of type ancestor descriptors, if necessary for
     # this type description.
     ancestors: typing.Optional[typing.FrozenSet[TypeRef]] = None
-    # If this is a union type, this would be a set of
-    # union elements.
+    # If this is a compound type, this is a non-overlapping set of
+    # constituent types.
     union: typing.Optional[typing.FrozenSet[TypeRef]] = None
     # Whether the union is specified by an exhaustive list of
     # types, and type inheritance should not be considered.
     union_is_exhaustive: bool = False
-    # If this is an intersection type, this would be a set of
-    # intersection elements.
-    intersection: typing.Optional[typing.FrozenSet[TypeRef]] = None
+    # If this is a complex type, record the expression used to generate the
+    # type. This is used later to get the correct rvar in `get_path_var`.
+    expr_intersection: typing.Optional[typing.FrozenSet[TypeRef]] = None
+    expr_union: typing.Optional[typing.FrozenSet[TypeRef]] = None
     # If this node is an element of a collection, and the
     # collection elements are named, this would be then
     # name of the element.

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1726,29 +1726,6 @@ def range_for_typeref(
             ctx=ctx,
         )
 
-    elif typeref.intersection:
-        wrapper = pgast.SelectStmt()
-        component_rvars = []
-        for component in typeref.intersection:
-            component_rvar = range_for_typeref(
-                component,
-                lateral=True,
-                path_id=path_id,
-                for_mutation=for_mutation,
-                dml_source=dml_source,
-                ctx=ctx,
-            )
-            pathctx.put_rvar_path_bond(component_rvar, path_id)
-            component_rvars.append(component_rvar)
-            include_rvar(wrapper, component_rvar, path_id, ctx=ctx)
-
-        int_rvar = pgast.IntersectionRangeVar(component_rvars=component_rvars)
-        for aspect in ('source', 'value'):
-            pathctx.put_path_rvar(wrapper, path_id, int_rvar, aspect=aspect)
-
-        pathctx.put_path_bond(wrapper, path_id)
-        rvar = rvar_for_rel(wrapper, lateral=lateral, typeref=typeref, ctx=ctx)
-
     else:
         rvar = range_for_material_objtype(
             typeref,
@@ -1860,6 +1837,7 @@ def range_from_queryset(
         # Just one class table, so return it directly
         from_rvar = set_ops[0][1].from_clause[0]
         assert isinstance(from_rvar, pgast.PathRangeVar)
+        from_rvar = from_rvar.replace(typeref=typeref)
         rvar = from_rvar
 
     return rvar


### PR DESCRIPTION
Remove special intersection behaviour and resolve all type expressions to produce a non-overlapping union of types. This will be helpful when implementing type expressions.

Currently, it's really only possible to create unions or intersections of unions, so this change should not affect behaviour.

Uses of both `typeref.union` and `typeref.intersection`:
- Creating a range for typeref
- Checking if `process_set_as_agg_expr` should be serialized

Uses of `typeref.union` only:
- Selecting all types for a delete statement
- Type check operator

## Typeref ranges

The current behaviour is:
- unions are implements as `union ALL`
- intersections are implemented as `join on id`

The proposed behaviour is:
- unions and intersections implemented as `union ALL`

In theory, it should be possible to convert a type expression into an intersection of non-overlapping unions:
- Convert type expression to CNF (should not result in any `~A` expressions)
- Expand unions into non-overlapping unions
- Remove any redundant union members

This can then be converted into SQL which matches the CNF. However, since the underlying types are implemented as views the query will be slower than just using the types directly.

One more performance consideration is that this new implementation will get all ancestors and children of a typeref. This may have performance impact on the compiler side.

## Effect of changes

### Non-overlapping union  `select Ba is CBa | Bb`

No changes:
```sql
    WITH 
    "t_schema::ObjectType~1" AS NOT MATERIALIZED 
        ((
            FROM LATERAL (
                FROM edgedbstd."schema::ObjectType_t" AS "ObjectType~2"
                CROSS JOIN LATERAL (
                    FROM LATERAL (
                        SELECT/*<pg.SelectStmt at 0x7fccb2558a40>*/
                            (NOT "ObjectType~2"."internal") AS "expr~1_value~1"
                    ) AS "expr-1~2"
                    CROSS JOIN (SELECT (NULL)::uuid AS "v~2") AS "v~1"
                    CROSS JOIN LATERAL (
                        SELECT/*<pg.SelectStmt at 0x7fccb2559640>*/
                            ("ObjectType~2".id IS NOT DISTINCT FROM "v~1"."v~2") AS "expr~2_value~1"
                    ) AS "expr-2~2"
                    SELECT/*<pg.SelectStmt at 0x7fccb29d5610>*/
                        ("expr-1~2"."expr~1_value~1" OR 
                         "expr-2~2"."expr~2_value~1") AS "expr~3_value~1"
                ) AS "expr-3~2"
                SELECT/*<pg.SelectStmt at 0x7fccb29d53a0>*/
                    "ObjectType~2".id AS "ObjectType_value~1"
                WHERE
                    "expr-3~2"."expr~3_value~1"
            ) AS "expr-4~2"
            SELECT/*<pg.SelectStmt at 0x7fccb29d6540>*/
                "expr-4~2"."ObjectType_value~1" AS "expr~4_identity~1"
        ))
    FROM edgedbpub."default::Ba_t" AS "Ba~2"
    CROSS JOIN LATERAL (
        SELECT/*<pg.SelectStmt at 0x7fccb29d5cd0>*/
            "Ba~2".__type__ AS "__type___identity~1"
    ) AS "q~1"
    JOIN LATERAL (
        FROM "t_schema::ObjectType~1" AS "t~1"
        SELECT/*<pg.SelectStmt at 0x7fccb29d5a00>*/
            "t~1"."expr~4_identity~1" AS "expr~4_identity~2"
    ) AS "q~2"
        ON ("q~1"."__type___identity~1" = "q~2"."expr~4_identity~2")
    CROSS JOIN LATERAL (
        SELECT/*<pg.SelectStmt at 0x7fccb2b4c4d0>*/
            edgedb.issubclass("q~2"."expr~4_identity~2", ARRAY[('default::CBa')::uuid, ('default::Bb')::uuid]) AS "expr~5_serialized~1"
    ) AS "expr-5~2"
    SELECT/*<pg.SelectStmt at 0x7fccb1e7eb40>*/
        "expr-5~2"."expr~5_serialized~1" AS "expr~5_serialized~2"
    WHERE
        ("expr-5~2"."expr~5_serialized~1" IS NOT NULL)
```

### Overlapping union `select Ba is Ba | Bb`


No changes:
```sql
WITH 
"t_schema::ObjectType~1" AS NOT MATERIALIZED 
    ((
        FROM LATERAL (
            FROM edgedbstd."schema::ObjectType_t" AS "ObjectType~2"
            CROSS JOIN LATERAL (
                FROM LATERAL (
                    SELECT/*<pg.SelectStmt at 0x7fccb2c28770>*/
                        (NOT "ObjectType~2"."internal") AS "expr~1_value~1"
                ) AS "expr-1~2"
                CROSS JOIN (SELECT (NULL)::uuid AS "v~2") AS "v~1"
                CROSS JOIN LATERAL (
                    SELECT/*<pg.SelectStmt at 0x7fccb2bd8b00>*/
                        ("ObjectType~2".id IS NOT DISTINCT FROM "v~1"."v~2") AS "expr~2_value~1"
                ) AS "expr-2~2"
                SELECT/*<pg.SelectStmt at 0x7fccb2c2b0e0>*/
                    ("expr-1~2"."expr~1_value~1" OR 
                     "expr-2~2"."expr~2_value~1") AS "expr~3_value~1"
            ) AS "expr-3~2"
            SELECT/*<pg.SelectStmt at 0x7fccc1c12db0>*/
                "ObjectType~2".id AS "ObjectType_value~1"
            WHERE
                "expr-3~2"."expr~3_value~1"
        ) AS "expr-4~2"
        SELECT/*<pg.SelectStmt at 0x7fccc1c12ae0>*/
            "expr-4~2"."ObjectType_value~1" AS "expr~4_identity~1"
    ))
FROM edgedbpub."default::Ba_t" AS "Ba~2"
CROSS JOIN LATERAL (
    SELECT/*<pg.SelectStmt at 0x7fccc1dbbd70>*/
        "Ba~2".__type__ AS "__type___identity~1"
) AS "q~1"
JOIN LATERAL (
    FROM "t_schema::ObjectType~1" AS "t~1"
    SELECT/*<pg.SelectStmt at 0x7fccc1c127e0>*/
        "t~1"."expr~4_identity~1" AS "expr~4_identity~2"
) AS "q~2"
    ON ("q~1"."__type___identity~1" = "q~2"."expr~4_identity~2")
CROSS JOIN LATERAL (
    SELECT/*<pg.SelectStmt at 0x7fccb2df12e0>*/
        edgedb.issubclass("q~2"."expr~4_identity~2", ARRAY[('default::CBb')::uuid, ('default::Ba')::uuid, ('default::CBaBc')::uuid, ('default::CBbBc')::uuid, ('default::CBaBb')::uuid, ('default::Bb')::uuid, ('default::CBa')::uuid, ('default::CBaBbBc')::uuid]) AS "expr~5_serialized~1"
) AS "expr-5~2"
SELECT/*<pg.SelectStmt at 0x7fccb2cf2210>*/
    "expr-5~2"."expr~5_serialized~1" AS "expr~5_serialized~2"
WHERE
    ("expr-5~2"."expr~5_serialized~1" IS NOT NULL)
```

### Simple intersection `select Ba [is Bb]`

Intersection changed to non-overlapping union.

On`master`:
```sql
FROM LATERAL (
    FROM edgedbpub."default::Ba_t" AS "Ba~2"
    JOIN edgedbpub."default::Bb_t" AS "Bb~1"
        ON ("Ba~2".id = "Bb~1".id)
    SELECT/*<pg.SelectStmt at 0x7fccb2197650>*/
        "Bb~1".id AS "indirection_value~1"
) AS "(default:Ba & default:Bb)_indirection~2"
SELECT/*<pg.SelectStmt at 0x7fccb2194860>*/
    ROW("(default:Ba & default:Bb)_indirection~2"."indirection_value~1") AS "indirection_serialized~1"
```

On branch:
```sql
FROM LATERAL (
    FROM edgedbpub."default::Ba_t" AS "Ba~2"
    JOIN LATERAL (
    (
        FROM edgedbpub."default::CBaBbBc_t" AS "CBaBbBc~1"
        SELECT/*<pg.SelectStmt at 0x7efc98d2f3b0>*/
            "CBaBbBc~1".id AS "Ba_identity~1",
            "CBaBbBc~1".id AS "indirection_value~1"
    ) union ALL (
        FROM edgedbpub."default::CBaBb_t" AS "CBaBb~1"
        SELECT/*<pg.SelectStmt at 0x7efc98d2f2f0>*/
            "CBaBb~1".id AS "Ba_identity~2",
            "CBaBb~1".id AS "indirection_value~2"
    )
    ) AS "(default:Ba & default:Bb)~1"
        ON ("Ba~2".id = "(default:Ba & default:Bb)~1"."Ba_identity~1")
    SELECT/*<pg.SelectStmt at 0x7efc98d2f6e0>*/
        "(default:Ba & default:Bb)~1"."indirection_value~1" AS "indirection_value~3"
) AS "(default:Ba & default:Bb)_indirection~2"
SELECT/*<pg.SelectStmt at 0x7efc98605d30>*/
    ROW("(default:Ba & default:Bb)_indirection~2"."indirection_value~3") AS "indirection_serialized~1"
```

### Complex intersection `select {Ba, Bb} [is Bc]`

Join target becomes a non-overlapping union. There is probably room for further optimization in `process_set_as_path_type_intersection`.

On`master`:
```sql
FROM LATERAL (
    FROM LATERAL (
        FROM LATERAL (
            FROM LATERAL (
            (
                FROM LATERAL (
                    FROM edgedbpub."default::Ba_t" AS "Ba~2"
                    SELECT/*<pg.SelectStmt at 0x7fccb231b6b0>*/
                        "Ba~2".id AS "Ba_value~1"
                ) AS "expr-1~2"
                SELECT/*<pg.SelectStmt at 0x7fccb2360320>*/
                    "expr-1~2"."Ba_value~1" AS "expr~1_value~1"
            ) UNION ALL (
                FROM LATERAL (
                    FROM edgedbpub."default::Bb_t" AS "Bb~2"
                    SELECT/*<pg.SelectStmt at 0x7fccb231af90>*/
                        "Bb~2".id AS "Bb_value~1"
                ) AS "expr-2~2"
                SELECT/*<pg.SelectStmt at 0x7fccb2360350>*/
                    "expr-2~2"."Bb_value~1" AS "expr~2_value~1"
            )
            ) AS "q~1"
            SELECT/*<pg.SelectStmt at 0x7fccb23603e0>*/
                "q~1"."expr~1_value~1" AS "expr~3_value~1"
        ) AS "expr-3~2"
        SELECT/*<pg.SelectStmt at 0x7fccb23615b0>*/
            "expr-3~2"."expr~3_value~1" AS "expr~3_value~2"
    ) AS "expr-4~2"
    JOIN edgedbpub."default::Bc_t" AS "Bc~1"  # <---------------- HERE
        ON ("expr-4~2"."expr~3_value~2" = "Bc~1".id)
    SELECT/*<pg.SelectStmt at 0x7fccb2361880>*/
        "Bc~1".id AS "indirection_value~1"
) AS "/oT+Jy3ZSAmLNhU7W5t0jQ: & default:Bc)_indirection~1"
SELECT/*<pg.SelectStmt at 0x7fccb2371790>*/
    ROW("/oT+Jy3ZSAmLNhU7W5t0jQ: & default:Bc)_indirection~1"."indirection_value~1") AS "indirection_serialized~1"
```

On branch:
```sql
FROM LATERAL (
    FROM LATERAL (
        FROM LATERAL (
            FROM LATERAL (
            (
                FROM LATERAL (
                    FROM edgedbpub."default::Ba_t" AS "Ba~2"
                    SELECT/*<pg.SelectStmt at 0x7efc98f95550>*/
                        "Ba~2".id AS "Ba_value~1"
                ) AS "expr-1~2"
                SELECT/*<pg.SelectStmt at 0x7efc991f03b0>*/
                    "expr-1~2"."Ba_value~1" AS "expr~1_value~1"
            ) UNION ALL (
                FROM LATERAL (
                    FROM edgedbpub."default::Bb_t" AS "Bb~2"
                    SELECT/*<pg.SelectStmt at 0x7efc98f958e0>*/
                        "Bb~2".id AS "Bb_value~1"
                ) AS "expr-2~2"
                SELECT/*<pg.SelectStmt at 0x7efc991f28a0>*/
                    "expr-2~2"."Bb_value~1" AS "expr~2_value~1"
            )
            ) AS "q~1"
            SELECT/*<pg.SelectStmt at 0x7efc991f03e0>*/
                "q~1"."expr~1_value~1" AS "expr~3_value~1"
        ) AS "expr-3~2"
        SELECT/*<pg.SelectStmt at 0x7efc9c90ba70>*/
            "expr-3~2"."expr~3_value~1" AS "expr~3_value~2"
    ) AS "expr-4~2"
    JOIN LATERAL (  # <---------------- HERE
    (
    (
        FROM edgedbpub."default::CBaBbBc_t" AS "CBaBbBc~1"
        SELECT/*<pg.SelectStmt at 0x7efc9be66bd0>*/
            "CBaBbBc~1".id AS "expr~4_identity~1",
            "CBaBbBc~1".id AS "indirection_value~1"
    ) union ALL (
        FROM edgedbpub."default::CBaBc_t" AS "CBaBc~1"
        SELECT/*<pg.SelectStmt at 0x7efc991f1df0>*/
            "CBaBc~1".id AS "expr~4_identity~2",
            "CBaBc~1".id AS "indirection_value~2"
    )
    ) union ALL (
        FROM edgedbpub."default::CBbBc_t" AS "CBbBc~1"
        SELECT/*<pg.SelectStmt at 0x7efc991f2270>*/
            "CBbBc~1".id AS "expr~4_identity~3",
            "CBbBc~1".id AS "indirection_value~3"
    )
    ) AS "Y24MZ7b6HtjJEPay5UJz3Q: default:Bb) & default:Bc)~1"
        ON ("expr-4~2"."expr~3_value~2" = "Y24MZ7b6HtjJEPay5UJz3Q: default:Bb) & default:Bc)~1"."expr~4_identity~1")
    SELECT/*<pg.SelectStmt at 0x7efc9be66150>*/
        "Y24MZ7b6HtjJEPay5UJz3Q: default:Bb) & default:Bc)~1"."indirection_value~1" AS "indirection_value~4"
) AS "/oT+Jy3ZSAmLNhU7W5t0jQ: & default:Bc)_indirection~1"
SELECT/*<pg.SelectStmt at 0x7efc990b07d0>*/
    ROW("/oT+Jy3ZSAmLNhU7W5t0jQ: & default:Bc)_indirection~1"."indirection_value~4") AS "indirection_serialized~1"
```
