### PR TITLE
Raise error when using query params in schema.

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -27,6 +27,7 @@ from typing import (Dict, FrozenSet, Generator, List, Mapping, Optional,
 import functools
 
 from contextlib import contextmanager
+from edb import errors
 from edb.schema import links as s_links
 from edb.schema import name as sn
 from edb.schema import objects as so
@@ -589,6 +590,14 @@ def trace_none(node: None, *, ctx: TracerContext) -> None:
 @trace.register
 def trace_Constant(node: qlast.BaseConstant, *, ctx: TracerContext) -> None:
     pass
+
+
+@trace.register
+def trace_Parameter(node: qlast.Parameter, *, ctx: TracerContext) -> None:
+    raise errors.SchemaError(
+        'query parameters are not allowed in schemas',
+        span=node.span,
+    )
 
 
 @trace.register

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -39,7 +39,6 @@ from edb import edgeql
 from edb.common import debug
 from edb.common import uuidgen
 from edb.common import verutils
-from edb.common.ast import find_children
 from edb.edgeql import ast as qlast
 from edb.edgeql import declarative as s_decl
 from edb.server import defines
@@ -470,16 +469,6 @@ def apply_sdl(
     testmode: bool = False,
     allow_dml_in_functions: bool=False,
 ) -> s_schema.Schema:
-    if params := find_children(
-        sdl_document,
-        qlast.Parameter,
-        terminate_early=True
-    ):
-        raise errors.SchemaError(
-            'query parameters are not allowed in schemas',
-            span=params[0].span,
-        )
-
     # group declarations by module
     documents: Dict[str, List[qlast.DDL]] = defaultdict(list)
     # initialize the "default" module

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -39,6 +39,7 @@ from edb import edgeql
 from edb.common import debug
 from edb.common import uuidgen
 from edb.common import verutils
+from edb.common.ast import find_children
 from edb.edgeql import ast as qlast
 from edb.edgeql import declarative as s_decl
 from edb.server import defines
@@ -469,6 +470,16 @@ def apply_sdl(
     testmode: bool = False,
     allow_dml_in_functions: bool=False,
 ) -> s_schema.Schema:
+    if params := find_children(
+        sdl_document,
+        qlast.Parameter,
+        terminate_early=True
+    ):
+        raise errors.SchemaError(
+            'query parameters are not allowed in schemas',
+            span=params[0].span,
+        )
+
     # group declarations by module
     documents: Dict[str, List[qlast.DDL]] = defaultdict(list)
     # initialize the "default" module

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2962,6 +2962,24 @@ class TestSchema(tb.BaseSchemaLoadTest):
         }
         """
 
+    @tb.must_fail(
+        errors.SchemaError,
+        "query parameters are not allowed in schemas",
+    )
+    def test_schema_query_parameter_01(self):
+        """
+        type Foo { foo := <int64>$0 }
+        """
+
+    @tb.must_fail(
+        errors.SchemaError,
+        "query parameters are not allowed in schemas",
+    )
+    def test_schema_query_parameter_02(self):
+        """
+        global foo := <int64>$0
+        """
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.


### PR DESCRIPTION
Given schema:
```
  type User {
    required name: str {
      default := <str>$0;
    }
  }
```

The following error is produced:
```
error: query parameters are not allowed in schemas
  │
5 │           default := <str>$0;
  │                           ^^ error
```

close #7393