### PR TITLE
Remove extraneous shape in `current_user` example

### DIFF
--- a/docs/guides/auth/index.rst
+++ b/docs/guides/auth/index.rst
@@ -313,7 +313,7 @@ protected resource, in this case being able to insert a ``Post``.
    module default {
      global current_user := (
        assert_single((
-         select User { id, name }
+         select User
          filter .identity = global ext::auth::ClientTokenIdentity
        ))
      );


### PR DESCRIPTION
Using a shape here causes a weird introspection bug where a module called `__default` is created, and causes invalid code to be generated by the query builder in JS.

A shape isn't really relevant here anyway, so just remove it.