### PR TITLE
CI: pin pgvector version to 0.6.2

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -49,7 +49,7 @@ jobs:
             multi-tenant-mode: 'multi-tenant'
     services:
       postgres:
-        image: pgvector/pgvector:pg${{ matrix.postgres-version }}
+        image: pgvector/pgvector:0.6.2-pg${{ matrix.postgres-version }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -356,7 +356,7 @@ jobs:
             multi-tenant-mode: 'multi-tenant'
     services:
       postgres:
-        image: pgvector/pgvector:pg${{ matrix.postgres-version }}
+        image: pgvector/pgvector:0.6.2-pg${{ matrix.postgres-version }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
This unbreaks the pg-versions CI that started to fail after pgvector 0.7.0 release.