### PR TITLE
Improve test runner status rendering

### DIFF
--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -641,13 +641,14 @@ class MultiLineRenderer(BaseRenderer):
 
         print_empty_line()
         print_line(
-            f'Progress: {self.completed_tests}/{self.total_tests} tests.')
+            f'Progress: {self.completed_tests}/{self.total_tests} tests.'
+        )
 
-        if last_render:
-            if self.max_lines > len(lines):
-                for _ in range(self.max_lines - len(lines)):
-                    lines.insert(0, ' ' * cols)
-        else:
+        if self.max_lines > len(lines):
+            for _ in range(self.max_lines - len(lines)):
+                lines.insert(0, ' ' * cols)
+
+        if not last_render:
             # If it's not the last test, check if our render buffer
             # requires more rows than currently visible.
             if len(lines) + 1 > rows:


### PR DESCRIPTION
Fix of test runner status rendering which would sometimes display this:

![image](https://github.com/edgedb/edgedb/assets/11072061/0a1f0216-a296-4125-8359-54d57452ba38)


It can be reproduced by such tests:
```
    def test_debug_with_really_long_names_fast_1(self):
        import time
        time.sleep(1)
    def test_debug_with_really_long_names_fast_2(self):
        import time
        time.sleep(1)
    def test_debug_with_really_long_names_fast_3(self):
        import time
        time.sleep(1)
    def test_debug_with_really_long_names_fast_4(self):
        import time
        time.sleep(1)
    def test_debug_with_really_long_names_fast_5(self):
        import time
        time.sleep(1)
    def test_debug_with_really_long_names_fast_6(self):
        import time
        time.sleep(1)
    def test_debug_with_really_long_names_slow_1(self):
        import time
        time.sleep(5)
```