### PR TITLE
Pin uv to 0.1.x in CI

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -54,7 +54,7 @@
     - name: Install Python dependencies
       run: |
         python -c "import sys; print(sys.prefix)"
-        python -m pip install uv && uv pip install -U -r requirements.txt
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     << caller() >>
 
@@ -330,7 +330,7 @@
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 <%- endmacro %>
 
 <% macro restore_cache() %>

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -c "import sys; print(sys.prefix)"
-        python -m pip install uv && uv pip install -U -r requirements.txt
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Our HA tests currently only work on Postgres 14 (see #6332),
     # so check it out before we compute our build cache keys.
@@ -389,7 +389,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -c "import sys; print(sys.prefix)"
-        python -m pip install uv && uv pip install -U -r requirements.txt
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     - name: Compute cache keys
       run: |
@@ -420,7 +420,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 
@@ -648,7 +648,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 
@@ -924,7 +924,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 
@@ -1166,7 +1166,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 
@@ -1396,7 +1396,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -c "import sys; print(sys.prefix)"
-        python -m pip install uv && uv pip install -U -r requirements.txt
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     - name: Compute cache keys
       run: |
@@ -389,7 +389,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -c "import sys; print(sys.prefix)"
-        python -m pip install uv && uv pip install -U -r requirements.txt
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     - name: Compute cache keys
       run: |
@@ -413,7 +413,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -c "import sys; print(sys.prefix)"
-        python -m pip install uv && uv pip install -U -r requirements.txt
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     - name: Compute cache keys and download the running times log
       env:
@@ -386,7 +386,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     - name: Download cache key
       uses: actions/download-artifact@v4
@@ -472,7 +472,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 
@@ -631,7 +631,7 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv && uv pip install -U -r requirements.txt
+      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     # Restore the artifacts and environment variables
 


### PR DESCRIPTION
Something about 0.2.0 breaks things and I'm pinning versions for
expediency.