### PR TITLE
Propagate spans in parsed SQL

### DIFF
--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -264,7 +264,7 @@ class SpanPropagator(ast.NodeVisitor):
                     span_list.append(span)
         return span_list
 
-    def generic_visit(self, node) -> Span | None:
+    def generic_visit(self, node):
         # base case: we already have span
         if not self._full_pass and getattr(node, 'span', None) is not None:
             return node.span

--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -33,7 +33,7 @@ contexts through the AST structure.
 
 from __future__ import annotations
 
-from typing import List
+from typing import Iterable, List
 import re
 import bisect
 
@@ -176,16 +176,20 @@ def get_span(*kids: List[ast.AST]):
     )
 
 
-def merge_spans(spans: List[Span]) -> Span:
-    spans.sort(key=lambda x: (x.start, x.end))
+def merge_spans(spans: Iterable[Span]) -> Span | None:
+    span_list = list(spans)
+    if not span_list:
+        return None
+
+    span_list.sort(key=lambda x: (x.start, x.end))
 
     # assume same name and buffer apply to all
     #
     return Span(
-        name=spans[0].name,
-        buffer=spans[0].buffer,
-        start=spans[0].start,
-        end=spans[-1].end,
+        name=span_list[0].name,
+        buffer=span_list[0].buffer,
+        start=span_list[0].start,
+        end=span_list[-1].end,
     )
 
 
@@ -233,43 +237,47 @@ class SpanPropagator(ast.NodeVisitor):
     also have correct span. For a node that has no span, its
     span is derived as a superset of all of the spans of its
     descendants.
+
+    If full_pass is True, nodes with span will still recurse into
+    children and their new span will also be superset of the existing span.
     """
 
-    def __init__(self, default=None):
+    def __init__(self, default=None, full_pass=False):
         super().__init__()
         self._default = default
+        self._full_pass = full_pass
 
-    def container_visit(self, node):
+    def repeated_node_visit(self, node):
+        return self.memo[node]
+
+    def container_visit(self, node) -> List[Span | None]:
         span_list = []
         for el in node:
             if isinstance(el, ast.AST) or typeutils.is_container(el):
                 span = self.visit(el)
 
-                if isinstance(span, list):
+                if not span:
+                    pass
+                elif isinstance(span, list):
                     span_list.extend(span)
                 else:
                     span_list.append(span)
         return span_list
 
-    def generic_visit(self, node):
+    def generic_visit(self, node) -> Span | None:
         # base case: we already have span
-        if getattr(node, 'span', None) is not None:
+        if not self._full_pass and getattr(node, 'span', None) is not None:
             return node.span
 
-        # we need to derive span based on the children
+        # recurse into children fields
         span_list = self.container_visit(v for _, v in ast.iter_fields(node))
 
-        if None in span_list:
-            node.dump()
-            print(list(ast.iter_fields(node)))
+        # also include own span (this can only happen in full_pass)
+        if existing := getattr(node, 'span', None):
+            span_list.append(existing)
 
-        # now that we have all of the children spans, let's merge
-        # them into one
-        #
-        if span_list:
-            node.span = merge_spans(span_list)
-        else:
-            node.span = self._default
+        # merge spans into one
+        node.span = merge_spans(s for s in span_list if s) or self._default
 
         return node.span
 

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -57,11 +57,7 @@ class Base(ast.AST):
         dump_sql(self, reordered=True, pretty=True)
 
 
-class ImmutableBase(ast.ImmutableASTMixin, Base):
-    pass
-
-
-class Alias(ImmutableBase):
+class Alias(Base):
     """Alias for a range variable."""
 
     # aliased relation name
@@ -70,7 +66,7 @@ class Alias(ImmutableBase):
     colnames: typing.Optional[typing.List[str]] = None
 
 
-class Keyword(ImmutableBase):
+class Keyword(Base):
     """An SQL keyword that must be output without quoting."""
 
     name: str                   # Keyword name
@@ -121,7 +117,7 @@ class BaseExpr(Base):
         return nullable
 
 
-class ImmutableBaseExpr(BaseExpr, ImmutableBase):
+class ImmutableBaseExpr(BaseExpr):
     pass
 
 
@@ -362,7 +358,7 @@ class DynamicRangeVar(PathRangeVar):
         self.dynamic_get_path = None  # type: ignore
 
 
-class TypeName(ImmutableBase):
+class TypeName(Base):
     """Type in definitions and casts."""
 
     name: typing.Tuple[str, ...]                # Type name
@@ -389,7 +385,7 @@ class ColumnRef(OutputVar):
             return super().__repr__()
 
 
-class TupleElementBase(ImmutableBase):
+class TupleElementBase(Base):
 
     path_id: irast.PathId
     name: typing.Optional[typing.Union[OutputVar, str]]
@@ -768,7 +764,7 @@ class VariadicArgument(ImmutableBaseExpr):
     nullable: bool = False
 
 
-class TableElement(ImmutableBase):
+class TableElement(Base):
     pass
 
 
@@ -848,7 +844,7 @@ class Slice(ImmutableBaseExpr):
     ridx: typing.Optional[BaseExpr]
 
 
-class RecordIndirectionOp(ImmutableBase):
+class RecordIndirectionOp(Base):
     name: str
 
 
@@ -876,7 +872,7 @@ class ArrayDimension(ImmutableBaseExpr):
     elements: typing.List[BaseExpr]
 
 
-class MultiAssignRef(ImmutableBase):
+class MultiAssignRef(Base):
     """UPDATE (a, b, c) = row-valued-expr."""
 
     # row-valued expression
@@ -885,7 +881,7 @@ class MultiAssignRef(ImmutableBase):
     columns: typing.List[ColumnRef]
 
 
-class SortBy(ImmutableBase):
+class SortBy(Base):
     """ORDER BY clause element."""
 
     # expression to sort on
@@ -896,7 +892,7 @@ class SortBy(ImmutableBase):
     nulls: typing.Optional[qlast.NonesOrder] = None
 
 
-class WindowDef(ImmutableBase):
+class WindowDef(Base):
     """WINDOW and OVER clauses."""
 
     # window name
@@ -1041,7 +1037,7 @@ class BooleanTest(ImmutableBaseExpr):
     nullable: bool = False
 
 
-class CaseWhen(ImmutableBase):
+class CaseWhen(Base):
 
     # Condition expression
     expr: BaseExpr
@@ -1084,14 +1080,14 @@ class Set(ImmutableBaseExpr):
     value: BaseExpr
 
 
-class ConfigureDatabase(ImmutableBase):
+class ConfigureDatabase(Base):
 
     database_name: str
     parameter_name: str
     value: BaseExpr
 
 
-class IteratorCTE(ImmutableBase):
+class IteratorCTE(Base):
     path_id: irast.PathId
     cte: CommonTableExpr
     parent: typing.Optional[IteratorCTE]

--- a/edb/pgsql/parser/__init__.py
+++ b/edb/pgsql/parser/__init__.py
@@ -26,7 +26,9 @@ from .parser import pg_parse
 from .ast_builder import build_stmts
 
 
-def parse(sql_query: str) -> List[pgast.Query | pgast.Statement]:
+def parse(
+    sql_query: str, propagate_spans: bool = False
+) -> List[pgast.Query | pgast.Statement]:
     ast_json = pg_parse(bytes(sql_query, encoding="UTF8"))
 
-    return build_stmts(json.loads(ast_json), sql_query)
+    return build_stmts(json.loads(ast_json), sql_query, propagate_spans)

--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -193,9 +193,10 @@ def register_projections(target_list: List[pgast.ResTarget], *, ctx: Context):
 def resolve_DMLQuery(
     query: pgast.DMLQuery, *, ctx: Context
 ) -> Tuple[pgast.DMLQuery, context.Table]:
-    raise errors.UnsupportedFeatureError(
+    raise errors.QueryError(
         'DML queries (INSERT/UPDATE/DELETE) are not supported',
         span=query.span,
+        pgext_code=pgerror.ERROR_FEATURE_NOT_SUPPORTED,
     )
 
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -615,7 +615,7 @@ class Compiler:
             'server_version': False,
             'server_version_num': False,
         }
-        stmts = pg_parser.parse(query_str)
+        stmts = pg_parser.parse(query_str, propagate_spans=True)
         sql_units = []
         for stmt in stmts:
             orig_text = pg_gen_source(stmt)

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -41,7 +41,7 @@ class TestEdgeQLSelect(tb.BaseDocTest):
         else:
             expected = source
 
-        ast = parser.parse(source)
+        ast = parser.parse(source, propagate_spans=True)
         sql_stmts = [
             codegen.generate_source(stmt, pretty=False) for stmt in ast
         ]


### PR DESCRIPTION
libpg_query emits a `"location"` fields that we already use and convert to our spans, but not on all nodes.

This PR make it so we now propagates spans from children into parents. It uses and improves existing `span.SpanPropagator`.