### PR TITLE
Catch aggregate calls in constraints and indexes in ql compiler

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -48,6 +48,7 @@ from edb.common import ast
 from edb.common import ordered
 
 from edb.edgeql import qltypes as ft
+from edb.schema import name as sn
 
 from . import ast as irast
 from . import typeutils
@@ -496,6 +497,49 @@ def contains_set_of_op(ir: irast.Base) -> bool:
             for arg in n.args.values()
         )
     return bool(ast.find_children(ir, irast.Call, flt, terminate_early=True))
+
+
+def is_singleton_set_of_call(
+    call: irast.Call
+) -> bool:
+    # Some set functions and operators are allowed in singleton mode
+    # as long as their inputs are singletons
+
+    return call.func_shortname in {
+        sn.QualName('std', 'IN'),
+        sn.QualName('std', 'NOT IN'),
+        sn.QualName('std', 'EXISTS'),
+        sn.QualName('std', '??'),
+        sn.QualName('std', 'IF'),
+    }
+
+
+def has_set_of_param(
+    call: irast.Call,
+) -> bool:
+    return any(
+        arg.param_typemod == ft.TypeModifier.SetOfType
+        for arg in call.args.values()
+    )
+
+
+def returns_set_of(
+    call: irast.Call,
+) -> bool:
+    return call.typemod == ft.TypeModifier.SetOfType
+
+
+def find_set_of_op(
+    ir: irast.Base,
+    has_multi_param: bool,
+) -> Optional[irast.Call]:
+    def flt(n: irast.Call) -> bool:
+        return (
+            (has_multi_param or not is_singleton_set_of_call(n))
+            and (has_set_of_param(n) or returns_set_of(n))
+        )
+    calls = ast.find_children(ir, irast.Call, flt, terminate_early=True)
+    return next(iter(calls or []), None)
 
 
 T = TypeVar('T')

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -490,15 +490,6 @@ def find_potentially_visible(
     return visible_paths
 
 
-def contains_set_of_op(ir: irast.Base) -> bool:
-    def flt(n: irast.Call) -> bool:
-        return any(
-            arg.param_typemod == ft.TypeModifier.SetOfType
-            for arg in n.args.values()
-        )
-    return bool(ast.find_children(ir, irast.Call, flt, terminate_early=True))
-
-
 def is_singleton_set_of_call(
     call: irast.Call
 ) -> bool:

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -433,10 +433,16 @@ def compile_OperatorCall(
                 dispatch.compile(r_expr, ctx=ctx),
             ],
         )
-    elif expr.typemod is ql_ft.TypeModifier.SetOfType:
+    elif irutils.is_singleton_set_of_call(expr):
+        ...
+    elif irutils.returns_set_of(expr):
         raise errors.UnsupportedFeatureError(
-            f'set returning operator {expr.func_shortname} is not supported '
-            f'in singleton expressions')
+            f"set returning operator '{expr.func_shortname}' is not supported "
+            f"in singleton expressions")
+    elif irutils.has_set_of_param(expr):
+        raise errors.UnsupportedFeatureError(
+            f"aggregate operator '{expr.func_shortname}' is not supported "
+            f"in singleton expressions")
 
     args, maybe_null = _compile_call_args(expr, ctx=ctx)
     return _wrap_call(
@@ -683,9 +689,15 @@ def compile_FunctionCall(
             f'unimplemented function for singleton mode: {fname}'
         )
 
-    if expr.typemod is ql_ft.TypeModifier.SetOfType:
+    if irutils.is_singleton_set_of_call(expr):
+        ...
+    elif irutils.returns_set_of(expr):
         raise errors.UnsupportedFeatureError(
             'set returning functions are not supported in simple expressions')
+    elif irutils.has_set_of_param(expr):
+        raise errors.UnsupportedFeatureError(
+            f"aggregate function '{expr.func_shortname}' is not supported "
+            f"in singleton expressions")
 
     args, maybe_null = _compile_call_args(expr, ctx=ctx)
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -434,7 +434,7 @@ def compile_OperatorCall(
             ],
         )
     elif irutils.is_singleton_set_of_call(expr):
-        ...
+        pass
     elif irutils.returns_set_of(expr):
         raise errors.UnsupportedFeatureError(
             f"set returning operator '{expr.func_shortname}' is not supported "
@@ -690,7 +690,7 @@ def compile_FunctionCall(
         )
 
     if irutils.is_singleton_set_of_call(expr):
-        ...
+        pass
     elif irutils.returns_set_of(expr):
         raise errors.UnsupportedFeatureError(
             'set returning functions are not supported in simple expressions')

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -931,12 +931,20 @@ class ConstraintCommand(
                     span=sourcectx
                 )
 
-            if has_any_multi and ir_utils.contains_set_of_op(
-                    final_subjectexpr.irast):
-                raise errors.InvalidConstraintDefinitionError(
-                    "cannot use aggregate functions or operators "
-                    "in a non-aggregating constraint",
-                    span=sourcectx
+            if set_of_op := ir_utils.find_set_of_op(
+                final_subjectexpr.irast,
+                has_any_multi,
+            ):
+                label = (
+                    'function'
+                    if isinstance(set_of_op, irast.FunctionCall) else
+                    'operator'
+                )
+                op_name = str(set_of_op.func_shortname)
+                raise errors.UnsupportedFeatureError(
+                    f"cannot use aggregate {label} '{op_name}' "
+                    f"in a non-aggregating constraint",
+                    span=set_of_op.span
                 )
 
             if (

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -942,8 +942,8 @@ class ConstraintCommand(
                 )
                 op_name = str(set_of_op.func_shortname)
                 raise errors.UnsupportedFeatureError(
-                    f"cannot use aggregate {label} '{op_name}' "
-                    f"in a non-aggregating constraint",
+                    f"cannot use SET OF {label} '{op_name}' "
+                    f"in a constraint",
                     span=set_of_op.span
                 )
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -862,7 +862,7 @@ class IndexCommand(
                 )
                 op_name = str(set_of_op.func_shortname)
                 raise errors.SchemaDefinitionError(
-                    f"cannot use aggregate {label} '{op_name}' "
+                    f"cannot use SET OF {label} '{op_name}' "
                     f"in an index expression",
                     span=set_of_op.span
                 )

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -798,6 +798,7 @@ class IndexCommand(
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
     ) -> s_expr.CompiledExpression:
+        from edb.ir import ast as irast
         from edb.ir import utils as irutils
 
         if field.name in {'expr', 'except_expr'}:
@@ -850,11 +851,20 @@ class IndexCommand(
                     has_multi = True
                     break
 
-            if has_multi and irutils.contains_set_of_op(expr.irast):
+            if set_of_op := irutils.find_set_of_op(
+                expr.irast,
+                has_multi,
+            ):
+                label = (
+                    'function'
+                    if isinstance(set_of_op, irast.FunctionCall) else
+                    'operator'
+                )
+                op_name = str(set_of_op.func_shortname)
                 raise errors.SchemaDefinitionError(
-                    "cannot use aggregate functions or operators "
-                    "in an index expression",
-                    span=self.span,
+                    f"cannot use aggregate {label} '{op_name}' "
+                    f"in an index expression",
+                    span=set_of_op.span
                 )
 
             # compile the expression to sql to preempt errors downstream

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1400,9 +1400,9 @@ class TestConstraintsDDL(tb.DDLTestCase):
             """)
 
         async with self.assertRaisesRegexTx(
-            edgedb.InvalidConstraintDefinitionError,
-            "cannot use aggregate functions or operators in a "
-            "non-aggregating constraint",
+            edgedb.UnsupportedFeatureError,
+            "cannot use aggregate operator 'std::EXISTS' "
+            "in a non-aggregating constraint",
         ):
             await self.con.execute("""
                 ALTER TYPE ObjCnstr2 {
@@ -1411,9 +1411,9 @@ class TestConstraintsDDL(tb.DDLTestCase):
             """)
 
         async with self.assertRaisesRegexTx(
-            edgedb.InvalidConstraintDefinitionError,
-            "cannot use aggregate functions or operators in a "
-            "non-aggregating constraint",
+            edgedb.UnsupportedFeatureError,
+            "cannot use aggregate operator 'std::EXISTS' "
+            "in a non-aggregating constraint",
         ):
             await self.con.execute("""
                 ALTER TYPE ObjCnstr2 {
@@ -2118,4 +2118,148 @@ class TestConstraintsDDL(tb.DDLTestCase):
         ):
             await self.con.execute("""
                 update ChatBase set { messages := 'hello world' };
+            """)
+
+    async def test_constraints_singleton_set_ops_01(self):
+        await self.con.execute(
+            """
+            create type X {
+                create property a -> int64 {
+                    create constraint expression on (
+                        __subject__ in {1}
+                    );
+                }
+            };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            "cannot use aggregate operator 'std::IN' "
+            "in a non-aggregating constraint"
+        ):
+            await self.con.execute(
+                """
+                create type Y {
+                    create multi property a -> int64 {
+                        create constraint expression on (
+                            __subject__ in {1}
+                        );
+                    }
+                };
+            """)
+
+    async def test_constraints_singleton_set_ops_02(self):
+        await self.con.execute(
+            """
+            create type X {
+                create property a -> int64 {
+                    create constraint expression on (
+                        __subject__ not in {1}
+                    );
+                }
+            };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            "cannot use aggregate operator 'std::NOT IN' "
+            "in a non-aggregating constraint"
+        ):
+            await self.con.execute(
+                """
+                create type Y {
+                    create multi property a -> int64 {
+                        create constraint expression on (
+                            __subject__ not in {1}
+                        );
+                    }
+                };
+            """)
+
+    async def test_constraints_singleton_set_ops_03(self):
+        await self.con.execute(
+            """
+            create type X {
+                create property a -> int64 {
+                    create constraint expression on (
+                        exists(__subject__)
+                    );
+                }
+            };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            "cannot use aggregate operator 'std::EXISTS' "
+            "in a non-aggregating constraint"
+        ):
+            await self.con.execute(
+                """
+                create type Y {
+                    create multi property a -> int64 {
+                        create constraint expression on (
+                            exists(__subject__)
+                        );
+                    }
+                };
+            """)
+
+    async def test_constraints_singleton_set_ops_04(self):
+        await self.con.execute(
+            """
+            create type X {
+                create property a -> int64 {
+                    create constraint expression on (
+                        __subject__ ?? 1 = 0
+                    );
+                }
+            };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            r"cannot use aggregate operator 'std::\?\?' "
+            r"in a non-aggregating constraint"
+        ):
+            await self.con.execute(
+                """
+                create type Y {
+                    create multi property a -> int64 {
+                        create constraint expression on (
+                            __subject__ ?? 1 = 0
+                        );
+                    }
+                };
+            """)
+
+    async def test_constraints_singleton_set_ops_05(self):
+        await self.con.execute(
+            """
+            create type X {
+                create property a -> tuple<bool, int64> {
+                    create constraint expression on (
+                        __subject__.1 < 0
+                        if __subject__.0 else
+                        __subject__.1 >= 0
+                    );
+                }
+            };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            "cannot use aggregate operator 'std::IF' "
+            "in a non-aggregating constraint"
+        ):
+            await self.con.execute(
+                """
+                create type Y {
+                    create multi property a -> tuple<bool, int64> {
+                        create constraint expression on (
+                            __subject__.1 < 0
+                            if __subject__.0 else
+                            __subject__.1 >= 0
+                        );
+                    }
+                };
             """)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1401,8 +1401,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            "cannot use aggregate operator 'std::EXISTS' "
-            "in a non-aggregating constraint",
+            "cannot use SET OF operator 'std::EXISTS' "
+            "in a constraint",
         ):
             await self.con.execute("""
                 ALTER TYPE ObjCnstr2 {
@@ -1412,8 +1412,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            "cannot use aggregate operator 'std::EXISTS' "
-            "in a non-aggregating constraint",
+            "cannot use SET OF operator 'std::EXISTS' "
+            "in a constraint",
         ):
             await self.con.execute("""
                 ALTER TYPE ObjCnstr2 {
@@ -2134,8 +2134,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            "cannot use aggregate operator 'std::IN' "
-            "in a non-aggregating constraint"
+            "cannot use SET OF operator 'std::IN' "
+            "in a constraint"
         ):
             await self.con.execute(
                 """
@@ -2162,8 +2162,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            "cannot use aggregate operator 'std::NOT IN' "
-            "in a non-aggregating constraint"
+            "cannot use SET OF operator 'std::NOT IN' "
+            "in a constraint"
         ):
             await self.con.execute(
                 """
@@ -2190,8 +2190,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            "cannot use aggregate operator 'std::EXISTS' "
-            "in a non-aggregating constraint"
+            "cannot use SET OF operator 'std::EXISTS' "
+            "in a constraint"
         ):
             await self.con.execute(
                 """
@@ -2218,8 +2218,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            r"cannot use aggregate operator 'std::\?\?' "
-            r"in a non-aggregating constraint"
+            r"cannot use SET OF operator 'std::\?\?' "
+            r"in a constraint"
         ):
             await self.con.execute(
                 """
@@ -2248,8 +2248,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            "cannot use aggregate operator 'std::IF' "
-            "in a non-aggregating constraint"
+            "cannot use SET OF operator 'std::IF' "
+            "in a constraint"
         ):
             await self.con.execute(
                 """

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13217,13 +13217,25 @@ type default::Foo {
 
     async def test_edgeql_ddl_index_08(self):
         async with self.assertRaisesRegexTx(
-                edgedb.UnsupportedFeatureError,
-                'set returning operator std::DISTINCT is not supported '
-                'in singleton expressions'):
+                edgedb.SchemaDefinitionError,
+                "cannot use aggregate operator 'std::DISTINCT' "
+                "in an index expression"):
             await self.con.execute(r"""
                 CREATE TYPE default::IndexNonSingletonTest {
                     CREATE PROPERTY has_bad_index: std::str;
                     CREATE INDEX ON (DISTINCT (.has_bad_index));
+                };
+            """)
+
+    async def test_edgeql_ddl_index_09(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.SchemaDefinitionError,
+                "cannot use aggregate function 'std::count' "
+                "in an index expression"):
+            await self.con.execute(r"""
+                CREATE TYPE default::IndexNonSingletonTest {
+                    CREATE PROPERTY has_bad_index: std::str;
+                    CREATE INDEX ON (std::count (.has_bad_index));
                 };
             """)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10852,8 +10852,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_27(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                'set returning operator std::DISTINCT is not supported '
-                'in singleton expressions'):
+                "cannot use aggregate operator 'std::DISTINCT' "
+                "in a non-aggregating constraint"):
             await self.con.execute(r"""
                 CREATE TYPE default::ConstraintNonSingletonTest {
                     CREATE PROPERTY has_bad_constraint: std::str {
@@ -10867,8 +10867,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_28(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                'set returning operator std::DISTINCT is not supported '
-                'in singleton expressions'):
+                "cannot use aggregate operator 'std::DISTINCT' "
+                "in a non-aggregating constraint"):
             await self.con.execute(r"""
                 CREATE TYPE default::ConstraintNonSingletonTest {
                     CREATE PROPERTY has_bad_constraint: std::str {
@@ -10882,8 +10882,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_29(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                'set returning operator std::DISTINCT is not supported '
-                'in singleton expressions'):
+                "cannot use aggregate operator 'std::DISTINCT' "
+                "in a non-aggregating constraint"):
             await self.con.execute(r"""
                 CREATE TYPE default::ConstraintNonSingletonTest {
                     CREATE PROPERTY has_bad_constraint: std::str;
@@ -10896,8 +10896,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_30(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                'set returning operator std::DISTINCT is not supported '
-                'in singleton expressions'):
+                "set returning operator 'std::DISTINCT' is not supported "
+                "in singleton expressions"):
             await self.con.execute(r"""
                 CREATE TYPE default::ConstraintNonSingletonTest {
                     CREATE PROPERTY has_bad_constraint: std::str;
@@ -10909,8 +10909,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_31(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                'set returning operator std::DISTINCT is not supported '
-                'in singleton expressions'):
+                "set returning operator 'std::DISTINCT' is not supported "
+                "in singleton expressions"):
             await self.con.execute(r"""
                 CREATE ABSTRACT CONSTRAINT default::bad_constraint {
                     USING ((DISTINCT __subject__ = __subject__));

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10852,8 +10852,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_27(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                "cannot use aggregate operator 'std::DISTINCT' "
-                "in a non-aggregating constraint"):
+                "cannot use SET OF operator 'std::DISTINCT' "
+                "in a constraint"):
             await self.con.execute(r"""
                 CREATE TYPE default::ConstraintNonSingletonTest {
                     CREATE PROPERTY has_bad_constraint: std::str {
@@ -10867,8 +10867,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_28(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                "cannot use aggregate operator 'std::DISTINCT' "
-                "in a non-aggregating constraint"):
+                "cannot use SET OF operator 'std::DISTINCT' "
+                "in a constraint"):
             await self.con.execute(r"""
                 CREATE TYPE default::ConstraintNonSingletonTest {
                     CREATE PROPERTY has_bad_constraint: std::str {
@@ -10882,8 +10882,8 @@ type default::Foo {
     async def test_edgeql_ddl_constraint_29(self):
         async with self.assertRaisesRegexTx(
                 edgedb.UnsupportedFeatureError,
-                "cannot use aggregate operator 'std::DISTINCT' "
-                "in a non-aggregating constraint"):
+                "cannot use SET OF operator 'std::DISTINCT' "
+                "in a constraint"):
             await self.con.execute(r"""
                 CREATE TYPE default::ConstraintNonSingletonTest {
                     CREATE PROPERTY has_bad_constraint: std::str;
@@ -13218,7 +13218,7 @@ type default::Foo {
     async def test_edgeql_ddl_index_08(self):
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaDefinitionError,
-                "cannot use aggregate operator 'std::DISTINCT' "
+                "cannot use SET OF operator 'std::DISTINCT' "
                 "in an index expression"):
             await self.con.execute(r"""
                 CREATE TYPE default::IndexNonSingletonTest {
@@ -13230,7 +13230,7 @@ type default::Foo {
     async def test_edgeql_ddl_index_09(self):
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaDefinitionError,
-                "cannot use aggregate function 'std::count' "
+                "cannot use SET OF function 'std::count' "
                 "in an index expression"):
             await self.con.execute(r"""
                 CREATE TYPE default::IndexNonSingletonTest {

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -173,8 +173,8 @@ class TestIndexes(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaDefinitionError,
-            "cannot use aggregate functions or operators in an "
-            "index expression",
+            "cannot use aggregate operator 'std::EXISTS' "
+            "in an index expression",
         ):
             await self.con.execute(
                 """
@@ -186,8 +186,8 @@ class TestIndexes(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaDefinitionError,
-            "cannot use aggregate functions or operators in an "
-            "index expression",
+            "cannot use aggregate function 'std::count' "
+            "in an index expression",
         ):
             await self.con.execute(
                 """

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -173,7 +173,7 @@ class TestIndexes(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaDefinitionError,
-            "cannot use aggregate operator 'std::EXISTS' "
+            "cannot use SET OF operator 'std::EXISTS' "
             "in an index expression",
         ):
             await self.con.execute(
@@ -186,7 +186,7 @@ class TestIndexes(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaDefinitionError,
-            "cannot use aggregate function 'std::count' "
+            "cannot use SET OF function 'std::count' "
             "in an index expression",
         ):
             await self.con.execute(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2875,9 +2875,9 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(
-        errors.UnsupportedFeatureError,
-        'set returning operator std::DISTINCT is not supported '
-        'in singleton expressions',
+        errors.SchemaDefinitionError,
+        "cannot use aggregate operator 'std::DISTINCT' "
+        "in an index expression",
     )
     def test_schema_index_non_singleton_01(self):
         """
@@ -2885,6 +2885,20 @@ class TestSchema(tb.BaseSchemaLoadTest):
             property has_bad_index -> str;
 
             index on (distinct .has_bad_index)
+        }
+        """
+
+    @tb.must_fail(
+        errors.SchemaDefinitionError,
+        "cannot use aggregate function 'std::count' "
+        "in an index expression",
+    )
+    def test_schema_index_non_singleton_02(self):
+        """
+        type IndexNonSingletonTest {
+            property has_bad_index -> str;
+
+            index on (count(.has_bad_index))
         }
         """
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2577,8 +2577,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        'set returning operator std::DISTINCT is not supported '
-        'in singleton expressions',
+        "cannot use aggregate operator 'std::DISTINCT' "
+        "in a non-aggregating constraint",
     )
     def test_schema_constraint_non_singleton_01(self):
         """
@@ -2593,8 +2593,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        'set returning operator std::DISTINCT is not supported '
-        'in singleton expressions',
+        "cannot use aggregate operator 'std::DISTINCT' "
+        "in a non-aggregating constraint",
     )
     def test_schema_constraint_non_singleton_02(self):
         """
@@ -2609,8 +2609,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        'set returning operator std::DISTINCT is not supported '
-        'in singleton expressions',
+        "cannot use aggregate operator 'std::DISTINCT' "
+        "in a non-aggregating constraint",
     )
     def test_schema_constraint_non_singleton_03(self):
         """
@@ -2623,8 +2623,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        'set returning operator std::DISTINCT is not supported '
-        'in singleton expressions',
+        "set returning operator 'std::DISTINCT' is not supported "
+        "in singleton expressions",
     )
     def test_schema_constraint_non_singleton_04(self):
         """
@@ -2639,14 +2639,239 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        'set returning operator std::DISTINCT is not supported '
-        'in singleton expressions',
+        "set returning operator 'std::DISTINCT' is not supported "
+        "in singleton expressions",
     )
     def test_schema_constraint_non_singleton_05(self):
         """
         abstract constraint bad_constraint {
             using (distinct __subject__ = __subject__);
         }
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "aggregate function 'std::count' is not supported "
+        "in singleton expressions",
+    )
+    def test_schema_constraint_non_singleton_06(self):
+        """
+        abstract constraint bad_constraint {
+            using (count(__subject__) <= 2);
+        }
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate function 'std::count' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_non_singleton_07(self):
+        """
+        type Foo;
+        type ConstraintNonSingletonTest {
+            link has_bad_constraint -> Foo {
+                constraint expression on (
+                    count(__subject__) <= 2
+                )
+            }
+        }
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate function 'std::count' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_non_singleton_08(self):
+        """
+        type Foo;
+        type ConstraintNonSingletonTest {
+            multi link has_bad_constraint -> Foo {
+                constraint expression on (
+                    count(__subject__) <= 2
+                )
+            }
+        }
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate operator 'std::DISTINCT' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_non_singleton_09(self):
+        """
+        type Foo;
+        type ConstraintNonSingletonTest {
+            link has_bad_constraint -> Foo {
+                constraint expression on (
+                    distinct __subject__ = __subject__
+                )
+            }
+        }
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate operator 'std::DISTINCT' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_non_singleton_10(self):
+        """
+        type Foo;
+        type ConstraintNonSingletonTest {
+            multi link has_bad_constraint -> Foo {
+                constraint expression on (
+                    distinct __subject__ = __subject__
+                )
+            }
+        }
+        """
+
+    def test_schema_constraint_singleton_01a(self):
+        # `IN` allowed in singleton
+        """
+        type X {
+            property a -> int64 {
+                constraint expression on (
+                    __subject__ in {1}
+                );
+            }
+        };
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate operator 'std::IN' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_singleton_01b(self):
+        """
+        type X {
+            multi property a -> int64 {
+                constraint expression on (
+                    __subject__ in {1}
+                );
+            }
+        };
+        """
+
+    def test_schema_constraint_singleton_02a(self):
+        # `NOT IN` allowed in singleton
+        """
+        type X {
+            property a -> int64 {
+                constraint expression on (
+                    __subject__ not in {1}
+                );
+            }
+        };
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate operator 'std::NOT IN' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_singleton_02b(self):
+        """
+        type X {
+            multi property a -> int64 {
+                constraint expression on (
+                    __subject__ not in {1}
+                );
+            }
+        };
+        """
+
+    def test_schema_constraint_singleton_03a(self):
+        # `EXISTS` allowed in singleton
+        """
+        type X {
+            property a -> int64 {
+                constraint expression on (
+                    exists(__subject__)
+                );
+            }
+        };
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate operator 'std::EXISTS' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_singleton_03b(self):
+        """
+        type Foo;
+        type ConstraintNonSingletonTest {
+            multi link has_bad_constraint -> Foo {
+                constraint expression on (
+                    exists(__subject__)
+                )
+            }
+        }
+        """
+
+    def test_schema_constraint_singleton_04a(self):
+        # `??` allowed in singleton
+        """
+        type X {
+            property a -> int64 {
+                constraint expression on (
+                    __subject__ ?? 1 = 0
+                );
+            }
+        };
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        r"cannot use aggregate operator 'std::\?\?' "
+        r"in a non-aggregating constraint",
+    )
+    def test_schema_constraint_singleton_04b(self):
+        """
+        type X {
+            multi property a -> int64 {
+                constraint expression on (
+                    __subject__ ?? 1 = 0
+                );
+            }
+        };
+        """
+
+    def test_schema_constraint_singleton_05a(self):
+        # `IF` allowed in singleton
+        """
+        type X {
+            property a -> tuple<bool, int64> {
+                constraint expression on (
+                    __subject__.1 < 0
+                    if __subject__.0 else
+                    __subject__.1 >= 0
+                );
+            }
+        };
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "cannot use aggregate operator 'std::IF' "
+        "in a non-aggregating constraint",
+    )
+    def test_schema_constraint_singleton_05b(self):
+        """
+        type X {
+            multi property a -> tuple<bool, int64> {
+                constraint expression on (
+                    __subject__.1 < 0
+                    if __subject__.0 else
+                    __subject__.1 >= 0
+                );
+            }
+        };
         """
 
     @tb.must_fail(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2577,8 +2577,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::DISTINCT' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::DISTINCT' "
+        "in a constraint",
     )
     def test_schema_constraint_non_singleton_01(self):
         """
@@ -2593,8 +2593,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::DISTINCT' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::DISTINCT' "
+        "in a constraint",
     )
     def test_schema_constraint_non_singleton_02(self):
         """
@@ -2609,8 +2609,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::DISTINCT' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::DISTINCT' "
+        "in a constraint",
     )
     def test_schema_constraint_non_singleton_03(self):
         """
@@ -2663,8 +2663,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate function 'std::count' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF function 'std::count' "
+        "in a constraint",
     )
     def test_schema_constraint_non_singleton_07(self):
         """
@@ -2680,8 +2680,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate function 'std::count' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF function 'std::count' "
+        "in a constraint",
     )
     def test_schema_constraint_non_singleton_08(self):
         """
@@ -2697,8 +2697,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::DISTINCT' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::DISTINCT' "
+        "in a constraint",
     )
     def test_schema_constraint_non_singleton_09(self):
         """
@@ -2714,8 +2714,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::DISTINCT' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::DISTINCT' "
+        "in a constraint",
     )
     def test_schema_constraint_non_singleton_10(self):
         """
@@ -2743,8 +2743,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::IN' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::IN' "
+        "in a constraint",
     )
     def test_schema_constraint_singleton_01b(self):
         """
@@ -2771,8 +2771,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::NOT IN' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::NOT IN' "
+        "in a constraint",
     )
     def test_schema_constraint_singleton_02b(self):
         """
@@ -2799,8 +2799,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::EXISTS' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::EXISTS' "
+        "in a constraint",
     )
     def test_schema_constraint_singleton_03b(self):
         """
@@ -2828,8 +2828,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        r"cannot use aggregate operator 'std::\?\?' "
-        r"in a non-aggregating constraint",
+        r"cannot use SET OF operator 'std::\?\?' "
+        r"in a constraint",
     )
     def test_schema_constraint_singleton_04b(self):
         """
@@ -2858,8 +2858,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.UnsupportedFeatureError,
-        "cannot use aggregate operator 'std::IF' "
-        "in a non-aggregating constraint",
+        "cannot use SET OF operator 'std::IF' "
+        "in a constraint",
     )
     def test_schema_constraint_singleton_05b(self):
         """
@@ -2876,7 +2876,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.SchemaDefinitionError,
-        "cannot use aggregate operator 'std::DISTINCT' "
+        "cannot use SET OF operator 'std::DISTINCT' "
         "in an index expression",
     )
     def test_schema_index_non_singleton_01(self):
@@ -2890,7 +2890,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.SchemaDefinitionError,
-        "cannot use aggregate function 'std::count' "
+        "cannot use SET OF function 'std::count' "
         "in an index expression",
     )
     def test_schema_index_non_singleton_02(self):


### PR DESCRIPTION
related #7264

- Catches aggregate calls in constraints and indexes earlier in the compilation process
    - Raises errors in migration create which were previously only caught on migrate
- Fixes abstract constraints not raising errors when using aggregate functions
- Adds more information in errors about aggregate functions

Given the schema:
```
  type User {
     name: str;
  }

  type HasTwoOrFewerUsers {
     users: User;
     constraint expression on (count(.users) <= 2);
  }
```

The following error is produced:
```
error: cannot use aggregate functions or operators in a non-aggregating constraint
   │
25 │      constraint expression on (count(.users) <= 2);
   │                                ^^^^^^^^^^^^^ error
```