### PR TITLE
Improve json cast error messages

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,7 +55,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2024_04_25_00_00
+EDGEDB_CATALOG_VERSION = 2024_05_09_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import (
     Optional,
     Tuple,
@@ -663,10 +664,11 @@ def _cast_json_to_tuple(
             qlast.Constant.boolean(allow_null),
         ]
         if error_message_context := cast_message_context(subctx):
-            detail = qlast.Constant.string(
-                '{"error_message_context": "' + error_message_context + '"}'
-            )
-            json_object_args.append(detail)
+            json_object_args.append(qlast.Constant.string(
+                json.dumps({
+                    "error_message_context": error_message_context
+                })
+            ))
         json_objects = qlast.FunctionCall(
             func=('__std__', '__tuple_validate_json'),
             args=json_object_args
@@ -697,10 +699,11 @@ def _cast_json_to_tuple(
 
             json_get_kwargs: dict[str, qlast.Expr] = {}
             if error_message_context := cast_message_context(subctx):
-                detail = qlast.Constant.string(
-                    '{"error_message_context": "' + error_message_context + '"}'
+                json_get_kwargs['detail'] = qlast.Constant.string(
+                    json.dumps({
+                        "error_message_context": error_message_context
+                    })
                 )
-                json_get_kwargs['detail'] = detail
             val_e = qlast.FunctionCall(
                 func=('__std__', '__json_get_not_null'),
                 args=[
@@ -993,10 +996,11 @@ def _cast_json_to_range(
 
         check_args: list[qlast.Expr] = [source_path]
         if error_message_context := cast_message_context(subctx):
-            detail = qlast.Constant.string(
-                '{"error_message_context": "' + error_message_context + '"}'
-            )
-            check_args.append(detail)
+            check_args.append(qlast.Constant.string(
+                json.dumps({
+                    "error_message_context": error_message_context
+                })
+            ))
         check = qlast.FunctionCall(
             func=('__std__', '__range_validate_json'),
             args=check_args

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1073,6 +1073,7 @@ class TypeCast(ImmutableExpr):
     sql_function: typing.Optional[str] = None
     sql_cast: bool
     sql_expr: bool
+    error_message_context: typing.Optional[str] = None
 
     @property
     def typeref(self) -> TypeRef:

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -1344,7 +1344,8 @@ CREATE CAST FROM std::json TO cal::local_datetime {
     SET volatility := 'Immutable';
     USING SQL $$
     SELECT edgedb.local_datetime_in(
-        edgedb.jsonb_extract_scalar(val, 'string'));
+        edgedb.jsonb_extract_scalar(val, 'string', detail => detail)
+    );
     $$;
 };
 
@@ -1352,7 +1353,9 @@ CREATE CAST FROM std::json TO cal::local_datetime {
 CREATE CAST FROM std::json TO cal::local_date {
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT edgedb.local_date_in(edgedb.jsonb_extract_scalar(val, 'string'));
+    SELECT edgedb.local_date_in(
+        edgedb.jsonb_extract_scalar(val, 'string', detail => detail)
+    );
     $$;
 };
 
@@ -1360,7 +1363,9 @@ CREATE CAST FROM std::json TO cal::local_date {
 CREATE CAST FROM std::json TO cal::local_time {
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT edgedb.local_time_in(edgedb.jsonb_extract_scalar(val, 'string'));
+    SELECT edgedb.local_time_in(
+        edgedb.jsonb_extract_scalar(val, 'string', detail => detail)
+    );
     $$;
 };
 
@@ -1368,7 +1373,9 @@ CREATE CAST FROM std::json TO cal::local_time {
 CREATE CAST FROM std::json TO cal::relative_duration {
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT edgedb.jsonb_extract_scalar(val, 'string')::interval::edgedb.relative_duration_t;
+    SELECT edgedb.jsonb_extract_scalar(
+        val, 'string', detail => detail
+    )::interval::edgedb.relative_duration_t;
     $$;
 };
 
@@ -1376,7 +1383,9 @@ CREATE CAST FROM std::json TO cal::relative_duration {
 CREATE CAST FROM std::json TO cal::date_duration {
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT edgedb.date_duration_in(edgedb.jsonb_extract_scalar(val, 'string'));
+    SELECT edgedb.date_duration_in(
+        edgedb.jsonb_extract_scalar(val, 'string', detail => detail)
+    );
     $$;
 };
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -348,7 +348,7 @@ CREATE CAST FROM std::json TO cfg::memory {
     SET volatility := 'Immutable';
     USING SQL $$
         SELECT edgedb.str_to_cfg_memory(
-            edgedb.jsonb_extract_scalar(val, 'string')
+            edgedb.jsonb_extract_scalar(val, 'string', detail => detail)
         )
     $$;
 };

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -220,9 +220,19 @@ def compile_TypeCast(
         func_name = common.get_cast_backend_name(
             expr.cast_name, aspect="function"
         )
+        args = [pg_expr]
+        if expr.error_message_context is not None:
+            detail = pgast.StringConstant(
+                val=(
+                    '{"error_message_context": "'
+                    + expr.error_message_context
+                    + '"}'
+                )
+            )
+            args.append(detail)
         res = pgast.FuncCall(
             name=func_name,
-            args=[pg_expr],
+            args=args,
         )
 
     elif expr.sql_function:

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -202,6 +202,16 @@ def compile_TypeCast(
 
     pg_expr = dispatch.compile(expr.expr, ctx=ctx)
 
+    detail: Optional[pgast.StringConstant] = None
+    if expr.error_message_context is not None:
+        detail = pgast.StringConstant(
+            val=(
+                '{"error_message_context": "'
+                + expr.error_message_context
+                + '"}'
+            )
+        )
+
     if expr.sql_cast:
         # Use explicit SQL cast.
 
@@ -220,15 +230,9 @@ def compile_TypeCast(
         func_name = common.get_cast_backend_name(
             expr.cast_name, aspect="function"
         )
+
         args = [pg_expr]
-        if expr.error_message_context is not None:
-            detail = pgast.StringConstant(
-                val=(
-                    '{"error_message_context": "'
-                    + expr.error_message_context
-                    + '"}'
-                )
-            )
+        if detail is not None:
             args.append(detail)
         res = pgast.FuncCall(
             name=func_name,
@@ -245,17 +249,20 @@ def compile_TypeCast(
         raise errors.UnsupportedFeatureError('cast not supported')
 
     if expr.cardinality_mod is qlast.CardinalityModifier.Required:
+        args = [
+            res,
+            pgast.StringConstant(
+                val='invalid_parameter_value',
+            ),
+            pgast.StringConstant(
+                val='invalid null value in cast',
+            ),
+        ]
+        if detail is not None:
+            args.append(detail)
         res = pgast.FuncCall(
             name=('edgedb', 'raise_on_null'),
-            args=[
-                res,
-                pgast.StringConstant(
-                    val='invalid_parameter_value',
-                ),
-                pgast.StringConstant(
-                    val='invalid null value in cast',
-                ),
-            ]
+            args=args
         )
 
     return res

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1932,10 +1932,13 @@ class CastCommand(MetaCommand):
         name = common.get_backend_name(
             schema, cast, catenate=False, aspect='function')
 
-        args = [(
-            'val',
-            types.pg_type_from_object(schema, cast.get_from_type(schema))
-        )]
+        args: Sequence[dbops.FunctionArg] = [
+            (
+                'val',
+                types.pg_type_from_object(schema, cast.get_from_type(schema))
+            ),
+            ('detail', ('text',), "''"),
+        ]
 
         returns = types.pg_type_from_object(schema, cast.get_to_type(schema))
 

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -453,9 +453,15 @@ def _static_interpret_invalid_param_value(
     err_details: ErrorDetails,
     from_graphql: bool = False,
 ):
+    error_message_context = ''
+    if err_details.detail_json:
+        error_message_context = (
+            err_details.detail_json.get('error_message_context', '')
+        )
+
     return errors.InvalidValueError(
-        err_details.message,
-        details=err_details.detail if err_details.detail else None
+        error_message_context + err_details.message,
+        details=err_details.detail if err_details.detail else None,
     )
 
 
@@ -469,11 +475,15 @@ def _static_interpret_wrong_object_type(
         return SchemaRequired
 
     hint = None
+    error_message_context = ''
     if err_details.detail_json:
         hint = err_details.detail_json.get('hint')
+        error_message_context = (
+            err_details.detail_json.get('error_message_context', '')
+        )
 
     return errors.InvalidValueError(
-        err_details.message,
+        error_message_context + err_details.message,
         details=err_details.detail if err_details.detail else None,
         hint=hint,
     )

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -6796,8 +6796,8 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_upper"'
-            r' boolean property'
+            r"JSON object representing a range must include an 'inc_upper'"
+            r" boolean property"
         ):
             await self.con.execute(r"""
                 select <range<int64>>to_json('{
@@ -6810,8 +6810,8 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_lower"'
-            r' boolean property'
+            r"JSON object representing a range must include an 'inc_lower'"
+            r" boolean property"
         ):
             await self.con.execute(r"""
                 select <range<int64>>to_json('{
@@ -6823,8 +6823,7 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_lower"'
-            r' boolean property'
+            r"expected JSON object or null; got JSON array"
         ):
             await self.con.execute(r"""
                 select <range<int64>>to_json('["bad", null]');
@@ -6832,8 +6831,8 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_lower"'
-            r' boolean property'
+            r"JSON object representing a range must include an 'inc_lower'"
+            r" boolean property"
         ):
             await self.con.execute(r"""
                 select <range<int64>>to_json('{"bad": null}');
@@ -6841,8 +6840,7 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_lower"'
-            r' boolean property'
+            r"expected JSON object or null; got JSON string"
         ):
             await self.con.execute(r"""
                 select <range<int64>>to_json('"bad"');
@@ -6850,8 +6848,7 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_lower"'
-            r' boolean property'
+            r"expected JSON object or null; got JSON number"
         ):
             await self.con.execute(r"""
                 select <range<int64>>to_json('1312');
@@ -6859,8 +6856,7 @@ aa \
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
-            r'JSON object representing a range must include an "inc_lower"'
-            r' boolean property'
+            r"expected JSON object or null; got JSON boolean"
         ):
             await self.con.execute(r"""
                 select <range<int64>>to_json('true');

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -5266,7 +5266,7 @@ aa';
             SET volatility := 'Stable';
             USING SQL $$
             SELECT edgedb.str_to_bigint(
-                edgedb.jsonb_extract_scalar(val, 'number')
+                edgedb.jsonb_extract_scalar(val, 'number', detail => detail)
             );
             $$;
         };


### PR DESCRIPTION
Provide context to error messages when casting to from json to collections.

Given `SELECT <tuple<a: int64>>to_json('{"b": 1}');` the following error is produced:
```
InvalidValueError: while casting 'std::json' to 'tuple<a: std::int64>', at tuple element 'a', missing value in JSON object
```

Given `SELECT <tuple<a: int64>>to_json('{"a": "b"}');` the following error is produced:
```
InvalidValueError: while casting 'std::json' to 'tuple<a: std::int64>', at tuple element 'a', expected JSON number or null; got JSON string
```
