### PR TITLE
Add array index number to output when casting from json to array.

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -814,11 +814,15 @@ class CollectionCastInfo(NamedTuple):
     from_type: s_types.Type
     to_type: s_types.Type
 
-    path_elements: list[Tuple[str, Optional[str]]]
+    path_elements: list[Tuple[str, Optional[str | qlast.Expr]]]
     """Represents a path to the current collection element being cast.
 
     A path element is a tuple of the collection type and an optional
     element name. eg. ('tuple', 'a') or ('array', None)
+
+    When casting a json array, the path element has the form
+    ('array_index', expr) where expr is a string representation of the index
+    in the current json array.
 
     The list is shared between the outermost context and all its sub contexts.
     When casting a collection, each element's path should be pushed before

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -802,7 +802,7 @@ def compile_TypeCast(
 
         except errors.QueryError as e:
             if (
-                (message_context := casts.cast_message_context(subctx))
+                (message_context := casts.get_error_message_context(subctx))
                 and use_message_context
             ):
                 e.args = (

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -863,6 +863,11 @@ def __infer_typecast(
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
+    if ir.error_message_context is not None:
+        infer_cardinality(
+            ir.error_message_context, scope_tree=scope_tree, ctx=ctx
+        )
+
     card = infer_cardinality(
         ir.expr, scope_tree=scope_tree, ctx=ctx,
     )

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -562,6 +562,11 @@ def __infer_typecast(
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
 ) -> inf_ctx.MultiplicityInfo:
+    if ir.error_message_context is not None:
+        infer_multiplicity(
+            ir.error_message_context, scope_tree=scope_tree, ctx=ctx
+        )
+
     return infer_multiplicity(
         ir.expr, scope_tree=scope_tree, ctx=ctx,
     )

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -53,7 +53,7 @@ from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 
-from edb.common.ast import visitor as ast_visitor, find_children
+from edb.common.ast import visitor as ast_visitor
 from edb.common import ordered
 from edb.common.typeutils import not_none
 
@@ -191,9 +191,6 @@ def fini_expression(
         if p.sub_params and p.sub_params.decoder_ir
     ]
     extra_exprs += [trigger.expr for stage in ir_triggers for trigger in stage]
-    for type_cast in find_children(ir, irast.TypeCast):
-        if type_cast.error_message_context is not None:
-            extra_exprs.append(type_cast.error_message_context)
 
     all_exprs = [ir] + extra_exprs
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -53,7 +53,7 @@ from edb.schema import expr as s_expr
 
 from edb.edgeql import ast as qlast
 
-from edb.common.ast import visitor as ast_visitor
+from edb.common.ast import visitor as ast_visitor, find_children
 from edb.common import ordered
 from edb.common.typeutils import not_none
 
@@ -191,6 +191,9 @@ def fini_expression(
         if p.sub_params and p.sub_params.decoder_ir
     ]
     extra_exprs += [trigger.expr for stage in ir_triggers for trigger in stage]
+    for type_cast in find_children(ir, irast.TypeCast):
+        if type_cast.error_message_context is not None:
+            extra_exprs.append(type_cast.error_message_context)
 
     all_exprs = [ir] + extra_exprs
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1074,7 +1074,7 @@ class TypeCast(ImmutableExpr):
     sql_function: typing.Optional[str] = None
     sql_cast: bool
     sql_expr: bool
-    error_message_context: typing.Optional[str] = None
+    error_message_context: typing.Optional[Set] = None
 
     @property
     def typeref(self) -> TypeRef:

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -202,15 +202,9 @@ def compile_TypeCast(
 
     pg_expr = dispatch.compile(expr.expr, ctx=ctx)
 
-    detail: Optional[pgast.StringConstant] = None
+    detail: Optional[pgast.BaseExpr] = None
     if expr.error_message_context is not None:
-        detail = pgast.StringConstant(
-            val=(
-                '{"error_message_context": "'
-                + expr.error_message_context
-                + '"}'
-            )
-        )
+        detail = dispatch.compile(expr.error_message_context, ctx=ctx)
 
     if expr.sql_cast:
         # Use explicit SQL cast.

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2460,6 +2460,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"while casting 'std::json' "
                 r"to 'array<std::int64>', "
                 r"in array elements, "
+                r"at index 0, "
                 r"expected JSON number or null; got JSON string"):
             await self.con.query_single(
                 r"SELECT <array<int64>><json>['asdf']")
@@ -2469,6 +2470,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"while casting 'std::json' "
                 r"to 'array<std::int64>', "
                 r"in array elements, "
+                r"at index 2, "
                 r"expected JSON number or null; got JSON string"):
             await self.con.query_single(
                 r"SELECT <array<int64>>to_json('[1, 2, \"asdf\"]')")
@@ -2478,6 +2480,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"while casting 'std::json' "
                 r"to 'array<std::int64>', "
                 r"in array elements, "
+                r"at index 0, "
                 r"expected JSON number or null; got JSON string"):
             await self.con.execute("""
                 SELECT <array<int64>>to_json('["a"]');
@@ -2497,6 +2500,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 edgedb.InvalidValueError,
                 r"array<std::int64>', "
                 r"in array elements, "
+                r"at index 2, "
                 r"invalid null value in cast"):
             await self.con.query_single(
                 r"SELECT <array<int64>>to_json('[1, 2, null]')")
@@ -2506,6 +2510,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"while casting 'array<std::json>' "
                 r"to 'array<std::int64>', "
                 r"in array elements, "
+                r"at index 2, "
                 r"invalid null value in cast"):
             await self.con.query_single(
                 r"SELECT <array<int64>><array<json>>to_json('[1, 2, null]')")
@@ -2525,6 +2530,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"to 'tuple<array<std::str>>', "
                 r"at tuple element '0', "
                 r"in array elements, "
+                r"at index 0, "
                 r"invalid null value in cast"):
             await self.con.query_single(
                 r"select <tuple<array<str>>>to_json('[[null]]')")
@@ -2543,6 +2549,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"while casting 'std::json' "
                 r"to 'array<std::int64>', "
                 r"in array elements, "
+                r"at index 0, "
                 r"expected JSON number or null; got JSON object"):
             await self.con.execute("""
                 SELECT <array<int64>>to_json('[{"a": 1}]');
@@ -2554,8 +2561,10 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"while casting 'std::json' "
                 r"to 'array<tuple<array<std::str>>>', "
                 r"in array elements, "
+                r"at index 0, "
                 r"at tuple element '0', "
                 r"in array elements, "
+                r"at index 0, "
                 r"expected JSON string or null; got JSON number"):
             await self.con.execute("""
                 SELECT <array<tuple<array<str>>>>to_json('[[[1]]]');


### PR DESCRIPTION
Given the query `SELECT <array<int64>>to_json('[1, 2, "asdf"]')`, produces the error:
```
InvalidValueError: while casting 'std::json' to 'array<std::int64>', in array elements, at index 2, expected JSON number or null; got JSON string
```