### PR TITLE
Fix SQL adapter COPY command

### DIFF
--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -106,11 +106,12 @@ def resolve_column_kind(
                 return pgast.ColumnRef(name=(table.reference_as, reference_as))
             else:
                 # In some cases tables might not have an assigned alias
-                # because that is not syntactically possible (COPY), or for some
-                # other reason.
-                # Here we make an assumption that in such cases, there is a
-                # single rel var in current context, so this will not be
-                # ambagious.
+                # because that is not syntactically possible (COPY), or because
+                # the table being referenced is currently being assembled
+                # (e.g. ORDER BY refers to a newly defined column).
+
+                # So we make an assumption that in such cases, this will not
+                # be ambiguous. I think this is not strictly correct.
                 return pgast.ColumnRef(name=(reference_as,))
 
         case context.ColumnStaticVal(val=val):

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -45,7 +45,7 @@ def resolve_BaseRangeVar(
         return _resolve_JoinExpr(range_var, ctx=ctx)
 
     # generate internal alias
-    internal_alias = ctx.names.get('relation')
+    internal_alias = ctx.names.get('rel')
     alias = pgast.Alias(
         aliasname=internal_alias, colnames=range_var.alias.colnames
     )

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1442,6 +1442,8 @@ class SQLQueryTestCase(BaseQueryTestCase):
 
     BASE_TEST_CLASS = True
 
+    scon: asyncpg.Connection
+
     @classmethod
     def setUpClass(cls):
         try:

--- a/tests/schemas/movies_setup.edgeql
+++ b/tests/schemas/movies_setup.edgeql
@@ -40,7 +40,7 @@ insert Movie {
         select Person { @role := 'Captain Miller' } filter .first_name = 'Tom'
     ),
     director := (
-        select Person filter .last_name = 'Spielberg' limit 1
+        select Person { @bar := 'bar' } filter .last_name = 'Spielberg' limit 1
     ),
     genre := (select Genre filter .name = 'Drama' limit 1),
 };
@@ -54,6 +54,12 @@ insert novel {
 insert Book {
     title:='Chronicles of Narnia',
     pages := 206,
+    chapters := {
+        'Lucy looks into a wardrobe',
+        'What Lucy found there',
+        'Edmund and the wardrobe',
+        'Turkish delight',
+    },
     genre:= (select Genre filter .name = 'Fiction' limit 1)
 };
 


### PR DESCRIPTION
Fixes a few bugs in COPY:

- copying link tables would fail because of missing id column,
- colnames were not handled correctly,