### PR TITLE
Remove xfail on two alias tests

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4644,18 +4644,6 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }],
         )
 
-    @test.xerror('''
-        edgedb.errors.SchemaError: ObjectType 'test::Base' is already
-        present in the schema <Schema gen:3757 at 0x7fc3319fa820>
-
-        Exception: Error while processing
-        'CREATE ALIAS test::Base := (
-            SELECT
-                test::Child {
-                    bar := test::Child
-                }
-        );'
-    ''')
     async def test_edgeql_migration_eq_23(self):
         await self.migrate(r"""
             type Child {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5092,26 +5092,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             );
         """])
 
-    @test.xerror(
-        '''
-        This wants to transmute an object type into an alias. It
-        produces DDL, but the DDL doesn't really make any sense. We
-        are going to probably need to add DDL syntax to accomplish
-        this.
-
-        Before we do that, we could just improve the error:
-        cannot produce migration because of a dependency cycle:
-          create alias 'default::Base' depends on
-          alter object type 'default::Alias01' depends on
-          create object type 'default::Base' depends on
-          drop object type 'default::Base' depends on
-          drop link '__type__' of object type 'default::Base' depends on
-          alter link '__type__' of link '__type__' depends on
-          alter object type 'default::Alias01' of
-            object type 'default::Alias01' depends on
-          create alias 'default::Base'
-        '''
-    )
     def test_schema_migrations_equivalence_23(self):
         self._assert_migration_equivalence([r"""
             type Child {


### PR DESCRIPTION
These two tests were fixed by #7380.

Apparently, they failing because we were not correctly detecting created schema types. I'm not sure exactly why, but it does not matter now.