### PR TITLE
Fix single-tenant metrics not to filter by tenant

### DIFF
--- a/edb/common/prometheus.py
+++ b/edb/common/prometheus.py
@@ -409,7 +409,6 @@ class BaseLabeledCounter(BaseMetric):
             fmt_label = ','.join(
                 f'{label}="{_format_label_val(label_val)}"'
                 for label, label_val in zip(self._labels, labels)
-                if label not in label_filters
             )
             buffer.append(
                 f'{self._name}{self._suffix}{{{fmt_label}}} {float(value)}'
@@ -425,7 +424,6 @@ class BaseLabeledCounter(BaseMetric):
                 fmt_label = ','.join(
                     f'{label}="{_format_label_val(label_val)}"'
                     for label, label_val in zip(self._labels, labels)
-                    if label not in label_filters
                 )
                 buffer.append(
                     f'{self._name}_created{{{fmt_label}}} {float(value)}'
@@ -618,7 +616,6 @@ class LabeledHistogram(BaseHistogram):
             fmt_label = ','.join(
                 f'{label}="{_format_label_val(label_val)}"'
                 for label, label_val in zip(self._labels, labels)
-                if label not in label_filters
             )
             accum = 0.0
             for buck, val in zip(self._buckets, values[1]):  # type: ignore
@@ -648,7 +645,6 @@ class LabeledHistogram(BaseHistogram):
                 fmt_label = ','.join(
                     f'{label}="{_format_label_val(label_val)}"'
                     for label, label_val in zip(self._labels, labels)
-                    if label not in label_filters
                 )
                 buffer.append(
                     f'{self._name}_created{{{fmt_label}}} {float(value)}'

--- a/edb/server/protocol/metrics.py
+++ b/edb/server/protocol/metrics.py
@@ -21,6 +21,7 @@ import http
 
 from edb import errors
 from edb.server import metrics
+from edb.server import server
 
 from edb.common import debug
 from edb.common import markup
@@ -32,7 +33,7 @@ async def handle_request(
     tenant,
 ):
     try:
-        if tenant is None:
+        if tenant is None or isinstance(tenant.server, server.Server):
             output = metrics.registry.generate()
         else:
             output = metrics.registry.generate(

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -317,6 +317,11 @@ class TestServerCompilerPool(tbs.TestCase):
             self.assertEqual(sd.call_system_api('/server/status/ready'), 'OK')
             pid1, pid2 = await self._get_worker_pids(sd)
 
+            data = sd.fetch_metrics()
+            self.assertRegex(
+                data, r'\nedgedb_server_compiler_processes_current 2.0\n'
+            )
+
             # Terminate one worker, the server is still OK
             self._kill_and_wait(pid1)
             self.assertEqual(sd.call_system_api('/server/status/ready'), 'OK')


### PR DESCRIPTION
This is a bug introduced in #7024 that `/metrics` returns different results using HTTP or HTTPS protocol under single-tenant mode. This PR fixes so that `/metrics` never filter by tenant under single-tenant mode.

This PR also fixes the test to `fetch_metrics()` with TLS certificate and adds a test to make sure `edgedb_server_compiler_processes_current` - as an example - is not filtered out.