### PR TITLE
Make linkprops (including @source/@target) work in conflict selects

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -432,6 +432,7 @@ def _compile_conflict_select(
     select_ast = qlast.Set(elements=frags)
     with ctx.new() as ectx:
         ectx.implicit_limit = 0
+        ectx.allow_endpoint_linkprops = True
         select_ir = dispatch.compile(select_ast, ctx=ectx)
         select_ir = setgen.scoped_set(
             select_ir, force_reassign=True, ctx=ectx)

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -556,6 +556,9 @@ class ContextLevel(compiler.ContextLevel):
     active_computeds: ordered.OrderedSet[s_pointers.Pointer]
     """A ordered set of currently compiling computeds"""
 
+    allow_endpoint_linkprops: bool
+    """Whether to allow references to endpoint linkpoints (@source, @target)."""
+
     disallow_dml: Optional[str]
     """Whether we are currently in a place where no dml is allowed,
         if not None, then it is of the form `in a FILTER clause`  """
@@ -623,6 +626,7 @@ class ContextLevel(compiler.ContextLevel):
             self.active_rewrites = frozenset()
             self.active_defaults = frozenset()
 
+            self.allow_endpoint_linkprops = False
             self.disallow_dml = None
 
         else:
@@ -666,6 +670,7 @@ class ContextLevel(compiler.ContextLevel):
             self.active_rewrites = prevlevel.active_rewrites
             self.active_defaults = prevlevel.active_defaults
 
+            self.allow_endpoint_linkprops = prevlevel.allow_endpoint_linkprops
             self.disallow_dml = prevlevel.disallow_dml
 
             if mode == ContextSwitchMode.SUBQUERY:

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -945,9 +945,11 @@ def extract_filters(
                         ptr = left_stype.getptr(schema, sn.UnqualName('id'))
                         pointers.append(ptr)
                     else:
-                        left = irutils.unwrap_set(left)
-
                         while left.path_id != result_set.path_id:
+                            if irutils.is_implicit_wrapper(left.expr):
+                                left = left.expr.result
+                                continue
+
                             assert isinstance(left.expr, irast.Pointer)
                             ptr = env.schema.get(
                                 left.expr.ptrref.name,

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -429,8 +429,11 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                 # anyway, so disallow them.
                 if (
                     ptr_expr.name in ('source', 'target')
-                    and ctx.env.options.schema_object_context
-                    not in (s_constr.Constraint, s_indexes.Index)
+                    and not ctx.allow_endpoint_linkprops
+                    and (
+                        ctx.env.options.schema_object_context
+                        not in (s_constr.Constraint, s_indexes.Index)
+                    )
                 ):
                     raise errors.QueryError(
                         f'@{ptr_expr.name} may only be used in index and '

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -197,6 +197,8 @@ def subject_substitute(
     for path in find_paths(ast):
         if is_anchor(path.steps[0], '__subject__'):
             path.steps[0] = new_subject
+        elif path.partial:
+            path.steps[0:0] = [new_subject]
     return ast
 
 

--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -76,8 +76,11 @@ abstract link translated_label {
 
 abstract link link_with_unique_property {
     property unique_property -> str {
-        constraint exclusive;
+        # TODO: Move the constraint back here once linkprop constraints
+        # supported in conflict selects.
+        # constraint exclusive;
     }
+    constraint exclusive on (@unique_property);
 }
 
 abstract link link_with_unique_property_inherited

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -500,12 +500,17 @@ class TestConstraintsSchema(tb.QueryTestCase):
         """)
 
     async def test_constraints_endpoint_constraint_02(self):
-        # testing (@source, @lang) on a single link
-        # This constraint is pointless and can never fail
+        # testing (@source, @lang) on a multi link
         await self.con.execute("""
             insert UniqueName {
                 translated_labels := ((insert Label { text := "x" }) {
                  @lang := 'x' })
+            };
+        """)
+
+        await self.con.execute("""
+            update UniqueName set {
+                translated_labels := Label {@lang := 'x' }
             };
         """)
 
@@ -562,7 +567,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
 
         # Same @target different @lang
         await self.con.execute("""
-            insert UniqueName {
+            insert UniqueNameInherited {
                 translated_label_tgt := (
                   select Label { @lang := 'y' } filter .text = 'x' limit 1)
             };
@@ -590,6 +595,26 @@ class TestConstraintsSchema(tb.QueryTestCase):
                 };
             """)
 
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            'violates exclusivity constraint'
+        ):
+            await self.con.execute("""
+                update UniqueName
+                filter .translated_label_tgt.text = 'x'
+                set { translated_label_tgt :=
+                    .translated_label_tgt { @lang := '!' }
+                }
+            """)
+
+        await self.con.execute("""
+            update UniqueName
+            filter .translated_label_tgt.text = 'x'
+            set { translated_label_tgt :=
+                .translated_label_tgt { @lang := @lang }
+            }
+        """)
+
     async def test_constraints_endpoint_constraint_04(self):
         # testing (@target, @lang) on a multi link
         await self.con.execute("""
@@ -616,10 +641,10 @@ class TestConstraintsSchema(tb.QueryTestCase):
         """)
 
         await self.con.execute("""
-                insert UniqueNameInherited {
-                    translated_labels_tgt := (
-                      select Label { @lang := 'x!' })
-                };
+            insert UniqueNameInherited {
+                translated_labels_tgt := (
+                  select Label { @lang := 'x!' })
+            };
         """)
 
         async with self.assertRaisesRegexTx(
@@ -655,6 +680,26 @@ class TestConstraintsSchema(tb.QueryTestCase):
                       filter .text = 'x')
                 };
             """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            'violates exclusivity constraint'
+        ):
+            await self.con.execute("""
+                update UniqueName
+                filter .translated_labels_tgt.text = 'x'
+                set { translated_labels_tgt :=
+                    .translated_labels_tgt { @lang := '!' }
+                }
+            """)
+
+        await self.con.execute("""
+            update UniqueName
+            filter .translated_labels_tgt.text = 'x'
+            set { translated_labels_tgt :=
+                .translated_labels_tgt { @lang := @lang }
+            }
+        """)
 
 
 class TestConstraintsSchemaMigration(tb.QueryTestCase):


### PR DESCRIPTION
Exclusive constraints on the linkprops themselves still don't work,
though it should be fixable.

Fixes #7263