### PR TITLE
Fix an UNLESS CONFLICT on links perf regression

### DIFF
--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -47,6 +47,7 @@ type User extending Named {
         text: str;
         property tag := .name ++ (("-" ++ @text) ?? "");
     }
+    constraint exclusive on (.avatar);
 }
 
 type Bot extending User;

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -290,6 +290,21 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             "unexpected semi-join",
         )
 
+    def test_codegen_unless_conflict_link_no_semijoin(self):
+        sql = self._compile('''
+          with module cards
+          insert User {
+              name := "x",
+              avatar := (select Card filter .name = 'Dragon')
+          }
+          unless conflict on (.avatar) else (User)
+       ''')
+
+        self.assertNotIn(
+            " IN ", sql,
+            "unexpected semi-join",
+        )
+
     def test_codegen_order_by_param_compare(self):
         sql = self._compile('''
             select Issue { name }


### PR DESCRIPTION
The regression was introduced in #7284, which made
`utils.subject_substitute` substitute `__subject__` in for the
implicit path prefix. That fixed an issue in some cases, but
introduced an extra level of Set/SelectStmt indirection in
others.

That level of indirection could cause us to emit redundant semijoins
in some cases, which caused a major performance regression on UNLESS
CONFLICT on object level exclusive constraints that referred to a link
using a partial path prefix. (Referring to the link using
`__subject__.` was already slow!)

Fix that by making `subject_substitute` smarter.

The redundant semi-join issue can come up in other cases too, like:
```
select (User, (User,).0.deck);
```