### PR TITLE
Collect test results and render them in test-conclusion

### DIFF
--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Install Python deps
         run: |
-          python -m pip install requests
+          python -m pip install requests click
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -155,7 +155,7 @@ jobs:
       # Render results and exit if they were unsuccessful
       - name: Render results
         run: |
-          python edb/tools/test/results.py .results/result_*.json
+          python edb/tools/test/results.py '.results/result_*.json'
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -106,13 +106,13 @@ jobs:
         path: .results
         retention-days: 1
 
-  collect:
+  python-test-list:
     needs: build
     runs-on: ubuntu-latest
     steps:
     <<- restore_cache() >>
 
-    # Collect tests and upload
+    # List tests and upload
 
     - name: Generate complete list of tests for verification
       env:
@@ -128,8 +128,9 @@ jobs:
         retention-days: 1
 
   test-conclusion:
-    needs: [cargo-test, python-test, collect]
+    needs: [cargo-test, python-test, python-test-list]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -139,6 +140,18 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install requests
+
+      - name: Download python-test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: python-test-results-*
+          merge-multiple: true
+          path: .results
+
+      # Render results and exit if they were unsuccessful
+      - name: Render results
+        run: |
+          python edb/tools/test/results.py .results/result_*.json
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v4
@@ -151,17 +164,6 @@ jobs:
         with:
           name: test-list
           path: .tmp
-
-      - name: Download python-test results
-        uses: actions/download-artifact@v4
-        with:
-          pattern: python-test-results-*
-          merge-multiple: true
-          path: .results
-
-      - name: Render results
-        run: |
-          python edb/tools/test/results.py .results/result_*.json
 
       - name: Merge stats and verify tests completion
         shell: python

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -96,7 +96,7 @@ jobs:
         mkdir -p .results/
         cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
         edb test --jobs 2 --verbose --shard ${SHARD}/16 \
-          --running-times-log=.results/running_times_${SHARD}.csv
+          --running-times-log=.results/running_times_${SHARD}.csv \
           --result-log=.results/result_${SHARD}.json
 
     - name: Upload test results

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -101,6 +101,7 @@ jobs:
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
+      if: ${{ always() }}
       with:
         name: python-test-results-${{ matrix.shard }}
         path: .results

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -141,6 +141,10 @@ jobs:
         run: |
           python -m pip install requests
 
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
       - name: Download python-test results
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -94,8 +94,10 @@ jobs:
         SHARD: ${{ matrix.shard }}
       run: |
         mkdir -p .results/
-        cp .tmp/time_stats.csv .results/shard_${SHARD}.csv
-        edb test -j2 -v -s ${SHARD}/16 --running-times-log=.results/shard_${SHARD}.csv
+        cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
+        edb test --jobs 2 --verbose --shard ${SHARD}/16 \
+          --running-times-log=.results/running_times_${SHARD}.csv
+          --result-log=.results/result_${SHARD}.json
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
@@ -157,6 +159,10 @@ jobs:
           merge-multiple: true
           path: .results
 
+      - name: Render results
+        run: |
+          python edb/tools/test/results.py .results/result_*.json
+
       - name: Merge stats and verify tests completion
         shell: python
         env:
@@ -182,7 +188,7 @@ jobs:
                   assert line not in all_tests, "duplicate test name in this run!"
                   all_tests.add(line.strip())
 
-          for new_file in glob.glob(".results/*.csv"):
+          for new_file in glob.glob(".results/running_times_*.csv"):
               with open(new_file) as f:
                   for name, t, c in csv.reader(f):
                       if int(c) > orig.get(name, (0, 0))[1]:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -759,7 +759,7 @@ jobs:
 
       - name: Install Python deps
         run: |
-          python -m pip install requests click shutil unittest
+          python -m pip install requests click
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -590,7 +590,7 @@ jobs:
         path: .results
         retention-days: 1
 
-  collect:
+  python-test-list:
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -732,7 +732,7 @@ jobs:
         # and don't want them to be reinstalled in an "isolated env".
         pip install --no-build-isolation --no-deps -e .[test,docs]
 
-    # Collect tests and upload
+    # List tests and upload
 
     - name: Generate complete list of tests for verification
       env:
@@ -748,8 +748,9 @@ jobs:
         retention-days: 1
 
   test-conclusion:
-    needs: [cargo-test, python-test, collect]
+    needs: [cargo-test, python-test, python-test-list]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -759,6 +760,18 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install requests
+
+      - name: Download python-test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: python-test-results-*
+          merge-multiple: true
+          path: .results
+
+      # Render results and exit if they were unsuccessful
+      - name: Render results
+        run: |
+          python edb/tools/test/results.py .results/result_*.json
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v4
@@ -771,17 +784,6 @@ jobs:
         with:
           name: test-list
           path: .tmp
-
-      - name: Download python-test results
-        uses: actions/download-artifact@v4
-        with:
-          pattern: python-test-results-*
-          merge-multiple: true
-          path: .results
-
-      - name: Render results
-        run: |
-          python edb/tools/test/results.py .results/result_*.json
 
       - name: Merge stats and verify tests completion
         shell: python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -585,6 +585,7 @@ jobs:
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
+      if: ${{ always() }}
       with:
         name: python-test-results-${{ matrix.shard }}
         path: .results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -761,6 +761,10 @@ jobs:
         run: |
           python -m pip install requests
 
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
       - name: Download python-test results
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -775,7 +775,7 @@ jobs:
       # Render results and exit if they were unsuccessful
       - name: Render results
         run: |
-          python edb/tools/test/results.py .results/result_*.json
+          python edb/tools/test/results.py '.results/result_*.json'
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -759,7 +759,7 @@ jobs:
 
       - name: Install Python deps
         run: |
-          python -m pip install requests
+          python -m pip install requests click shutil unittest
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -578,8 +578,10 @@ jobs:
         SHARD: ${{ matrix.shard }}
       run: |
         mkdir -p .results/
-        cp .tmp/time_stats.csv .results/shard_${SHARD}.csv
-        edb test -j2 -v -s ${SHARD}/16 --running-times-log=.results/shard_${SHARD}.csv
+        cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
+        edb test --jobs 2 --verbose --shard ${SHARD}/16 \
+          --running-times-log=.results/running_times_${SHARD}.csv
+          --result-log=.results/result_${SHARD}.json
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
@@ -777,6 +779,10 @@ jobs:
           merge-multiple: true
           path: .results
 
+      - name: Render results
+        run: |
+          python edb/tools/test/results.py .results/result_*.json
+
       - name: Merge stats and verify tests completion
         shell: python
         env:
@@ -802,7 +808,7 @@ jobs:
                   assert line not in all_tests, "duplicate test name in this run!"
                   all_tests.add(line.strip())
 
-          for new_file in glob.glob(".results/*.csv"):
+          for new_file in glob.glob(".results/running_times_*.csv"):
               with open(new_file) as f:
                   for name, t, c in csv.reader(f):
                       if int(c) > orig.get(name, (0, 0))[1]:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -580,7 +580,7 @@ jobs:
         mkdir -p .results/
         cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
         edb test --jobs 2 --verbose --shard ${SHARD}/16 \
-          --running-times-log=.results/running_times_${SHARD}.csv
+          --running-times-log=.results/running_times_${SHARD}.csv \
           --result-log=.results/result_${SHARD}.json
 
     - name: Upload test results

--- a/edb/tools/test/results.py
+++ b/edb/tools/test/results.py
@@ -25,7 +25,6 @@ import binascii
 import dataclasses
 import datetime
 import functools
-import itertools
 import json
 import pathlib
 import sys

--- a/edb/tools/test/results.py
+++ b/edb/tools/test/results.py
@@ -32,11 +32,10 @@ import traceback
 import typing
 import unittest
 import glob
-
 import shutil
 from unittest.result import STDERR_LINE, STDOUT_LINE
-import click
 
+import click
 
 if typing.TYPE_CHECKING:
     from . import runner
@@ -344,13 +343,11 @@ def read_unsuccessful(path_template: str) -> typing.List[str]:
 
 
 def _dataclass_from_dict(cls: typing.Type | None, data: typing.Any):
-    from edb.common import typing_inspect
-
     if not cls:
         return data
 
-    if typing_inspect.get_origin(cls) is list:
-        args = typing_inspect.get_args(cls)
+    if hasattr(cls, '__origin__') and cls.__origin__ is list:
+        args = cls.__args__
         return [_dataclass_from_dict(args[0], e) for e in data]
 
     if not dataclasses.is_dataclass(cls):

--- a/edb/tools/test/results.py
+++ b/edb/tools/test/results.py
@@ -378,7 +378,7 @@ if __name__ == '__main__':
     result = functools.reduce(
         lambda acc, r: _combine_test_results(acc, r) if acc else r,
         results,
-        None,
+        typing.cast(typing.Optional[TestResult], None),
     )
     if not result:
         raise ValueError(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -42,37 +42,36 @@ class EdgeQLSyntaxTest(tb.BaseSyntaxTest):
 
 class TestEdgeQLParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_empty_01(self):
-        """aasxasxasx"""
+        """"""
 
     def test_edgeql_syntax_empty_02(self):
-        """asx# only comment"""
+        """# only comment"""
 
     def test_edgeql_syntax_empty_03(self):
         """
-        asxasx
+
         # only comment
 
         """
 
     def test_edgeql_syntax_empty_04(self):
         """;
-        asxasx
 % OK %  """
 
     def test_edgeql_syntax_empty_05(self):
-        """asxasx;# only comment
+        """;# only comment
 % OK %  """
 
     def test_edgeql_syntax_empty_06(self):
         """
-        ;asxasxas
+        ;
         # only comment
         ;
 % OK %
         """
 
     def test_edgeql_syntax_case_01(self):
-        """asxasxasx
+        """
         Select 1;
         select 1;
         SELECT 1;
@@ -81,7 +80,6 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
 
     def test_edgeql_syntax_omit_semicolon_01(self):
         """
-        asxasxasx
         SELECT 1
 
 % OK %
@@ -91,7 +89,6 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
 
     def test_edgeql_syntax_omit_semicolon_02(self):
         """
-        asxasx
         SELECT 2;
         SELECT 1
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -42,36 +42,37 @@ class EdgeQLSyntaxTest(tb.BaseSyntaxTest):
 
 class TestEdgeQLParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_empty_01(self):
-        """"""
+        """aasxasxasx"""
 
     def test_edgeql_syntax_empty_02(self):
-        """# only comment"""
+        """asx# only comment"""
 
     def test_edgeql_syntax_empty_03(self):
         """
-
+        asxasx
         # only comment
 
         """
 
     def test_edgeql_syntax_empty_04(self):
         """;
+        asxasx
 % OK %  """
 
     def test_edgeql_syntax_empty_05(self):
-        """;# only comment
+        """asxasx;# only comment
 % OK %  """
 
     def test_edgeql_syntax_empty_06(self):
         """
-        ;
+        ;asxasxas
         # only comment
         ;
 % OK %
         """
 
     def test_edgeql_syntax_case_01(self):
-        """
+        """asxasxasx
         Select 1;
         select 1;
         SELECT 1;
@@ -80,6 +81,7 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
 
     def test_edgeql_syntax_omit_semicolon_01(self):
         """
+        asxasxasx
         SELECT 1
 
 % OK %
@@ -89,6 +91,7 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
 
     def test_edgeql_syntax_omit_semicolon_02(self):
         """
+        asxasx
         SELECT 2;
         SELECT 1
 


### PR DESCRIPTION
Closes #6781

- make `edb test` take path where to write the log of the results
- make GHA `tests.yaml` write that file and upload it into GHA cache,
- add code for reading a bunch of result files and rendering the result,
- make test_conclusion step of `tests.yaml` run regardless of success of prev test steps, render the result and fail if tests were unsuccessful.
