### PR TITLE
Automatically do github releases in release jobs

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -364,6 +364,27 @@
 <%- endfor %>
 <%- endif %>
 
+<% if subdist == "" or subdist == "testing" %>
+  publish-github-release:
+    needs: collect
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Publish Github Release
+      uses: elprans/gh-action-create-release@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        target: ${{ github.event.pull_request.base.ref }}
+        body: EdgeDB v${{ steps.relver.outputs.version }}
+<% if subdist == "testing" %>
+        prerelease: true
+<% endif %>
+<%- endif %>
+
 <%- set docker_tgts = targets.linux | selectattr("docker_arch") | list %>
 <%- if docker_tgts and publications %>
 <%- set pub_outputs = "needs.check-published-" + (docker_tgts|first)["name"] + ".outputs" %>

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1436,6 +1436,8 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/test.sh
 
+
+
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'
     name: Notify in Slack on failures

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2541,6 +2541,8 @@ jobs:
         PKG_PLATFORM_VERSION: "aarch64"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
+
+
   publish-docker:
     needs:
       - check-published-debian-buster-x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2116,6 +2116,24 @@ jobs:
         PKG_PLATFORM_VERSION: "aarch64"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
+
+  publish-github-release:
+    needs: collect
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Publish Github Release
+      uses: elprans/gh-action-create-release@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        target: ${{ github.event.pull_request.base.ref }}
+        body: EdgeDB v${{ steps.relver.outputs.version }}
+
+
   publish-docker:
     needs:
       - check-published-debian-buster-x86_64

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2202,6 +2202,26 @@ jobs:
         PKG_PLATFORM_VERSION: "aarch64"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
+
+  publish-github-release:
+    needs: collect
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Publish Github Release
+      uses: elprans/gh-action-create-release@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        target: ${{ github.event.pull_request.base.ref }}
+        body: EdgeDB v${{ steps.relver.outputs.version }}
+
+        prerelease: true
+
+
   publish-docker:
     needs:
       - check-published-debian-buster-x86_64


### PR DESCRIPTION
I'm not sure what the best way to test/debug this is. Should we
release a 6.0a1 in order to validate it, or should we just see how it
does on 5.x point releases and go from there?