### PR TITLE
Fix dumps of types that have both AI and FTS indexes

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -3149,7 +3149,7 @@ def _describe_object(
         # and include them in the dump.
         nschema = schema
         for (name, col, _type) in source.get_addon_columns(schema):
-            nschema, fake_ptr = _add_fake_property(source, name, schema)
+            nschema, fake_ptr = _add_fake_property(source, name, nschema)
             cols.append(col)
             shape.append(fake_ptr)
 

--- a/tests/schemas/dump_v5_default.esdl
+++ b/tests/schemas/dump_v5_default.esdl
@@ -38,4 +38,9 @@ type Astronomy {
     content: str;
     deferred index ext::ai::index(embedding_model := 'text-embedding-test')
         on (.content);
+
+    # N.B: This was added late, for 5.5, so won't appear in 5.0 dumps.
+    # Test that having both AI and FTS indexes works.
+    index fts::index on (
+      fts::with_options(.content, language := fts::Language.eng));
 };


### PR DESCRIPTION
When adding "fake" columns to the schema for the dump descriptor
for the shadow columns for AI and FTS indexes, we used the wrong
version of the immutable schema object, so only added the last
such column to the schema.