### PR TITLE
Use CTE instead of inheritance views when generating ranges for types

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -116,9 +116,6 @@ class flags(metaclass=FlagsMeta):
     edgeql_disable_normalization = Flag(
         doc="Disable EdgeQL normalization (constant extraction etc)")
 
-    edgeql_expand_inhviews = Flag(
-        doc="Force the EdgeQL compiler to expand inhviews *always*")
-
     graphql_compile = Flag(
         doc="Debug GraphQL compiler.")
 

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -85,7 +85,7 @@ class GlobalCompilerOptions:
     #: Should type inheritance be expanded using CTEs.
     #: When not explaining CTEs can be used to provide access to a type and its
     #: descendents.
-    use_type_inheritance_ctes: bool = False
+    use_type_inheritance_ctes: bool = True
 
     #: The name that can be used in a "DML is disallowed in ..."
     #: error. When this is not None, any DML should cause an error.

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -85,7 +85,7 @@ class GlobalCompilerOptions:
     #: Should type inheritance be expanded using CTEs.
     #: When not explaining CTEs can be used to provide access to a type and its
     #: descendents.
-    use_type_inheritance_ctes: bool = True
+    use_inheritance_ctes: bool = True
 
     #: The name that can be used in a "DML is disallowed in ..."
     #: error. When this is not None, any DML should cause an error.

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -77,10 +77,10 @@ class GlobalCompilerOptions:
     #: definitions.
     func_params: Optional[s_func.ParameterLikeList] = None
 
-    #: Should the backend compiler expand out inheritance views instead of
-    #: using them. This is needed by EXPLAIN to maintain alias names in
+    #: Should the backend compiler expand inheritance CTEs in place.
+    #: This is needed by EXPLAIN to maintain alias names in
     #: the query plan.
-    expand_inhviews: bool = False
+    is_explain: bool = False
 
     #: Should type inheritance be expanded using CTEs.
     #: When not explaining CTEs can be used to provide access to a type and its

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -82,6 +82,11 @@ class GlobalCompilerOptions:
     #: the query plan.
     expand_inhviews: bool = False
 
+    #: Should type inheritance be expanded using CTEs.
+    #: When not explaining CTEs can be used to provide access to a type and its
+    #: descendents.
+    use_type_inheritance_ctes: bool = False
+
     #: The name that can be used in a "DML is disallowed in ..."
     #: error. When this is not None, any DML should cause an error.
     in_ddl_context_name: Optional[str] = None

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -82,11 +82,6 @@ class GlobalCompilerOptions:
     #: the query plan.
     is_explain: bool = False
 
-    #: Should type inheritance be expanded using CTEs.
-    #: When not explaining CTEs can be used to provide access to a type and its
-    #: descendents.
-    use_inheritance_ctes: bool = True
-
     #: The name that can be used in a "DML is disallowed in ..."
     #: error. When this is not None, any DML should cause an error.
     in_ddl_context_name: Optional[str] = None

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -401,13 +401,7 @@ def type_to_typeref(
     include_children = (
         expr_type is s_types.ExprType.Update
         or expr_type is s_types.ExprType.Delete
-        or (
-            (
-                env.options.is_explain or
-                env.options.use_inheritance_ctes
-            )
-            and isinstance(t, s_objtypes.ObjectType)
-        )
+        or isinstance(t, s_objtypes.ObjectType)
     )
     include_ancestors = (
         expr_type is s_types.ExprType.Insert

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -403,7 +403,7 @@ def type_to_typeref(
         or expr_type is s_types.ExprType.Delete
         or (
             (
-                env.options.expand_inhviews or
+                env.options.is_explain or
                 env.options.use_inheritance_ctes
             )
             and isinstance(t, s_objtypes.ObjectType)

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -402,7 +402,11 @@ def type_to_typeref(
         expr_type is s_types.ExprType.Update
         or expr_type is s_types.ExprType.Delete
         or (
-            isinstance(t, s_objtypes.ObjectType)
+            (
+                env.options.expand_inhviews or
+                env.options.use_type_inheritance_ctes
+            )
+            and isinstance(t, s_objtypes.ObjectType)
         )
     )
     include_ancestors = (

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -402,8 +402,7 @@ def type_to_typeref(
         expr_type is s_types.ExprType.Update
         or expr_type is s_types.ExprType.Delete
         or (
-            env.options.expand_inhviews
-            and isinstance(t, s_objtypes.ObjectType)
+            isinstance(t, s_objtypes.ObjectType)
         )
     )
     include_ancestors = (

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -404,7 +404,7 @@ def type_to_typeref(
         or (
             (
                 env.options.expand_inhviews or
-                env.options.use_type_inheritance_ctes
+                env.options.use_inheritance_ctes
             )
             and isinstance(t, s_objtypes.ObjectType)
         )

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -173,6 +173,8 @@ class TypeRef(ImmutableBase):
     is_scalar: bool = False
     # True, if this describes a view
     is_view: bool = False
+    # True, if this describes a cfg view
+    is_cfg_view: bool = False
     # True, if this describes an abstract type
     is_abstract: bool = False
     # True, if the collection type is persisted in the schema

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -257,8 +257,6 @@ class PathId:
         which case it is used instead.
 
         Args:
-            schema:
-                A schema instance where the type *t* is defined.
             typeref:
                 The descriptor of a type of the variable being defined.
             namespace:
@@ -276,6 +274,28 @@ class PathId:
             typename = typeref.id
         pid._norm_path = (typename,)
         pid._namespace = frozenset(namespace)
+        return pid
+
+    @classmethod
+    def from_ptrref(
+        cls,
+        ptrref: irast.PointerRef,
+        *,
+        namespace: AbstractSet[Namespace] = frozenset(),
+    ) -> PathId:
+        """Return a ``PathId`` instance for a given :class:`ir.ast.PointerRef`
+
+        Args:
+            ptrref:
+                The descriptor of a ptr of the variable being defined.
+            namespace:
+                Optional namespace in which the variable is defined.
+
+        Returns:
+            A ``PathId`` instance of type described by *ptrref*.
+        """
+        pid = cls.from_typeref(ptrref.out_source, namespace=namespace)
+        pid = pid.extend(ptrref=ptrref)
         return pid
 
     @classmethod

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -66,7 +66,7 @@ def compile_ir_to_sql_tree(
     singleton_mode: bool = False,
     named_param_prefix: Optional[tuple[str, ...]] = None,
     expected_cardinality_one: bool = False,
-    expand_inhviews: bool = False,
+    is_explain: bool = False,
     use_inheritance_ctes: bool = False,
     external_rvars: Optional[
         Mapping[Tuple[irast.PathId, pgce.PathAspect], pgast.PathRangeVar]
@@ -128,7 +128,7 @@ def compile_ir_to_sql_tree(
             type_rewrites=type_rewrites,
             ignore_object_shapes=ignore_shapes,
             explicit_top_cast=explicit_top_cast,
-            expand_inhviews=expand_inhviews,
+            is_explain=is_explain,
             use_inheritance_ctes=use_inheritance_ctes,
             singleton_mode=singleton_mode,
             scope_tree_nodes=scope_tree_nodes,

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -67,7 +67,7 @@ def compile_ir_to_sql_tree(
     named_param_prefix: Optional[tuple[str, ...]] = None,
     expected_cardinality_one: bool = False,
     expand_inhviews: bool = False,
-    use_type_inheritance_ctes: bool = False,
+    use_inheritance_ctes: bool = False,
     external_rvars: Optional[
         Mapping[Tuple[irast.PathId, pgce.PathAspect], pgast.PathRangeVar]
     ] = None,
@@ -129,7 +129,7 @@ def compile_ir_to_sql_tree(
             ignore_object_shapes=ignore_shapes,
             explicit_top_cast=explicit_top_cast,
             expand_inhviews=expand_inhviews,
-            use_type_inheritance_ctes=use_type_inheritance_ctes,
+            use_inheritance_ctes=use_inheritance_ctes,
             singleton_mode=singleton_mode,
             scope_tree_nodes=scope_tree_nodes,
             external_rvars=external_rvars,

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -67,6 +67,7 @@ def compile_ir_to_sql_tree(
     named_param_prefix: Optional[tuple[str, ...]] = None,
     expected_cardinality_one: bool = False,
     expand_inhviews: bool = False,
+    use_type_inheritance_ctes: bool = False,
     external_rvars: Optional[
         Mapping[Tuple[irast.PathId, pgce.PathAspect], pgast.PathRangeVar]
     ] = None,
@@ -128,6 +129,7 @@ def compile_ir_to_sql_tree(
             ignore_object_shapes=ignore_shapes,
             explicit_top_cast=explicit_top_cast,
             expand_inhviews=expand_inhviews,
+            use_type_inheritance_ctes=use_type_inheritance_ctes,
             singleton_mode=singleton_mode,
             scope_tree_nodes=scope_tree_nodes,
             external_rvars=external_rvars,

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -67,7 +67,6 @@ def compile_ir_to_sql_tree(
     named_param_prefix: Optional[tuple[str, ...]] = None,
     expected_cardinality_one: bool = False,
     is_explain: bool = False,
-    use_inheritance_ctes: bool = False,
     external_rvars: Optional[
         Mapping[Tuple[irast.PathId, pgce.PathAspect], pgast.PathRangeVar]
     ] = None,
@@ -129,7 +128,6 @@ def compile_ir_to_sql_tree(
             ignore_object_shapes=ignore_shapes,
             explicit_top_cast=explicit_top_cast,
             is_explain=is_explain,
-            use_inheritance_ctes=use_inheritance_ctes,
             singleton_mode=singleton_mode,
             scope_tree_nodes=scope_tree_nodes,
             external_rvars=external_rvars,

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -420,7 +420,7 @@ def fini_toplevel(
     stmt.ctes[:0] = [
         *ctx.param_ctes.values(),
         *ctx.ptr_ctes.values(),
-        *ctx.ordered_type_ctes,
+        *ctx.ordered_inheritance_ctes,
     ]
 
     if ctx.env.named_param_prefix is None:

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -419,8 +419,8 @@ def fini_toplevel(
         stmt.ctes = []
     stmt.ctes[:0] = [
         *ctx.param_ctes.values(),
-        *ctx.ptr_ctes.values(),
-        *ctx.ordered_inheritance_ctes,
+        *ctx.ptr_inheritance_ctes.values(),
+        *ctx.ordered_type_ctes,
     ]
 
     if ctx.env.named_param_prefix is None:

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -420,8 +420,7 @@ def fini_toplevel(
     stmt.ctes[:0] = [
         *ctx.param_ctes.values(),
         *ctx.ptr_ctes.values(),
-        *ctx.type_ctes.values(),
-        *ctx.type_inheritance_ctes.values(),
+        *ctx.ordered_type_ctes,
     ]
 
     if ctx.env.named_param_prefix is None:

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -409,12 +409,9 @@ def scan_check_ctes(
     ))
 
 
-def fini_toplevel(
-        stmt: pgast.Query, ctx: context.CompilerContextLevel) -> None:
-
-    scan_check_ctes(stmt, ctx.env.check_ctes, ctx=ctx)
-
-    # Type rewrites go first.
+def insert_ctes(
+    stmt: pgast.Query, ctx: context.CompilerContextLevel
+) -> None:
     if stmt.ctes is None:
         stmt.ctes = []
     stmt.ctes[:0] = [
@@ -422,6 +419,15 @@ def fini_toplevel(
         *ctx.ptr_inheritance_ctes.values(),
         *ctx.ordered_type_ctes,
     ]
+
+
+def fini_toplevel(
+        stmt: pgast.Query, ctx: context.CompilerContextLevel) -> None:
+
+    scan_check_ctes(stmt, ctx.env.check_ctes, ctx=ctx)
+
+    # Type rewrites and inheritance CTEs go first.
+    insert_ctes(stmt, ctx)
 
     if ctx.env.named_param_prefix is None:
         # Adding unused parameters into a CTE

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -421,6 +421,7 @@ def fini_toplevel(
         *ctx.param_ctes.values(),
         *ctx.ptr_ctes.values(),
         *ctx.type_ctes.values(),
+        *ctx.type_inheritance_ctes.values(),
     ]
 
     if ctx.env.named_param_prefix is None:

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -246,6 +246,9 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: materialized for performance reasons.
     ptr_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
 
+    #: CTEs representing pointers and their inherited pointers
+    ptr_inheritance_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
+
     #: CTEs representing types, when rewritten based on access policy
     type_ctes: Dict[FullRewriteKey, pgast.CommonTableExpr]
 
@@ -359,6 +362,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.rel_hierarchy = {}
             self.param_ctes = {}
             self.ptr_ctes = {}
+            self.ptr_inheritance_ctes = {}
             self.type_ctes = {}
             self.pending_type_ctes = set()
             self.type_inheritance_ctes = {}
@@ -401,6 +405,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.rel_hierarchy = prevlevel.rel_hierarchy
             self.param_ctes = prevlevel.param_ctes
             self.ptr_ctes = prevlevel.ptr_ctes
+            self.ptr_inheritance_ctes = prevlevel.ptr_inheritance_ctes
             self.type_ctes = prevlevel.type_ctes
             self.pending_type_ctes = prevlevel.pending_type_ctes
             self.type_inheritance_ctes = prevlevel.type_inheritance_ctes

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -548,6 +548,7 @@ class Environment:
         ignore_object_shapes: bool,
         singleton_mode: bool,
         expand_inhviews: bool,
+        use_type_inheritance_ctes: bool,
         explicit_top_cast: Optional[irast.TypeRef],
         query_params: List[irast.Param],
         type_rewrites: Dict[RewriteKey, irast.Set],
@@ -567,6 +568,7 @@ class Environment:
         self.ignore_object_shapes = ignore_object_shapes
         self.singleton_mode = singleton_mode
         self.expand_inhviews = expand_inhviews
+        self.use_type_inheritance_ctes = use_type_inheritance_ctes
         self.explicit_top_cast = explicit_top_cast
         self.query_params = query_params
         self.type_rewrites = type_rewrites

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -242,25 +242,21 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: CTEs representing decoded parameters
     param_ctes: Dict[str, pgast.CommonTableExpr]
 
-    #: CTEs representing pointer tables that we need to force to be
-    #: materialized for performance reasons.
-    ptr_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
-
     #: CTEs representing pointers and their inherited pointers
     ptr_inheritance_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
 
     #: CTEs representing types, when rewritten based on access policy
-    type_ctes: Dict[FullRewriteKey, pgast.CommonTableExpr]
+    type_rewrite_ctes: Dict[FullRewriteKey, pgast.CommonTableExpr]
 
     #: A set of type CTEs currently being generated
-    pending_type_ctes: Set[RewriteKey]
+    pending_type_rewrite_ctes: Set[RewriteKey]
 
     #: CTEs representing types and their inherited types
     type_inheritance_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
 
     # Type and type inheriance CTEs in creation order. This ensures type CTEs
     # referring to other CTEs are in the correct order.
-    ordered_inheritance_ctes: list[pgast.CommonTableExpr]
+    ordered_type_ctes: list[pgast.CommonTableExpr]
 
     #: The logical parent of the current query in the
     #: query hierarchy
@@ -361,12 +357,11 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.rel = NO_STMT
             self.rel_hierarchy = {}
             self.param_ctes = {}
-            self.ptr_ctes = {}
             self.ptr_inheritance_ctes = {}
-            self.type_ctes = {}
-            self.pending_type_ctes = set()
+            self.type_rewrite_ctes = {}
+            self.pending_type_rewrite_ctes = set()
             self.type_inheritance_ctes = {}
-            self.ordered_inheritance_ctes = []
+            self.ordered_type_ctes = []
             self.dml_stmts = {}
             self.parent_rel = None
             self.pending_query = None
@@ -404,12 +399,11 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.rel = prevlevel.rel
             self.rel_hierarchy = prevlevel.rel_hierarchy
             self.param_ctes = prevlevel.param_ctes
-            self.ptr_ctes = prevlevel.ptr_ctes
             self.ptr_inheritance_ctes = prevlevel.ptr_inheritance_ctes
-            self.type_ctes = prevlevel.type_ctes
-            self.pending_type_ctes = prevlevel.pending_type_ctes
+            self.type_rewrite_ctes = prevlevel.type_rewrite_ctes
+            self.pending_type_rewrite_ctes = prevlevel.pending_type_rewrite_ctes
             self.type_inheritance_ctes = prevlevel.type_inheritance_ctes
-            self.ordered_inheritance_ctes = prevlevel.ordered_inheritance_ctes
+            self.ordered_type_ctes = prevlevel.ordered_type_ctes
             self.dml_stmts = prevlevel.dml_stmts
             self.parent_rel = prevlevel.parent_rel
             self.pending_query = prevlevel.pending_query
@@ -472,7 +466,9 @@ class CompilerContextLevel(compiler.ContextLevel):
                 self.disable_semi_join = frozenset()
                 self.force_optional = frozenset()
                 self.intersection_narrowing = {}
-                self.pending_type_ctes = set(prevlevel.pending_type_ctes)
+                self.pending_type_rewrite_ctes = set(
+                    prevlevel.pending_type_rewrite_ctes
+                )
 
             elif mode == ContextSwitchMode.NEWSCOPE:
                 self.path_scope = prevlevel.path_scope.new_child()

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -255,6 +255,10 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: CTEs representing types and their inherited types
     type_inheritance_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
 
+    # Type and type inheriance CTEs in creation order. This ensures type CTEs
+    # referring to other CTEs are in the correct order.
+    ordered_type_ctes: list[pgast.CommonTableExpr]
+
     #: The logical parent of the current query in the
     #: query hierarchy
     parent_rel: Optional[pgast.Query]
@@ -358,6 +362,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.type_ctes = {}
             self.pending_type_ctes = set()
             self.type_inheritance_ctes = {}
+            self.ordered_type_ctes = []
             self.dml_stmts = {}
             self.parent_rel = None
             self.pending_query = None
@@ -399,6 +404,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.type_ctes = prevlevel.type_ctes
             self.pending_type_ctes = prevlevel.pending_type_ctes
             self.type_inheritance_ctes = prevlevel.type_inheritance_ctes
+            self.ordered_type_ctes = prevlevel.ordered_type_ctes
             self.dml_stmts = prevlevel.dml_stmts
             self.parent_rel = prevlevel.parent_rel
             self.pending_query = prevlevel.pending_query

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -552,7 +552,7 @@ class Environment:
         expected_cardinality_one: bool,
         ignore_object_shapes: bool,
         singleton_mode: bool,
-        expand_inhviews: bool,
+        is_explain: bool,
         use_inheritance_ctes: bool,
         explicit_top_cast: Optional[irast.TypeRef],
         query_params: List[irast.Param],
@@ -572,7 +572,7 @@ class Environment:
         self.expected_cardinality_one = expected_cardinality_one
         self.ignore_object_shapes = ignore_object_shapes
         self.singleton_mode = singleton_mode
-        self.expand_inhviews = expand_inhviews
+        self.is_explain = is_explain
         self.use_inheritance_ctes = use_inheritance_ctes
         self.explicit_top_cast = explicit_top_cast
         self.query_params = query_params

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -252,6 +252,9 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: A set of type CTEs currently being generated
     pending_type_ctes: Set[RewriteKey]
 
+    #: CTEs representing types and their inherited types
+    type_inheritance_ctes: Dict[uuid.UUID, pgast.CommonTableExpr]
+
     #: The logical parent of the current query in the
     #: query hierarchy
     parent_rel: Optional[pgast.Query]
@@ -354,6 +357,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.ptr_ctes = {}
             self.type_ctes = {}
             self.pending_type_ctes = set()
+            self.type_inheritance_ctes = {}
             self.dml_stmts = {}
             self.parent_rel = None
             self.pending_query = None
@@ -394,6 +398,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.ptr_ctes = prevlevel.ptr_ctes
             self.type_ctes = prevlevel.type_ctes
             self.pending_type_ctes = prevlevel.pending_type_ctes
+            self.type_inheritance_ctes = prevlevel.type_inheritance_ctes
             self.dml_stmts = prevlevel.dml_stmts
             self.parent_rel = prevlevel.parent_rel
             self.pending_query = prevlevel.pending_query

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -260,7 +260,7 @@ class CompilerContextLevel(compiler.ContextLevel):
 
     # Type and type inheriance CTEs in creation order. This ensures type CTEs
     # referring to other CTEs are in the correct order.
-    ordered_type_ctes: list[pgast.CommonTableExpr]
+    ordered_inheritance_ctes: list[pgast.CommonTableExpr]
 
     #: The logical parent of the current query in the
     #: query hierarchy
@@ -366,7 +366,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.type_ctes = {}
             self.pending_type_ctes = set()
             self.type_inheritance_ctes = {}
-            self.ordered_type_ctes = []
+            self.ordered_inheritance_ctes = []
             self.dml_stmts = {}
             self.parent_rel = None
             self.pending_query = None
@@ -409,7 +409,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.type_ctes = prevlevel.type_ctes
             self.pending_type_ctes = prevlevel.pending_type_ctes
             self.type_inheritance_ctes = prevlevel.type_inheritance_ctes
-            self.ordered_type_ctes = prevlevel.ordered_type_ctes
+            self.ordered_inheritance_ctes = prevlevel.ordered_inheritance_ctes
             self.dml_stmts = prevlevel.dml_stmts
             self.parent_rel = prevlevel.parent_rel
             self.pending_query = prevlevel.pending_query
@@ -553,7 +553,7 @@ class Environment:
         ignore_object_shapes: bool,
         singleton_mode: bool,
         expand_inhviews: bool,
-        use_type_inheritance_ctes: bool,
+        use_inheritance_ctes: bool,
         explicit_top_cast: Optional[irast.TypeRef],
         query_params: List[irast.Param],
         type_rewrites: Dict[RewriteKey, irast.Set],
@@ -573,7 +573,7 @@ class Environment:
         self.ignore_object_shapes = ignore_object_shapes
         self.singleton_mode = singleton_mode
         self.expand_inhviews = expand_inhviews
-        self.use_type_inheritance_ctes = use_type_inheritance_ctes
+        self.use_inheritance_ctes = use_inheritance_ctes
         self.explicit_top_cast = explicit_top_cast
         self.query_params = query_params
         self.type_rewrites = type_rewrites

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -549,7 +549,6 @@ class Environment:
         ignore_object_shapes: bool,
         singleton_mode: bool,
         is_explain: bool,
-        use_inheritance_ctes: bool,
         explicit_top_cast: Optional[irast.TypeRef],
         query_params: List[irast.Param],
         type_rewrites: Dict[RewriteKey, irast.Set],
@@ -569,7 +568,6 @@ class Environment:
         self.ignore_object_shapes = ignore_object_shapes
         self.singleton_mode = singleton_mode
         self.is_explain = is_explain
-        self.use_inheritance_ctes = use_inheritance_ctes
         self.explicit_top_cast = explicit_top_cast
         self.query_params = query_params
         self.type_rewrites = type_rewrites

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -3139,9 +3139,9 @@ def compile_triggers(
         # FIXME: I think we actually need to keep the old type_ctes
         # available for pointers off of __old__ to use.
         ictx.trigger_mode = True
-        ictx.type_ctes = {}
+        ictx.type_rewrite_ctes = {}
         ictx.type_inheritance_ctes = {}
-        ictx.ordered_inheritance_ctes = []
+        ictx.ordered_type_ctes = []
         ictx.toplevel_stmt = stmt
 
         for stage in triggers:
@@ -3158,7 +3158,7 @@ def compile_triggers(
 
     # Install any newly created type CTEs before the CTEs created from
     # this trigger compilation but after anything compiled before.
-    stmt.ctes[start_ctes:start_ctes] = ictx.ordered_inheritance_ctes
+    stmt.ctes[start_ctes:start_ctes] = ictx.ordered_type_ctes
 
 
 def compile_trigger(

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -3141,7 +3141,7 @@ def compile_triggers(
         ictx.trigger_mode = True
         ictx.type_ctes = {}
         ictx.type_inheritance_ctes = {}
-        ictx.ordered_type_ctes = []
+        ictx.ordered_inheritance_ctes = []
         ictx.toplevel_stmt = stmt
 
         for stage in triggers:
@@ -3158,7 +3158,7 @@ def compile_triggers(
 
     # Install any newly created type CTEs before the CTEs created from
     # this trigger compilation but after anything compiled before.
-    stmt.ctes[start_ctes:start_ctes] = ictx.ordered_type_ctes
+    stmt.ctes[start_ctes:start_ctes] = ictx.ordered_inheritance_ctes
 
 
 def compile_trigger(

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -3140,6 +3140,8 @@ def compile_triggers(
         # available for pointers off of __old__ to use.
         ictx.trigger_mode = True
         ictx.type_ctes = {}
+        ictx.type_inheritance_ctes = {}
+        ictx.ordered_type_ctes = []
         ictx.toplevel_stmt = stmt
 
         for stage in triggers:
@@ -3156,7 +3158,7 @@ def compile_triggers(
 
     # Install any newly created type CTEs before the CTEs created from
     # this trigger compilation but after anything compiled before.
-    stmt.ctes[start_ctes:start_ctes] = list(ictx.type_ctes.values())
+    stmt.ctes[start_ctes:start_ctes] = ictx.ordered_type_ctes
 
 
 def compile_trigger(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -2257,6 +2257,10 @@ def _range_for_component_ptrref(
                     rarg=rarg,
                 )
 
+            # Add the path to the CTE's query. This allows for the proper
+            # path mapping ot occur when processing link properties
+            inheritance_qry.path_id = component_ptrref_path_id
+
             ptr_cte = pgast.CommonTableExpr(
                 name=ctx.env.aliases.get(f't_{component_ptrref.name}'),
                 query=inheritance_qry,

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1650,7 +1650,7 @@ def range_for_material_objtype(
             # using a CTE. This allows postgres to actually give us back the
             # alias names that we use for relations, which we use to track which
             # parts of the query are being referred to.
-            not ctx.env.use_inheritance_ctes
+            ctx.env.is_explain
 
             # Don't use CTEs if there is no inheritance. (ie. There is only a
             # single material type)
@@ -2173,7 +2173,9 @@ def _range_for_component_ptrref(
     )
 
     if (
-        not ctx.env.use_inheritance_ctes
+        # When we are compiling a query for EXPLAIN, expand out pointer
+        # references in place. See range_for_material_objtype for more details.
+        ctx.env.is_explain
 
         # Don't use CTEs if there is no inheritance. (ie. There is only a
         # single ptrref)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1638,6 +1638,7 @@ def range_for_material_objtype(
                 sctx.rel, lateral=lateral, typeref=typeref, ctx=sctx)
 
     else:
+        assert not typeref.is_view, "attempting to generate range from view"
         typeref_descendants = _get_typeref_descendants(
             typeref,
             include_descendants=(
@@ -1869,7 +1870,6 @@ def _table_from_typeref(
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
     assert isinstance(typeref.name_hint, sn.QualName)
-    assert not typeref.is_view, "attempting to generate range from view"
 
     aspect = 'table'
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1804,7 +1804,23 @@ def _get_typeref_descendants(
         include_descendants
         and not for_mutation
     ):
-        descendants = [typeref, *irtyputils.get_typeref_descendants(typeref)]
+        descendants = [
+            typeref,
+            *(
+                descendant
+                for descendant in irtyputils.get_typeref_descendants(typeref)
+
+                # XXX: Exclude sys/cfg tables from non sys/cfg inheritance CTEs.
+                # This probably isn't *really* what we want to do, but until we
+                # figure that out, do *something* so that DDL isn't
+                # excruciatingly slow because of the cost of explicit id
+                # checks. See #5168.
+                if (
+                    not descendant.is_cfg_view
+                    or typeref.is_cfg_view
+                )
+            )
+        ]
 
         # Try to only select from actual concrete types.
         concrete_descendants = [

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1657,11 +1657,7 @@ def range_for_material_objtype(
             or len(typeref_descendants) <= 1
         ):
             inheritance_selects = _selects_for_typeref_descendants(
-                typeref_descendants,
-                path_id,
-                for_mutation=for_mutation,
-                include_descendants=include_descendants,
-                ctx=ctx,
+                typeref_descendants, path_id, ctx=ctx,
             )
             ops = [
                 (context.OverlayOp.UNION, select)
@@ -1690,11 +1686,7 @@ def range_for_material_objtype(
 
             if typeref.id not in ctx.type_inheritance_ctes:
                 inheritance_selects = _selects_for_typeref_descendants(
-                    typeref_descendants,
-                    typeref_path,
-                    for_mutation=False,
-                    include_descendants=False,
-                    ctx=ctx,
+                    typeref_descendants, typeref_path, ctx=ctx,
                 )
 
                 type_qry: pgast.SelectStmt = inheritance_selects[0]
@@ -1833,18 +1825,12 @@ def _selects_for_typeref_descendants(
     typeref_descendants: Sequence[irast.TypeRef],
     path_id: irast.PathId,
     *,
-    for_mutation: bool,
-    include_descendants: bool,
     ctx: context.CompilerContextLevel,
 ) -> list[pgast.SelectStmt]:
     selects = []
     for subref in typeref_descendants:
         rvar = _table_from_typeref(
-            subref,
-            path_id,
-            for_mutation=for_mutation,
-            include_descendants=include_descendants,
-            ctx=ctx,
+            subref, path_id, ctx=ctx,
         )
         qry = pgast.SelectStmt(from_clause=[rvar])
         sub_path_id = path_id
@@ -1860,20 +1846,11 @@ def _table_from_typeref(
     typeref: irast.TypeRef,
     path_id: irast.PathId,
     *,
-    for_mutation: bool,
-    include_descendants: bool,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
     assert isinstance(typeref.name_hint, sn.QualName)
 
     aspect = 'table'
-
-    if (
-        include_descendants
-        and not for_mutation
-        and typeref.name_hint.module in {'cfg', 'sys', 'schema'}
-    ):
-        aspect = 'inhview'
 
     table_schema_name, table_name = common.get_objtype_backend_name(
         typeref.id,

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1641,12 +1641,7 @@ def range_for_material_objtype(
         assert not typeref.is_view, "attempting to generate range from view"
         typeref_descendants = _get_typeref_descendants(
             typeref,
-            include_descendants=(
-                include_descendants
-
-                # HACK: This is a workaround for #4491
-                and typeref.name_hint.module not in {'cfg', 'sys'}
-            ),
+            include_descendants=include_descendants,
             for_mutation=for_mutation,
         )
         if (
@@ -2131,12 +2126,7 @@ def range_for_ptrref(
         component_refs = {ptrref}
 
     assert isinstance(ptrref.out_source.name_hint, sn.QualName)
-    include_descendants = (
-        not ptrref.union_is_exhaustive
-
-        # HACK: This is a workaround for #4491
-        and ptrref.out_source.name_hint.module not in {'sys', 'cfg'}
-    )
+    include_descendants = not ptrref.union_is_exhaustive
 
     output_cols = ('source', 'target')
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1621,7 +1621,7 @@ def range_for_material_objtype(
                         materialized=is_global or force_cte,
                     )
                     ctx.type_ctes[key] = type_cte
-                    ctx.ordered_type_ctes.append(type_cte)
+                    ctx.ordered_inheritance_ctes.append(type_cte)
                     type_rel = type_cte
         else:
             type_rel = type_cte
@@ -1655,7 +1655,7 @@ def range_for_material_objtype(
             # relying on the inheritance views. This allows postgres to actually
             # give us back the alias names that we use for relations, which we
             # use to track which parts of the query are being referred to.
-            not ctx.env.use_type_inheritance_ctes
+            not ctx.env.use_inheritance_ctes
 
             # Don't use CTEs if there is no inheritance. (ie. There is only a
             # single material type)
@@ -1717,7 +1717,7 @@ def range_for_material_objtype(
                     materialized=False,
                 )
                 ctx.type_inheritance_ctes[typeref.id] = type_cte
-                ctx.ordered_type_ctes.append(type_cte)
+                ctx.ordered_inheritance_ctes.append(type_cte)
 
             else:
                 type_cte = ctx.type_inheritance_ctes[typeref.id]
@@ -2212,7 +2212,7 @@ def _range_for_component_ptrref(
     )
 
     if (
-        not ctx.env.use_type_inheritance_ctes
+        not ctx.env.use_inheritance_ctes
 
         # Don't use CTEs if there is no inheritance. (ie. There is only a
         # single ptrref)
@@ -2267,7 +2267,7 @@ def _range_for_component_ptrref(
                 materialized=False,
             )
             ctx.ptr_inheritance_ctes[component_ptrref.id] = ptr_cte
-            ctx.ordered_type_ctes.append(ptr_cte)
+            ctx.ordered_inheritance_ctes.append(ptr_cte)
 
         else:
             ptr_cte = ctx.ptr_inheritance_ctes[component_ptrref.id]

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1646,43 +1646,80 @@ def range_for_material_objtype(
     # alias names that we use for relations, which we use to track which
     # parts of the query are being referred to.
     elif (
-        ctx.env.expand_inhviews
-        and include_descendants
+        include_descendants
         and not for_mutation
         and typeref.children is not None
 
         # HACK: This is a workaround for #4491
         and typeref.name_hint.module not in {'cfg', 'sys'}
     ):
-        ops = []
-        typerefs = [typeref, *irtyputils.get_typeref_descendants(typeref)]
-        all_abstract = all(subref.is_abstract for subref in typerefs)
-        for subref in typerefs:
-            if subref.is_abstract and not all_abstract:
-                continue
-            rvar = range_for_material_objtype(
-                subref, path_id, lateral=lateral,
-                include_descendants=False,
-                include_overlays=False,
-                ignore_rewrites=ignore_rewrites,  # XXX: Is this right?
+        typeref_path: irast.PathId = irast.PathId.from_typeref(
+            typeref,
+            # If there are backlinks and the path revisits a type, a semi-join
+            # is produced. This ensures that the rvar produced does not have
+            # a duplicate path var.
+            # For example: (select A.b.<b[is A])
+            namespace=frozenset({'typeref'})
+        )
+
+        if typeref.id not in ctx.type_inheritance_ctes:
+            ops = []
+            typerefs = [typeref, *irtyputils.get_typeref_descendants(typeref)]
+            all_abstract = all(subref.is_abstract for subref in typerefs)
+            for subref in typerefs:
+                if subref.is_abstract and not all_abstract:
+                    continue
+                rvar = range_for_material_objtype(
+                    subref, typeref_path, lateral=lateral,
+                    include_descendants=False,
+                    include_overlays=False,
+                    ignore_rewrites=ignore_rewrites,  # XXX: Is this right?
+                    ctx=ctx,
+                )
+                qry = pgast.SelectStmt(from_clause=[rvar])
+                sub_path_id = typeref_path
+                pathctx.put_path_value_rvar(qry, sub_path_id, rvar)
+                pathctx.put_path_source_rvar(qry, sub_path_id, rvar)
+
+                ops.append((context.OverlayOp.UNION, qry))
+
+            type_qry: pgast.SelectStmt = ops[0][1]
+            for op, rarg in ops[1:]:
+                type_qry = pgast.SelectStmt(
+                    op=op,
+                    all=True,
+                    larg=type_qry,
+                    rarg=rarg,
+                )
+
+            type_cte = pgast.CommonTableExpr(
+                name=ctx.env.aliases.get(f't_{typeref.name_hint}'),
+                query=type_qry,
+                materialized=False,
+            )
+            ctx.type_inheritance_ctes[typeref.id] = type_cte
+
+        else:
+            type_cte = ctx.type_inheritance_ctes[typeref.id]
+
+        with ctx.subrel() as sctx:
+            cte_rvar = rvar_for_rel(
+                type_cte,
+                typeref=typeref,
                 ctx=ctx,
             )
-            qry = pgast.SelectStmt(from_clause=[rvar])
-            sub_path_id = path_id
-            pathctx.put_path_value_rvar(qry, sub_path_id, rvar)
-            pathctx.put_path_source_rvar(qry, sub_path_id, rvar)
 
-            ops.append((context.OverlayOp.UNION, qry))
-
-        rvar = range_from_queryset(
-            ops,
-            typeref.name_hint,
-            lateral=lateral,
-            path_id=path_id,
-            typeref=typeref,
-            tag='expanded-inhview',
-            ctx=ctx,
-        )
+            if path_id != typeref_path:
+                pathctx.put_path_id_map(sctx.rel, path_id, typeref_path)
+            include_rvar(
+                sctx.rel,
+                cte_rvar,
+                typeref_path,
+                pull_namespace=False,
+                ctx=sctx,
+            )
+            rvar = rvar_for_rel(
+                sctx.rel, lateral=lateral, typeref=typeref, ctx=sctx)
 
     else:
         assert not typeref.is_view, "attempting to generate range from view"

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1621,6 +1621,7 @@ def range_for_material_objtype(
                         materialized=is_global or force_cte,
                     )
                     ctx.type_ctes[key] = type_cte
+                    ctx.ordered_type_ctes.append(type_cte)
                     type_rel = type_cte
         else:
             type_rel = type_cte
@@ -1698,6 +1699,7 @@ def range_for_material_objtype(
                 materialized=False,
             )
             ctx.type_inheritance_ctes[typeref.id] = type_cte
+            ctx.ordered_type_ctes.append(type_cte)
 
         else:
             type_cte = ctx.type_inheritance_ctes[typeref.id]

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1641,11 +1641,6 @@ def range_for_material_objtype(
             rvar = rvar_for_rel(
                 sctx.rel, lateral=lateral, typeref=typeref, ctx=sctx)
 
-    # When we are compiling a query for EXPLAIN, expand out type references
-    # to an explicit union of all the types, rather than relying on the
-    # inheritance views. This allows postgres to actually give us back the
-    # alias names that we use for relations, which we use to track which
-    # parts of the query are being referred to.
     elif (
         include_descendants
         and not for_mutation
@@ -1654,74 +1649,96 @@ def range_for_material_objtype(
         # HACK: This is a workaround for #4491
         and typeref.name_hint.module not in {'cfg', 'sys'}
     ):
-        typeref_path: irast.PathId = irast.PathId.from_typeref(
-            typeref,
-            # If there are backlinks and the path revisits a type, a semi-join
-            # is produced. This ensures that the rvar produced does not have
-            # a duplicate path var.
-            # For example: (select A.b.<b[is A])
-            namespace=frozenset({'typeref'})
-        )
+        if (
+            # When we are compiling a query for EXPLAIN, expand out type
+            # references to an explicit union of all the types, rather than
+            # relying on the inheritance views. This allows postgres to actually
+            # give us back the alias names that we use for relations, which we
+            # use to track which parts of the query are being referred to.
+            not ctx.env.use_type_inheritance_ctes
 
-        if typeref.id not in ctx.type_inheritance_ctes:
-            ops = []
-            typerefs = [typeref, *irtyputils.get_typeref_descendants(typeref)]
-            all_abstract = all(subref.is_abstract for subref in typerefs)
-            for subref in typerefs:
-                if subref.is_abstract and not all_abstract:
-                    continue
-                rvar = range_for_material_objtype(
-                    subref, typeref_path, lateral=lateral,
-                    include_descendants=False,
-                    include_overlays=False,
-                    ignore_rewrites=ignore_rewrites,  # XXX: Is this right?
-                    ctx=ctx,
-                )
-                qry = pgast.SelectStmt(from_clause=[rvar])
-                sub_path_id = typeref_path
-                pathctx.put_path_value_rvar(qry, sub_path_id, rvar)
-                pathctx.put_path_source_rvar(qry, sub_path_id, rvar)
-
-                ops.append((context.OverlayOp.UNION, qry))
-
-            type_qry: pgast.SelectStmt = ops[0][1]
-            for op, rarg in ops[1:]:
-                type_qry = pgast.SelectStmt(
-                    op=op,
-                    all=True,
-                    larg=type_qry,
-                    rarg=rarg,
-                )
-
-            type_cte = pgast.CommonTableExpr(
-                name=ctx.env.aliases.get(f't_{typeref.name_hint}'),
-                query=type_qry,
-                materialized=False,
+            # Don't use CTEs if there is no inheritance. (ie. There is only a
+            # single material type)
+            or len(typeref.children) == 0
+        ):
+            inheritance_selects = _selects_for_typeref_inheritance(
+                typeref,
+                path_id,
+                lateral=lateral,
+                ignore_rewrites=ignore_rewrites,
+                ctx=ctx
             )
-            ctx.type_inheritance_ctes[typeref.id] = type_cte
-            ctx.ordered_type_ctes.append(type_cte)
+            ops = [
+                (context.OverlayOp.UNION, select)
+                for select in inheritance_selects
+            ]
 
-        else:
-            type_cte = ctx.type_inheritance_ctes[typeref.id]
-
-        with ctx.subrel() as sctx:
-            cte_rvar = rvar_for_rel(
-                type_cte,
+            rvar = range_from_queryset(
+                ops,
+                typeref.name_hint,
+                lateral=lateral,
+                path_id=path_id,
                 typeref=typeref,
+                tag='expanded-inhview',
                 ctx=ctx,
             )
 
-            if path_id != typeref_path:
-                pathctx.put_path_id_map(sctx.rel, path_id, typeref_path)
-            include_rvar(
-                sctx.rel,
-                cte_rvar,
-                typeref_path,
-                pull_namespace=False,
-                ctx=sctx,
+        else:
+            typeref_path: irast.PathId = irast.PathId.from_typeref(
+                typeref,
+                # If there are backlinks and the path revisits a type, a
+                # semi-join is produced. This ensures that the rvar produced
+                # does not have a duplicate path var.
+                # For example: (select A.b.<b[is A])
+                namespace=frozenset({'typeref'})
             )
-            rvar = rvar_for_rel(
-                sctx.rel, lateral=lateral, typeref=typeref, ctx=sctx)
+
+            if typeref.id not in ctx.type_inheritance_ctes:
+                inheritance_selects = _selects_for_typeref_inheritance(
+                    typeref,
+                    typeref_path,
+                    lateral=lateral,
+                    ignore_rewrites=ignore_rewrites,
+                    ctx=ctx
+                )
+
+                type_qry: pgast.SelectStmt = inheritance_selects[0]
+                for rarg in inheritance_selects[1:]:
+                    type_qry = pgast.SelectStmt(
+                        op='union',
+                        all=True,
+                        larg=type_qry,
+                        rarg=rarg,
+                    )
+
+                type_cte = pgast.CommonTableExpr(
+                    name=ctx.env.aliases.get(f't_{typeref.name_hint}'),
+                    query=type_qry,
+                    materialized=False,
+                )
+                ctx.type_inheritance_ctes[typeref.id] = type_cte
+                ctx.ordered_type_ctes.append(type_cte)
+
+            else:
+                type_cte = ctx.type_inheritance_ctes[typeref.id]
+
+            with ctx.subrel() as sctx:
+                cte_rvar = rvar_for_rel(
+                    type_cte,
+                    typeref=typeref,
+                    ctx=ctx,
+                )
+                if path_id != typeref_path:
+                    pathctx.put_path_id_map(sctx.rel, path_id, typeref_path)
+                include_rvar(
+                    sctx.rel,
+                    cte_rvar,
+                    typeref_path,
+                    pull_namespace=False,
+                    ctx=sctx,
+                )
+                rvar = rvar_for_rel(
+                    sctx.rel, lateral=lateral, typeref=typeref, ctx=sctx)
 
     else:
         assert not typeref.is_view, "attempting to generate range from view"
@@ -1816,6 +1833,37 @@ def range_for_material_objtype(
         )
 
     return rvar
+
+
+def _selects_for_typeref_inheritance(
+    typeref: irast.TypeRef,
+    path_id: irast.PathId,
+    *,
+    lateral: bool=False,
+    ignore_rewrites: bool=False,
+    ctx: context.CompilerContextLevel,
+) -> list[pgast.SelectStmt]:
+    selects = []
+    typerefs = [typeref, *irtyputils.get_typeref_descendants(typeref)]
+    all_abstract = all(subref.is_abstract for subref in typerefs)
+    for subref in typerefs:
+        if subref.is_abstract and not all_abstract:
+            continue
+        rvar = range_for_material_objtype(
+            subref, path_id, lateral=lateral,
+            include_descendants=False,
+            include_overlays=False,
+            ignore_rewrites=ignore_rewrites,  # XXX: Is this right?
+            ctx=ctx,
+        )
+        qry = pgast.SelectStmt(from_clause=[rvar])
+        sub_path_id = path_id
+        pathctx.put_path_value_rvar(qry, sub_path_id, rvar)
+        pathctx.put_path_source_rvar(qry, sub_path_id, rvar)
+
+        selects.append(qry)
+
+    return selects
 
 
 def range_for_typeref(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -2180,12 +2180,12 @@ def _range_for_component_ptrref(
             path_id=path_id,
             ctx=ctx,
         )
-        descentant_ops = [
+        descendant_ops = [
             (context.OverlayOp.UNION, select)
             for select in descendant_selects
         ]
         component_rvar = range_from_queryset(
-            descentant_ops,
+            descendant_ops,
             component_ptrref.shortname,
             path_id=path_id,
             ctx=ctx,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -927,6 +927,21 @@ def process_set_as_link_property_ref(
                         ),
                     ),
                 )
+        elif isinstance(link_rvar.query, pgast.SelectStmt):
+            # When processing link properties into a CTE, map the current link
+            # path id into the form used by the CTE.
+
+            for from_rvar in link_rvar.query.from_clause:
+                if (
+                    isinstance(from_rvar, pgast.RelRangeVar)
+                    and isinstance(from_rvar.relation, pgast.CommonTableExpr)
+                    and from_rvar.relation.query.path_id is not None
+                ):
+                    pathctx.put_path_id_map(
+                        link_rvar.query,
+                        link_path_id,
+                        from_rvar.relation.query.path_id
+                    )
 
         rvars.append(SetRVar(
             link_rvar,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -897,7 +897,7 @@ def process_set_as_link_property_ref(
                 {spec.id for spec in rptr_specialization}
                 if rptr_specialization is not None else None
             )
-            if ctx.env.expand_inhviews and ptr_ids and rptr_specialization:
+            if ptr_ids and rptr_specialization:
                 ptr_ids.update(
                     x.id for spec in rptr_specialization
                     for x in spec.descendants()

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -243,7 +243,7 @@ def get_set_rvar(
         rvars = _get_expr_set_rvar(ir_set.expr, ir_set, ctx=subctx)
         relctx.update_scope_masks(ir_set, rvars.main.rvar, ctx=subctx)
 
-        if ctx.env.expand_inhviews:
+        if ctx.env.is_explain:
             for srvar in rvars.new:
                 if not srvar.rvar.ir_origins:
                     srvar.rvar.ir_origins = []

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1169,6 +1169,19 @@ class FunctionCommand(MetaCommand):
     ) -> s_expr.CompiledExpression:
         if isinstance(body, s_expr.CompiledExpression):
             return body
+
+        # HACK: When an object type selected by a function (via
+        # inheritance) is dropped, the function gets
+        # recompiled. Unfortunately, 'caused' subcommands run *before*
+        # the object is actually deleted, and so we would ordinarily
+        # still try to select from the deleted object. To avoid
+        # needing to add *another* type of subcommand, we work around
+        # this by temporarily stripping all objects that are about to
+        # be deleted from the schema.
+        for ctx in context.stack:
+            if isinstance(ctx.op, s_objtypes.DeleteObjectType):
+                schema = schema.delete(ctx.op.scls)
+
         return s_funcs.compile_function(
             schema,
             context,

--- a/edb/pgsql/inheritance.py
+++ b/edb/pgsql/inheritance.py
@@ -7,6 +7,8 @@ from edb.schema import pointers as s_pointers
 from edb.schema import sources as s_sources
 from edb.schema import schema as s_schema
 
+from edb.ir import typeutils as irtyputils
+
 from . import ast as pgast
 from . import types
 from . import common
@@ -69,8 +71,8 @@ def get_inheritance_view(
         # excruciatingly slow because of the cost of explicit id
         # checks. See #5168.
         and (
-            not types.is_cfg_view(child, schema)
-            or types.is_cfg_view(obj, schema)
+            not irtyputils.is_cfg_view(child, schema)
+            or irtyputils.is_cfg_view(obj, schema)
         )
     ]
 
@@ -125,7 +127,7 @@ def _get_select_from(
     system_cols = ['tableoid', 'xmin', 'cmin', 'xmax', 'cmax', 'ctid']
     for sys_col_name in system_cols:
         val: pgast.BaseExpr
-        if not types.is_cfg_view(obj, schema):
+        if not irtyputils.is_cfg_view(obj, schema):
             val = pgast.ColumnRef(name=(table_rvar_name, sys_col_name))
         else:
             val = pgast.NullConstant()

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -768,36 +768,6 @@ def _ptrref_storable_in_pointer(ptrref: irast.BasePointerRef) -> bool:
         )
 
 
-# Modules where all the "types" in them are really just custom views
-# provided by metaschema.
-VIEW_MODULES = ('sys', 'cfg')
-
-
-def is_cfg_view(
-    obj: s_obj.Object,
-    schema: s_schema.Schema,
-) -> bool:
-    return (
-        isinstance(obj, (s_objtypes.ObjectType, s_pointers.Pointer))
-        and (
-            obj.get_name(schema).module in VIEW_MODULES
-            or bool(
-                (cfg_object := schema.get(
-                    'cfg::ConfigObject',
-                    type=s_objtypes.ObjectType, default=None
-                ))
-                and (
-                    nobj := (
-                        obj if isinstance(obj, s_objtypes.ObjectType)
-                        else obj.get_source(schema)
-                    )
-                )
-                and nobj.issubclass(schema, cfg_object)
-            )
-        )
-    )
-
-
 def has_table(
     obj: Optional[s_obj.InheritingObject], schema: s_schema.Schema
 ) -> bool:

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2088,6 +2088,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         context: CommandContext,
         *,
         action: str,
+        include_self: bool=True,
         include_ancestors: bool=False,
         extra_refs: Optional[Dict[so.Object, List[str]]]=None,
         filter: Type[so.Object] | Tuple[Type[so.Object], ...] | None = None,
@@ -2104,7 +2105,9 @@ class ObjectCommand(Command, Generic[so.Object_T]):
             fixer = None
 
         scls = self.scls
-        expr_refs = s_expr.get_expr_referrers(schema, scls)
+        expr_refs: dict[so.Object, list[str]] = {}
+        if include_self:
+            expr_refs.update(s_expr.get_expr_referrers(schema, scls))
         if include_ancestors and isinstance(scls, so.InheritingObject):
             for anc in scls.get_ancestors(schema).objects(schema):
                 expr_refs.update(s_expr.get_expr_referrers(schema, anc))
@@ -3203,6 +3206,8 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
         context: CommandContext,
     ) -> s_schema.Schema:
         if not context.canonical:
+            # This is rarely triggered.
+            schema = self._finalize_affected_refs(schema, context)
             self.validate_object(schema, context)
         return schema
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -51,6 +51,7 @@ from edb import errors
 
 from edb import edgeql
 from edb.ir import statypes
+from edb.ir import typeutils as irtyputils
 from edb.edgeql import ast as qlast
 
 from edb.common import debug
@@ -79,7 +80,6 @@ from edb.server import pgcluster
 from edb.server import pgcon
 
 from edb.pgsql import common as pg_common
-from edb.pgsql import types as pg_types
 from edb.pgsql import dbops
 from edb.pgsql import delta as delta_cmds
 from edb.pgsql import metaschema
@@ -1135,7 +1135,7 @@ async def create_branch(
     multi_properties = {
         prop for prop in schema.get_objects(type=s_props.Property)
         if prop.get_cardinality(schema).is_multi()
-        and prop.get_name(schema).module not in pg_types.VIEW_MODULES
+        and prop.get_name(schema).module not in irtyputils.VIEW_MODULES
     }
 
     for mprop in multi_properties:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1705,7 +1705,7 @@ def _get_compile_options(
             and not ctx.bootstrap_mode
             and not ctx.schema_reflection_mode
         ) or is_explain,
-        use_type_inheritance_ctes=(
+        use_inheritance_ctes=(
             not is_explain
             and not ctx.bootstrap_mode
             and not ctx.schema_reflection_mode
@@ -1895,7 +1895,7 @@ def _compile_ql_query(
         output_format=_convert_format(ctx.output_format),
         backend_runtime_params=ctx.backend_runtime_params,
         expand_inhviews=options.expand_inhviews,
-        use_type_inheritance_ctes=options.use_type_inheritance_ctes,
+        use_inheritance_ctes=options.use_inheritance_ctes,
         detach_params=(use_persistent_cache
                        and cache_mode is config.QueryCacheMode.PgFunc),
         versioned_stdlib=True,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1701,9 +1701,6 @@ def _get_compile_options(
         allow_user_specified_id=_get_config_val(
             ctx, 'allow_user_specified_id') or ctx.schema_reflection_mode,
         is_explain=is_explain,
-        use_inheritance_ctes=(
-            not is_explain
-        ),
         testmode=_get_config_val(ctx, '__internal_testmode'),
         schema_reflection_mode=(
             ctx.schema_reflection_mode
@@ -1889,7 +1886,6 @@ def _compile_ql_query(
         output_format=_convert_format(ctx.output_format),
         backend_runtime_params=ctx.backend_runtime_params,
         is_explain=options.is_explain,
-        use_inheritance_ctes=options.use_inheritance_ctes,
         detach_params=(use_persistent_cache
                        and cache_mode is config.QueryCacheMode.PgFunc),
         versioned_stdlib=True,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1705,6 +1705,11 @@ def _get_compile_options(
             and not ctx.bootstrap_mode
             and not ctx.schema_reflection_mode
         ) or is_explain,
+        use_type_inheritance_ctes=(
+            not is_explain
+            and not ctx.bootstrap_mode
+            and not ctx.schema_reflection_mode
+        ),
         testmode=_get_config_val(ctx, '__internal_testmode'),
         schema_reflection_mode=(
             ctx.schema_reflection_mode
@@ -1890,6 +1895,7 @@ def _compile_ql_query(
         output_format=_convert_format(ctx.output_format),
         backend_runtime_params=ctx.backend_runtime_params,
         expand_inhviews=options.expand_inhviews,
+        use_type_inheritance_ctes=options.use_type_inheritance_ctes,
         detach_params=(use_persistent_cache
                        and cache_mode is config.QueryCacheMode.PgFunc),
         versioned_stdlib=True,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1703,8 +1703,6 @@ def _get_compile_options(
         is_explain=is_explain,
         use_inheritance_ctes=(
             not is_explain
-            and not ctx.bootstrap_mode
-            and not ctx.schema_reflection_mode
         ),
         testmode=_get_config_val(ctx, '__internal_testmode'),
         schema_reflection_mode=(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1700,11 +1700,7 @@ def _get_compile_options(
             ctx, 'apply_access_policies'),
         allow_user_specified_id=_get_config_val(
             ctx, 'allow_user_specified_id') or ctx.schema_reflection_mode,
-        expand_inhviews=(
-            debug.flags.edgeql_expand_inhviews
-            and not ctx.bootstrap_mode
-            and not ctx.schema_reflection_mode
-        ) or is_explain,
+        is_explain=is_explain,
         use_inheritance_ctes=(
             not is_explain
             and not ctx.bootstrap_mode
@@ -1894,7 +1890,7 @@ def _compile_ql_query(
         expected_cardinality_one=ctx.expected_cardinality_one,
         output_format=_convert_format(ctx.output_format),
         backend_runtime_params=ctx.backend_runtime_params,
-        expand_inhviews=options.expand_inhviews,
+        is_explain=options.is_explain,
         use_inheritance_ctes=options.use_inheritance_ctes,
         detach_params=(use_persistent_cache
                        and cache_mode is config.QueryCacheMode.PgFunc),


### PR DESCRIPTION
If a type or pointer has children and the compiler is not using EXPLAIN, use a CTE instead of the current inheritance views.

Also remove the `expand_inhview` debug flag.