### PR TITLE
Fix recursive definition error when computed property refers to different object's computed property.

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -885,7 +885,13 @@ def trace_Path(
                                 # We haven't computed the target yet,
                                 # so try computing it now.
                                 ctx.visited.add(ptr)
-                                ptr_target = trace(ptr.target_expr, ctx=ctx)
+
+                                target_ctx = _fork_context(ctx)
+                                target_ctx.path_prefix = sname
+                                ptr_target = trace(
+                                    ptr.target_expr, ctx=target_ctx
+                                )
+
                                 if isinstance(ptr_target, (Type,
                                                            s_types.Type)):
                                     tip = ptr.target = ptr_target

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4186,6 +4186,23 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_get_migration_55(self):
+        # In Bar, `.foo.b` refers to `.a`. Ensure that when tracing, `.a` is
+        # correctly `Foo.a`, otherwise a recurisve definition is found.
+        schema = r'''
+            type Foo {
+                property a -> str;
+                property b := .a;
+            }
+
+            type Bar {
+                property a := .foo.b;
+                link foo -> Foo;
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6437,8 +6437,8 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         with self.assertRaisesRegex(
             errors.InvalidDefinitionError,
             "definition dependency cycle between "
-            "property 'val' of object type 'default::Bar' and "
-            "property 'val' of object type 'default::Foo'"
+            "property 'val' of object type 'default::Foo' and "
+            "property 'val' of object type 'default::Bar'"
         ):
             self._assert_migration_equivalence([r"""
                 type Foo {


### PR DESCRIPTION
In the following schema
```
  type Foo {
    property a -> str;
    property b := .a;
  }

  type Bar {
    property a := .foo.b;
    link foo -> Foo;
  }
```

`Bar.a` refers to `Foo.b`, which refers to `Foo.a`. During path tracing, the `.a` was mistakenly taken to be `Bar.a` resulting in a faulty recursive definition error.

close #5063