### PR TITLE
Docs: Add note about config timeout values

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -124,14 +124,22 @@ Client connections
   while in a transaction. Defaults to 10 seconds; set to ``<duration>'0'`` to
   disable the mechanism.
 
+  .. note::
+
+      For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
+      values under 1ms are rounded down to zero, which will disable the timeout.
+      In order to set a timeout, please set a duration of 1ms or greater.
+
+      ``session_idle_timeout`` can take values below 1ms.
+
 :eql:synopsis:`query_execution_timeout -> std::duration`
   How long an individual query can run before being aborted. A value of
   ``<duration>'0'`` disables the mechanism; it is disabled by default.
 
-.. note::
+  .. note::
 
-    For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
-    values under 1ms are rounded down to zero, which will disable the timeout.
-    In order to set a timeout, please set a duration of 1ms or greater.
+      For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
+      values under 1ms are rounded down to zero, which will disable the timeout.
+      In order to set a timeout, please set a duration of 1ms or greater.
 
-    ``session_idle_timeout`` can take values below 1ms.
+      ``session_idle_timeout`` can take values below 1ms.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -127,3 +127,11 @@ Client connections
 :eql:synopsis:`query_execution_timeout -> std::duration`
   How long an individual query can run before being aborted. A value of
   ``<duration>'0'`` disables the mechanism; it is disabled by default.
+
+.. note::
+
+    For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
+    values under 1ms are rounded down to zero, which will disable the timeout.
+    In order to set a timeout, please set a duration of 1ms or greater.
+
+    ``session_idle_timeout`` can take values below 1ms.

--- a/docs/stdlib/cfg.rst
+++ b/docs/stdlib/cfg.rst
@@ -243,6 +243,14 @@ Client connections
   Setting it to ``<duration>'0'`` disables the mechanism.
   The timeout isn't enabled by default.
 
+.. note::
+
+    For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
+    values under 1ms are rounded down to zero, which will disable the timeout.
+    In order to set a timeout, please set a duration of 1ms or greater.
+
+    ``session_idle_timeout`` can take values below 1ms.
+
 ----------
 
 

--- a/docs/stdlib/cfg.rst
+++ b/docs/stdlib/cfg.rst
@@ -237,19 +237,27 @@ Client connections
   The default is 10 seconds. Setting it to ``<duration>'0'`` disables
   the mechanism.
 
+  .. note::
+
+      For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
+      values under 1ms are rounded down to zero, which will disable the timeout.
+      In order to set a timeout, please set a duration of 1ms or greater.
+
+      ``session_idle_timeout`` can take values below 1ms.
+
 :eql:synopsis:`query_execution_timeout -> std::duration`
   Sets a time limit on how long a query can be run.
 
   Setting it to ``<duration>'0'`` disables the mechanism.
   The timeout isn't enabled by default.
 
-.. note::
+  .. note::
 
-    For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
-    values under 1ms are rounded down to zero, which will disable the timeout.
-    In order to set a timeout, please set a duration of 1ms or greater.
+      For ``session_idle_transaction_timeout`` and ``query_execution_timeout``,
+      values under 1ms are rounded down to zero, which will disable the timeout.
+      In order to set a timeout, please set a duration of 1ms or greater.
 
-    ``session_idle_timeout`` can take values below 1ms.
+      ``session_idle_timeout`` can take values below 1ms.
 
 ----------
 


### PR DESCRIPTION
I could have explained that values under 501 microseconds will work in the REPL, but I figured better to keep it simple and just tell users not to use values under 1ms.