### PR TITLE
Add context to errors when casting to collections.

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -569,6 +569,19 @@ class ContextLevel(compiler.ContextLevel):
     active_defaults: FrozenSet[s_objtypes.ObjectType]
     """For detecting cycles in defaults"""
 
+    collection_cast_path: Optional[list[Tuple[str, Optional[str]]]]
+    """For generating errors messages when casting to collections.
+        List of collection type and possibly an element name.
+        eg. ('tuple', 'a') or ('array', None)"""
+
+    collection_cast_from_type: Optional[s_types.Type]
+    """For generating errors messages when casting to collections.
+        Only ever set in outermost cast."""
+
+    collection_cast_to_type: Optional[s_types.Type]
+    """For generating errors messages when casting to collections.
+        Only ever set in outermost cast."""
+
     def __init__(
         self,
         prevlevel: Optional[ContextLevel],
@@ -629,6 +642,10 @@ class ContextLevel(compiler.ContextLevel):
             self.allow_endpoint_linkprops = False
             self.disallow_dml = None
 
+            self.collection_cast_path = None
+            self.collection_cast_from_type = None
+            self.collection_cast_to_type = None
+
         else:
             self.env = prevlevel.env
             self.derived_target_module = prevlevel.derived_target_module
@@ -672,6 +689,10 @@ class ContextLevel(compiler.ContextLevel):
 
             self.allow_endpoint_linkprops = prevlevel.allow_endpoint_linkprops
             self.disallow_dml = prevlevel.disallow_dml
+
+            self.collection_cast_path = prevlevel.collection_cast_path
+            self.collection_cast_from_type = prevlevel.collection_cast_from_type
+            self.collection_cast_to_type = prevlevel.collection_cast_to_type
 
             if mode == ContextSwitchMode.SUBQUERY:
                 self.anchors = prevlevel.anchors.copy()

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -35,6 +35,7 @@ from typing import (
     List,
     Set,
     FrozenSet,
+    NamedTuple,
     cast,
     overload,
     TYPE_CHECKING,
@@ -569,27 +570,15 @@ class ContextLevel(compiler.ContextLevel):
     active_defaults: FrozenSet[s_objtypes.ObjectType]
     """For detecting cycles in defaults"""
 
-    collection_cast_path: Optional[list[Tuple[str, Optional[str]]]]
+    collection_cast_info: Optional[CollectionCastInfo]
     """For generating errors messages when casting to collections.
-        Only ever set in outermost cast.
 
-    The cast path element is a tuple of the collection type and an optional
-    element name. eg. ('tuple', 'a') or ('array', None)
+    This will be set by the outermost cast and then shared between all
+    sub-casts.
 
-    The list is shared between the outermost context and all its sub contexts.
-    When casting a collection, each element's path should be pushed before
-    entering the "sub-cast" and popped immediately after.
-
-    In the event of a cast error, the list is preserved at the outermost cast.
+    Some casts (eg. arrays) will generate select statements containing other
+    type casts. These will also share the outermost cast info.
     """
-
-    collection_cast_from_type: Optional[s_types.Type]
-    """For generating errors messages when casting to collections.
-        Only ever set in outermost cast."""
-
-    collection_cast_to_type: Optional[s_types.Type]
-    """For generating errors messages when casting to collections.
-        Only ever set in outermost cast."""
 
     def __init__(
         self,
@@ -651,9 +640,7 @@ class ContextLevel(compiler.ContextLevel):
             self.allow_endpoint_linkprops = False
             self.disallow_dml = None
 
-            self.collection_cast_path = None
-            self.collection_cast_from_type = None
-            self.collection_cast_to_type = None
+            self.collection_cast_info = None
 
         else:
             self.env = prevlevel.env
@@ -699,9 +686,7 @@ class ContextLevel(compiler.ContextLevel):
             self.allow_endpoint_linkprops = prevlevel.allow_endpoint_linkprops
             self.disallow_dml = prevlevel.disallow_dml
 
-            self.collection_cast_path = prevlevel.collection_cast_path
-            self.collection_cast_from_type = prevlevel.collection_cast_from_type
-            self.collection_cast_to_type = prevlevel.collection_cast_to_type
+            self.collection_cast_info = prevlevel.collection_cast_info
 
             if mode == ContextSwitchMode.SUBQUERY:
                 self.anchors = prevlevel.anchors.copy()
@@ -821,3 +806,23 @@ class ContextLevel(compiler.ContextLevel):
 class CompilerContext(compiler.CompilerContext[ContextLevel]):
     ContextLevelClass = ContextLevel
     default_mode = ContextSwitchMode.NEW
+
+
+class CollectionCastInfo(NamedTuple):
+    """For generating errors messages when casting to collections."""
+
+    from_type: s_types.Type
+    to_type: s_types.Type
+
+    path_elements: list[Tuple[str, Optional[str]]]
+    """Represents a path to the current collection element being cast.
+
+    A path element is a tuple of the collection type and an optional
+    element name. eg. ('tuple', 'a') or ('array', None)
+
+    The list is shared between the outermost context and all its sub contexts.
+    When casting a collection, each element's path should be pushed before
+    entering the "sub-cast" and popped immediately after.
+
+    In the event of a cast error, the list is preserved at the outermost cast.
+    """

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -571,8 +571,17 @@ class ContextLevel(compiler.ContextLevel):
 
     collection_cast_path: Optional[list[Tuple[str, Optional[str]]]]
     """For generating errors messages when casting to collections.
-        List of collection type and possibly an element name.
-        eg. ('tuple', 'a') or ('array', None)"""
+        Only ever set in outermost cast.
+
+    The cast path element is a tuple of the collection type and an optional
+    element name. eg. ('tuple', 'a') or ('array', None)
+
+    The list is shared between the outermost context and all its sub contexts.
+    When casting a collection, each element's path should be pushed before
+    entering the "sub-cast" and popped immediately after.
+
+    In the event of a cast error, the list is preserved at the outermost cast.
+    """
 
     collection_cast_from_type: Optional[s_types.Type]
     """For generating errors messages when casting to collections.

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -776,11 +776,12 @@ def compile_TypeCast(
         orig_stype = setgen.get_set_type(ir_expr, ctx=ctx)
 
         use_message_context = False
-        if target_stype.is_collection() and subctx.collection_cast_path is None:
-            subctx.collection_cast_path = []
-
-            subctx.collection_cast_to_type = target_stype
-            subctx.collection_cast_from_type = orig_stype
+        if target_stype.is_collection() and subctx.collection_cast_info is None:
+            subctx.collection_cast_info = context.CollectionCastInfo(
+                from_type=orig_stype,
+                to_type=target_stype,
+                path_elements=[]
+            )
 
             use_message_context = (
                 orig_stype.is_array() and target_stype.is_array()

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -773,14 +773,42 @@ def compile_TypeCast(
             subctx.implicit_tname_in_shapes = False
 
         ir_expr = dispatch.compile(expr.expr, ctx=subctx)
+        orig_stype = setgen.get_set_type(ir_expr, ctx=ctx)
 
-        res = casts.compile_cast(
-            ir_expr,
-            target_stype,
-            cardinality_mod=expr.cardinality_mod,
-            ctx=subctx,
-            span=expr.span,
-        )
+        use_message_context = False
+        if target_stype.is_collection() and subctx.collection_cast_path is None:
+            subctx.collection_cast_path = []
+
+            subctx.collection_cast_to_type = target_stype
+            subctx.collection_cast_from_type = orig_stype
+
+            use_message_context = (
+                orig_stype.is_array() and target_stype.is_array()
+                or (
+                    orig_stype.is_tuple(ctx.env.schema)
+                    and target_stype.is_tuple(ctx.env.schema)
+                )
+            )
+
+        try:
+            res = casts.compile_cast(
+                ir_expr,
+                target_stype,
+                cardinality_mod=expr.cardinality_mod,
+                ctx=subctx,
+                span=expr.span,
+            )
+
+        except errors.QueryError as e:
+            if (
+                (message_context := casts.cast_message_context(subctx))
+                and use_message_context
+            ):
+                e.args = (
+                    (message_context + e.args[0],)
+                    + e.args[1:]
+                )
+            raise e
 
     return stmt.maybe_add_view(res, ctx=ctx)
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1572,6 +1572,18 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 SELECT <array<tuple<array<int64>>>>[([(1,)],)];
             """)
 
+    async def test_edgeql_casts_collection_errors_12(self):
+        # tuple with multiple elements, error in later element
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"while casting 'tuple<std::int64, std::int64, std::int64>' "
+                r"to 'tuple<std::int64, std::int64, array<std::int64>>', "
+                r"at tuple element '2', "
+                r"cannot cast 'std::int64' to 'array<std::int64>"):
+            await self.con.execute("""
+                SELECT <tuple<int64, int64, array<int64>>>(1, 2, 3);
+            """)
+
     # casting into an abstract scalar should be illegal
     async def test_edgeql_casts_illegal_01(self):
         async with self.assertRaisesRegexTx(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1453,6 +1453,125 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             [[['1'], ['2'], ['3']]],
         )
 
+    # check that casting to collections produces the correct error messages
+    async def test_edgeql_casts_collection_errors_01(self):
+        # scalar to array
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"cannot cast 'std::int64' to 'array<std::int64>'"):
+            await self.con.execute("""
+                SELECT <array<int64>>1;
+            """)
+
+    async def test_edgeql_casts_collection_errors_02(self):
+        # tuple to array
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"cannot cast 'tuple<std::int64>' to 'array<std::int64>'"):
+            await self.con.execute("""
+                SELECT <array<int64>>(1,);
+            """)
+
+    async def test_edgeql_casts_collection_errors_03(self):
+        # object to array
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"cannot cast 'std::FreeObject' to 'array<std::int64>'"):
+            await self.con.execute("""
+                SELECT <array<int64>>{a := 1};
+            """)
+
+    async def test_edgeql_casts_collection_errors_04(self):
+        # array to array, mismatched element types
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"while casting 'array<tuple<std::int64>>' "
+                r"to 'array<std::int64>', "
+                r"in array elements, "
+                r"cannot cast 'tuple<std::int64>' to 'std::int64'"):
+            await self.con.execute("""
+                SELECT <array<int64>>[(1,)];
+            """)
+
+    async def test_edgeql_casts_collection_errors_05(self):
+        # scalar to tuple
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"cannot cast 'std::int64' to 'tuple<std::int64>'"):
+            await self.con.execute("""
+                SELECT <tuple<int64>>1;
+            """)
+
+    async def test_edgeql_casts_collection_errors_06(self):
+        # array to tuple
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"cannot cast 'array<std::int64>' to 'tuple<std::int64>'"):
+            await self.con.execute("""
+                SELECT <tuple<int64>>[1];
+            """)
+
+    async def test_edgeql_casts_collection_errors_07(self):
+        # object to array
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"cannot cast 'std::FreeObject' to 'tuple<std::int64>'"):
+            await self.con.execute("""
+                SELECT <tuple<int64>>{a := 1};
+            """)
+
+    async def test_edgeql_casts_collection_errors_08(self):
+        # tuple to tuple, mismatched element types
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"while casting 'tuple<array<std::int64>>' "
+                r"to 'tuple<std::int64>', "
+                r"at tuple element '0', "
+                r"cannot cast 'array<std::int64>' to 'std::int64'"):
+            await self.con.execute("""
+                SELECT <tuple<int64>>([1],);
+            """)
+
+    async def test_edgeql_casts_collection_errors_09(self):
+        # named tuple to named tuple, use new element name
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"while casting 'tuple<b: array<std::int64>>' "
+                r"to 'tuple<a: std::int64>', "
+                r"at tuple element 'a', "
+                r"cannot cast 'array<std::int64>' to 'std::int64'"):
+            await self.con.execute("""
+                SELECT <tuple<a: int64>>(b := [1]);
+            """)
+
+    async def test_edgeql_casts_collection_errors_10(self):
+        # nested tuple to nested tuple
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"while casting 'tuple<tuple<array<std::int64>>>' "
+                r"to 'tuple<a: tuple<b: std::int64>>', "
+                r"at tuple element 'a', "
+                r"at tuple element 'b', "
+                r"cannot cast 'array<std::int64>' to 'std::int64'"):
+            await self.con.execute("""
+                SELECT <tuple<a: tuple<b: int64>>>(([1],),);
+            """)
+
+    async def test_edgeql_casts_collection_errors_11(self):
+        # nested array to nested array
+        # note: arrays can't be directly nested
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"while casting 'array<tuple<array<tuple<std::int64>>>>' "
+                r"to 'array<tuple<array<std::int64>>>', "
+                r"in array elements, "
+                r"at tuple element '0', "
+                r"in array elements, "
+                r"cannot cast 'tuple<std::int64>' to 'std::int64'"):
+            await self.con.execute("""
+                SELECT <array<tuple<array<int64>>>>[([(1,)],)];
+            """)
+
     # casting into an abstract scalar should be illegal
     async def test_edgeql_casts_illegal_01(self):
         async with self.assertRaisesRegexTx(


### PR DESCRIPTION
If there is an incompatible element when casting to a collection, the `to` and `from` type are added as well as the name of the element.

For example, given the query `SELECT <tuple<a: array<tuple<b: int64>>>>(c:=[(d:=[1])]);`, the following error is produced:
```
error: QueryError: while casting 'tuple<c: array<tuple<d: array<std::int64>>>>' to 'tuple<a: array<tuple<b: std::int64>>>', at tuple element 'a', in array elements, at tuple element 'b', cannot cast 'array<std::int64>' to 'std::int64'
  ┌─ <query>:1:8
  │
1 │ SELECT <tuple<a: array<tuple<b: int64>>>>(c:=[(d:=[1])]);
  │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error
```