### PR TITLE
Fix regression in using some tuple literals as a default

### DIFF
--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -839,10 +839,6 @@ def compile_TupleIndirectionPointer(
     rptr: irast.TupleIndirectionPointer, *, ctx: context.CompilerContextLevel
 ) -> pgast.BaseExpr:
     tuple_val = dispatch.compile(rptr.source, ctx=ctx)
-    if not isinstance(tuple_val, pgast.ColumnRef):
-        raise errors.UnsupportedFeatureError(
-            'dereference of complex tuple expression in simple expression')
-
     set_expr = astutils.tuple_getattr(
         tuple_val,
         rptr.source.typeref,

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -839,6 +839,10 @@ def compile_TupleIndirectionPointer(
     rptr: irast.TupleIndirectionPointer, *, ctx: context.CompilerContextLevel
 ) -> pgast.BaseExpr:
     tuple_val = dispatch.compile(rptr.source, ctx=ctx)
+    if not isinstance(tuple_val, pgast.ColumnRef):
+        raise errors.UnsupportedFeatureError(
+            'dereference of complex tuple expression in simple expression')
+
     set_expr = astutils.tuple_getattr(
         tuple_val,
         rptr.source.typeref,

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -667,6 +667,8 @@ def ptr_default_to_col_default(schema, ptr, expr):
 
     if not ir_utils.is_const(ir):
         return None
+    if ast.find_children(ir, irast.TupleIndirectionPointer):
+        return None
 
     try:
         sql_res = compiler.compile_ir_to_sql_tree(ir, singleton_mode=True)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10774,6 +10774,9 @@ type default::Foo {
                 };
             """)
 
+    @test.xerror('''
+        We should reject this but I don't want to do it in a point release
+    ''')
     async def test_edgeql_ddl_constraint_32(self):
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError, ''

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2033,6 +2033,18 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
+    async def test_edgeql_ddl_default_15(self):
+        await self.con.execute(r"""
+            create type T;
+            insert T;
+            alter type T {
+                create required property tup: tuple<int32, int32> {
+                    set default := ((0, 0));
+                };
+            };
+            insert T;
+        """)
+
     async def test_edgeql_ddl_default_circular(self):
         await self.con.execute(r"""
             CREATE TYPE TestDefaultCircular {
@@ -10759,6 +10771,24 @@ type default::Foo {
             await self.con.execute(r"""
                 CREATE ABSTRACT CONSTRAINT default::bad_constraint {
                     USING ((DISTINCT __subject__ = __subject__));
+                };
+            """)
+
+    async def test_edgeql_ddl_constraint_32(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError, ''
+        ):
+            await self.con.execute(r"""
+                create type S {
+                    create constraint expression on (((0, 0)).0 = 0);
+                };
+            """)
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError, ''
+        ):
+            await self.con.execute(r"""
+                create type S {
+                    create constraint expression on (((true, 0)).0);
                 };
             """)
 


### PR DESCRIPTION
When we set defaults, we try to set a SQL default as well, since it
can greatly speed up populating a column.

If the naturally inferred type of the expression doesn't match the
property type exactly (say, `(0, 0)` getting inferred as `tuple<int64,
int64>` for a property with type `tuple<int32, int32>`), we need to
try casting it.

That cast gets expanded into something like
`(<int32>((0, 0).0), <int32>((0, 0).0))`.

That expression would get compiled to something postgres rejects.
Reject that sort of thing in the simple expression compiler path. This
also fixes some ISEs when an expression like this gets used in a
constraint or index.

The cause of the regression was that previously, `irutils.is_const`
would report tuple dereferences as not being const, even though they
clearly are. This change was introduced in #6938, the TypeRoot
refactor.