### PR TITLE
Remove non-array type hint when creating array.

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1374,9 +1374,16 @@ def compile_result_clause(
                 span=result_expr.span,
             )
         elif astutils.is_ql_empty_array(result_expr):
+            type_hint: Optional[s_types.Type] = None
+            if (
+                sctx.empty_result_type_hint is not None
+                and sctx.empty_result_type_hint.is_array()
+            ):
+                type_hint = sctx.empty_result_type_hint
+
             expr = setgen.new_array_set(
                 [],
-                stype=sctx.empty_result_type_hint,
+                stype=type_hint,
                 ctx=sctx,
                 span=result_expr.span,
             )

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1393,8 +1393,10 @@ def _compile_qlexpr(
         if should_set_partial_prefix:
             shape_expr_ctx.partial_path_prefix = source_set
 
-        if s_ctx.exprtype.is_mutation() and ptrcls is not None:
-            shape_expr_ctx.expr_exposed = context.Exposure.EXPOSED
+        if ptrcls is not None:
+            if s_ctx.exprtype.is_mutation():
+                shape_expr_ctx.expr_exposed = context.Exposure.EXPOSED
+
             shape_expr_ctx.empty_result_type_hint = \
                 ptrcls.get_target(ctx.env.schema)
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4588,16 +4588,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_empty_05(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'expression returns value of indeterminate type'):
-            await self.con.query(r"""
-                SELECT Issue {
-                    number,
-                    # the empty set is of an unspecified type
-                    time_estimate := {}
-                } ORDER BY .number;
-                """)
+        await self.assert_query_result(
+            r"""
+            SELECT Issue {
+                number,
+                # the empty set is of an unspecified type
+                time_estimate := {}
+            } ORDER BY .number;
+            """,
+            [
+                {'number': '1', 'time_estimate': None},
+                {'number': '2', 'time_estimate': None},
+                {'number': '3', 'time_estimate': None},
+                {'number': '4', 'time_estimate': None},
+            ],
+        )
 
     async def test_edgeql_select_empty_object_01(self):
         await self.assert_query_result(


### PR DESCRIPTION
When compiling pointers in a mutating statement (ie. insert and update), a type hint is provided so that empty sets and arrays can be meaningfully interpreted.

This PR fixes the following issues caused by the hint being propagated through the entire pointer compilation:
- assert failures when an untyped array is used anywhere in a non-array pointer's expression
- the wrong array type being used if an inner select statement also uses an untyped array

close #7356