### PR TITLE
Cleanup references between modules

### DIFF
--- a/edb/pgsql/params.py
+++ b/edb/pgsql/params.py
@@ -126,8 +126,24 @@ def get_default_runtime_params(
             **instance_params,
         )
     if 'version' not in instance_params:
+        try:
+            version = buildmeta.get_pg_version()
+        except buildmeta.MetadataError as _:
+            # HACK: if get_pg_version fails, this means we have no pg_config,
+            # which happens for edgedb-ls. It is invoking pg compiler from
+            # schema delta. Ideally, schema delta would not need pg compiler,
+            # but that would require a lot of cleanups.
+            version = BackendVersion(
+                major=100,
+                minor=0,
+                micro=0,
+                releaselevel='final',
+                serial=0,
+                string='100.0'
+            )
+
         instance_params = dict(
-            version=buildmeta.get_pg_version(),
+            version=version,
             **instance_params,
         )
 

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -41,7 +41,6 @@ from edb.common import uuidgen
 from edb.common import verutils
 from edb.edgeql import ast as qlast
 from edb.edgeql import declarative as s_decl
-from edb.server import defines
 
 from . import delta as sd
 from . import expr as s_expr
@@ -472,7 +471,7 @@ def apply_sdl(
     # group declarations by module
     documents: Dict[str, List[qlast.DDL]] = defaultdict(list)
     # initialize the "default" module
-    documents[defines.DEFAULT_MODULE_ALIAS] = []
+    documents[s_mod.DEFAULT_MODULE_ALIAS] = []
     extensions = {}
     futures = {}
 

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -36,6 +36,9 @@ RESERVED_MODULE_NAMES = {
 }
 
 
+DEFAULT_MODULE_ALIAS = 'default'
+
+
 class Module(
     s_anno.AnnotationSubject,
     so.Object,  # Help reflection figure out the right db MRO

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -134,8 +134,9 @@ class CompileContext:
     schema_object_ids: Optional[
         Mapping[tuple[s_name.Name, Optional[str]], uuid.UUID]] = None
     source: Optional[edgeql.Source] = None
-    backend_runtime_params: pg_params.BackendRuntimeParams = (
-        pg_params.get_default_runtime_params())
+    backend_runtime_params: pg_params.BackendRuntimeParams = dataclasses.field(
+        default_factory=pg_params.get_default_runtime_params
+    )
     compat_ver: Optional[verutils.Version] = None
     bootstrap_mode: bool = False
     internal_schema_mode: bool = False
@@ -201,7 +202,7 @@ class CompileContext:
 
 
 DEFAULT_MODULE_ALIASES_MAP: immutables.Map[Optional[str], str] = (
-    immutables.Map({None: defines.DEFAULT_MODULE_ALIAS}))
+    immutables.Map({None: s_mod.DEFAULT_MODULE_ALIAS}))
 
 
 def compile_edgeql_script(
@@ -2235,7 +2236,7 @@ def _compile_ql_sess_state(
         aliases = aliases.set(ql.decl.alias, ql.decl.module)
 
     elif isinstance(ql, qlast.SessionResetModule):
-        aliases = aliases.set(None, defines.DEFAULT_MODULE_ALIAS)
+        aliases = aliases.set(None, s_mod.DEFAULT_MODULE_ALIAS)
 
     elif isinstance(ql, qlast.SessionResetAllAliases):
         aliases = DEFAULT_MODULE_ALIASES_MAP

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -41,7 +41,6 @@ from edb.edgeql import parser as qlparser
 from edb.edgeql.parser import grammar as qlgrammar
 from edb.edgeql import qltypes
 
-from edb.server import defines
 from edb.server import compiler as edbcompiler
 
 from edb.schema import ddl as s_ddl
@@ -51,6 +50,7 @@ from edb.schema import reflection as s_refl
 from edb.schema import schema as s_schema
 from edb.schema import std as s_std
 from edb.schema import utils as s_utils
+from edb.schema import modules as s_mod
 
 
 def must_fail(exc_type, exc_msg_re=None, **kwargs):
@@ -298,7 +298,7 @@ class BaseSchemaTest(BaseDocTest):
             cls.schema = _load_std_schema()
 
     @classmethod
-    def run_ddl(cls, schema, ddl, default_module=defines.DEFAULT_MODULE_ALIAS):
+    def run_ddl(cls, schema, ddl, default_module=s_mod.DEFAULT_MODULE_ALIAS):
         statements = edgeql.parse_block(ddl)
 
         current_schema = schema


### PR DESCRIPTION
To make edgedb-ls package smaller, I don't include the following:

```
- postgres (and pg_config)
- edb/graphql
- edb/graphql-rewrite
- edb/_graphql_rewrite.*.so
- edb/testbase
- edb/protocol
- edb/pgsql/parser
- edb/pgsql/resolver
- edb/pgsql/dbops
- edb/server/dbview
- edb/server/pgcon
- edb/server/protocol
- edb/server/pgproto
```

To make language server work regardless, I had to cleanup a few imports so modules don't depend on other modules existing:

- Make edb/schema not depend on edb/server
- Make edb/server not depend on pg_config

---

If this whole project were to be converted to Rust, we'd probably segment it into crates corresponding to directories in `edb/`. We would need to create a DAG of dependencies between crates, and cleanup all references to stuff that is not dependent crates.

The DAG would be something like this:

```
edgeql -> edgeql-parser, ir, common, (also schema)
pgsql -> ir, edgeql, (also schema)
schema -> lib, edgeql, ir, pgsql (many of these are because of delta ops)
server -> edgeql, schema, protocol, lib
```
