### PR TITLE
Fix EDGEDB_SERVER_CONFIG configuration of enum values

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -867,7 +867,7 @@ def initialize_static_cfg(
         choices = setting.enum_values
         if setting.type is bool:
             choices = ['true', 'false']
-        env_value = env_value.lower()
+            env_value = env_value.lower()
         if choices is not None and env_value not in choices:
             raise server.StartupError(
                 f"Environment variable {env_name!r} can only be one of: " +


### PR DESCRIPTION
Currently we force lowercase the input string. We should only do that
for booleans.