### PR TITLE
Copy meta fields when copying AST nodes.

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -262,7 +262,7 @@ class AST:
 
     def __copy__(self):
         copied = self.__class__()
-        for field, value in iter_fields(self, include_meta=False):
+        for field, value in iter_fields(self, include_meta=True):
             try:
                 object.__setattr__(copied, field, value)
             except AttributeError:
@@ -272,7 +272,7 @@ class AST:
 
     def __deepcopy__(self, memo):
         copied = self.__class__()
-        for field, value in iter_fields(self, include_meta=False):
+        for field, value in iter_fields(self, include_meta=True):
             object.__setattr__(copied, field, copy.deepcopy(value, memo))
         return copied
 

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -211,7 +211,7 @@ class BaseRangeVar(ImmutableBaseExpr):
     This can be though as a specific instance of a table within a query.
     """
 
-    __ast_meta__ = {'tag', 'ir_origins'}
+    __ast_meta__ = {'schema_object_id', 'tag', 'ir_origins'}
     __ast_mutable_fields__ = frozenset(['ir_origins'])
 
     # This is a hack, since there is some code that relies on not


### PR DESCRIPTION
Meta fields ought to be copied when copying ast nodes as well.

Additionally, re-add `schema_object_id` to the meta fields for pg ast.