### PR TITLE
Add a warning message to buildmeta about catalog version and backports

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -55,6 +55,11 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
+#
+# WARNING: DO NOT INCREMENT THIS WHEN BACKPORTING CHANGES TO A RELEASE BRANCH.
+# The merge conflict there is a nice reminder that you probably need
+# to write a patch in edb/pgsql/patches.py, and then you should preserve
+# the old value.
 EDGEDB_CATALOG_VERSION = 2024_05_23_00_00
 EDGEDB_MAJOR_VERSION = 6
 


### PR DESCRIPTION
This already exists in 5.x, so this is a forward port of that.