### PR TITLE
Fix constraint handling when pointer has cardinality or computedness changed

### DIFF
--- a/edb/pgsql/dbops/constraints.py
+++ b/edb/pgsql/dbops/constraints.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 from typing import Optional, Sequence, List
 
-from edb.pgsql import ast as pgast
-
 from .. import common
 from . import base
 
@@ -30,10 +28,10 @@ from . import base
 class Constraint(base.DBObject):
     def __init__(
         self,
-        subject_name: Sequence[str | pgast.Star],
+        subject_name: Sequence[str],
         constraint_name: Optional[str] = None,
     ):
-        self._subject_name = subject_name
+        self._subject_name = tuple(subject_name)
         self._constraint_name = constraint_name
 
     def get_type(self):

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -543,13 +543,14 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
 
     def drop_constraint(self, constraint: SchemaConstraintTableConstraint):
         if constraint.requires_triggers():
-            self.add_commands(self.drop_constr_trigger(self.name, constraint))
+            self.add_commands(self.drop_constr_trigger(
+                constraint._subject_name, constraint))
             proc_name = constraint.get_trigger_procname()
             self.add_commands(self.drop_constr_trigger_function(proc_name))
 
         # Drop the constraint normally from our table
         #
-        my_alter = dbops.AlterTable(self.name)
+        my_alter = dbops.AlterTable(constraint._subject_name)
 
         drop_constr = AlterTableDropMultiConstraint(constraint=constraint)
         my_alter.add_command(drop_constr)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3129,6 +3129,76 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ]
         )
 
+    async def test_edgeql_ddl_ptr_set_cardinality_02(self):
+        await self.con.execute(r"""
+            create type B {
+                create multi property x -> str {
+                    create constraint exclusive;
+                };
+            };
+            create type C extending B;
+        """)
+
+        await self.con.execute(r"""
+            alter type B alter property x set single using (select .x limit 1);
+        """)
+
+        await self.con.execute('''
+            insert B { x := 'a' };
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert B { x := 'a' };
+            ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert C { x := 'a' };
+            ''')
+
+        await self.con.execute(r"""
+            drop type C;
+            drop type B;
+        """)
+
+    async def test_edgeql_ddl_ptr_set_cardinality_03(self):
+        await self.con.execute(r"""
+            create type B {
+                create property x -> str {
+                    create constraint exclusive;
+                }
+            };
+            create type C extending B;
+        """)
+
+        await self.con.execute(r"""
+            alter type B alter property x set multi;
+        """)
+
+        await self.con.execute('''
+            insert B { x := 'a' };
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert B { x := 'a' };
+            ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert C { x := 'a' };
+            ''')
+
+        await self.con.execute(r"""
+            drop type C;
+            drop type B;
+        """)
+
     async def test_edgeql_ddl_ptr_set_cardinality_validation(self):
         await self.con.execute(r"""
             CREATE TYPE Bar;
@@ -3202,6 +3272,79 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute("""
                 ALTER TYPE Foo ALTER LINK l SET SINGLE USING (SELECT Bar)
             """)
+
+    async def test_edgeql_ddl_ptr_using_01(self):
+        await self.con.execute(r"""
+            create type B {
+                create property y -> str;
+                create property x -> str {
+                    create constraint exclusive;
+                };
+                create constraint exclusive on (.x);
+            };
+            create type C extending B;
+        """)
+
+        await self.con.execute(r"""
+            alter type B alter property x using (.y);
+        """)
+
+        await self.con.execute('''
+            insert B { y := 'a' };
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert B { y := 'a' };
+            ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert C { y := 'a' };
+            ''')
+
+        await self.con.execute(r"""
+            drop type C;
+            drop type B;
+        """)
+
+    async def test_edgeql_ddl_ptr_using_02(self):
+        await self.con.execute(r"""
+            create type B {
+                create multi property y -> str;
+                create multi property x -> str {
+                    create constraint exclusive;
+                };
+            };
+            create type C extending B;
+        """)
+
+        await self.con.execute(r"""
+            alter type B alter property x using (.y);
+        """)
+
+        await self.con.execute('''
+            insert B { y := 'a' };
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert B { y := 'a' };
+            ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError, ''
+        ):
+            await self.con.execute('''
+                insert C { y := 'a' };
+            ''')
+
+        await self.con.execute(r"""
+            drop type C;
+            drop type B;
+        """)
 
     async def test_edgeql_ddl_ptr_set_required_01(self):
         await self.con.execute(r"""


### PR DESCRIPTION
The solutions are different for the two cases:
 * For cardinality changes, we drop and restore the constraints
   explicitly, before and after the operation. As things stand right now,
   we can't just make sure to have a constraint alter as a subcommand,
   unless we arranged to have innards actually run in the middle of a
   cardinality alter.
 * For computedness, the a constraint alter already gets generated and
   innards get run at the right time, we just need to make a couple
   tweaks to make sure the right names are used.

Fixes #7273.