### PR TITLE
Start namespacing and trampolining the standard library

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_06_05_00_00
+EDGEDB_CATALOG_VERSION = 2024_06_06_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -106,6 +106,7 @@ from .common import quote_type as qt
 from . import compiler
 from . import codegen
 from . import schemamech
+from . import trampoline
 from . import types
 
 if TYPE_CHECKING:
@@ -1177,8 +1178,14 @@ class FunctionCommand(MetaCommand):
     def make_function(self, func: s_funcs.Function, code, schema):
         func_return_typemod = func.get_return_typemod(schema)
         func_params = func.get_params(schema)
-        return dbops.Function(
-            name=self.get_pgname(func, schema),
+
+        name = self.get_pgname(func, schema)
+        cls = (
+            trampoline.VersionedFunction if name[0] == 'edgedbstd'
+            else dbops.Function
+        )
+        return cls(
+            name=name,
             args=self.compile_args(func, schema),
             has_variadic=func_params.find_variadic(schema) is not None,
             set_returning=func_return_typemod is ql_ft.TypeModifier.SetOfType,
@@ -1186,7 +1193,8 @@ class FunctionCommand(MetaCommand):
             strict=func.get_impl_is_strict(schema),
             returns=self.get_pgtype(
                 func, func.get_return_type(schema), schema),
-            text=code)
+            text=code,
+        )
 
     def compile_sql_function(self, func: s_funcs.Function, schema):
         return self.make_function(func, func.get_code(schema), schema)
@@ -1564,8 +1572,17 @@ class FunctionCommand(MetaCommand):
                     f'unsupported language {func_language}',
                     span=self.span)
 
-            op = dbops.CreateFunction(dbf, or_replace=or_replace)
-            return (op,)
+            ops = []
+
+            ops.append(dbops.CreateFunction(dbf, or_replace=or_replace))
+            # XXX: TRAMPOLINE: Is this where we want to do this???
+            if isinstance(dbf, trampoline.VersionedFunction):
+                ops.append(
+                    dbops.CreateFunction(
+                        trampoline.make_trampoline(dbf), or_replace=True
+                    )
+                )
+            return ops
 
 
 class CreateFunction(

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -7417,12 +7417,6 @@ async def execute_sql_script(
 ) -> None:
     from edb.server import pgcon
 
-    try:
-        with open('bootstrap_script.sql', 'a') as f:
-            f.write(sql_text)
-    except Exception:
-        pass
-
     if debug.flags.bootstrap:
         debug.header('Bootstrap Script')
         if len(sql_text) > 102400:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -7417,6 +7417,12 @@ async def execute_sql_script(
 ) -> None:
     from edb.server import pgcon
 
+    try:
+        with open('bootstrap_script.sql', 'a') as f:
+            f.write(sql_text)
+    except Exception:
+        pass
+
     if debug.flags.bootstrap:
         debug.header('Bootstrap Script')
         if len(sql_text) > 102400:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -6881,13 +6881,14 @@ def get_support_views(
     for alias_view in sys_alias_views:
         commands.add_command(dbops.CreateView(alias_view, or_replace=True))
 
+    # TODO: XXX: We still want to trampoline fewer of these.
+    # Currently we only skip the information schema stuff.
+    trampolines = []
+    trampolines.extend(trampoline_command(commands))
+
     commands.add_commands(_generate_sql_information_schema())
 
-    # TODO: XXX: We do not actually want to trampoline all of these!
-    # As few as possible, to be honest.
-    commands.add_commands(
-        trampoline_command(commands),
-    )
+    commands.add_commands(trampolines)
 
     return commands
 

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -25,6 +25,7 @@ import uuid
 from edb import errors
 
 from edb.pgsql import ast as pgast
+from edb.pgsql import trampoline
 
 from . import dispatch
 from . import context
@@ -331,8 +332,10 @@ def resolve_SortBy(
 
 
 func_calls_remapping: Dict[Tuple[str, ...], Tuple[str, ...]] = {
-    ('information_schema', '_pg_truetypid'): ('edgedbsql', '_pg_truetypid'),
-    ('information_schema', '_pg_truetypmod'): ('edgedbsql', '_pg_truetypmod'),
+    ('information_schema', '_pg_truetypid'): (
+        trampoline.versioned_schema('edgedbsql'), '_pg_truetypid'),
+    ('information_schema', '_pg_truetypmod'): (
+        trampoline.versioned_schema('edgedbsql'), '_pg_truetypmod'),
     ('pg_catalog', 'format_type'): ('edgedb', '_format_type'),
 }
 

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -27,6 +27,7 @@ from edb.server.pgcon import errors as pgerror
 from edb.pgsql import ast as pgast
 from edb.pgsql import common as pgcommon
 from edb.pgsql import codegen as pgcodegen
+from edb.pgsql import trampoline
 
 from edb.schema import objtypes as s_objtypes
 from edb.schema import links as s_links
@@ -223,9 +224,15 @@ def resolve_relation(
     # try information_schema, pg_catalog and pg_toast
     preset_tables = None
     if relation.schemaname == 'information_schema':
-        preset_tables = (sql_introspection.INFORMATION_SCHEMA, 'edgedbsql')
+        preset_tables = (
+            sql_introspection.INFORMATION_SCHEMA,
+            trampoline.versioned_schema('edgedbsql'),
+        )
     elif not relation.schemaname or relation.schemaname == 'pg_catalog':
-        preset_tables = (sql_introspection.PG_CATALOG, 'edgedbsql')
+        preset_tables = (
+            sql_introspection.PG_CATALOG,
+            trampoline.versioned_schema('edgedbsql'),
+        )
     elif relation.schemaname == 'pg_toast':
         preset_tables = ({relation.name: PG_TOAST_TABLE}, 'pg_toast')
 

--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -26,10 +26,13 @@ from edb import errors
 
 from edb.pgsql import ast as pgast
 from edb.pgsql import parser as pgparser
+from edb.pgsql import trampoline
 from edb.server import defines
 
 from . import context
 from . import dispatch
+
+V = trampoline.versioned_schema
 
 Context = context.ResolverContextLevel
 
@@ -255,7 +258,7 @@ def eval_FuncCall(
             'has_column_privilege',
         }
         if fn_name in has_wrapper:
-            return pgast.FuncCall(name=('edgedbsql', fn_name), args=fn_args)
+            return pgast.FuncCall(name=(V('edgedbsql'), fn_name), args=fn_args)
 
         return pgast.FuncCall(name=('pg_catalog', fn_name), args=fn_args)
 
@@ -271,7 +274,7 @@ def eval_FuncCall(
         )
 
         return pgast.FuncCall(
-            name=('edgedbsql', fn_name),
+            name=(V('edgedbsql'), fn_name),
             args=[arg_0, arg_1]
         )
 
@@ -343,8 +346,8 @@ def to_regclass(reg_class_name: str, ctx: Context) -> pgast.BaseExpr:
     [stmt] = pgparser.parse(
         f'''
         SELECT pc.oid
-        FROM edgedbsql.pg_class pc
-        JOIN edgedbsql.pg_namespace pn ON pn.oid = pc.relnamespace
+        FROM {V('edgedbsql')}.pg_class pc
+        JOIN {V('edgedbsql')}.pg_namespace pn ON pn.oid = pc.relnamespace
         WHERE {ql(namespace)} = pn.nspname AND pc.relname = {ql(rel_name)}
         '''
     )

--- a/edb/pgsql/trampoline.py
+++ b/edb/pgsql/trampoline.py
@@ -17,7 +17,21 @@
 #
 
 
-"""Support for namespacing and trampolining the standard library."""
+"""Support for namespacing and trampolining the standard library.
+
+The idea here is that all of the functions, tables, and views in
+edgedb/edgedbstd/edgedbsql should be moved into namespaced libraries
+of the form `edgedb_VER`, where VER will be substituted with some
+version identifier.
+
+Then, for anything that might be referenced by a function, constraint,
+etc, we will create a *trampoline* in the un-suffixed namespace.
+When doing (eventually) in-place version upgrades, we will create the
+new namespace and then update the trampolines to point to it.
+
+CURRENT STATUS: So far, functions and views are mostly
+namespaced. Standard library schema object tables aren't yet.
+"""
 
 from __future__ import annotations
 from typing import (
@@ -47,7 +61,7 @@ def versioned_schema(s: str, version: Optional[int]=None) -> str:
 
 V = versioned_schema
 
-SCHEMAS = ['edgedb', 'edgedbstd', 'edgedbsql']
+SCHEMAS = ('edgedb', 'edgedbstd', 'edgedbsql')
 
 
 def fixup_query(query: str) -> str:

--- a/edb/pgsql/trampoline.py
+++ b/edb/pgsql/trampoline.py
@@ -54,8 +54,12 @@ qi = common.quote_ident
 
 def versioned_schema(s: str, version: Optional[int]=None) -> str:
     if version is None:
-        # ... get_version_dict() is cached
+        # ... get_version_dict() is cached, so we use it instead of
+        # get_version(). We might change this to use catalog version at
+        # some point?
         version = buildmeta.get_version_dict()['major']
+    # N.B: We don't bother quoting the schema name, so make sure it is
+    # lower case and doesn't have weird characters.
     return f'{s}_v{version}'
 
 

--- a/edb/pgsql/trampoline.py
+++ b/edb/pgsql/trampoline.py
@@ -1,0 +1,120 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""Support for namespacing and trampolining the standard library."""
+
+from __future__ import annotations
+from typing import (
+    Optional,
+    TYPE_CHECKING,
+)
+
+import copy
+
+
+from edb import buildmeta
+
+from . import common
+from . import dbops
+
+
+q = common.qname
+qi = common.quote_ident
+
+
+def versioned_schema(s: str, version: Optional[int]=None) -> str:
+    if version is None:
+        # ... get_version_dict() is cached
+        version = buildmeta.get_version_dict()['major']
+    return f'{s}_v{version}'
+
+
+V = versioned_schema
+
+SCHEMAS = ['edgedb', 'edgedbstd', 'edgedbsql']
+
+
+def fixup_query(query: str) -> str:
+    for s in SCHEMAS:
+        query = query.replace(f"{s}_VER", V(s))
+    return query
+
+
+class VersionedFunction(dbops.Function):
+    if not TYPE_CHECKING:
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.name = (V(self.name[0]), *self.name[1:])
+            self.text = fixup_query(self.text)
+
+            if self.args:
+                nargs = []
+                for arg in self.args:
+                    if isinstance(arg, tuple) and isinstance(arg[1], tuple):
+                        new_name = (
+                            arg[1][0].replace('_VER', V('')), *arg[1][1:])
+                        arg = (arg[0], new_name, *arg[2:])
+                    nargs.append(arg)
+                self.args = nargs
+
+
+class VersionedView(dbops.View):
+    if not TYPE_CHECKING:
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.name = (V(self.name[0]), *self.name[1:])
+            self.query = fixup_query(self.query)
+
+
+def make_trampoline(func: dbops.Function) -> dbops.Function:
+    new_func = copy.copy(func)
+    schema, name = func.name
+    namespace = V('')
+    assert schema.endswith(namespace), schema
+    new_func.name = (schema[:-len(namespace)], name)
+
+    args = []
+    for arg in (func.args or ()):
+        if isinstance(arg, str):
+            args.append(arg)
+        else:
+            assert arg[0]
+            args.append(arg[0])
+    args = [qi(arg) for arg in args]
+    if func.has_variadic:
+        args[-1] = f'VARIADIC {args[-1]}'
+
+    new_func.text = f'select {q(*func.name)}({", ".join(args)})'
+    new_func.language = 'sql'
+    new_func.strict = False
+    return new_func
+
+
+def make_view_trampoline(view: dbops.View) -> dbops.View:
+    schema, name = view.name
+    namespace = V('')
+    assert schema.endswith(namespace), schema
+    new_name = (schema[:-len(namespace)], name)
+
+    return dbops.View(
+        name=new_name,
+        query=f'''
+            SELECT * FROM {q(*view.name)}
+        ''',
+    )


### PR DESCRIPTION
The idea here is that all of the functions, tables, and views in
edgedb/edgedbstd/edgedbsql should be moved into namespaced libraries
of the form `edgedb_VER`, where VER will be substituted with some
version identifier.

Then, for anything that might be referenced by a function, constraint,
etc, we will create a *trampoline* in the un-suffixed namespace.
When doing (eventually) in-place version upgrades, we will create the
new namespace and then update the trampolines to point to it.

So far, functions and views are mostly namespaced. Standard library
schema object tables aren't yet.