### PR TITLE
Add remaining config file fs watch for multi-tenants

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -280,6 +280,7 @@ async def _run_server(
         )
 
         ss.init_jwcrypto(args.jws_key_file, jws_keys_newly_generated)
+        ss.start_watching_files()
 
         def load_configuration(_signum):
             if args.reload_config_files not in [

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -74,6 +74,7 @@ class MultiTenantServer(server.BaseServer):
 
     _tenants_by_sslobj: MutableMapping
     _tenants_conf: dict[str, dict[str, str]]
+    _last_tenants_conf: dict[str, dict[str, str]]
     _tenants_lock: MutableMapping[str, asyncio.Lock]
     _tenants_serial: dict[str, int]
     _tenants: dict[str, edbtenant.Tenant]
@@ -101,6 +102,7 @@ class MultiTenantServer(server.BaseServer):
 
         self._tenants_by_sslobj = weakref.WeakKeyDictionary()
         self._tenants_conf = {}
+        self._last_tenants_conf = {}
         self._tenants_lock = collections.defaultdict(asyncio.Lock)
         self._tenants_serial = {}
         self._tenants = {}
@@ -135,6 +137,13 @@ class MultiTenantServer(server.BaseServer):
         assert self._task_group is not None
         await self._task_group.__aenter__()
         fs = self.reload_tenants()
+
+        def reload_config_file(_file_modified, _event):
+            logger.info("Reloading multi-tenant config file.")
+            self.reload_tenants()
+
+        self.monitor_fs(self._config_file, reload_config_file)
+
         if fs:
             await asyncio.wait(fs)
 
@@ -167,6 +176,7 @@ class MultiTenantServer(server.BaseServer):
     def reload_tenants(self) -> Sequence[asyncio.Future]:
         with self._config_file.open() as cf:
             conf = json.load(cf)
+        self._last_tenants_conf = self._tenants_conf
         rv = []
         for sni, tenant_conf in conf.items():
             if sni not in self._tenants_conf:
@@ -328,17 +338,35 @@ class MultiTenantServer(server.BaseServer):
                 if serial > self._tenants_serial.get(sni, 0):
                     if tenant := self._tenants.get(sni):
                         current_tenant.set(tenant.get_instance_name())
-                        tenant.set_reloadable_files(
+
+                        orig = self._last_tenants_conf.get(sni, {})
+                        diff = set(orig.keys()) - set(conf)
+                        for k, v in conf.items():
+                            if orig.get(k) != v:
+                                diff.add(k)
+                        diff -= {
+                            "readiness-state-file",
+                            "jwt-sub-allowlist-file",
+                            "jwt-revocation-list-file",
+                        }
+                        if diff:
+                            logger.warning(
+                                "The following config of tenant %s changed, "
+                                "but reloading them is not yet supported: %s",
+                                sni,
+                                ", ".join(diff),
+                            )
+
+                        if not tenant.set_reloadable_files(
                             readiness_state_file=conf.get(
                                 "readiness-state-file"),
                             jwt_sub_allowlist_file=conf.get(
                                 "jwt-sub-allowlist-file"),
                             jwt_revocation_list_file=conf.get(
                                 "jwt-revocation-list-file"),
-                        )
-                        # XXX: Changing other config values like `backend-dsn`
-                        # is NOT supported currently. Ideally we should raise
-                        # warnings here if unsupported changes are detected.
+                        ):
+                            # none of the reloadable values was modified
+                            return
 
                         tenant.reload()
                         logger.info("Reloaded Tenant %s", sni)

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -251,6 +251,7 @@ class MultiTenantServer(server.BaseServer):
         try:
             await tenant.init_sys_pgcon()
             await tenant.init()
+            tenant.start_watching_files()
             await tenant.start_accepting_new_tasks()
             tenant.start_running()
 
@@ -455,6 +456,7 @@ async def run_server(
             args.tls_client_ca_file,
         )
         ss.init_jwcrypto(args.jws_key_file, jws_keys_newly_generated)
+        ss.start_watching_files()
 
         def load_configuration(_signum):
             if args.reload_config_files not in [

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -936,6 +936,10 @@ class BaseServer:
         if client_ca_file is not None:
             self.monitor_fs(client_ca_file, reload_tls)
 
+    def start_watching_files(self):
+        # TODO(fantix): include the monitor_fs() lines above
+        pass
+
     def load_jwcrypto(self, jws_key_file: pathlib.Path) -> None:
         try:
             self._jws_key = secretkey.load_secret_key(jws_key_file)
@@ -1726,6 +1730,10 @@ class Server(BaseServer):
         rv = super()._get_compiler_args()
         rv.update(self._tenant.get_compiler_args())
         return rv
+
+    def start_watching_files(self):
+        super().start_watching_files()
+        self._tenant.start_watching_files()
 
 
 def _cleanup_wildcard_addrs(

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -196,16 +196,28 @@ class Tenant(ha_base.ClusterProtocol):
         readiness_state_file: str | pathlib.Path | None = None,
         jwt_sub_allowlist_file: str | pathlib.Path | None = None,
         jwt_revocation_list_file: str | pathlib.Path | None = None,
-    ) -> None:
+    ) -> bool:
+        rv = False
+
         if isinstance(readiness_state_file, str):
             readiness_state_file = pathlib.Path(readiness_state_file)
-        self._readiness_state_file = readiness_state_file
+        if self._readiness_state_file != readiness_state_file:
+            self._readiness_state_file = readiness_state_file
+            rv = True
+
         if isinstance(jwt_sub_allowlist_file, str):
             jwt_sub_allowlist_file = pathlib.Path(jwt_sub_allowlist_file)
-        self._jwt_sub_allowlist_file = jwt_sub_allowlist_file
+        if self._jwt_sub_allowlist_file != jwt_sub_allowlist_file:
+            self._jwt_sub_allowlist_file = jwt_sub_allowlist_file
+            rv = True
+
         if isinstance(jwt_revocation_list_file, str):
             jwt_revocation_list_file = pathlib.Path(jwt_revocation_list_file)
-        self._jwt_revocation_list_file = jwt_revocation_list_file
+        if self._jwt_revocation_list_file != jwt_revocation_list_file:
+            self._jwt_revocation_list_file = jwt_revocation_list_file
+            rv = True
+
+        return rv
 
     def set_server(self, server: edbserver.BaseServer) -> None:
         self._server = server
@@ -413,6 +425,29 @@ class Tenant(ha_base.ClusterProtocol):
             self._file_watch_finalizers.append(
                 self._server.monitor_fs(
                     self._readiness_state_file, reload_state_file
+                )
+            )
+
+        if self._jwt_sub_allowlist_file is not None:
+
+            def reload_jwt_sub_allowlist_file(_file_modified, _event):
+                self.load_jwt_sub_allowlist()
+
+            self._file_watch_finalizers.append(
+                self._server.monitor_fs(
+                    self._jwt_sub_allowlist_file, reload_jwt_sub_allowlist_file
+                )
+            )
+
+        if self._jwt_revocation_list_file is not None:
+
+            def reload_jwt_revocation_list_file(_file_modified, _event):
+                self.load_jwt_revocation_list()
+
+            self._file_watch_finalizers.append(
+                self._server.monitor_fs(
+                    self._jwt_revocation_list_file,
+                    reload_jwt_revocation_list_file,
                 )
             )
 
@@ -1138,6 +1173,10 @@ class Tenant(ha_base.ClusterProtocol):
             self.create_task(self._load_reported_config(), interruptable=True)
 
     def load_jwcrypto(self) -> None:
+        self.load_jwt_sub_allowlist()
+        self.load_jwt_revocation_list()
+
+    def load_jwt_sub_allowlist(self) -> None:
         if self._jwt_sub_allowlist_file is not None:
             logger.info(
                 "(re-)loading JWT subject allowlist from "
@@ -1154,6 +1193,7 @@ class Tenant(ha_base.ClusterProtocol):
                     f"cannot load JWT sub allowlist: {e}"
                 ) from e
 
+    def load_jwt_revocation_list(self) -> None:
         if self._jwt_revocation_list_file is not None:
             logger.info(
                 "(re-)loading JWT revocation list from "

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -413,10 +413,9 @@ class Tenant(ha_base.ClusterProtocol):
 
         self.populate_sys_auth()
         self.reload_readiness_state()
-        self._start_watching_files()
         self._initing = False
 
-    def _start_watching_files(self):
+    def start_watching_files(self):
         if self._readiness_state_file is not None:
 
             def reload_state_file(_file_modified, _event):
@@ -1296,7 +1295,7 @@ class Tenant(ha_base.ClusterProtocol):
         self.reload_readiness_state()
         self.load_jwcrypto()
 
-        self._start_watching_files()
+        self.start_watching_files()
 
     async def on_before_drop_db(
         self,


### PR DESCRIPTION
A known issue is that, if the watched file is moved/renamed, uvloop `_monitor_fs()` will still report the changes of the NEW path, while the reloading tasks are all using the OLD path. This effectively cripples the reload feature on fs change. This is particularly found when any config file is edited using vim. I'll create a new PR to fix it to survive renames (that also includes watching the containing folder so that a new file at the OLD path can be picked up, but that may need some discussion).

Updating the config file content works fine.