### PR TITLE
Fix modifying global that is used in a policy on a type it refers to

### DIFF
--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -374,6 +374,12 @@ class AlterAliasLike(
         context: sd.CommandContext,
     ) -> s_schema.Schema:
         if not context.canonical:
+            schema = self._propagate_if_expr_refs(
+                schema,
+                context,
+                action=self.get_friendly_description(schema=schema),
+            )
+
             expr = self.get_attribute_value('expr')
             is_computable = self._is_computable(self.scls, schema)
             if expr:
@@ -414,12 +420,6 @@ class AlterAliasLike(
                             self.scls, schema, context, unset_type=False
                         )
                     )
-
-            schema = self._propagate_if_expr_refs(
-                schema,
-                context,
-                action=self.get_friendly_description(schema=schema),
-            )
 
         return super()._alter_begin(schema, context)
 


### PR DESCRIPTION
Fix is simple: we need to call _propagate_if_expr_refs to eliminate
any references to the alias *before* we recompile it, not after.