### PR TITLE
server: add missing args env vars

### DIFF
--- a/docs/reference/environment.rst
+++ b/docs/reference/environment.rst
@@ -274,6 +274,13 @@ and ``*_ENV`` variants are also supported.
 .. _URI format:
    https://www.postgresql.org/docs/13/libpq-connect.html#id-1.7.3.8.3.6
 
+EDGEDB_SERVER_MAX_BACKEND_CONNECTIONS
+.....................................
+
+The maximum NUM of connections this EdgeDB instance could make to the backend
+PostgreSQL cluster. If not set, EdgeDB will detect and calculate the NUM:
+RAM/100MiB for local Postgres, or pg_settings.max_connections for remote
+Postgres minus the NUM of ``--reserved-pg-connections``.
 
 EDGEDB_SERVER_BINARY_ENDPOINT_SECURITY
 ......................................

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -731,6 +731,7 @@ _server_options = [
              f'by default)'),
     click.option(
         '--max-backend-connections', type=int, metavar='NUM',
+        envvar="EDGEDB_SERVER_MAX_BACKEND_CONNECTIONS",
         help=f'The maximum NUM of connections this EdgeDB instance could make '
              f'to the backend PostgreSQL cluster. If not set, EdgeDB will '
              f'detect and calculate the NUM: RAM/100MiB='
@@ -740,11 +741,13 @@ _server_options = [
         callback=_validate_max_backend_connections),
     click.option(
         '--compiler-pool-size', type=int,
+        envvar="EDGEDB_SERVER_COMPILER_POOL_SIZE",
         callback=_validate_compiler_pool_size),
     click.option(
         '--compiler-pool-mode',
         type=CompilerPoolModeChoice(),
         default=CompilerPoolMode.Default.value,
+        envvar="EDGEDB_SERVER_COMPILER_POOL_MODE",
         help='Choose a mode for the compiler pool to scale. "fixed" means the '
              'pool will not scale and sticks to --compiler-pool-size, while '
              '"on_demand" means the pool will maintain at least 1 worker and '
@@ -756,6 +759,7 @@ _server_options = [
         '--compiler-pool-addr',
         hidden=True,
         callback=_validate_host_port,
+        envvar="EDGEDB_SERVER_COMPILER_POOL_ADDR",
         help=f'Specify the host[:port] of the compiler pool to connect to, '
              f'only used if --compiler-pool-mode=remote. Default host is '
              f'localhost, port is {defines.EDGEDB_REMOTE_COMPILER_PORT}',
@@ -765,6 +769,7 @@ _server_options = [
         hidden=True,
         type=int,
         default=100,
+        envvar="EDGEDB_SERVER_COMPILER_POOL_TENANT_CACHE_SIZE",
         help="Maximum number of tenants for which each compiler worker can "
              "cache their schemas, "
              "only used when --compiler-pool-mode=fixed_multi_tenant"

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -631,6 +631,7 @@ _server_options = [
         '--tenant-id',
         type=str,
         callback=_validate_tenant_id,
+        envvar="EDGEDB_SERVER_TENANT_ID",
         help='Specifies the tenant ID of this server when hosting'
              ' multiple EdgeDB instances on one Postgres cluster.'
              ' Must be an alphanumeric ASCII string, maximum'

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -501,7 +501,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
                     await con.execute(f'CREATE DATABASE {tenant}')
                     await con.execute(f'CREATE SUPERUSER ROLE {tenant}')
                     databases = await con.query('SELECT sys::Database.name')
-                    self.assertEqual(set(databases), {'edgedb', tenant})
+                    self.assertEqual(set(databases), {'main', tenant})
                     roles = await con.query('SELECT sys::Role.name')
                     self.assertEqual(set(roles), {'edgedb', tenant})
                 finally:
@@ -519,7 +519,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
 
             await cluster.start()
             try:
-                async with taskgroup.TaskGroup() as tg:
+                async with asyncio.TaskGroup() as tg:
                     tg.create_task(test(td, 'tenant1'))
                     tg.create_task(test(td, 'tenant2'))
             finally:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -488,6 +488,43 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
             finally:
                 await cluster.stop()
 
+    async def test_server_ops_postgres_multitenant_env(self):
+        async def test(pgdata_path, tenant):
+            async with tb.start_edgedb_server(
+                reset_auth=True,
+                backend_dsn=f'postgres:///?user=postgres&host={pgdata_path}',
+                runstate_dir=None if devmode.is_in_dev_mode() else pgdata_path,
+                env={"EDGEDB_SERVER_TENANT_ID": tenant},
+            ) as sd:
+                con = await sd.connect()
+                try:
+                    await con.execute(f'CREATE DATABASE {tenant}')
+                    await con.execute(f'CREATE SUPERUSER ROLE {tenant}')
+                    databases = await con.query('SELECT sys::Database.name')
+                    self.assertEqual(set(databases), {'edgedb', tenant})
+                    roles = await con.query('SELECT sys::Role.name')
+                    self.assertEqual(set(roles), {'edgedb', tenant})
+                finally:
+                    await con.aclose()
+
+        with tempfile.TemporaryDirectory() as td:
+            cluster = await pgcluster.get_local_pg_cluster(td, log_level='s')
+            cluster.set_connection_params(
+                pgconnparams.ConnectionParameters(
+                    user='postgres',
+                    database='template1',
+                ),
+            )
+            self.assertTrue(await cluster.ensure_initialized())
+
+            await cluster.start()
+            try:
+                async with taskgroup.TaskGroup() as tg:
+                    tg.create_task(test(td, 'tenant1'))
+                    tg.create_task(test(td, 'tenant2'))
+            finally:
+                await cluster.stop()
+
     async def test_server_ops_postgres_multitenant(self):
         async def test(pgdata_path, tenant):
             async with tb.start_edgedb_server(


### PR DESCRIPTION
This is somehow missing and mismatching the documentation.

Closes #5364