### PR TITLE
Set content-type header for AI extension errors

### DIFF
--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -848,6 +848,7 @@ async def handle_request(
             ex = InternalError(str(ex))
 
         response.status = ex.get_http_status()
+        response.content_type = b'application/json'
         response.body = json.dumps(ex.json()).encode("utf-8")
         response.close_connection = True
         return


### PR DESCRIPTION
We are returning JSON here, but without setting the header it returns `text/plain` so user agents aren't able to predict that the content is actually JSON.