### PR TITLE
workflows: Use an explicit label when selecting runners for builds

### DIFF
--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -10,125 +10,125 @@ targets:
           platform: debian
           platform_version: buster
           family: debian
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
           docker_arch: linux/amd64
         - name: debian-buster-aarch64
           arch: aarch64
           platform: debian
           platform_version: buster
           family: debian
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
           docker_arch: linux/arm64
         - name: debian-bullseye-x86_64
           arch: x86_64
           platform: debian
           platform_version: bullseye
           family: debian
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: debian-bullseye-aarch64
           arch: aarch64
           platform: debian
           platform_version: bullseye
           family: debian
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: debian-bookworm-x86_64
           arch: x86_64
           platform: debian
           platform_version: bookworm
           family: debian
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: debian-bookworm-aarch64
           arch: aarch64
           platform: debian
           platform_version: bookworm
           family: debian
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: ubuntu-bionic-x86_64
           arch: x86_64
           platform: ubuntu
           platform_version: bionic
           family: debian
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: ubuntu-bionic-aarch64
           arch: aarch64
           platform: ubuntu
           platform_version: bionic
           family: debian
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: ubuntu-focal-x86_64
           arch: x86_64
           platform: ubuntu
           platform_version: focal
           family: debian
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: ubuntu-focal-aarch64
           arch: aarch64
           platform: ubuntu
           platform_version: focal
           family: debian
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: ubuntu-jammy-x86_64
           arch: x86_64
           platform: ubuntu
           platform_version: jammy
           family: debian
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: ubuntu-jammy-aarch64
           arch: aarch64
           platform: ubuntu
           platform_version: jammy
           family: debian
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: centos-8-x86_64
           arch: x86_64
           platform: centos
           platform_version: 8
           family: redhat
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: centos-8-aarch64
           arch: aarch64
           platform: centos
           platform_version: 8
           family: redhat
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: rockylinux-9-x86_64
           arch: x86_64
           platform: rockylinux
           platform_version: 9
           family: redhat
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: rockylinux-9-aarch64
           arch: aarch64
           platform: rockylinux
           platform_version: 9
           family: redhat
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: linux-x86_64
           arch: x86_64
           platform: linux
           platform_version: x86_64
           family: generic
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: linux-aarch64
           arch: aarch64
           platform: linux
           platform_version: aarch64
           family: generic
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
         - name: linuxmusl-x86_64
           arch: x86_64
           platform: linux
           platform_version: x86_64
           platform_libc: musl
           family: generic
-          runs_on: [self-hosted, linux, x64]
+          runs_on: [package-builder, self-hosted, linux, x64]
         - name: linuxmusl-aarch64
           arch: aarch64
           platform: linux
           platform_version: aarch64
           platform_libc: musl
           family: generic
-          runs_on: [self-hosted, linux, arm64]
+          runs_on: [package-builder, self-hosted, linux, arm64]
 
     macos:
         - name: macos-x86_64

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -362,7 +362,7 @@ jobs:
 
 
   build-debian-buster-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_buster_x86_64 == 'true'
@@ -386,7 +386,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-buster-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_buster_aarch64 == 'true'
@@ -410,7 +410,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-bullseye-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bullseye_x86_64 == 'true'
@@ -434,7 +434,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bullseye-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bullseye_aarch64 == 'true'
@@ -458,7 +458,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bookworm-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bookworm_x86_64 == 'true'
@@ -482,7 +482,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-debian-bookworm-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bookworm_aarch64 == 'true'
@@ -506,7 +506,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-ubuntu-bionic-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_bionic_x86_64 == 'true'
@@ -530,7 +530,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-bionic-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_bionic_aarch64 == 'true'
@@ -554,7 +554,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-focal-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_focal_x86_64 == 'true'
@@ -578,7 +578,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-focal-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_focal_aarch64 == 'true'
@@ -602,7 +602,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-jammy-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_jammy_x86_64 == 'true'
@@ -626,7 +626,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-ubuntu-jammy-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_jammy_aarch64 == 'true'
@@ -650,7 +650,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-centos-8-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_centos_8_x86_64 == 'true'
@@ -674,7 +674,7 @@ jobs:
         path: artifacts/centos-8
 
   build-centos-8-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_centos_8_aarch64 == 'true'
@@ -698,7 +698,7 @@ jobs:
         path: artifacts/centos-8
 
   build-rockylinux-9-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_rockylinux_9_x86_64 == 'true'
@@ -722,7 +722,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-rockylinux-9-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_rockylinux_9_aarch64 == 'true'
@@ -746,7 +746,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-linux-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_linux_x86_64 == 'true'
@@ -771,7 +771,7 @@ jobs:
         path: artifacts/linux-x86_64
 
   build-linux-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_linux_aarch64 == 'true'
@@ -796,7 +796,7 @@ jobs:
         path: artifacts/linux-aarch64
 
   build-linuxmusl-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_linuxmusl_x86_64 == 'true'
@@ -822,7 +822,7 @@ jobs:
         path: artifacts/linuxmusl-x86_64
 
   build-linuxmusl-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_linuxmusl_aarch64 == 'true'
@@ -965,7 +965,7 @@ jobs:
 
   test-debian-buster-x86_64:
     needs: [build-debian-buster-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -986,7 +986,7 @@ jobs:
 
   test-debian-buster-aarch64:
     needs: [build-debian-buster-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1007,7 +1007,7 @@ jobs:
 
   test-debian-bullseye-x86_64:
     needs: [build-debian-bullseye-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1028,7 +1028,7 @@ jobs:
 
   test-debian-bullseye-aarch64:
     needs: [build-debian-bullseye-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1049,7 +1049,7 @@ jobs:
 
   test-debian-bookworm-x86_64:
     needs: [build-debian-bookworm-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1070,7 +1070,7 @@ jobs:
 
   test-debian-bookworm-aarch64:
     needs: [build-debian-bookworm-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1091,7 +1091,7 @@ jobs:
 
   test-ubuntu-bionic-x86_64:
     needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1112,7 +1112,7 @@ jobs:
 
   test-ubuntu-bionic-aarch64:
     needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1133,7 +1133,7 @@ jobs:
 
   test-ubuntu-focal-x86_64:
     needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1154,7 +1154,7 @@ jobs:
 
   test-ubuntu-focal-aarch64:
     needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1175,7 +1175,7 @@ jobs:
 
   test-ubuntu-jammy-x86_64:
     needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1196,7 +1196,7 @@ jobs:
 
   test-ubuntu-jammy-aarch64:
     needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1217,7 +1217,7 @@ jobs:
 
   test-centos-8-x86_64:
     needs: [build-centos-8-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1238,7 +1238,7 @@ jobs:
 
   test-centos-8-aarch64:
     needs: [build-centos-8-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1259,7 +1259,7 @@ jobs:
 
   test-rockylinux-9-x86_64:
     needs: [build-rockylinux-9-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1280,7 +1280,7 @@ jobs:
 
   test-rockylinux-9-aarch64:
     needs: [build-rockylinux-9-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1301,7 +1301,7 @@ jobs:
 
   test-linux-x86_64:
     needs: [build-linux-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1322,7 +1322,7 @@ jobs:
 
   test-linux-aarch64:
     needs: [build-linux-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1343,7 +1343,7 @@ jobs:
 
   test-linuxmusl-x86_64:
     needs: [build-linuxmusl-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1364,7 +1364,7 @@ jobs:
 
   test-linuxmusl-aarch64:
     needs: [build-linuxmusl-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -367,7 +367,7 @@ jobs:
 
 
   build-debian-buster-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_buster_x86_64 == 'true'
@@ -391,7 +391,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-buster-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_buster_aarch64 == 'true'
@@ -415,7 +415,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-bullseye-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bullseye_x86_64 == 'true'
@@ -439,7 +439,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bullseye-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bullseye_aarch64 == 'true'
@@ -463,7 +463,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bookworm-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bookworm_x86_64 == 'true'
@@ -487,7 +487,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-debian-bookworm-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_debian_bookworm_aarch64 == 'true'
@@ -511,7 +511,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-ubuntu-bionic-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_bionic_x86_64 == 'true'
@@ -535,7 +535,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-bionic-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_bionic_aarch64 == 'true'
@@ -559,7 +559,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-focal-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_focal_x86_64 == 'true'
@@ -583,7 +583,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-focal-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_focal_aarch64 == 'true'
@@ -607,7 +607,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-jammy-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_jammy_x86_64 == 'true'
@@ -631,7 +631,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-ubuntu-jammy-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_ubuntu_jammy_aarch64 == 'true'
@@ -655,7 +655,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-centos-8-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_centos_8_x86_64 == 'true'
@@ -679,7 +679,7 @@ jobs:
         path: artifacts/centos-8
 
   build-centos-8-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_centos_8_aarch64 == 'true'
@@ -703,7 +703,7 @@ jobs:
         path: artifacts/centos-8
 
   build-rockylinux-9-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_rockylinux_9_x86_64 == 'true'
@@ -727,7 +727,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-rockylinux-9-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_rockylinux_9_aarch64 == 'true'
@@ -751,7 +751,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-linux-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_linux_x86_64 == 'true'
@@ -776,7 +776,7 @@ jobs:
         path: artifacts/linux-x86_64
 
   build-linux-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_linux_aarch64 == 'true'
@@ -801,7 +801,7 @@ jobs:
         path: artifacts/linux-aarch64
 
   build-linuxmusl-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
     if: needs.prep.outputs.if_linuxmusl_x86_64 == 'true'
@@ -827,7 +827,7 @@ jobs:
         path: artifacts/linuxmusl-x86_64
 
   build-linuxmusl-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
     if: needs.prep.outputs.if_linuxmusl_aarch64 == 'true'
@@ -970,7 +970,7 @@ jobs:
 
   test-debian-buster-x86_64:
     needs: [build-debian-buster-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -991,7 +991,7 @@ jobs:
 
   test-debian-buster-aarch64:
     needs: [build-debian-buster-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1012,7 +1012,7 @@ jobs:
 
   test-debian-bullseye-x86_64:
     needs: [build-debian-bullseye-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1033,7 +1033,7 @@ jobs:
 
   test-debian-bullseye-aarch64:
     needs: [build-debian-bullseye-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1054,7 +1054,7 @@ jobs:
 
   test-debian-bookworm-x86_64:
     needs: [build-debian-bookworm-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1075,7 +1075,7 @@ jobs:
 
   test-debian-bookworm-aarch64:
     needs: [build-debian-bookworm-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1096,7 +1096,7 @@ jobs:
 
   test-ubuntu-bionic-x86_64:
     needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1117,7 +1117,7 @@ jobs:
 
   test-ubuntu-bionic-aarch64:
     needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1138,7 +1138,7 @@ jobs:
 
   test-ubuntu-focal-x86_64:
     needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1159,7 +1159,7 @@ jobs:
 
   test-ubuntu-focal-aarch64:
     needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1180,7 +1180,7 @@ jobs:
 
   test-ubuntu-jammy-x86_64:
     needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1201,7 +1201,7 @@ jobs:
 
   test-ubuntu-jammy-aarch64:
     needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1222,7 +1222,7 @@ jobs:
 
   test-centos-8-x86_64:
     needs: [build-centos-8-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1243,7 +1243,7 @@ jobs:
 
   test-centos-8-aarch64:
     needs: [build-centos-8-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1264,7 +1264,7 @@ jobs:
 
   test-rockylinux-9-x86_64:
     needs: [build-rockylinux-9-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1285,7 +1285,7 @@ jobs:
 
   test-rockylinux-9-aarch64:
     needs: [build-rockylinux-9-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1306,7 +1306,7 @@ jobs:
 
   test-linux-x86_64:
     needs: [build-linux-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1327,7 +1327,7 @@ jobs:
 
   test-linux-aarch64:
     needs: [build-linux-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1348,7 +1348,7 @@ jobs:
 
   test-linuxmusl-x86_64:
     needs: [build-linuxmusl-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1369,7 +1369,7 @@ jobs:
 
   test-linuxmusl-aarch64:
     needs: [build-linuxmusl-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1463,7 +1463,7 @@ jobs:
 
   check-published-debian-buster-x86_64:
     needs: [publish-debian-buster-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1515,7 +1515,7 @@ jobs:
 
   check-published-debian-buster-aarch64:
     needs: [publish-debian-buster-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1567,7 +1567,7 @@ jobs:
 
   check-published-debian-bullseye-x86_64:
     needs: [publish-debian-bullseye-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1619,7 +1619,7 @@ jobs:
 
   check-published-debian-bullseye-aarch64:
     needs: [publish-debian-bullseye-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1671,7 +1671,7 @@ jobs:
 
   check-published-debian-bookworm-x86_64:
     needs: [publish-debian-bookworm-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1723,7 +1723,7 @@ jobs:
 
   check-published-debian-bookworm-aarch64:
     needs: [publish-debian-bookworm-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1775,7 +1775,7 @@ jobs:
 
   check-published-ubuntu-bionic-x86_64:
     needs: [publish-ubuntu-bionic-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1827,7 +1827,7 @@ jobs:
 
   check-published-ubuntu-bionic-aarch64:
     needs: [publish-ubuntu-bionic-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1879,7 +1879,7 @@ jobs:
 
   check-published-ubuntu-focal-x86_64:
     needs: [publish-ubuntu-focal-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1931,7 +1931,7 @@ jobs:
 
   check-published-ubuntu-focal-aarch64:
     needs: [publish-ubuntu-focal-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1983,7 +1983,7 @@ jobs:
 
   check-published-ubuntu-jammy-x86_64:
     needs: [publish-ubuntu-jammy-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2035,7 +2035,7 @@ jobs:
 
   check-published-ubuntu-jammy-aarch64:
     needs: [publish-ubuntu-jammy-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2087,7 +2087,7 @@ jobs:
 
   check-published-centos-8-x86_64:
     needs: [publish-centos-8-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2139,7 +2139,7 @@ jobs:
 
   check-published-centos-8-aarch64:
     needs: [publish-centos-8-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2191,7 +2191,7 @@ jobs:
 
   check-published-rockylinux-9-x86_64:
     needs: [publish-rockylinux-9-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2243,7 +2243,7 @@ jobs:
 
   check-published-rockylinux-9-aarch64:
     needs: [publish-rockylinux-9-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2295,7 +2295,7 @@ jobs:
 
   check-published-linux-x86_64:
     needs: [publish-linux-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2347,7 +2347,7 @@ jobs:
 
   check-published-linux-aarch64:
     needs: [publish-linux-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2399,7 +2399,7 @@ jobs:
 
   check-published-linuxmusl-x86_64:
     needs: [publish-linuxmusl-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2451,7 +2451,7 @@ jobs:
 
   check-published-linuxmusl-aarch64:
     needs: [publish-linuxmusl-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
 
   build-debian-buster-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -45,7 +45,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-buster-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -67,7 +67,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-bullseye-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -89,7 +89,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bullseye-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -111,7 +111,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bookworm-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -133,7 +133,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-debian-bookworm-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -155,7 +155,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-ubuntu-bionic-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -177,7 +177,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-bionic-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -199,7 +199,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-focal-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -221,7 +221,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-focal-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -243,7 +243,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-jammy-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -265,7 +265,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-ubuntu-jammy-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -287,7 +287,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-centos-8-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -309,7 +309,7 @@ jobs:
         path: artifacts/centos-8
 
   build-centos-8-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -331,7 +331,7 @@ jobs:
         path: artifacts/centos-8
 
   build-rockylinux-9-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -353,7 +353,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-rockylinux-9-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -375,7 +375,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-linux-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -398,7 +398,7 @@ jobs:
         path: artifacts/linux-x86_64
 
   build-linux-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -421,7 +421,7 @@ jobs:
         path: artifacts/linux-aarch64
 
   build-linuxmusl-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -445,7 +445,7 @@ jobs:
         path: artifacts/linuxmusl-x86_64
 
   build-linuxmusl-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -582,7 +582,7 @@ jobs:
 
   test-debian-buster-x86_64:
     needs: [build-debian-buster-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -602,7 +602,7 @@ jobs:
 
   test-debian-buster-aarch64:
     needs: [build-debian-buster-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -622,7 +622,7 @@ jobs:
 
   test-debian-bullseye-x86_64:
     needs: [build-debian-bullseye-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -642,7 +642,7 @@ jobs:
 
   test-debian-bullseye-aarch64:
     needs: [build-debian-bullseye-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -662,7 +662,7 @@ jobs:
 
   test-debian-bookworm-x86_64:
     needs: [build-debian-bookworm-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -682,7 +682,7 @@ jobs:
 
   test-debian-bookworm-aarch64:
     needs: [build-debian-bookworm-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -702,7 +702,7 @@ jobs:
 
   test-ubuntu-bionic-x86_64:
     needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -722,7 +722,7 @@ jobs:
 
   test-ubuntu-bionic-aarch64:
     needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -742,7 +742,7 @@ jobs:
 
   test-ubuntu-focal-x86_64:
     needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -762,7 +762,7 @@ jobs:
 
   test-ubuntu-focal-aarch64:
     needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -782,7 +782,7 @@ jobs:
 
   test-ubuntu-jammy-x86_64:
     needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -802,7 +802,7 @@ jobs:
 
   test-ubuntu-jammy-aarch64:
     needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -822,7 +822,7 @@ jobs:
 
   test-centos-8-x86_64:
     needs: [build-centos-8-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -842,7 +842,7 @@ jobs:
 
   test-centos-8-aarch64:
     needs: [build-centos-8-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -862,7 +862,7 @@ jobs:
 
   test-rockylinux-9-x86_64:
     needs: [build-rockylinux-9-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -882,7 +882,7 @@ jobs:
 
   test-rockylinux-9-aarch64:
     needs: [build-rockylinux-9-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -902,7 +902,7 @@ jobs:
 
   test-linux-x86_64:
     needs: [build-linux-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -922,7 +922,7 @@ jobs:
 
   test-linux-aarch64:
     needs: [build-linux-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -942,7 +942,7 @@ jobs:
 
   test-linuxmusl-x86_64:
     needs: [build-linuxmusl-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -962,7 +962,7 @@ jobs:
 
   test-linuxmusl-aarch64:
     needs: [build-linuxmusl-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1079,7 +1079,7 @@ jobs:
 
   check-published-debian-buster-x86_64:
     needs: [publish-debian-buster-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1129,7 +1129,7 @@ jobs:
 
   check-published-debian-buster-aarch64:
     needs: [publish-debian-buster-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1179,7 +1179,7 @@ jobs:
 
   check-published-debian-bullseye-x86_64:
     needs: [publish-debian-bullseye-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1229,7 +1229,7 @@ jobs:
 
   check-published-debian-bullseye-aarch64:
     needs: [publish-debian-bullseye-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1279,7 +1279,7 @@ jobs:
 
   check-published-debian-bookworm-x86_64:
     needs: [publish-debian-bookworm-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1329,7 +1329,7 @@ jobs:
 
   check-published-debian-bookworm-aarch64:
     needs: [publish-debian-bookworm-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1379,7 +1379,7 @@ jobs:
 
   check-published-ubuntu-bionic-x86_64:
     needs: [publish-ubuntu-bionic-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1429,7 +1429,7 @@ jobs:
 
   check-published-ubuntu-bionic-aarch64:
     needs: [publish-ubuntu-bionic-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1479,7 +1479,7 @@ jobs:
 
   check-published-ubuntu-focal-x86_64:
     needs: [publish-ubuntu-focal-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1529,7 +1529,7 @@ jobs:
 
   check-published-ubuntu-focal-aarch64:
     needs: [publish-ubuntu-focal-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1579,7 +1579,7 @@ jobs:
 
   check-published-ubuntu-jammy-x86_64:
     needs: [publish-ubuntu-jammy-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1629,7 +1629,7 @@ jobs:
 
   check-published-ubuntu-jammy-aarch64:
     needs: [publish-ubuntu-jammy-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1679,7 +1679,7 @@ jobs:
 
   check-published-centos-8-x86_64:
     needs: [publish-centos-8-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1729,7 +1729,7 @@ jobs:
 
   check-published-centos-8-aarch64:
     needs: [publish-centos-8-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1779,7 +1779,7 @@ jobs:
 
   check-published-rockylinux-9-x86_64:
     needs: [publish-rockylinux-9-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1829,7 +1829,7 @@ jobs:
 
   check-published-rockylinux-9-aarch64:
     needs: [publish-rockylinux-9-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1879,7 +1879,7 @@ jobs:
 
   check-published-linux-x86_64:
     needs: [publish-linux-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1929,7 +1929,7 @@ jobs:
 
   check-published-linux-aarch64:
     needs: [publish-linux-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1979,7 +1979,7 @@ jobs:
 
   check-published-linuxmusl-x86_64:
     needs: [publish-linuxmusl-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2029,7 +2029,7 @@ jobs:
 
   check-published-linuxmusl-aarch64:
     needs: [publish-linuxmusl-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
 
 
   build-debian-buster-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -46,7 +46,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-buster-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -69,7 +69,7 @@ jobs:
         path: artifacts/debian-buster
 
   build-debian-bullseye-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -92,7 +92,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bullseye-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -115,7 +115,7 @@ jobs:
         path: artifacts/debian-bullseye
 
   build-debian-bookworm-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -138,7 +138,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-debian-bookworm-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -161,7 +161,7 @@ jobs:
         path: artifacts/debian-bookworm
 
   build-ubuntu-bionic-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -184,7 +184,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-bionic-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -207,7 +207,7 @@ jobs:
         path: artifacts/ubuntu-bionic
 
   build-ubuntu-focal-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -230,7 +230,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-focal-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -253,7 +253,7 @@ jobs:
         path: artifacts/ubuntu-focal
 
   build-ubuntu-jammy-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -276,7 +276,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-ubuntu-jammy-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -299,7 +299,7 @@ jobs:
         path: artifacts/ubuntu-jammy
 
   build-centos-8-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -322,7 +322,7 @@ jobs:
         path: artifacts/centos-8
 
   build-centos-8-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -345,7 +345,7 @@ jobs:
         path: artifacts/centos-8
 
   build-rockylinux-9-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -368,7 +368,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-rockylinux-9-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -391,7 +391,7 @@ jobs:
         path: artifacts/rockylinux-9
 
   build-linux-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -415,7 +415,7 @@ jobs:
         path: artifacts/linux-x86_64
 
   build-linux-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -439,7 +439,7 @@ jobs:
         path: artifacts/linux-aarch64
 
   build-linuxmusl-x86_64:
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
     needs: prep
 
 
@@ -464,7 +464,7 @@ jobs:
         path: artifacts/linuxmusl-x86_64
 
   build-linuxmusl-aarch64:
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
@@ -604,7 +604,7 @@ jobs:
 
   test-debian-buster-x86_64:
     needs: [build-debian-buster-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -625,7 +625,7 @@ jobs:
 
   test-debian-buster-aarch64:
     needs: [build-debian-buster-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -646,7 +646,7 @@ jobs:
 
   test-debian-bullseye-x86_64:
     needs: [build-debian-bullseye-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -667,7 +667,7 @@ jobs:
 
   test-debian-bullseye-aarch64:
     needs: [build-debian-bullseye-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -688,7 +688,7 @@ jobs:
 
   test-debian-bookworm-x86_64:
     needs: [build-debian-bookworm-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -709,7 +709,7 @@ jobs:
 
   test-debian-bookworm-aarch64:
     needs: [build-debian-bookworm-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -730,7 +730,7 @@ jobs:
 
   test-ubuntu-bionic-x86_64:
     needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -751,7 +751,7 @@ jobs:
 
   test-ubuntu-bionic-aarch64:
     needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -772,7 +772,7 @@ jobs:
 
   test-ubuntu-focal-x86_64:
     needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -793,7 +793,7 @@ jobs:
 
   test-ubuntu-focal-aarch64:
     needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -814,7 +814,7 @@ jobs:
 
   test-ubuntu-jammy-x86_64:
     needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -835,7 +835,7 @@ jobs:
 
   test-ubuntu-jammy-aarch64:
     needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -856,7 +856,7 @@ jobs:
 
   test-centos-8-x86_64:
     needs: [build-centos-8-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -877,7 +877,7 @@ jobs:
 
   test-centos-8-aarch64:
     needs: [build-centos-8-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -898,7 +898,7 @@ jobs:
 
   test-rockylinux-9-x86_64:
     needs: [build-rockylinux-9-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -919,7 +919,7 @@ jobs:
 
   test-rockylinux-9-aarch64:
     needs: [build-rockylinux-9-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -940,7 +940,7 @@ jobs:
 
   test-linux-x86_64:
     needs: [build-linux-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -961,7 +961,7 @@ jobs:
 
   test-linux-aarch64:
     needs: [build-linux-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -982,7 +982,7 @@ jobs:
 
   test-linuxmusl-x86_64:
     needs: [build-linuxmusl-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1003,7 +1003,7 @@ jobs:
 
   test-linuxmusl-aarch64:
     needs: [build-linuxmusl-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1124,7 +1124,7 @@ jobs:
 
   check-published-debian-buster-x86_64:
     needs: [publish-debian-buster-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1176,7 +1176,7 @@ jobs:
 
   check-published-debian-buster-aarch64:
     needs: [publish-debian-buster-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1228,7 +1228,7 @@ jobs:
 
   check-published-debian-bullseye-x86_64:
     needs: [publish-debian-bullseye-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1280,7 +1280,7 @@ jobs:
 
   check-published-debian-bullseye-aarch64:
     needs: [publish-debian-bullseye-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1332,7 +1332,7 @@ jobs:
 
   check-published-debian-bookworm-x86_64:
     needs: [publish-debian-bookworm-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1384,7 +1384,7 @@ jobs:
 
   check-published-debian-bookworm-aarch64:
     needs: [publish-debian-bookworm-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1436,7 +1436,7 @@ jobs:
 
   check-published-ubuntu-bionic-x86_64:
     needs: [publish-ubuntu-bionic-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1488,7 +1488,7 @@ jobs:
 
   check-published-ubuntu-bionic-aarch64:
     needs: [publish-ubuntu-bionic-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1540,7 +1540,7 @@ jobs:
 
   check-published-ubuntu-focal-x86_64:
     needs: [publish-ubuntu-focal-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1592,7 +1592,7 @@ jobs:
 
   check-published-ubuntu-focal-aarch64:
     needs: [publish-ubuntu-focal-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1644,7 +1644,7 @@ jobs:
 
   check-published-ubuntu-jammy-x86_64:
     needs: [publish-ubuntu-jammy-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1696,7 +1696,7 @@ jobs:
 
   check-published-ubuntu-jammy-aarch64:
     needs: [publish-ubuntu-jammy-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1748,7 +1748,7 @@ jobs:
 
   check-published-centos-8-x86_64:
     needs: [publish-centos-8-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1800,7 +1800,7 @@ jobs:
 
   check-published-centos-8-aarch64:
     needs: [publish-centos-8-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1852,7 +1852,7 @@ jobs:
 
   check-published-rockylinux-9-x86_64:
     needs: [publish-rockylinux-9-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1904,7 +1904,7 @@ jobs:
 
   check-published-rockylinux-9-aarch64:
     needs: [publish-rockylinux-9-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -1956,7 +1956,7 @@ jobs:
 
   check-published-linux-x86_64:
     needs: [publish-linux-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2008,7 +2008,7 @@ jobs:
 
   check-published-linux-aarch64:
     needs: [publish-linux-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2060,7 +2060,7 @@ jobs:
 
   check-published-linuxmusl-x86_64:
     needs: [publish-linuxmusl-x86_64]
-    runs-on: ['self-hosted', 'linux', 'x64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
     - uses: actions/download-artifact@v4
@@ -2112,7 +2112,7 @@ jobs:
 
   check-published-linuxmusl-aarch64:
     needs: [publish-linuxmusl-aarch64]
-    runs-on: ['self-hosted', 'linux', 'arm64']
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
We are relabeling our self-hosted runners to avoid conflicts between
them, so be more specific about the target here.
