### PR TITLE
server: fix monitor_fs() to track target recreation

### DIFF
--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -138,7 +138,7 @@ class MultiTenantServer(server.BaseServer):
         await self._task_group.__aenter__()
         fs = self.reload_tenants()
 
-        def reload_config_file(_file_modified, _event):
+        def reload_config_file():
             logger.info("Reloading multi-tenant config file.")
             self.reload_tenants()
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -38,6 +38,7 @@ import itertools
 import json
 import logging
 import os
+import pathlib
 import pickle
 import socket
 import ssl
@@ -82,7 +83,6 @@ from .compiler import sertypes
 
 if TYPE_CHECKING:
     import asyncio.base_events
-    import pathlib
 
     from edb.pgsql import params as pgparams
 
@@ -371,13 +371,46 @@ class BaseServer:
     def monitor_fs(
         self,
         path: str | pathlib.Path,
-        cb: Callable[[str, int], None],
+        cb: Callable[[], None],
     ) -> Callable[[], None]:
         if not self._use_monitor_fs:
             return lambda: None
 
+        handle = None
+        parent_dir = pathlib.Path(path).parent
+
+        def watch_dir(file_modified, _event):
+            nonlocal handle
+            if parent_dir / os.fsdecode(file_modified) == pathlib.Path(path):
+                try:
+                    new_handle = self.__loop._monitor_fs(  # type: ignore
+                        str(path), callback)
+                except FileNotFoundError:
+                    pass
+                else:
+                    finalizer()
+                    handle = new_handle
+                    self._file_watch_handles.append(handle)
+
+        def callback(_file_modified, event):
+            nonlocal handle
+            if event == 2:  # CHANGE
+                cb()
+            else:  # RENAME, RENAME_CHANGE
+                # File is likely renamed or deleted, stop watching
+                finalizer()
+                try:
+                    # Then, see if we can directly re-watch the target path
+                    handle = self.__loop._monitor_fs(  # type: ignore
+                        str(path), callback)
+                except FileNotFoundError:
+                    # If not, watch the parent directory to wait for recreation
+                    handle = self.__loop._monitor_fs(  # type: ignore
+                        str(parent_dir), watch_dir)
+                self._file_watch_handles.append(handle)
+
         # ... we depend on an event loop internal _monitor_fs
-        handle = self.__loop._monitor_fs(str(path), cb)  # type: ignore
+        handle = self.__loop._monitor_fs(str(path), callback)  # type: ignore
 
         def finalizer():
             try:
@@ -903,7 +936,7 @@ class BaseServer:
         self._tls_cert_file = str(tls_cert_file)
         self._tls_cert_newly_generated = tls_cert_newly_generated
 
-        def reload_tls(_file_modified, _event, retry=0):
+        def reload_tls(retry=0):
             try:
                 self.reload_tls(tls_cert_file, tls_key_file, client_ca_file)
             except (StartupError, FileNotFoundError) as e:
@@ -917,8 +950,6 @@ class BaseServer:
                         self.__loop.call_later(
                             delay,
                             reload_tls,
-                            _file_modified,
-                            _event,
                             retry + 1,
                         )
                     )

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -396,7 +396,7 @@ class BaseServer:
             nonlocal handle
             if event == 2:  # CHANGE
                 cb()
-            else:  # RENAME, RENAME_CHANGE
+            elif event == 1 or event == 3:  # RENAME, RENAME_CHANGE
                 # File is likely renamed or deleted, stop watching
                 finalizer()
                 try:
@@ -408,6 +408,9 @@ class BaseServer:
                     handle = self.__loop._monitor_fs(  # type: ignore
                         str(parent_dir), watch_dir)
                 self._file_watch_handles.append(handle)
+            else:
+                # Unknown events are ignored
+                pass
 
         # ... we depend on an event loop internal _monitor_fs
         handle = self.__loop._monitor_fs(str(path), callback)  # type: ignore

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -418,7 +418,7 @@ class Tenant(ha_base.ClusterProtocol):
     def start_watching_files(self):
         if self._readiness_state_file is not None:
 
-            def reload_state_file(_file_modified, _event):
+            def reload_state_file():
                 self.reload_readiness_state()
 
             self._file_watch_finalizers.append(
@@ -429,7 +429,7 @@ class Tenant(ha_base.ClusterProtocol):
 
         if self._jwt_sub_allowlist_file is not None:
 
-            def reload_jwt_sub_allowlist_file(_file_modified, _event):
+            def reload_jwt_sub_allowlist_file():
                 self.load_jwt_sub_allowlist()
 
             self._file_watch_finalizers.append(
@@ -440,7 +440,7 @@ class Tenant(ha_base.ClusterProtocol):
 
         if self._jwt_revocation_list_file is not None:
 
-            def reload_jwt_revocation_list_file(_file_modified, _event):
+            def reload_jwt_revocation_list_file():
                 self.load_jwt_revocation_list()
 
             self._file_watch_finalizers.append(


### PR DESCRIPTION
Refs #7280, this PR wraps the callbacks given to `monitor_fs()` so as to follow target file recreation.