### PR TITLE
Cleanup ql-compiler created_schema_objects

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -359,7 +359,6 @@ def compile_ast_fragment_to_ir(
         view_shapes_metadata={},
         schema_refs=frozenset(),
         schema_ref_exprs=None,
-        created_schema_types=frozenset(),
         scope_tree=ctx.path_scope,
         type_rewrites={},
         singletons=[],

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -213,9 +213,6 @@ class Environment:
 
     This is used for rewriting expressions in the schema after a rename. """
 
-    created_schema_objects: Set[s_obj.Object]
-    """A set of all schema objects derived by this compilation."""
-
     # Caches for costly operations in edb.ir.typeutils
     ptr_ref_cache: PointerRefCache
     type_ref_cache: Dict[irtyputils.TypeRefCacheKey, irast.TypeRef]
@@ -310,7 +307,6 @@ class Environment:
             irast.ViewShapeMetadata)
         self.schema_refs = set()
         self.schema_ref_exprs = {} if options.track_schema_ref_exprs else None
-        self.created_schema_objects = set()
         self.ptr_ref_cache = PointerRefCache()
         self.type_ref_cache = {}
         self.dml_exprs = []

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -239,10 +239,8 @@ def new_tuple_set(
 ) -> irast.Set:
 
     element_types = {el.name: get_set_type(el.val, ctx=ctx) for el in elements}
-    ctx.env.schema, stype, has_been_created = s_types.Tuple.create(
+    ctx.env.schema, stype = s_types.Tuple.create(
         ctx.env.schema, element_types=element_types, named=named)
-    if has_been_created:
-        ctx.env.created_schema_objects.add(stype)
     result_path_id = pathctx.get_expression_path_id(stype, ctx=ctx)
 
     final_elems = []
@@ -287,11 +285,9 @@ def new_array_set(
 
     if stype is None:
         assert element_type
-        ctx.env.schema, stype, has_created = s_types.Array.create(
+        ctx.env.schema, stype = s_types.Array.create(
             ctx.env.schema, element_type=element_type, dimensions=[-1]
         )
-        if has_created:
-            ctx.env.created_schema_objects.add(stype)
     typeref = typegen.type_to_typeref(stype, env=ctx.env)
     arr = irast.Array(elements=elements, typeref=typeref)
     return ensure_set(arr, type_override=stype, ctx=ctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -369,14 +369,12 @@ def compile_InternalGroupQuery(
             viewgen.late_compile_view_shapes(stmt.group_binding, ctx=topctx)
 
             if expr.grouping_alias:
-                ctx.env.schema, grouping_stype, created = s_types.Array.create(
+                ctx.env.schema, grouping_stype = s_types.Array.create(
                     ctx.env.schema,
                     element_type=(
                         ctx.env.schema.get('std::str', type=s_types.Type)
                     )
                 )
-                if created:
-                    ctx.env.created_schema_objects.add(grouping_stype)
                 stmt.grouping_binding = _make_group_binding(
                     grouping_stype, expr.grouping_alias, ctx=topctx)
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -160,7 +160,7 @@ def init_context(
 def fini_expression(
     ir: irast.Set,
     *,
-    ctx: context.ContextLevel,
+    ctx: context.ContextLevel
 ) -> irast.Statement | irast.ConfigCommand:
 
     ctx.path_scope = ctx.env.path_scope
@@ -290,8 +290,12 @@ def fini_expression(
         },
         view_shapes_metadata=ctx.env.view_shapes_metadata,
         schema=ctx.env.schema,
-        schema_refs=frozenset(
-            ctx.env.schema_refs - ctx.env.created_schema_objects),
+        schema_refs=frozenset({
+            r
+            for r in ctx.env.schema_refs
+            # filter out newly derived objects
+            if ctx.env.orig_schema.has_object(r.id)
+        }),
         schema_ref_exprs=ctx.env.schema_ref_exprs,
         type_rewrites={
             (typ.id, not skip_subtypes): s

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -293,10 +293,6 @@ def fini_expression(
         schema_refs=frozenset(
             ctx.env.schema_refs - ctx.env.created_schema_objects),
         schema_ref_exprs=ctx.env.schema_ref_exprs,
-        created_schema_types=frozenset(
-            t for t in ctx.env.created_schema_objects
-            if isinstance(t, s_types.Type)
-        ),
         type_rewrites={
             (typ.id, not skip_subtypes): s
             for (typ, skip_subtypes), s in ctx.env.type_rewrites.items()

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -158,9 +158,7 @@ def init_context(
 
 
 def fini_expression(
-    ir: irast.Set,
-    *,
-    ctx: context.ContextLevel
+    ir: irast.Set, *, ctx: context.ContextLevel
 ) -> irast.Statement | irast.ConfigCommand:
 
     ctx.path_scope = ctx.env.path_scope
@@ -290,12 +288,14 @@ def fini_expression(
         },
         view_shapes_metadata=ctx.env.view_shapes_metadata,
         schema=ctx.env.schema,
-        schema_refs=frozenset({
-            r
-            for r in ctx.env.schema_refs
-            # filter out newly derived objects
-            if ctx.env.orig_schema.has_object(r.id)
-        }),
+        schema_refs=frozenset(
+            {
+                r
+                for r in ctx.env.schema_refs
+                # filter out newly derived objects
+                if ctx.env.orig_schema.has_object(r.id)
+            }
+        ),
         schema_ref_exprs=ctx.env.schema_ref_exprs,
         type_rewrites={
             (typ.id, not skip_subtypes): s

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2642,7 +2642,5 @@ def _record_created_collection_types(
     if isinstance(
         type, s_types.Collection
     ) and not ctx.env.orig_schema.get_by_id(type.id, default=None):
-        ctx.env.created_schema_objects.add(type)
-
         for sub_type in type.get_subtypes(ctx.env.schema):
             _record_created_collection_types(sub_type, ctx)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -787,7 +787,6 @@ class Statement(Command):
     schema_refs: typing.FrozenSet[so.Object]
     schema_ref_exprs: typing.Optional[
         typing.Dict[so.Object, typing.Set[qlast.Base]]]
-    created_schema_types: typing.FrozenSet[s_types.Type]
     scope_tree: ScopeTreeNode
     dml_exprs: typing.List[qlast.Base]
     type_rewrites: typing.Dict[typing.Tuple[uuid.UUID, bool], Set]

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -572,7 +572,7 @@ def sub_expr(ir: irast.Set) -> Optional[irast.Expr]:
 
 class CollectSchemaTypesVisitor(ast.NodeVisitor):
     types: Set[uuid.UUID]
-    
+
     def __init__(self) -> None:
         super().__init__()
         self.types = set()

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -568,3 +568,23 @@ def sub_expr(ir: irast.Set) -> Optional[irast.Expr]:
         return ir.expr.expr
     else:
         return ir.expr
+
+
+class CollectSchemaTypesVisitor(ast.NodeVisitor):
+    types: Set[uuid.UUID]
+    
+    def __init__(self) -> None:
+        super().__init__()
+        self.types = set()
+
+    def visit_Set(self, node: irast.Set) -> None:
+        self.types.add(node.typeref.id)
+        self.generic_visit(node)
+
+
+def collect_schema_types(stmt: irast.Base) -> Set[uuid.UUID]:
+    """Collect ids of all types referenced in the statement."""
+
+    visitor = CollectSchemaTypesVisitor()
+    visitor.visit(stmt)
+    return visitor.types

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -508,6 +508,7 @@ def _create_alias_types(
     Set[so.ObjectShell[s_types.Type]],
 ]:
     from . import ordering as s_ordering
+    from edb.ir import utils as irutils
 
     ir = expr.irast
     new_schema = ir.schema
@@ -516,7 +517,12 @@ def _create_alias_types(
 
     created_type_shells: Set[so.ObjectShell[s_types.Type]] = set()
 
-    for ty in ir.created_schema_types:
+    for ty_id in irutils.collect_schema_types(ir.expr):
+        if schema.has_object(ty_id):
+            # this is not a new type, skip
+            continue
+        ty = new_schema.get_by_id(ty_id, type=s_types.Type)
+
         name = ty.get_name(new_schema)
         if (
             not isinstance(ty, s_types.Collection)

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -417,7 +417,7 @@ def get_or_create_intersection_type(
     *,
     module: Optional[str] = None,
     transient: bool = False,
-) -> Tuple[s_schema.Schema, ObjectType, bool]:
+) -> Tuple[s_schema.Schema, ObjectType]:
 
     name = s_types.get_intersection_type_name(
         (c.get_name(schema) for c in components),
@@ -425,7 +425,6 @@ def get_or_create_intersection_type(
     )
 
     objtype = schema.get(name, default=None, type=ObjectType)
-    created = objtype is None
     if objtype is None:
         components = list(components)
 
@@ -469,7 +468,7 @@ def get_or_create_intersection_type(
                 schema = objtype.add_pointer(schema, ptr)
 
     assert isinstance(objtype, ObjectType)
-    return schema, objtype, created
+    return schema, objtype
 
 
 class ObjectTypeCommandContext(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3227,7 +3227,7 @@ def get_or_create_intersection_pointer(
     targets: Sequence[s_types.Type]
     targets = list(filter(None, [p.get_target(schema) for p in components]))
     targets = utils.simplify_intersection_types(schema, targets)
-    schema, target, _ = utils.ensure_intersection_type(
+    schema, target = utils.ensure_intersection_type(
         schema, targets, module=modname)
 
     cardinality = qltypes.SchemaCardinality.One

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -184,7 +184,7 @@ class RewriteCommand(
             )
             # __specified__
             bool_type = schema.get("std::bool", type=s_types.Type)
-            schema, specified_type, _ = s_types.Tuple.create(
+            schema, specified_type = s_types.Tuple.create(
                 schema,
                 named=True,
                 element_types={

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1253,7 +1253,7 @@ class Array(
         dimensions: Sequence[int] = (),
         element_type: Any,
         **kwargs: Any,
-    ) -> typing.Tuple[s_schema.Schema, Array_T, bool]:
+    ) -> typing.Tuple[s_schema.Schema, Array_T]:
         if not dimensions:
             dimensions = [-1]
 
@@ -1269,10 +1269,7 @@ class Array(
         else:
             result = schema.get_global(cls, name, default=None)
 
-        has_been_created = False
-
         if result is None:
-            has_been_created = True
             schema, result = super().create_in_schema(
                 schema,
                 id=id,
@@ -1284,7 +1281,7 @@ class Array(
             # Compute material type so that we can retrieve it safely later
             schema, _ = result.material_type(schema)
 
-        return schema, result, has_been_created
+        return schema, result
 
     def get_generated_name(self, schema: s_schema.Schema) -> s_name.UnqualName:
         return type(self).generate_name(
@@ -1456,7 +1453,7 @@ class Array(
         # One-dimensional unbounded array.
         dimensions = [-1]
 
-        schema, ty, _ = cls.create(
+        schema, ty = cls.create(
             schema,
             element_type=stype,
             dimensions=dimensions,
@@ -1653,7 +1650,7 @@ class Tuple(
         element_types: Mapping[str, Type],
         named: bool = False,
         **kwargs: Any,
-    ) -> typing.Tuple[s_schema.Schema, Tuple_T, bool]:
+    ) -> typing.Tuple[s_schema.Schema, Tuple_T]:
         el_types = so.ObjectDict[str, Type].create(schema, element_types)
         if name is None:
             name = cls.generate_name(
@@ -1666,10 +1663,7 @@ class Tuple(
         else:
             result = schema.get_global(cls, name, default=None)
 
-        has_been_created = False
-
         if result is None:
-            has_been_created = True
             schema, result = super().create_in_schema(
                 schema,
                 id=id,
@@ -1681,7 +1675,7 @@ class Tuple(
             # Compute material type so that we can retrieve it safely later
             schema, _ = result.material_type(schema)
 
-        return schema, result, has_been_created
+        return schema, result
 
     def get_generated_name(self, schema: s_schema.Schema) -> s_name.UnqualName:
         els = {n: st.get_name(schema) for n, st in self.iter_subtypes(schema)}
@@ -1799,7 +1793,7 @@ class Tuple(
             types = subtypes
         else:
             types = {str(i): type for i, type in enumerate(subtypes)}
-        schema, ty, _ = cls.create(
+        schema, ty = cls.create(
             schema, element_types=types, named=named, name=name, **kwargs)
         return schema, ty
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -1262,12 +1262,12 @@ def ensure_intersection_type(
     *,
     transient: bool = False,
     module: Optional[str] = None,
-) -> Tuple[s_schema.Schema, s_types.Type, bool]:
+) -> Tuple[s_schema.Schema, s_types.Type]:
 
     from edb.schema import objtypes as s_objtypes
 
     if len(types) == 1:
-        return schema, next(iter(types)), False
+        return schema, next(iter(types))
 
     seen_scalars = False
     seen_objtypes = False


### PR DESCRIPTION
Followup for https://github.com/edgedb/edgedb/pull/7375

Removes `Context.created_schema_objects` and instead relies on:
- collecting schema types from the irast.Set.typeref for aliases,
- `schema_refs` not returning created schema objects by filtering it with `ctx.env.orig_schema`