### PR TITLE
Add force_database_error hooks to enable testing failing restores and upgrades

### DIFF
--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -24,6 +24,7 @@ from .compiler import CompileContext, CompilerDatabaseState
 from .compiler import compile_edgeql_script
 from .compiler import new_compiler, new_compiler_from_pg, new_compiler_context
 from .compiler import compile, compile_schema_storage_in_delta
+from .compiler import maybe_force_database_error
 from .dbstate import QueryUnit, QueryUnitGroup
 from .enums import Capability, Cardinality
 from .enums import InputFormat, OutputFormat
@@ -43,6 +44,7 @@ __all__ = (
     'OutputFormat',
     'analyze_explain_output',
     'compile_edgeql_script',
+    'maybe_force_database_error',
     'new_compiler',
     'new_compiler_from_pg',
     'new_compiler_context',

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -58,6 +58,8 @@ from . import dbview
 from . import defines
 from . import metrics
 from . import pgcon
+from . import compiler as edbcompiler
+
 from .ha import adaptive as adaptive_ha
 from .ha import base as ha_base
 from .pgcon import errors as pgcon_errors
@@ -392,6 +394,12 @@ class Tenant(ha_base.ClusterProtocol):
         sys_config = await self._load_sys_config()
         default_sysconfig = await self._load_sys_config("sysconfig_default")
         await self._load_reported_config()
+
+        # To make in-place upgrade failures more testable, check
+        # 'force_database_error' with a 'startup' scope.
+        force_error = self._server.config_lookup(
+            'force_database_error', sys_config)
+        edbcompiler.maybe_force_database_error(force_error, scope='startup')
 
         self._dbindex = dbview.DatabaseIndex(
             self,

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1300,6 +1300,11 @@ class TestServerConfig(tb.QueryTestCase):
     async def test_server_proto_configure_error(self):
         con1 = self.con
         con2 = await self.connect(database=con1.dbname)
+
+        version_str = await con1.query_single('''
+            select sys::get_version_as_str();
+        ''')
+
         try:
             await con2.execute('''
                 select 1;
@@ -1328,6 +1333,49 @@ class TestServerConfig(tb.QueryTestCase):
                         async for tx in con2.retrying_transaction():
                             async with tx:
                                 await tx.query('select schema::Object')
+
+            # If we change the '_version' to something else we
+            # should be good
+            err = {
+                'type': 'SchemaError',
+                'message': 'danger',
+                'context': {'start': 42},
+                '_versions': [version_str + '1'],
+            }
+            await con1.execute(f'''
+                configure current database set force_database_error :=
+                  {qlquote.quote_literal(json.dumps(err))};
+            ''')
+            await con1.query('select schema::Object')
+
+            # It should also be fine if we set a '_scopes' other than 'query'
+            err = {
+                'type': 'SchemaError',
+                'message': 'danger',
+                'context': {'start': 42},
+                '_scopes': ['restore'],
+            }
+            await con1.execute(f'''
+                configure current database set force_database_error :=
+                  {qlquote.quote_literal(json.dumps(err))};
+            ''')
+            await con1.query('select schema::Object')
+
+            # But if we make it the current version it should still fail
+            err = {
+                'type': 'SchemaError',
+                'message': 'danger',
+                'context': {'start': 42},
+                '_versions': [version_str],
+            }
+            await con1.execute(f'''
+                configure current database set force_database_error :=
+                  {qlquote.quote_literal(json.dumps(err))};
+            ''')
+            with self.assertRaisesRegex(edgedb.SchemaError, 'danger'):
+                async for tx in con1.retrying_transaction():
+                    async with tx:
+                        await tx.query('select schema::Object')
 
             await con2.execute(f'''
                 configure session set force_database_error := "false";


### PR DESCRIPTION
Add two new optional fields to the JSON object used to configure
`force_database_error`.

 * `_scopes`: Determines what operations will trigger an
   error. Defaults to `["query"]`. Other checked scopes are `restore`
   and `startup`. The `startup` scope is only checked against
   `INSTANCE` configuration, not database configurations.
 * `_versions`: If set, only fail if the current version is present
   in the array.