### PR TITLE
Create key derivation function

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1694,8 +1694,8 @@ class Router:
         ) = None,
         expires_in: datetime.timedelta | None = None,
     ) -> str:
-        initial_key_material = self._get_auth_signing_key()
-        signing_key = util.derive_key(initial_key_material, derive_for_info)
+        input_key_material = self._get_auth_signing_key()
+        signing_key = util.derive_key(input_key_material, derive_for_info)
         expires_in = (
             datetime.timedelta(minutes=10) if expires_in is None else expires_in
         )
@@ -1713,8 +1713,8 @@ class Router:
     def _verify_and_extract_claims(
         self, jwtStr: str, key_info: str
     ) -> dict[str, str | int | float | bool]:
-        initial_key_material = self._get_auth_signing_key()
-        signing_key = util.derive_key(initial_key_material, key_info)
+        input_key_material = self._get_auth_signing_key()
+        signing_key = util.derive_key(input_key_material, key_info)
         verified = jwt.JWT(key=signing_key, jwt=jwtStr)
         return json.loads(verified.claims)
 

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1711,10 +1711,13 @@ class Router:
         )
 
     def _verify_and_extract_claims(
-        self, jwtStr: str, key_info: str
+        self, jwtStr: str, key_info: str | None = None
     ) -> dict[str, str | int | float | bool]:
         input_key_material = self._get_auth_signing_key()
-        signing_key = util.derive_key(input_key_material, key_info)
+        if key_info is None:
+            signing_key = input_key_material
+        else:
+            signing_key = util.derive_key(input_key_material, key_info)
         verified = jwt.JWT(key=signing_key, jwt=jwtStr)
         return json.loads(verified.claims)
 

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -725,7 +725,10 @@ class Router:
                 ) = await email_password_client.get_identity_and_secret(data)
 
                 new_reset_token = self._make_secret_token(
-                    identity.id, secret, {"challenge": data["challenge"]}
+                    identity.id,
+                    secret,
+                    "reset",
+                    {"challenge": data["challenge"]},
                 )
 
                 reset_token_params = {"reset_token": new_reset_token}
@@ -1685,12 +1688,14 @@ class Router:
         self,
         identity_id: str,
         secret: str,
+        derive_for_info: str,
         additional_claims: (
             dict[str, str | int | float | bool | None] | None
         ) = None,
         expires_in: datetime.timedelta | None = None,
     ) -> str:
-        signing_key = self._get_auth_signing_key()
+        initial_key_material = self._get_auth_signing_key()
+        signing_key = util.derive_key(initial_key_material, derive_for_info)
         expires_in = (
             datetime.timedelta(minutes=10) if expires_in is None else expires_in
         )
@@ -1706,15 +1711,16 @@ class Router:
         )
 
     def _verify_and_extract_claims(
-        self, jwtStr: str
+        self, jwtStr: str, key_info: str
     ) -> dict[str, str | int | float | bool]:
-        signing_key = self._get_auth_signing_key()
+        initial_key_material = self._get_auth_signing_key()
+        signing_key = util.derive_key(initial_key_material, key_info)
         verified = jwt.JWT(key=signing_key, jwt=jwtStr)
         return json.loads(verified.claims)
 
     def _get_data_from_magic_link_token(self, token: str):
         try:
-            claims = self._verify_and_extract_claims(token)
+            claims = self._verify_and_extract_claims(token, "magic_link")
         except Exception:
             raise errors.InvalidData("Invalid 'magic_link_token'")
 
@@ -1728,7 +1734,7 @@ class Router:
 
     def _get_data_from_reset_token(self, token: str) -> Tuple[str, str, str]:
         try:
-            claims = self._verify_and_extract_claims(token)
+            claims = self._verify_and_extract_claims(token, "reset")
         except Exception:
             raise errors.InvalidData("Invalid 'reset_token'")
 
@@ -1745,7 +1751,7 @@ class Router:
         self, token: str
     ) -> Tuple[str, float, str, Optional[str], Optional[str]]:
         try:
-            claims = self._verify_and_extract_claims(token)
+            claims = self._verify_and_extract_claims(token, "verify")
         except Exception:
             raise errors.InvalidData("Invalid 'verification_token'")
 
@@ -1894,6 +1900,7 @@ class Router:
         verification_token = self._make_secret_token(
             identity_id=identity_id,
             secret=str(uuid.uuid4()),
+            derive_for_info="verify",
             additional_claims={
                 "iat": issued_at,
                 "challenge": maybe_challenge,

--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -103,14 +103,16 @@ select identity { * };""",
         challenge: str,
         redirect_on_failure: str,
     ):
-        signing_key = self._get_signing_key()
+        initial_key_material = self._get_signing_key()
         identity_id = await self.get_identity_id_by_email(
-            email, factor_type='MagicLinkFactor')
+            email, factor_type='MagicLinkFactor'
+        )
 
         if identity_id is None:
             await auth_emails.send_fake_email(self.tenant)
             return
 
+        signing_key = util.derive_key(initial_key_material, "magic_link")
         token = util.make_token(
             signing_key=signing_key,
             issuer=self.issuer,

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -177,11 +177,10 @@ def derive_key(key: jwk.JWK, info: str) -> jwk.JWK:
         algorithm=hashes.SHA256(),
         length=32,
         info=info.encode("utf-8"),
-        backend=backend
+        backend=backend,
     )
     new_key_bytes = hkdf.derive(input_key_material)
     return jwk.JWK(
         kty="oct",
         k=new_key_bytes.hex(),
     )
-

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -21,7 +21,7 @@ import base64
 import urllib.parse
 import datetime
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
 from cryptography.hazmat.backends import default_backend
 
 from jwcrypto import jwt, jwk
@@ -173,10 +173,9 @@ def derive_key(key: jwk.JWK, info: str) -> jwk.JWK:
     input_key_material = base64.urlsafe_b64decode(raw_key_base64url)
 
     backend = default_backend()
-    hkdf = HKDF(
+    hkdf = HKDFExpand(
         algorithm=hashes.SHA256(),
         length=32,
-        salt=None,
         info=info.encode("utf-8"),
         backend=backend
     )

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -170,7 +170,7 @@ def derive_key(key: jwk.JWK, info: str) -> jwk.JWK:
 
     # n.b. the key is returned as a base64url-encoded string
     raw_key_base64url = cast(str, key.get_op_key())
-    raw_key = base64.urlsafe_b64decode(raw_key_base64url)
+    input_key_material = base64.urlsafe_b64decode(raw_key_base64url)
 
     backend = default_backend()
     hkdf = HKDF(
@@ -180,7 +180,7 @@ def derive_key(key: jwk.JWK, info: str) -> jwk.JWK:
         info=info.encode("utf-8"),
         backend=backend
     )
-    new_key_bytes = hkdf.derive(raw_key)
+    new_key_bytes = hkdf.derive(input_key_material)
     return jwk.JWK(
         kty="oct",
         k=new_key_bytes.hex(),

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -17,8 +17,12 @@
 #
 
 
+import base64
 import urllib.parse
 import datetime
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.backends import default_backend
 
 from jwcrypto import jwt, jwk
 from typing import TypeVar, Type, overload, Any, cast, Optional
@@ -159,3 +163,26 @@ def make_token(
     token.make_signed_token(signing_key)
 
     return token.serialize()
+
+
+def derive_key(key: jwk.JWK, info: str) -> jwk.JWK:
+    """Derive a new key from the given symmetric key using HKDF."""
+
+    # n.b. the key is returned as a base64url-encoded string
+    raw_key_base64url = cast(str, key.get_op_key())
+    raw_key = base64.urlsafe_b64decode(raw_key_base64url)
+
+    backend = default_backend()
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=info.encode("utf-8"),
+        backend=backend
+    )
+    new_key_bytes = hkdf.derive(raw_key)
+    return jwk.JWK(
+        kty="oct",
+        k=new_key_bytes.hex(),
+    )
+


### PR DESCRIPTION
Use a separate derived key for signing each different kind of JWTs other than the auth_token JWT. This avoids accidentally being able to use these other (short-lived) tokens as auth tokens directly.