### PR TITLE
Skip sqlite interpreter tests if sqlite missing or old

### DIFF
--- a/edb/testbase/experimental_interpreter.py
+++ b/edb/testbase/experimental_interpreter.py
@@ -16,14 +16,13 @@ bag = assert_data_shape.bag
 class ExperimentalInterpreterTestCase(unittest.TestCase):
     SCHEMA: Optional[str] = None
     SETUP: Optional[str] = None
-    INTERPRETER_USE_SQLITE = True
+    INTERPRETER_USE_SQLITE = False
 
     client: EdgeQLInterpreter
     initial_state: object
 
     @classmethod
     def setUpClass(cls):
-        # print("Setting up")
         if cls.SCHEMA is not None:
             with open(cls.SCHEMA) as f:
                 schema_content = f.read()
@@ -33,6 +32,14 @@ class ExperimentalInterpreterTestCase(unittest.TestCase):
         sqlite_filename = None
         if cls.INTERPRETER_USE_SQLITE:
             sqlite_filename = ":memory:"
+
+            try:
+                import sqlite3
+            except ModuleNotFoundError:
+                raise unittest.SkipTest("sqlite is not installed")
+
+            if sqlite3.sqlite_version_info < (3, 37):
+                raise unittest.SkipTest("sqlite version is too old (need 3.37)")
 
         cls.client = EdgeQLInterpreter(schema_content, sqlite_filename)
 

--- a/edb/tools/experimental_interpreter/new_interpreter.py
+++ b/edb/tools/experimental_interpreter/new_interpreter.py
@@ -68,7 +68,6 @@ def default_dbschema() -> DBSchema:
     interpreter_internal_path = os.path.join(
         os.path.dirname(__file__), relative_path_to_interpreter_internal
     )
-    print("Loading standard library at", std_path)
     add_ddl_library(
         initial_db,
         [
@@ -83,7 +82,6 @@ def default_dbschema() -> DBSchema:
     name_resolution.checked_module_name_resolve(initial_db, ("std",))
     sck.re_populate_module_inheritance(initial_db, ("std",))
     sck.re_populate_module_inheritance(initial_db, ("schema",))
-    print("=== Standard library loaded ====")
     return initial_db
 
 

--- a/edb/tools/experimental_interpreter/sqlite/sqlite_adapter.py
+++ b/edb/tools/experimental_interpreter/sqlite/sqlite_adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Sequence, Optional, List
-import sqlite3
+from typing import Any, Dict, Sequence, Optional, List, TYPE_CHECKING
 import json
 
 from dataclasses import dataclass
@@ -11,6 +10,9 @@ from .. import db_interface
 from ..data.data_ops import EdgeID, ObjectVal, Val, MultiSetVal, DBSchema
 from ..data import data_ops as e
 from ..elab_schema import add_module_from_sdl_defs
+
+if TYPE_CHECKING:
+    import sqlite3
 
 
 # SQLITE_PRINT_QUERIES = True
@@ -795,6 +797,8 @@ class SQLiteEdgeDatabaseStorageProvider(EdgeDatabaseStorageProviderInterface):
 def schema_and_db_from_sqlite(
     sdl_file_content: Optional[str], sqlite_file_name: str
 ):
+    import sqlite3
+
     # Connect to the SQLite database
     conn = sqlite3.connect(sqlite_file_name)
     c = conn.cursor()


### PR DESCRIPTION
We don't build it as part of our release builds, so nightlies are
failing.  Also my ubuntu 20.04 system (which I should upgrade) has a
sqlite too old for STRICT to work.