### PR TITLE
Add sql_setup_script and sql_teardown_script fields to extension packages

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_06_14_00_00
+EDGEDB_CATALOG_VERSION = 2024_06_19_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -914,7 +914,8 @@ class CreateExtensionPackageBodyBlock(NestedQLBlock):
     @property
     def allowed_fields(self) -> typing.FrozenSet[str]:
         return frozenset(
-            {'internal', 'ext_module', 'sql_extensions', 'dependencies'}
+            {'internal', 'ext_module', 'sql_extensions', 'dependencies',
+             'sql_setup_script', 'sql_teardown_script'}
         )
 
     @property

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5080,6 +5080,8 @@ def _generate_extension_views(schema: s_schema.Schema) -> List[dbops.View]:
             )
         ''',
         'ext_module': "(e.value->>'ext_module')",
+        'sql_setup_script': "(e.value->>'sql_setup_script')",
+        'sql_teardown_script': "(e.value->>'sql_teardown_script')",
         'computed_fields': 'ARRAY[]::text[]',
         'builtin': "(e.value->>'builtin')::bool",
         'internal': "(e.value->>'internal')::bool",

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -74,6 +74,12 @@ class ExtensionPackage(
         compcoef=0.9,
     )
 
+    sql_setup_script = so.SchemaField(
+        str, default=None, compcoef=0.9)
+
+    sql_teardown_script = so.SchemaField(
+        str, default=None, compcoef=0.9)
+
     ext_module = so.SchemaField(
         str, default=None, compcoef=0.9)
 


### PR DESCRIPTION
This lets us create any pure SQL things we need. Teardown obviously
needs to clean up after setup.
Specified as string literals, so using $$ strings is recommended.