### PR TITLE
Fix ai::to_context duplication

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -347,6 +347,18 @@ def compile_FunctionCall(
     else:
         res = fcall
 
+    if isinstance(res, irast.FunctionCall) and res.body:
+        # If we are generating a special-cased inlined function call,
+        # make sure to register all the arguments in the scope tree
+        # to ensure that the compiled arguments get picked up when
+        # compiling the body.
+        for arg in res.args.values():
+            pathctx.register_set_in_scope(
+                arg.expr,
+                optional=arg.param_typemod == ft.TypeModifier.OptionalType,
+                ctx=ctx,
+            )
+
     ir_set = setgen.ensure_set(res, typehint=rtype, path_id=path_id, ctx=ctx)
     return stmt.maybe_add_view(ir_set, ctx=ctx)
 

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -357,6 +357,9 @@ def __infer_func_call(
         for g_arg in ir.global_args:
             _infer_set(g_arg, scope_tree=scope_tree, ctx=ctx)
 
+    if ir.body:
+        infer_multiplicity(ir.body, scope_tree=scope_tree, ctx=ctx)
+
     if card.is_single():
         return UNIQUE
     elif str(ir.func_shortname) == 'std::assert_distinct':

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -36,7 +36,7 @@ type Astronomy {
 type Stuff extending Astronomy {
     content2: str;
     deferred index ext::ai::index(embedding_model := 'text-embedding-test')
-        on (.content ++ .content2);
+        on ({.content} ++ {.content2});
 };
 
 type Star extending Astronomy;

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -209,6 +209,17 @@ class TestExtAI(tb.BaseHttpExtensionTest):
             variables=dict(qv=qv),
         )
 
+        await self.assert_query_result(
+            '''
+            select _ := ext::ai::to_context((select Stuff))
+            order by _
+            ''',
+            [
+                'Skies on Earth are blue',
+                'Skies on Mars are red',
+            ],
+        )
+
         async for tr in self.try_until_succeeds(
             ignore=(AssertionError,),
             timeout=10.0,
@@ -259,6 +270,17 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                 content := 'Skies on Earth are blue'
             };
             """,
+        )
+
+        await self.assert_query_result(
+            '''
+            select _ := ext::ai::to_context((select Star))
+            order by _
+            ''',
+            [
+                'Skies on Earth are blue',
+                'Skies on Mars are red',
+            ],
         )
 
         async for tr in self.try_until_succeeds(


### PR DESCRIPTION
The problem is that when we use the new inlined `body` field of
`FunctionCall`, the backend compiler still always compiles the
arguments, and since the arguments weren't registered in the scope
tree, the compiled arguments might not get picked up.

Fix this by always registering arguments when we produce an inlined body.
(We could *not* compile the arguments unconditionally for inlined
functions like this, but we'd still need to register the sets in case
the argument is used twice).

Fixes #7463.