### PR TITLE
Semi-rationalize get_dummy_expr_field_value implementations

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -632,7 +632,7 @@ class ConstraintCommand(
         value: Any,
     ) -> Optional[s_expr.Expression]:
         if field.name in {'expr', 'subjectexpr', 'finalexpr', 'except_expr'}:
-            return s_expr.Expression(text='SELECT false')
+            return s_expr.Expression(text='false')
         else:
             raise NotImplementedError(f'unhandled field {field.name!r}')
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -100,6 +100,7 @@ class AliasLikeCommand(
     """
 
     TYPE_FIELD_NAME = ''
+    ALIAS_LIKE_EXPR_FIELDS: tuple[str, ...] = ()
 
     @classmethod
     def _get_alias_name(cls, type_name: sn.QualName) -> sn.QualName:
@@ -188,9 +189,9 @@ class AliasLikeCommand(
         field: so.Field[Any],
         value: Any,
     ) -> Optional[s_expr.Expression]:
-        if field.name == 'expr':
-            # XXX: this is imprecise
-            return s_expr.Expression(text='std::Object')
+        if field.name in self.ALIAS_LIKE_EXPR_FIELDS:
+            rt = self.get_type(self.scls, schema)
+            return s_types.type_dummy_expr(rt, schema)
         else:
             raise NotImplementedError(f'unhandled field {field.name!r}')
 
@@ -250,6 +251,7 @@ class AliasCommand(
     context_class=AliasCommandContext,
 ):
     TYPE_FIELD_NAME = 'type'
+    ALIAS_LIKE_EXPR_FIELDS = ('expr',)
 
     @classmethod
     def _get_alias_name(cls, type_name: sn.QualName) -> sn.QualName:

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1331,16 +1331,6 @@ class Function(
     ) -> str:
         return f"function '{self.get_signature_as_str(schema)}'"
 
-    def get_dummy_body(self, schema: s_schema.Schema) -> s_expr.Expression:
-        """Return a minimal function body that satisfies its return type."""
-        rt = self.get_return_type(schema)
-
-        text = f'''
-            SELECT assert_exists(<{rt.get_displayname(schema)}>{{}}) LIMIT 1
-        '''
-
-        return s_expr.Expression(text=text)
-
     def find_object_param_overloads(
         self,
         schema: s_schema.Schema,
@@ -1565,7 +1555,8 @@ class FunctionCommand(
     ) -> Optional[s_expr.Expression]:
         if field.name == 'nativecode':
             func = schema.get(self.classname, type=Function)
-            return func.get_dummy_body(schema)
+            rt = func.get_return_type(schema)
+            return s_types.type_dummy_expr(rt, schema)
         else:
             raise NotImplementedError(f'unhandled field {field.name!r}')
 

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -117,6 +117,7 @@ class GlobalCommand(
     context_class=GlobalCommandContext,
 ):
     TYPE_FIELD_NAME = 'target'
+    ALIAS_LIKE_EXPR_FIELDS = ('expr', 'default')
 
     @classmethod
     def _get_alias_name(cls, type_name: sn.QualName) -> sn.QualName:
@@ -276,22 +277,6 @@ class GlobalCommand(
                     f'default expression, which is not allowed',
                     span=span,
                 )
-
-    def get_dummy_expr_field_value(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        field: so.Field[Any],
-        value: Any,
-    ) -> Optional[s_expr.Expression]:
-        if field.name in ('expr', 'default'):
-            rt = self.scls.get_target(schema)
-            if isinstance(rt, so.DerivableInheritingObject):
-                rt = rt.get_nearest_non_derived_parent(schema)
-            text = f'SELECT assert_exists(<{rt.get_displayname(schema)}>{{}})'
-            return s_expr.Expression(text=text)
-        else:
-            raise NotImplementedError(f'unhandled field {field.name!r}')
 
     def compile_expr_field(
         self,

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Tuple, Type, Iterable, List, Set, cast
+from typing import Optional, Tuple, Type, Iterable, List, Set, cast
 
 import collections
 
@@ -32,7 +32,6 @@ from . import abc as s_abc
 from . import annos as s_anno
 from . import constraints
 from . import delta as sd
-from . import expr as s_expr
 from . import inheriting
 from . import links
 from . import properties
@@ -512,18 +511,6 @@ class ObjectTypeCommand(
                         f"cannot extend system type '{name}'",
                         span=self.span,
                     )
-
-    def get_dummy_expr_field_value(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        field: so.Field[Any],
-        value: Any,
-    ) -> Optional[s_expr.Expression]:
-        if field.name == 'expr':
-            return s_expr.Expression(text=f'SELECT std::Object LIMIT 1')
-        else:
-            raise NotImplementedError(f'unhandled field {field.name!r}')
 
 
 class CreateObjectType(

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -233,9 +233,8 @@ class RewriteCommand(
         value: Any,
     ) -> Optional[s_expr.Expression]:
         if field.name == 'expr':
-            pt = self.scls.get_ptr_target(schema)
-            text = f'<{pt.get_displayname(schema)}>{{}}'
-            return s_expr.Expression(text=text)
+            return s_types.type_dummy_expr(
+                self.scls.get_ptr_target(schema), schema)
         else:
             raise NotImplementedError(f'unhandled field {field.name!r}')
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Tuple, Type, Iterable, Sequence, cast
+from typing import Optional, Tuple, Type, Iterable, Sequence, cast
 
 from edb import errors
 
@@ -466,18 +466,6 @@ class ScalarTypeCommand(
                 ancestors.extend(base.get_ancestors(schema).objects(schema))
 
             self.validate_scalar_ancestors(ancestors, schema, context)
-
-    def get_dummy_expr_field_value(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        field: so.Field[Any],
-        value: Any,
-    ) -> Optional[s_expr.Expression]:
-        if field.name == 'expr':
-            return s_expr.Expression(text=f'0')
-        else:
-            raise NotImplementedError(f'unhandled field {field.name!r}')
 
 
 class CreateScalarType(

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2910,6 +2910,16 @@ def ensure_schema_type_expr_type(
     return cmd
 
 
+def type_dummy_expr(
+    typ: Type,
+    schema: s_schema.Schema,
+) -> Optional[s_expr.Expression]:
+    if isinstance(typ, so.DerivableInheritingObject):
+        typ = typ.get_nearest_non_derived_parent(schema)
+    text = f'assert_exists(<{typ.get_displayname(schema)}>{{}})'
+    return s_expr.Expression(text=text)
+
+
 class TypeCommand(sd.ObjectCommand[TypeT]):
 
     @classmethod
@@ -2971,9 +2981,7 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
         value: Any,
     ) -> Optional[s_expr.Expression]:
         if field.name == 'expr':
-            raise AssertionError(
-                f"{self} must define get_dummy_expr_field_value() "
-                f"for {field.name}")
+            return type_dummy_expr(self.scls, schema)
         else:
             raise NotImplementedError(f'unhandled field {field.name!r}')
 
@@ -3239,18 +3247,7 @@ class AlterTupleExprAlias(
     CollectionExprAliasCommand[TupleExprAlias],
     sd.AlterObject[TupleExprAlias],
 ):
-
-    def get_dummy_expr_field_value(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        field: so.Field[Any],
-        value: Any,
-    ) -> Optional[s_expr.Expression]:
-        if field.name == 'expr':
-            return s_expr.Expression(text='()')
-        else:
-            raise AssertionError(f'unhandled field {field.name!r}')
+    pass
 
 
 class CreateArray(CreateCollectionType[Array]):
@@ -3285,18 +3282,7 @@ class AlterArrayExprAlias(
     CollectionExprAliasCommand[ArrayExprAlias],
     sd.AlterObject[ArrayExprAlias],
 ):
-
-    def get_dummy_expr_field_value(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        field: so.Field[Any],
-        value: Any,
-    ) -> Optional[s_expr.Expression]:
-        if field.name == 'expr':
-            return s_expr.Expression(text='[]')
-        else:
-            raise AssertionError(f'unhandled field {field.name!r}')
+    pass
 
 
 class CreateRange(CreateCollectionType[Range]):
@@ -3331,18 +3317,7 @@ class AlterRangeExprAlias(
     CollectionExprAliasCommand[RangeExprAlias],
     sd.AlterObject[RangeExprAlias],
 ):
-
-    def get_dummy_expr_field_value(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        field: so.Field[Any],
-        value: Any,
-    ) -> Optional[s_expr.Expression]:
-        if field.name == 'expr':
-            return s_expr.Expression(text='range()')
-        else:
-            raise AssertionError(f'unhandled field {field.name!r}')
+    pass
 
 
 class CreateMultiRange(CreateCollectionType[MultiRange]):
@@ -3377,18 +3352,7 @@ class AlterMultiRangeExprAlias(
     CollectionExprAliasCommand[MultiRangeExprAlias],
     sd.AlterObject[MultiRangeExprAlias],
 ):
-
-    def get_dummy_expr_field_value(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        field: so.Field[Any],
-        value: Any,
-    ) -> Optional[s_expr.Expression]:
-        if field.name == 'expr':
-            return s_expr.Expression(text='multirange()')
-        else:
-            raise AssertionError(f'unhandled field {field.name!r}')
+    pass
 
 
 class DeleteTuple(DeleteCollectionType[Tuple]):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11394,6 +11394,30 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             };
         """)
 
+    async def test_edgeql_migration_globals_04(self):
+        await self.migrate(r"""
+            global cur := true;
+
+            type Foo {
+              access policy s allow select using (global cur);
+            };
+            type Bar {
+              access policy s allow select using (global cur);
+            };
+        """)
+
+        await self.migrate(r"""
+            global ok := (exists Foo);
+            global cur := global ok;
+
+            type Foo {
+              access policy s allow select using (global cur);
+            };
+            type Bar {
+              access policy s allow select using (global cur);
+            };
+        """)
+
     async def test_edgeql_migration_dml_rewrites_01(self):
         await self.migrate(r"""
             type Post {


### PR DESCRIPTION
If there is an actual type involved that might matter,
get_dummy_expr_field_value ought to produce a value of that type.

Write one helper function for this in `edb.schema.types` and call it
everywhere that cares.

This fixes at least one bug involving globals in a somewhat twisted
interaction with policies (though I am still doing some more thinking
about those cases, so I may fix it in an additional way in a
follow-up).