### PR TITLE
Check if type exists when tracing type cast, is, and introspect.

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -695,7 +695,9 @@ def trace_IsOp(node: qlast.IsOp, *, ctx: TracerContext) -> None:
 
             hint: Optional[str] = None
             if typename.name.lower() in ['null', 'none']:
-                hint = 'Did you mean to use `exists`?'
+                hint = (
+                    'Did you mean to use `exists` to check if a set is empty?'
+                )
             check_type_exists(typename, ctx, node.right.span, hint=hint)
 
             ctx.refs.add(typename)

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -28,6 +28,7 @@ import functools
 
 from contextlib import contextmanager
 from edb import errors
+from edb.common import parsing
 from edb.schema import links as s_links
 from edb.schema import name as sn
 from edb.schema import objects as so
@@ -656,12 +657,33 @@ def trace_Global(
     return tip
 
 
+def check_type_exists(
+    typename: sn.QualName,
+    ctx: TracerContext,
+    span: Optional[parsing.Span],
+    *,
+    hint: Optional[str] = None,
+) -> None:
+    if typename in ctx.objects:
+        return
+
+    try:
+        # Check if the typename is already in the schema
+        ctx.schema.get(typename, type=s_types.Type, sourcectx=span)
+    except errors.InvalidReferenceError as e:
+        if hint and not e.hint:
+            e.set_hint_and_details(hint, e.details)
+        raise e
+
+
 @trace.register
 def trace_TypeCast(node: qlast.TypeCast, *, ctx: TracerContext) -> None:
     trace(node.expr, ctx=ctx)
     if isinstance(node.type, qlast.TypeName):
         if not node.type.subtypes:
-            ctx.refs.add(ctx.get_ref_name(node.type.maintype))
+            typename: sn.QualName = ctx.get_ref_name(node.type.maintype)
+            check_type_exists(typename, ctx, node.type.span)
+            ctx.refs.add(typename)
 
 
 @trace.register
@@ -669,14 +691,23 @@ def trace_IsOp(node: qlast.IsOp, *, ctx: TracerContext) -> None:
     trace(node.left, ctx=ctx)
     if isinstance(node.right, qlast.TypeName):
         if not node.right.subtypes:
-            ctx.refs.add(ctx.get_ref_name(node.right.maintype))
+            typename: sn.QualName = ctx.get_ref_name(node.right.maintype)
+
+            hint: Optional[str] = None
+            if typename.name.lower() in ['null', 'none']:
+                hint = 'Did you mean to use `exists`?'
+            check_type_exists(typename, ctx, node.right.span, hint=hint)
+
+            ctx.refs.add(typename)
 
 
 @trace.register
 def trace_Introspect(node: qlast.Introspect, *, ctx: TracerContext) -> None:
     if isinstance(node.type, qlast.TypeName):
         if not node.type.subtypes:
-            ctx.refs.add(ctx.get_ref_name(node.type.maintype))
+            typename: sn.QualName = ctx.get_ref_name(node.type.maintype)
+            check_type_exists(typename, ctx, node.type.span)
+            ctx.refs.add(typename)
 
 
 @trace.register

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2980,6 +2980,71 @@ class TestSchema(tb.BaseSchemaLoadTest):
         global foo := <int64>$0
         """
 
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::C' does not exist",
+    )
+    def test_schema_unknown_typename_01(self):
+        """
+        type A;
+        type B {
+            link a -> A;
+            property x := <C>.a;
+        }
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::C' does not exist",
+    )
+    def test_schema_unknown_typename_02(self):
+        """
+        type A;
+        type B {
+            link a -> A;
+            property x := .a is C;
+        }
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::null' does not exist",
+        hint='Did you mean to use `exists`?'
+    )
+    def test_schema_unknown_typename_03(self):
+        """
+        type A;
+        type B {
+            link a -> A;
+            property x := .a is null;
+        }
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::NONE' does not exist",
+        hint='Did you mean to use `exists`?'
+    )
+    def test_schema_unknown_typename_04(self):
+        """
+        type A;
+        type B {
+            link a -> A;
+            property x := .a is NONE;
+        }
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::C' does not exist",
+    )
+    def test_schema_unknown_typename_05(self):
+        """
+        type B {
+            property x := (introspect C).name;
+        }
+        """
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3009,7 +3009,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
     @tb.must_fail(
         errors.InvalidReferenceError,
         "type 'test::null' does not exist",
-        hint='Did you mean to use `exists`?'
+        hint='Did you mean to use `exists` to check if a set is empty?'
     )
     def test_schema_unknown_typename_03(self):
         """
@@ -3023,7 +3023,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
     @tb.must_fail(
         errors.InvalidReferenceError,
         "type 'test::NONE' does not exist",
-        hint='Did you mean to use `exists`?'
+        hint='Did you mean to use `exists` to check if a set is empty?'
     )
     def test_schema_unknown_typename_04(self):
         """


### PR DESCRIPTION
Given the schema:
```
  type MyType {
    parent: MyType;
    is_initial := .parent is null;
  }
```

A nicer error is produced:
```
error: type 'default::null' does not exist
  │
6 │     is_initial := .parent is null;
  │                              ^^^^ Did you mean to use `exists`?
```

close #7256