### PR TITLE
Fix issue with abstract types, exclusive constraints, and ANALYZE

### DIFF
--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -2065,6 +2065,14 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "messages violates exclusivity constraint"
         ):
             await self.con.execute("""
+                analyze
+                update ChatBase set { messages += 'hello world' };
+            """)
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "messages violates exclusivity constraint"
+        ):
+            await self.con.execute("""
                 update ChatBase set { messages := 'hello world' };
             """)
 


### PR DESCRIPTION
When we have inheritance views expanded (either by config or because
of ANALYZE), we fail to raise exclusive constraint errors caused by
`UPDATE`ing an abstract type such that two different subtypes have
conflicting values for a multi property. (See
`test_constraints_abstract_object_01`.)

This is because that query relies on explicitly looking for conflicts
in the query we generate, and doing that relies on pointer overlays
being used to look at the new values.

`range_for_ptrref` unfortunately has a bug when expanding inhviews
that prevents abstract types having overlays applied. This is because
of how range_for_ptrref is structured to apply overlays, which it does
mixed in with processing the expanded descendants.

I fixed this for now by disabling the optimization where we ignore
abstract types in expansions when there is an overlay to apply.  This
is a pretty hacky fix, though, and might not be worth landing.  I
think @dnwpark is going to need to untangle this in order to put
expanded pointers into CTEs, so maybe we should just fix it then.