### PR TITLE
Add pointer overlays to pointers grouped by inheritance.

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -32,6 +32,7 @@ from typing import (
     List,
     Set,
     NamedTuple,
+    cast,
 )
 
 import uuid
@@ -1952,7 +1953,7 @@ def range_for_ptrref(
     assert isinstance(ptrref.out_source.name_hint, sn.QualName)
     # expand_inhviews helps support EXPLAIN. see
     # range_for_material_objtype for details.
-    lrefs: List[irast.BasePointerRef]
+    lrefs: dict[irast.PointerRef, list[irast.PointerRef]]
     if (
         ctx.env.expand_inhviews
         and include_descendants
@@ -1962,95 +1963,91 @@ def range_for_ptrref(
         and ptrref.out_source.name_hint.module not in {'sys', 'cfg'}
     ):
         include_descendants = False
-        lrefs = []
-        has_overlays = False
+        lrefs = {}
         for ref in list(refs):
-            lrefs.extend(ref.descendants())
-            lrefs.append(ref)
+            assert isinstance(ref, irast.PointerRef), \
+                "expected regular PointerRef"
+            lref_entries: list[irast.PointerRef] = []
+            lref_entries.extend(
+                cast(Iterable[irast.PointerRef], ref.descendants())
+            )
+            lref_entries.append(ref)
             assert isinstance(ref, irast.PointerRef)
-            has_overlays |= bool(get_ptr_rel_overlays(
-                ref, dml_source=dml_source, ctx=ctx))
 
-        # Try to only select from actual concrete types.
-        concrete_lrefs = [
-            ref for ref in lrefs if not ref.out_source.is_abstract
-        ]
-        if (
+            # Try to only select from actual concrete types.
+            concrete_lrefs = [
+                ref for ref in lref_entries if not ref.out_source.is_abstract
+            ]
             # If there aren't any concrete types, we still need to
             # generate *something*, so just do all the abstract ones.
-            concrete_lrefs
-            # If any of the pointers being expanded have overlays
-            # active, don't skip abstract types. That's because the
-            # abstract base it needed to trigger the overlays being
-            # applied in the logic below.
-            #
-            # TODO: Separate out union types, expansions, and overlays
-            # more cleanly, like we do for types, instead of applying
-            # them all at once.
-            and not has_overlays
-        ):
-            lrefs = concrete_lrefs
+            if concrete_lrefs:
+                lrefs[ref] = concrete_lrefs
+            else:
+                lrefs[ref] = lref_entries
+
     else:
-        lrefs = list(refs)
+        lrefs = {}
+        for ref in list(refs):
+            assert isinstance(ref, irast.PointerRef), \
+                "expected regular PointerRef"
+            lrefs[ref] = [ref]
 
-    for src_ptrref in lrefs:
-        assert isinstance(src_ptrref, irast.PointerRef), \
-            "expected regular PointerRef"
-
-        # Most references to inline links are dispatched to a separate
-        # code path (_new_inline_pointer_rvar) by new_pointer_rvar,
-        # but when we have union pointers, some might be inline.  We
-        # always use the link table if it exists (because this range
-        # needs to contain any link properties, for one reason.)
-        ptr_info = pg_types.get_ptrref_storage_info(
-            src_ptrref, resolve_type=False, link_bias=True,
-        )
-        if not ptr_info:
-            assert ptrref.union_components
-
+    for orig_ptrref, src_ptrrefs in lrefs.items():
+        for src_ptrref in src_ptrrefs:
+            # Most references to inline links are dispatched to a separate
+            # code path (_new_inline_pointer_rvar) by new_pointer_rvar,
+            # but when we have union pointers, some might be inline.  We
+            # always use the link table if it exists (because this range
+            # needs to contain any link properties, for one reason.)
             ptr_info = pg_types.get_ptrref_storage_info(
-                src_ptrref, resolve_type=False, link_bias=False,
+                src_ptrref, resolve_type=False, link_bias=True,
             )
+            if not ptr_info:
+                assert ptrref.union_components
 
-        cols = [
-            'source' if ptr_info.table_type == 'link' else 'id',
-            ptr_info.column_name,
-        ]
+                ptr_info = pg_types.get_ptrref_storage_info(
+                    src_ptrref, resolve_type=False, link_bias=False,
+                )
 
-        table = table_from_ptrref(
-            src_ptrref,
-            ptr_info,
-            include_descendants=include_descendants,
-            for_mutation=for_mutation,
-            ctx=ctx,
-        )
-        table.query.path_id = path_id
+            cols = [
+                'source' if ptr_info.table_type == 'link' else 'id',
+                ptr_info.column_name,
+            ]
 
-        qry = pgast.SelectStmt()
-        qry.from_clause.append(table)
+            table = table_from_ptrref(
+                src_ptrref,
+                ptr_info,
+                include_descendants=include_descendants,
+                for_mutation=for_mutation,
+                ctx=ctx,
+            )
+            table.query.path_id = path_id
 
-        # Make sure all property references are pulled up properly
-        for colname, output_colname in zip(cols, output_cols):
-            selexpr = pgast.ColumnRef(
-                name=[table.alias.aliasname, colname])
-            qry.target_list.append(
-                pgast.ResTarget(val=selexpr, name=output_colname))
+            qry = pgast.SelectStmt()
+            qry.from_clause.append(table)
 
-        set_ops.append(('union', qry))
+            # Make sure all property references are pulled up properly
+            for colname, output_colname in zip(cols, output_cols):
+                selexpr = pgast.ColumnRef(
+                    name=[table.alias.aliasname, colname])
+                qry.target_list.append(
+                    pgast.ResTarget(val=selexpr, name=output_colname))
 
-        # We need the identity var for semi_join to work and
-        # the source rvar so that linkprops can be found here.
-        if path_id:
-            target_ref = qry.target_list[1].val
-            pathctx.put_path_identity_var(qry, path_id, var=target_ref)
-            pathctx.put_path_source_rvar(qry, path_id, table)
+            set_ops.append(('union', qry))
+
+            # We need the identity var for semi_join to work and
+            # the source rvar so that linkprops can be found here.
+            if path_id:
+                target_ref = qry.target_list[1].val
+                pathctx.put_path_identity_var(qry, path_id, var=target_ref)
+                pathctx.put_path_source_rvar(qry, path_id, table)
 
         # Only fire off the overlays at the end of each expanded inhview.
         # This only matters when we are doing expand_inhviews, and prevents
         # us from repeating the overlays many times in that case.
-        if src_ptrref in refs and not for_mutation:
+        if orig_ptrref in refs and not for_mutation:
             overlays = get_ptr_rel_overlays(
-                src_ptrref, dml_source=dml_source, ctx=ctx)
+                orig_ptrref, dml_source=dml_source, ctx=ctx)
 
             for op, cte, cte_path_id in overlays:
                 rvar = rvar_for_rel(cte, ctx=ctx)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -2065,6 +2065,14 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "messages violates exclusivity constraint"
         ):
             await self.con.execute("""
+                analyze
+                update ChatBase set { messages += 'hello world' };
+            """)
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "messages violates exclusivity constraint"
+        ):
+            await self.con.execute("""
                 update ChatBase set { messages := 'hello world' };
             """)
 


### PR DESCRIPTION
Instead of disabling inhviews entirely if overlays are present, expand the inhview, but then apply the overlay to the resulting expanded setops.