### PR TITLE
Remove primary key constraint on 'id'.

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5811,15 +5811,6 @@ class PropertyMetaCommand(PointerMetaCommand[s_props.Property]):
                         cmd = dbops.AlterTableAddColumn(col)
                         alter_table.add_operation(cmd)
 
-                        if col.name == 'id':
-                            constraint = dbops.PrimaryKey(
-                                table_name=alter_table.name,
-                                columns=[col.name],
-                            )
-                            alter_table.add_operation(
-                                dbops.AlterTableAddConstraint(constraint),
-                            )
-
                     self.pgops.add(alter_table)
 
                 self.schedule_inhview_source_update(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16916,9 +16916,6 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         self.assertEqual(cnt, 1)
         self.assertEqual(len(objs), 1)
 
-    @test.xfail('''
-        Issue #7413: We create two indexes on `.id`
-    ''')
     async def test_edgeql_ddl_single_index(self):
         # Test that types only have a single index for id
         await self.con.execute('''


### PR DESCRIPTION
Remove special creation of primary key constraint on `id` column.

close #7413