### PR TITLE
Add span for error when accessing a non-existant tuple field.

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1215,9 +1215,14 @@ def tuple_indirection_set(
 
     assert isinstance(source, s_types.Tuple)
 
-    el_name = ptr_name
-    el_norm_name = source.normalize_index(ctx.env.schema, el_name)
-    el_type = source.get_subtype(ctx.env.schema, el_name)
+    try:
+        el_name = ptr_name
+        el_norm_name = source.normalize_index(ctx.env.schema, el_name)
+        el_type = source.get_subtype(ctx.env.schema, el_name)
+    except errors.InvalidReferenceError as e:
+        if span and not e.has_span():
+            e.set_span(span)
+        raise e
 
     path_id = pathctx.get_tuple_indirection_path_id(
         path_tip.path_id, el_norm_name, el_type, ctx=ctx)


### PR DESCRIPTION
The query `select (a := 1).b + 1;` currently produces no span for its error. After adding the span, the error becomes:
```
error: InvalidReferenceError: b is not a member of tuple<a: std::int64>
  ┌─ <query>:1:16
  │
1 │ select (a := 1).b + 1;
  │                ^^ error
```

Also improves similar errors produced in the schema by `__specified__`:
```
  type User {
    property bar -> bool { rewrite insert using (__specified__.foo); };
  };
```

related  #6524