### PR TITLE
Version a lot more, trampoline a bit less

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -203,7 +203,11 @@ def edgedb_name_to_pg_name(name: str, prefix_length: int = 0) -> str:
     return _edgedb_name_to_pg_name(name, prefix_length)
 
 
-def convert_name(name: s_name.QualName, suffix='', catenate=True):
+def convert_name(
+    name: s_name.QualName, suffix='', catenate=True,
+    *,
+    versioned=False,
+):
     schema = get_module_backend_name(name.get_module_name())
     if suffix:
         sname = f'{name.name}_{suffix}'
@@ -211,6 +215,10 @@ def convert_name(name: s_name.QualName, suffix='', catenate=True):
         sname = name.name
 
     dbname = edgedb_name_to_pg_name(sname)
+
+    if versioned:
+        from . import trampoline
+        schema = trampoline.maybe_versioned_schema(schema)
 
     if catenate:
         return qname(schema, dbname)
@@ -280,6 +288,7 @@ def get_objtype_backend_name(
     module_name: str,
     *,
     catenate: bool = True,
+    versioned: bool = False,
     aspect: Optional[str] = None,
 ):
     if aspect is None:
@@ -296,10 +305,13 @@ def get_objtype_backend_name(
     name = s_name.QualName(module=module_name, name=str(id))
 
     suffix = get_aspect_suffix(aspect)
-    return convert_name(name, suffix=suffix, catenate=catenate)
+    return convert_name(
+        name, suffix=suffix, catenate=catenate, versioned=versioned)
 
 
-def get_pointer_backend_name(id, module_name, *, catenate=False, aspect=None):
+def get_pointer_backend_name(
+    id, module_name, *, catenate=False, aspect=None, versioned=False
+):
     if aspect is None:
         aspect = 'table'
 
@@ -310,7 +322,9 @@ def get_pointer_backend_name(id, module_name, *, catenate=False, aspect=None):
     name = s_name.QualName(module=module_name, name=str(id))
 
     suffix = get_aspect_suffix(aspect)
-    return convert_name(name, suffix=suffix, catenate=catenate)
+    return convert_name(
+        name, suffix=suffix, catenate=catenate, versioned=versioned
+    )
 
 
 operator_map = {

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -206,7 +206,7 @@ def edgedb_name_to_pg_name(name: str, prefix_length: int = 0) -> str:
 def convert_name(
     name: s_name.QualName, suffix='', catenate=True,
     *,
-    versioned=False,
+    versioned=True,
 ):
     schema = get_module_backend_name(name.get_module_name())
     if suffix:
@@ -310,7 +310,7 @@ def get_objtype_backend_name(
 
 
 def get_pointer_backend_name(
-    id, module_name, *, catenate=False, aspect=None, versioned=False
+    id, module_name, *, catenate=False, aspect=None, versioned=True
 ):
     if aspect is None:
         aspect = 'table'
@@ -341,7 +341,7 @@ operator_map = {
 
 
 def get_operator_backend_name(
-    name, catenate=False, *, versioned=False, aspect=None
+    name, catenate=False, *, versioned=True, aspect=None
 ):
     if aspect is None:
         aspect = 'operator'
@@ -382,7 +382,7 @@ def get_cast_backend_name(
 
 
 def get_function_backend_name(
-    name, backend_name, catenate=False, versioned=False,
+    name, backend_name, catenate=False, versioned=True,
 ):
     real_name = backend_name or name.name
 
@@ -444,7 +444,7 @@ def get_backend_name(
     obj: so.Object,
     catenate: Literal[True]=True,
     *,
-    versioned: bool=False,
+    versioned: bool=True,
     aspect: Optional[str]=None
 ) -> str:
     ...
@@ -456,7 +456,7 @@ def get_backend_name(
     obj: so.Object,
     catenate: Literal[False],
     *,
-    versioned: bool=False,
+    versioned: bool=True,
     aspect: Optional[str]=None
 ) -> tuple[str, str]:
     ...
@@ -468,7 +468,7 @@ def get_backend_name(
     catenate: bool=True,
     *,
     aspect: Optional[str]=None,
-    versioned: bool=False,
+    versioned: bool=True,
 ) -> Union[str, tuple[str, str]]:
     name: Union[s_name.QualName, s_name.Name]
     if isinstance(obj, s_objtypes.ObjectType):

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -24,7 +24,7 @@ import functools
 import hashlib
 import base64
 import re
-from typing import Literal, Optional, Tuple, Union, overload
+from typing import Any, Literal, Optional, Tuple, Union, overload
 import uuid
 
 from edb.common import uuidgen
@@ -424,6 +424,7 @@ def get_backend_name(
     obj: so.Object,
     catenate: Literal[True]=True,
     *,
+    versioned: bool=False,
     aspect: Optional[str]=None
 ) -> str:
     ...
@@ -435,12 +436,28 @@ def get_backend_name(
     obj: so.Object,
     catenate: Literal[False],
     *,
+    versioned: bool=False,
     aspect: Optional[str]=None
 ) -> tuple[str, str]:
     ...
 
 
 def get_backend_name(
+    schema: s_schema.Schema,
+    obj: so.Object,
+    catenate: bool=True,
+    *,
+    aspect: Optional[str]=None,
+    versioned: bool=False,
+) -> Union[str, tuple[str, str]]:
+    name: Any = _get_backend_name(schema, obj, catenate=catenate, aspect=aspect)
+    if versioned and isinstance(name, tuple):
+        from . import trampoline
+        name = trampoline.versioned_name(name)
+    return name
+
+
+def _get_backend_name(
     schema: s_schema.Schema,
     obj: so.Object,
     catenate: bool=True,

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -508,6 +508,7 @@ class Environment:
     external_rvars: Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
     materialized_views: Dict[uuid.UUID, irast.Set]
     backend_runtime_params: pgparams.BackendRuntimeParams
+    versioned_stdlib: bool
 
     #: A list of CTEs that implement constraint validation at the
     #: query level.
@@ -530,6 +531,7 @@ class Environment:
             Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
         ] = None,
         backend_runtime_params: pgparams.BackendRuntimeParams,
+        versioned_stdlib: bool = True,
     ) -> None:
         self.aliases = aliases.AliasGenerator()
         self.output_format = output_format
@@ -547,6 +549,8 @@ class Environment:
         self.materialized_views = {}
         self.check_ctes = []
         self.backend_runtime_params = backend_runtime_params
+        # XXX: TRAMPOLINE: THIS IS WRONG
+        self.versioned_stdlib = True
 
 
 # XXX: this context hack is necessary until pathctx is converted

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -531,6 +531,7 @@ class Environment:
             Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
         ] = None,
         backend_runtime_params: pgparams.BackendRuntimeParams,
+        # XXX: TRAMPOLINE: THIS IS WRONG
         versioned_stdlib: bool = True,
     ) -> None:
         self.aliases = aliases.AliasGenerator()
@@ -549,8 +550,7 @@ class Environment:
         self.materialized_views = {}
         self.check_ctes = []
         self.backend_runtime_params = backend_runtime_params
-        # XXX: TRAMPOLINE: THIS IS WRONG
-        self.versioned_stdlib = True
+        self.versioned_stdlib = versioned_stdlib
 
 
 # XXX: this context hack is necessary until pathctx is converted

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1585,6 +1585,7 @@ def range_for_material_objtype(
                 'inhview'
             ),
             catenate=False,
+            versioned=ctx.env.versioned_stdlib,
         )
 
         relation = pgast.Relation(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -113,6 +113,9 @@ if TYPE_CHECKING:
     from edb.schema import schema as s_schema
 
 
+V = trampoline.versioned_schema
+
+
 # Modules where all the "types" in them are really just custom views
 # provided by metaschema.
 VIEW_MODULES = ('sys', 'cfg')
@@ -402,7 +405,7 @@ class AlterSchemaVersion(
                             (SELECT
                                 version::text
                             FROM
-                                edgedb."_SchemaSchemaVersion"
+                                {V('edgedb')}."_SchemaSchemaVersion"
                             FOR UPDATE),
                             {ql(str(expected_ver))}
                         )),
@@ -410,7 +413,7 @@ class AlterSchemaVersion(
                         msg => (
                             'Cannot serialize DDL: '
                             || (SELECT version::text FROM
-                                edgedb."_SchemaSchemaVersion")
+                                {V('edgedb')}."_SchemaSchemaVersion")
                         )
                     )
                 INTO _dummy_text
@@ -560,7 +563,7 @@ class AlterGlobalSchemaVersion(
                         msg => (
                             'Cannot serialize global DDL: '
                             || (SELECT version::text FROM
-                                edgedb."_SysGlobalSchemaVersion")
+                                {V('edgedb')}."_SysGlobalSchemaVersion")
                         )
                     )
                 INTO _dummy_text
@@ -577,7 +580,7 @@ class AlterGlobalSchemaVersion(
                             (SELECT
                                 version::text
                             FROM
-                                edgedb."_SysGlobalSchemaVersion"
+                                {V('edgedb')}."_SysGlobalSchemaVersion"
                             ),
                             {ql(str(expected_ver))}
                         )),
@@ -585,7 +588,7 @@ class AlterGlobalSchemaVersion(
                         msg => (
                             'Cannot serialize global DDL: '
                             || (SELECT version::text FROM
-                                edgedb."_SysGlobalSchemaVersion")
+                                {V('edgedb')}."_SysGlobalSchemaVersion")
                         )
                     )
                 INTO _dummy_text
@@ -1335,7 +1338,7 @@ class FunctionCommand(MetaCommand):
                             target AS ancestor,
                             index
                         FROM
-                            edgedb."_SchemaObjectType__ancestors"
+                            edgedb._object_ancestors
                             WHERE source = {qi(type_param_name)}
                         ) a
                     WHERE ancestor IN ({impl_ids})
@@ -6261,7 +6264,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                             edgedb._get_schema_object_name(link.{far_endpoint})
                             INTO linkname, endname
                         FROM
-                            edgedb."_SchemaLink" AS link
+                            edgedb._schema_links AS link
                         WHERE
                             link.id = link_type_id;
                         RAISE foreign_key_violation
@@ -6483,7 +6486,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                             edgedb._get_schema_object_name(link.{far_endpoint})
                             INTO linkname, endname
                         FROM
-                            edgedb."_SchemaLink" AS link
+                            edgedb._schema_links AS link
                         WHERE
                             link.id = link_type_id;
                         RAISE foreign_key_violation

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3069,7 +3069,7 @@ class CompositeMetaCommand(MetaCommand):
         is_internal_view = is_cfg_view(obj, schema)
         aspect = 'dummy' if is_internal_view else None
         return common.get_backend_name(
-            schema, obj, catenate=False, versioned=True, aspect=aspect)
+            schema, obj, catenate=False, aspect=aspect)
 
     @classmethod
     def _refresh_fake_cfg_view_cmd(
@@ -3100,7 +3100,7 @@ class CompositeMetaCommand(MetaCommand):
         # Then, when we run the metaschema script, it simply swaps out
         # this hacky view for the real one and everything works out fine.
         orig_name = common.get_backend_name(
-            schema, obj, catenate=False, versioned=True
+            schema, obj, catenate=False,
         )
         dummy_name = cls._get_table_name(obj, schema)
         query = f'''
@@ -3216,7 +3216,7 @@ class CompositeMetaCommand(MetaCommand):
             (SELECT
                {coltext}
              FROM
-               {q(*trampoline.versioned_name(tabname))} AS {talias}
+               {q(*tabname)} AS {talias}
             )
         ''')
 
@@ -3231,7 +3231,7 @@ class CompositeMetaCommand(MetaCommand):
         pg_schema: Optional[str] = None,
     ) -> dbops.View:
         inhview_name = common.get_backend_name(
-            schema, obj, catenate=False, aspect='inhview', versioned=True)
+            schema, obj, catenate=False, aspect='inhview')
 
         if pg_schema is not None:
             inhview_name = (pg_schema, inhview_name[1])
@@ -3476,7 +3476,7 @@ class CompositeMetaCommand(MetaCommand):
         conditional: bool = False,
     ) -> None:
         inhview_name = common.get_backend_name(
-            schema, obj, catenate=False, aspect='inhview', versioned=True)
+            schema, obj, catenate=False, aspect='inhview')
         conditions = []
         if conditional:
             conditions.append(dbops.ViewExists(inhview_name))
@@ -4245,7 +4245,6 @@ class PointerMetaCommand(
             orig_schema,
             source,
             catenate=False,
-            versioned=True,
         ))
 
         # initial extern relvar (see docs of _compile_conversion_expr)
@@ -4343,7 +4342,6 @@ class PointerMetaCommand(
                 orig_schema,
                 source,
                 catenate=False,
-                versioned=True,
             ))
 
             update_qry = textwrap.dedent(f'''\
@@ -4446,7 +4444,7 @@ class PointerMetaCommand(
         if fill_expr is not None:
 
             assert ptr_stor_info.table_name
-            tab = q(*trampoline.versioned_name(ptr_stor_info.table_name))
+            tab = q(*ptr_stor_info.table_name)
             target_col = ptr_stor_info.column_name
             source = ptr.get_source(orig_schema)
             assert source
@@ -4454,7 +4452,6 @@ class PointerMetaCommand(
                 orig_schema,
                 source,
                 catenate=False,
-                versioned=True,
             ))
 
             if not is_multi:
@@ -4617,7 +4614,7 @@ class PointerMetaCommand(
                 schema=orig_schema,
             )
 
-        tab = q(*trampoline.versioned_name(old_ptr_stor_info.table_name))
+        tab = q(*old_ptr_stor_info.table_name)
         target_col = old_ptr_stor_info.column_name
         aux_ptr_table = None
         aux_ptr_col = None
@@ -6937,8 +6934,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
         inline: bool = False,
     ) -> None:
 
-        table_name = trampoline.versioned_name(common.get_backend_name(
-            schema, objtype, catenate=False))
+        table_name = common.get_backend_name(schema, objtype, catenate=False)
 
         trigger_name = self.get_trigger_name(
             schema, objtype, disposition=disposition,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3068,8 +3068,8 @@ class CompositeMetaCommand(MetaCommand):
     def _get_table_name(obj, schema) -> tuple[str, str]:
         is_internal_view = is_cfg_view(obj, schema)
         aspect = 'dummy' if is_internal_view else None
-        return common.get_backend_name(
-            schema, obj, catenate=False, aspect=aspect)
+        return trampoline.versioned_name(common.get_backend_name(
+            schema, obj, catenate=False, aspect=aspect))
 
     @classmethod
     def _refresh_fake_cfg_view_cmd(
@@ -3214,7 +3214,7 @@ class CompositeMetaCommand(MetaCommand):
             (SELECT
                {coltext}
              FROM
-               {q(*tabname)} AS {talias}
+               {q(*trampoline.versioned_name(tabname))} AS {talias}
             )
         ''')
 
@@ -6932,8 +6932,8 @@ class UpdateEndpointDeleteActions(MetaCommand):
         inline: bool = False,
     ) -> None:
 
-        table_name = common.get_backend_name(
-            schema, objtype, catenate=False)
+        table_name = trampoline.versioned_name(common.get_backend_name(
+            schema, objtype, catenate=False))
 
         trigger_name = self.get_trigger_name(
             schema, objtype, disposition=disposition,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -103,6 +103,7 @@ from .common import qname as q
 from .common import quote_literal as ql
 from .common import quote_ident as qi
 from .common import quote_type as qt
+from .common import versioned_schema as V
 from . import compiler
 from . import codegen
 from . import schemamech
@@ -111,9 +112,6 @@ from . import types
 
 if TYPE_CHECKING:
     from edb.schema import schema as s_schema
-
-
-V = trampoline.versioned_schema
 
 
 # Modules where all the "types" in them are really just custom views

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -327,6 +327,31 @@ class MetaCommand(sd.Command, metaclass=CommandMeta):
         assert isinstance(ctx.op, CompositeMetaCommand)
         ctx.op.post_inhview_update_commands.append(cmd)
 
+    @staticmethod
+    def get_function_type(
+        name: tuple[str, str]
+    ) -> Type[dbops.Function] | Type[trampoline.VersionedFunction]:
+        return (
+            trampoline.VersionedFunction if name[0] == 'edgedbstd'
+            else dbops.Function
+        )
+
+    @staticmethod
+    def maybe_trampoline_inline(
+        f: Optional[dbops.Function]
+    ) -> dbops.Command:
+        if isinstance(f, trampoline.VersionedFunction):
+            return dbops.CreateFunction(
+                trampoline.make_trampoline(f), or_replace=True
+            )
+        else:
+            return dbops.CommandGroup()
+
+    def maybe_trampoline(self, f: Optional[dbops.Function]) -> None:
+        # XXX: TRAMPOLINE: Is this where we want to do this???
+        if isinstance(f, trampoline.VersionedFunction):
+            self.pgops.add(self.maybe_trampoline_inline(f))
+
 
 class CommandGroupAdapted(MetaCommand, adapts=sd.CommandGroup):
     pass
@@ -1102,8 +1127,9 @@ class AlterParameter(
 
 
 class FunctionCommand(MetaCommand):
-    def get_pgname(self, func: s_funcs.Function, schema):
-        return common.get_backend_name(schema, func, catenate=False)
+    def get_pgname(self, func: s_funcs.Function, schema, versioned: bool=False):
+        return common.get_backend_name(
+            schema, func, catenate=False, versioned=versioned)
 
     def get_pgtype(self, func: s_funcs.CallableObject, obj, schema):
         if obj.is_any(schema):
@@ -1180,12 +1206,8 @@ class FunctionCommand(MetaCommand):
         func_return_typemod = func.get_return_typemod(schema)
         func_params = func.get_params(schema)
 
-        name = self.get_pgname(func, schema)
-        cls = (
-            trampoline.VersionedFunction if name[0] == 'edgedbstd'
-            else dbops.Function
-        )
-        return cls(
+        name = self.get_pgname(func, schema, versioned=False)
+        return self.get_function_type(name)(
             name=name,
             args=self.compile_args(func, schema),
             has_variadic=func_params.find_variadic(schema) is not None,
@@ -1573,16 +1595,10 @@ class FunctionCommand(MetaCommand):
                     f'unsupported language {func_language}',
                     span=self.span)
 
-            ops = []
+            ops: list[dbops.Command] = []
 
             ops.append(dbops.CreateFunction(dbf, or_replace=or_replace))
-            # XXX: TRAMPOLINE: Is this where we want to do this???
-            if isinstance(dbf, trampoline.VersionedFunction):
-                ops.append(
-                    dbops.CreateFunction(
-                        trampoline.make_trampoline(dbf), or_replace=True
-                    )
-                )
+            ops.append(self.maybe_trampoline_inline(dbf))
             return ops
 
 
@@ -1596,7 +1612,8 @@ class CreateFunction(
         context: sd.CommandContext,
     ) -> s_schema.Schema:
         schema = super().apply(schema, context)
-        self.pgops.update(self.make_op(self.scls, schema, context))
+        ops = self.make_op(self.scls, schema, context)
+        self.pgops.update(ops)
         return schema
 
 
@@ -1711,13 +1728,8 @@ class OperatorCommand(FunctionCommand):
 
     def make_operator_function(self, oper: s_opers.Operator, schema):
         name = common.get_backend_name(
-            schema, oper, catenate=False, aspect='function')
-        cls = (
-            trampoline.VersionedFunction if name[0] == 'edgedbstd'
-            else dbops.Function
-        )
-
-        return cls(
+            schema, oper, catenate=False, versioned=False, aspect='function')
+        return self.get_function_type(name)(
             name=name,
             args=self.compile_args(oper, schema),
             volatility=oper.get_volatility(schema),
@@ -1803,13 +1815,7 @@ class CreateOperator(OperatorCommand, adapts=s_opers.CreateOperator):
             oper_func = self.make_operator_function(oper, schema)
             self.pgops.add(dbops.CreateFunction(oper_func))
 
-            # XXX: TRAMPOLINE: Is this where we want to do this???
-            if isinstance(oper_func, trampoline.VersionedFunction):
-                self.pgops.add(
-                    dbops.CreateFunction(
-                        trampoline.make_trampoline(oper_func), or_replace=True
-                    )
-                )
+            self.maybe_trampoline(oper_func)
 
             if not params.has_polymorphic(schema):
                 cexpr = self.get_dummy_func_call(
@@ -1866,7 +1872,7 @@ class DeleteOperator(OperatorCommand, adapts=s_opers.DeleteOperator):
 class CastCommand(MetaCommand):
     def make_cast_function(self, cast: s_casts.Cast, schema):
         name = common.get_backend_name(
-            schema, cast, catenate=False, aspect='function')
+            schema, cast, catenate=False, versioned=False, aspect='function')
 
         args: Sequence[dbops.FunctionArg] = [
             (
@@ -1885,7 +1891,7 @@ class CastCommand(MetaCommand):
         # is heavy on json casts), so instead we just need to make sure
         # to write cast code that is naturally strict (this is enforced
         # by test_edgeql_casts_all_null).
-        return dbops.Function(
+        return self.get_function_type(name)(
             name=name,
             args=args,
             returns=returns,
@@ -1910,6 +1916,7 @@ class CreateCast(CastCommand, adapts=s_casts.CreateCast):
         if cast_language is ql_ast.Language.SQL and cast_code:
             cast_func = self.make_cast_function(cast, schema)
             self.pgops.add(dbops.CreateFunction(cast_func))
+            self.maybe_trampoline(cast_func)
 
         elif from_cast is not None or from_expr is not None:
             # This operator is handled by the compiler and does not
@@ -2405,13 +2412,15 @@ class CreateScalarType(ScalarTypeMetaCommand,
             dbops.CreateEnum(dbops.Enum(name=new_enum_name, values=values))
         )
 
+        fcls = cls.get_function_type(new_enum_name)
+
         # Cast wrapper function is needed for immutable casts, which are
         # needed for casting within indexes/constraints.
         # (Postgres casts are only stable)
         cast_func_name = common.get_backend_name(
             schema, scalar, catenate=False, aspect="enum-cast-from-str"
         )
-        cast_func = dbops.Function(
+        cast_func = fcls(
             name=cast_func_name,
             args=[("value", ("anyelement",))],
             volatility="immutable",
@@ -2419,12 +2428,13 @@ class CreateScalarType(ScalarTypeMetaCommand,
             text=f"SELECT value::{qt(new_enum_name)}",
         )
         ops.add_command(dbops.CreateFunction(cast_func))
+        ops.add_command(cls.maybe_trampoline_inline(cast_func))
 
         # Simialry, uncast from enum to str
         uncast_func_name = common.get_backend_name(
             schema, scalar, catenate=False, aspect="enum-cast-into-str"
         )
-        uncast_func = dbops.Function(
+        uncast_func = fcls(
             name=uncast_func_name,
             args=[("value", ("anyelement",))],
             volatility="immutable",
@@ -2432,6 +2442,7 @@ class CreateScalarType(ScalarTypeMetaCommand,
             text=f"SELECT value::text",
         )
         ops.add_command(dbops.CreateFunction(uncast_func))
+        ops.add_command(cls.maybe_trampoline_inline(uncast_func))
         return ops
 
     def _create_begin(

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -33,6 +33,7 @@ from edb.schema import objects as s_obj
 from edb.pgsql import common
 from edb.pgsql import dbops
 from edb.pgsql import schemamech
+from edb.pgsql import trampoline
 
 
 class SchemaDBObjectMeta(adapter.Adapter):  # type: ignore
@@ -304,8 +305,9 @@ class MultiConstraintItem:
 
     def get_id(self):
         raw_name = self.constraint.raw_constraint_name()
-        name = common.edgedb_name_to_pg_name(
-            '{}#{}'.format(raw_name, self.index))
+        # XXX
+        name = trampoline.versioned_name(common.edgedb_name_to_pg_name(
+            '{}#{}'.format(raw_name, self.index)))
         name = common.quote_ident(name)
 
         return '{} ON {} {}'.format(

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4872,6 +4872,7 @@ def tabname(
         obj,
         aspect='table',
         catenate=False,
+        versioned=True,
     )
 
 
@@ -4883,6 +4884,7 @@ def inhviewname(
         obj,
         aspect='inhview',
         catenate=False,
+        versioned=True,
     )
 
 
@@ -5577,6 +5579,7 @@ def _generate_schema_alias_view(
         obj,
         aspect='inhview',
         catenate=False,
+        versioned=True,
     )
 
     targets = []

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -6889,6 +6889,36 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
     )
 
 
+class ObjectAncestorsView(trampoline.VersionedView):
+    """A trampolined and explicit version of _SchemaObjectType__ancestors"""
+
+    query = r'''
+        SELECT source, target, index
+        FROM edgedb_VER."_SchemaObjectType__ancestors"
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', '_object_ancestors'),
+            query=self.query,
+        )
+
+
+class LinksView(trampoline.VersionedView):
+    """A trampolined and explicit version of _SchemaLink"""
+
+    query = r'''
+        SELECT id, name, source, target
+        FROM edgedb_VER."_SchemaLink"
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', '_schema_links'),
+            query=self.query,
+        )
+
+
 def get_config_type_views(
     schema: s_schema.Schema,
     conf: s_objtypes.ObjectType,
@@ -6951,6 +6981,33 @@ def get_config_views(
     return commands
 
 
+def get_synthetic_type_views(
+    schema: s_schema.Schema,
+    backend_params: params.BackendRuntimeParams,
+) -> dbops.CommandGroup:
+    commands = dbops.CommandGroup()
+
+    commands.add_command(get_config_views(schema))
+
+    for dbview in _generate_database_views(schema):
+        commands.add_command(dbops.CreateView(dbview, or_replace=True))
+
+    for extview in _generate_extension_views(schema):
+        commands.add_command(dbops.CreateView(extview, or_replace=True))
+
+    if backend_params.has_create_role:
+        role_views = _generate_role_views(schema)
+    else:
+        role_views = _generate_single_role_views(schema)
+    for roleview in role_views:
+        commands.add_command(dbops.CreateView(roleview, or_replace=True))
+
+    for verview in _generate_schema_ver_views(schema):
+        commands.add_command(dbops.CreateView(verview, or_replace=True))
+
+    return commands
+
+
 def get_support_views(
     schema: s_schema.Schema,
     backend_params: params.BackendRuntimeParams,
@@ -6977,37 +7034,28 @@ def get_support_views(
     for alias_view in schema_alias_views:
         commands.add_command(dbops.CreateView(alias_view, or_replace=True))
 
-    commands.add_command(get_config_views(schema))
+    synthetic_types = get_synthetic_type_views(schema, backend_params)
+    commands.add_command(synthetic_types)
 
-    for dbview in _generate_database_views(schema):
-        commands.add_command(dbops.CreateView(dbview, or_replace=True))
-
-    for extview in _generate_extension_views(schema):
-        commands.add_command(dbops.CreateView(extview, or_replace=True))
-
-    if backend_params.has_create_role:
-        role_views = _generate_role_views(schema)
-    else:
-        role_views = _generate_single_role_views(schema)
-    for roleview in role_views:
-        commands.add_command(dbops.CreateView(roleview, or_replace=True))
-
-    for verview in _generate_schema_ver_views(schema):
-        commands.add_command(dbops.CreateView(verview, or_replace=True))
+    # Create some trampolined wrapper views around _Schema types we need
+    # to reference from functions.
+    wrapper_commands = dbops.CommandGroup()
+    wrapper_commands.add_command(
+        dbops.CreateView(ObjectAncestorsView(), or_replace=True))
+    wrapper_commands.add_command(
+        dbops.CreateView(LinksView(), or_replace=True))
+    commands.add_command(wrapper_commands)
 
     sys_alias_views = _generate_schema_alias_views(
         schema, s_name.UnqualName('sys'))
     for alias_view in sys_alias_views:
         commands.add_command(dbops.CreateView(alias_view, or_replace=True))
 
-    # TODO: XXX: We still want to trampoline fewer of these.
-    # Currently we only skip the information schema stuff.
-    trampolines = []
-    trampolines.extend(trampoline_command(commands))
-
     commands.add_commands(_generate_sql_information_schema())
 
-    commands.add_commands(trampolines)
+    # The synthetic type views (cfg::, sys::) need to be trampolined
+    commands.add_commands(trampoline_command(synthetic_types))
+    commands.add_commands(trampoline_command(wrapper_commands))
 
     return commands
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5982,7 +5982,7 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
             ctid
         FROM pg_namespace
         WHERE nspname IN ('pg_catalog', 'pg_toast', 'information_schema',
-                          'edgedb', 'edgedbstd')
+                          'edgedb', 'edgedbstd', 'edgedb_VER', 'edgedbstd_VER')
         UNION ALL
 
         -- virtual schemas
@@ -6034,7 +6034,8 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
         JOIN pg_namespace pn ON pt.typnamespace = pn.oid
         WHERE
             nspname IN ('pg_catalog', 'pg_toast', 'information_schema',
-                        'edgedb', 'edgedbstd', 'edgedbpub')
+                        'edgedb', 'edgedbstd', 'edgedb_VER', 'edgedbstd_VER',
+                        'edgedbpub')
         """.format(
                 ",".join(
                     f"pt.{col}"

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -79,8 +79,7 @@ q = common.qname
 qi = common.quote_ident
 ql = common.quote_literal
 qt = common.quote_type
-
-V = trampoline.versioned_schema
+V = common.versioned_schema
 
 
 DATABASE_ID_NAMESPACE = uuidgen.UUID('0e6fed66-204b-11e9-8666-cffd58a5240b')

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -26,7 +26,7 @@ import uuid
 from edb import errors
 
 from edb.pgsql import ast as pgast
-from edb.pgsql import trampoline
+from edb.pgsql import common
 from edb.pgsql import compiler as pgcompiler
 
 from edb.schema import types as s_types
@@ -380,11 +380,11 @@ def resolve_SortBy(
 
 func_calls_remapping: Dict[Tuple[str, ...], Tuple[str, ...]] = {
     ('information_schema', '_pg_truetypid'): (
-        trampoline.versioned_schema('edgedbsql'),
+        common.versioned_schema('edgedbsql'),
         '_pg_truetypid',
     ),
     ('information_schema', '_pg_truetypmod'): (
-        trampoline.versioned_schema('edgedbsql'),
+        common.versioned_schema('edgedbsql'),
         '_pg_truetypmod',
     ),
     ('pg_catalog', 'format_type'): ('edgedb', '_format_type'),

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -27,7 +27,6 @@ from edb.server.pgcon import errors as pgerror
 from edb.pgsql import ast as pgast
 from edb.pgsql import common as pgcommon
 from edb.pgsql import codegen as pgcodegen
-from edb.pgsql import trampoline
 
 from edb.schema import objtypes as s_objtypes
 from edb.schema import links as s_links
@@ -226,12 +225,12 @@ def resolve_relation(
     if relation.schemaname == 'information_schema':
         preset_tables = (
             sql_introspection.INFORMATION_SCHEMA,
-            trampoline.versioned_schema('edgedbsql'),
+            pgcommon.versioned_schema('edgedbsql'),
         )
     elif not relation.schemaname or relation.schemaname == 'pg_catalog':
         preset_tables = (
             sql_introspection.PG_CATALOG,
-            trampoline.versioned_schema('edgedbsql'),
+            pgcommon.versioned_schema('edgedbsql'),
         )
     elif relation.schemaname == 'pg_toast':
         preset_tables = ({relation.name: PG_TOAST_TABLE}, 'pg_toast')

--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -25,14 +25,14 @@ from typing import Optional, Sequence, List
 from edb import errors
 
 from edb.pgsql import ast as pgast
+from edb.pgsql import common
 from edb.pgsql import parser as pgparser
-from edb.pgsql import trampoline
 from edb.server import defines
 
 from . import context
 from . import dispatch
 
-V = trampoline.versioned_schema
+V = common.versioned_schema
 
 Context = context.ResolverContextLevel
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -300,7 +300,7 @@ def compile_constraint(
 
         assert subject_table
         subject_db_name = common.get_backend_name(
-            schema, subject_table, catenate=False, versioned=True
+            schema, subject_table, catenate=False,
         )
         table_type = 'ObjectType'
 
@@ -358,7 +358,6 @@ def compile_constraint(
                 schema,
                 origin_subject,
                 catenate=False,
-                versioned=True,
             )
 
         origin_except_data = None
@@ -750,7 +749,7 @@ def get_ref_storage_info(
 
     for ref, (ptr, src) in ref_ptrs.items():
         ptr_info = types.get_pointer_storage_info(
-            ptr, source=src, resolve_type=False, schema=schema, versioned=True)
+            ptr, source=src, resolve_type=False, schema=schema)
 
         # See if any of the refs are hosted in pointer tables and others
         # are not...
@@ -767,7 +766,7 @@ def get_ref_storage_info(
             ptr, src = ref_ptrs[ref]
             ptr_info = types.get_pointer_storage_info(
                 ptr, source=src, resolve_type=False, link_bias=True,
-                schema=schema, versioned=True)
+                schema=schema)
 
             if ptr_info is not None and ptr_info.table_type == 'link':
                 link_biased[ref] = ptr_info

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -54,7 +54,6 @@ from . import common
 from . import types
 from . import compiler
 from . import codegen
-from . import trampoline
 from .common import qname as qn
 
 
@@ -301,7 +300,7 @@ def compile_constraint(
 
         assert subject_table
         subject_db_name = common.get_backend_name(
-            schema, subject_table, catenate=False
+            schema, subject_table, catenate=False, versioned=True
         )
         table_type = 'ObjectType'
 
@@ -359,6 +358,7 @@ def compile_constraint(
                 schema,
                 origin_subject,
                 catenate=False,
+                versioned=True,
             )
 
         origin_except_data = None
@@ -523,7 +523,7 @@ class SchemaTableConstraint:
         assert table_name
 
         return deltadbops.SchemaConstraintTableConstraint(
-            trampoline.versioned_name(table_name),
+            table_name,
             constraint=constr.constraint,
             exprdata=expressions,
             origin_exprdata=origin_expressions,
@@ -750,7 +750,7 @@ def get_ref_storage_info(
 
     for ref, (ptr, src) in ref_ptrs.items():
         ptr_info = types.get_pointer_storage_info(
-            ptr, source=src, resolve_type=False, schema=schema)
+            ptr, source=src, resolve_type=False, schema=schema, versioned=True)
 
         # See if any of the refs are hosted in pointer tables and others
         # are not...
@@ -767,7 +767,7 @@ def get_ref_storage_info(
             ptr, src = ref_ptrs[ref]
             ptr_info = types.get_pointer_storage_info(
                 ptr, source=src, resolve_type=False, link_bias=True,
-                schema=schema)
+                schema=schema, versioned=True)
 
             if ptr_info is not None and ptr_info.table_type == 'link':
                 link_biased[ref] = ptr_info

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -54,6 +54,7 @@ from . import common
 from . import types
 from . import compiler
 from . import codegen
+from . import trampoline
 from .common import qname as qn
 
 
@@ -521,7 +522,7 @@ class SchemaTableConstraint:
         origin_expressions = pg_c.origin_expressions
 
         return deltadbops.SchemaConstraintTableConstraint(
-            table_name,
+            trampoline.versioned_name(table_name),
             constraint=constr.constraint,
             exprdata=expressions,
             origin_exprdata=origin_expressions,
@@ -537,7 +538,9 @@ class SchemaTableConstraint:
 
         tabconstr = self._table_constraint(self)
         add_constr = deltadbops.AlterTableAddConstraint(
-            name=tabconstr.get_subject_name(quote=False), constraint=tabconstr)
+            name=tabconstr.get_subject_name(quote=False),
+            constraint=tabconstr,
+        )
 
         ops.add_command(add_constr)
 
@@ -565,7 +568,9 @@ class SchemaTableConstraint:
 
         tabconstr = self._table_constraint(self)
         add_constr = deltadbops.AlterTableDropConstraint(
-            name=tabconstr.get_subject_name(quote=False), constraint=tabconstr)
+            name=tabconstr.get_subject_name(quote=False),
+            constraint=tabconstr,
+        )
 
         ops.add_command(add_constr)
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -520,6 +520,7 @@ class SchemaTableConstraint:
         table_name = pg_c.subject_db_name
         expressions = pg_c.expressions
         origin_expressions = pg_c.origin_expressions
+        assert table_name
 
         return deltadbops.SchemaConstraintTableConstraint(
             trampoline.versioned_name(table_name),

--- a/edb/pgsql/trampoline.py
+++ b/edb/pgsql/trampoline.py
@@ -52,6 +52,9 @@ q = common.qname
 qi = common.quote_ident
 
 
+SCHEMAS = ('edgedb', 'edgedbstd', 'edgedbsql')
+
+
 def versioned_schema(s: str, version: Optional[int]=None) -> str:
     if version is None:
         # ... get_version_dict() is cached, so we use it instead of
@@ -63,18 +66,20 @@ def versioned_schema(s: str, version: Optional[int]=None) -> str:
     return f'{s}_v{version}'
 
 
+def maybe_versioned_schema(s: str, version: Optional[int]=None) -> str:
+    return versioned_schema(s, version=version) if s in SCHEMAS else s
+
+
 def versioned_name(
     s: tuple[str, ...], version: Optional[int]=None
-) -> str:
+) -> tuple[str, ...]:
     if len(s) > 1:
-        return (versioned_schema(s[0], version), *s[1:])
+        return (maybe_versioned_schema(s[0], version), *s[1:])
     else:
         return s
 
 
 V = versioned_schema
-
-SCHEMAS = ('edgedb', 'edgedbstd', 'edgedbsql')
 
 
 def fixup_query(query: str) -> str:

--- a/edb/pgsql/trampoline.py
+++ b/edb/pgsql/trampoline.py
@@ -63,6 +63,15 @@ def versioned_schema(s: str, version: Optional[int]=None) -> str:
     return f'{s}_v{version}'
 
 
+def versioned_name(
+    s: tuple[str, ...], version: Optional[int]=None
+) -> str:
+    if len(s) > 1:
+        return (versioned_schema(s[0], version), *s[1:])
+    else:
+        return s
+
+
 V = versioned_schema
 
 SCHEMAS = ('edgedb', 'edgedbstd', 'edgedbsql')

--- a/edb/pgsql/trampoline.py
+++ b/edb/pgsql/trampoline.py
@@ -92,7 +92,7 @@ class VersionedFunction(dbops.Function):
     if not TYPE_CHECKING:
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.name = (V(self.name[0]), *self.name[1:])
+            self.name = (maybe_versioned_schema(self.name[0]), *self.name[1:])
             self.text = fixup_query(self.text)
 
             if self.args:
@@ -110,7 +110,7 @@ class VersionedView(dbops.View):
     if not TYPE_CHECKING:
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.name = (V(self.name[0]), *self.name[1:])
+            self.name = (maybe_versioned_schema(self.name[0]), *self.name[1:])
             self.query = fixup_query(self.query)
 
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -84,6 +84,7 @@ from edb.pgsql import delta as delta_cmds
 from edb.pgsql import metaschema
 from edb.pgsql import params
 from edb.pgsql import patches
+from edb.pgsql import trampoline
 from edb.pgsql.common import quote_ident as qi
 from edb.pgsql.common import quote_literal as ql
 
@@ -1152,6 +1153,7 @@ async def create_branch(
     dump_args = [
         '--data-only',
         '--table=edgedbstd.*',
+        f'--table={trampoline.versioned_schema("edgedbstd")}.*',
         '--table=edgedb._db_config',
         '--table=edgedbinstdata.instdata',
         *data_arg,

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -84,7 +84,6 @@ from edb.pgsql import delta as delta_cmds
 from edb.pgsql import metaschema
 from edb.pgsql import params
 from edb.pgsql import patches
-from edb.pgsql import trampoline
 from edb.pgsql.common import quote_ident as qi
 from edb.pgsql.common import quote_literal as ql
 
@@ -1153,7 +1152,7 @@ async def create_branch(
     dump_args = [
         '--data-only',
         '--table=edgedbstd.*',
-        f'--table={trampoline.versioned_schema("edgedbstd")}.*',
+        f'--table={pg_common.versioned_schema("edgedbstd")}.*',
         '--table=edgedb._db_config',
         '--table=edgedbinstdata.instdata',
         *data_arg,

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -48,6 +48,7 @@ from edb.schema import version as s_ver
 from edb.pgsql import common as pg_common
 from edb.pgsql import delta as pg_delta
 from edb.pgsql import dbops as pg_dbops
+from edb.pgsql import trampoline
 
 from . import dbstate
 from . import compiler
@@ -207,7 +208,7 @@ def compile_and_apply_ddl_stmt(
                 f'{pg_common.quote_literal(tid)}::uuid' for tid in new_types
             ]
             sql = sql + (
-                textwrap.dedent(
+                trampoline.fixup_query(textwrap.dedent(
                     f'''\
                 SELECT
                     json_build_object(
@@ -220,7 +221,7 @@ def compile_and_apply_ddl_stmt(
                                 "backend_id"
                             )
                             FROM
-                            edgedb."_SchemaType"
+                            edgedb_VER."_SchemaType"
                             WHERE
                                 "id" = any(ARRAY[
                                     {', '.join(new_type_ids)}
@@ -228,7 +229,7 @@ def compile_and_apply_ddl_stmt(
                         )
                     )::text;
             '''
-                ).encode('utf-8'),
+                )).encode('utf-8'),
             )
 
     create_db = None

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -897,10 +897,11 @@ class Tenant(ha_base.ClusterProtocol):
     async def _introspect_extensions(
         self, conn: pgcon.PGConnection
     ) -> set[str]:
+        from edb.pgsql import trampoline
         extension_names_json = await conn.sql_fetch_val(
-            b"""
-                SELECT json_agg(name) FROM edgedb."_SchemaExtension";
-            """,
+            trampoline.fixup_query("""
+                SELECT json_agg(name) FROM edgedb_VER."_SchemaExtension";
+            """).encode('utf-8'),
         )
         if extension_names_json:
             extensions = set(json.loads(extension_names_json))
@@ -926,6 +927,7 @@ class Tenant(ha_base.ClusterProtocol):
 
         Returns True if the query cache mode changed.
         """
+        from edb.pgsql import trampoline
         logger.info("introspecting database '%s'", dbname)
 
         assert self._dbindex is not None
@@ -968,15 +970,15 @@ class Tenant(ha_base.ClusterProtocol):
             )
 
             backend_ids_json = await conn.sql_fetch_val(
-                b"""
+                trampoline.fixup_query("""
                 SELECT
                     json_object_agg(
                         "id"::text,
                         "backend_id"
                     )::text
                 FROM
-                    edgedb."_SchemaType"
-                """,
+                    edgedb_VER."_SchemaType"
+                """).encode('utf-8'),
             )
             backend_ids = json.loads(backend_ids_json)
 


### PR DESCRIPTION
Don't trampoline schema alias views, but do still version them.

Version schema stdlib types.

Teach common.get_backend_name and friends about versioning.
Importantly, and unlike previously, the *default* is now to version
the names.

Currently this results in us basically *always* using the
versioned names and almost never using the trampolines.

Next up is making whether to use versioned names fully configurable
throughout the compiler and configuring it properly when calling into
it.

Progress towards #6697.