### PR TITLE
Make ai and auth extension object types extend BaseObject instead of Object

### DIFF
--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -156,7 +156,7 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
     create abstract inheritable annotation
         ext::ai::model_provider;
 
-    create abstract type ext::ai::Model {
+    create abstract type ext::ai::Model extending std::BaseObject {
         create annotation ext::ai::model_name := "<must override>";
         create annotation ext::ai::model_provider := "<must override>";
     };
@@ -396,7 +396,7 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
     create scalar type ext::ai::ChatParticipantRole
         extending enum<System, User, Assistant, Tool>;
 
-    create type ext::ai::ChatPromptMessage {
+    create type ext::ai::ChatPromptMessage extending std::BaseObject {
         create required property participant_role:
             ext::ai::ChatParticipantRole
         {
@@ -415,7 +415,7 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         };
     };
 
-    create type ext::ai::ChatPrompt {
+    create type ext::ai::ChatPrompt extending std::BaseObject {
         create required property name: str {
             create constraint exclusive;
             create annotation std::description :=

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -23,7 +23,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
 
     create module ext::auth;
 
-    create abstract type ext::auth::Auditable {
+    create abstract type ext::auth::Auditable extending std::BaseObject {
         create required property created_at: std::datetime {
             set default := std::datetime_current();
             set readonly := true;

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2542,11 +2542,8 @@ class ObjectCommand(Command, Generic[so.Object_T]):
 
             if (
                 isinstance(self.classname, sn.QualName)
-                and (modname := self.classname.get_module_name())
-                and (
-                    (modroot := sn.UnqualName(modname.name.partition('::')[0]))
-                    in s_schema.STD_MODULES
-                )
+                and (modroot := self.classname.get_root_module_name())
+                and modroot in s_schema.STD_MODULES
                 and not (
                     modroot == s_schema.EXT_MODULE
                     and context.transient_derivation

--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -92,6 +92,9 @@ if TYPE_CHECKING:
         def get_module_name(self) -> Name:
             ...
 
+        def get_root_module_name(self) -> UnqualName:
+            ...
+
     class UnqualName(Name):
 
         __slots__ = ('name',)
@@ -146,6 +149,9 @@ else:
 
         def get_module_name(self) -> Name:
             return UnqualName(self.module)
+
+        def get_root_module_name(self) -> UnqualName:
+            return UnqualName(self.module.partition('::')[0])
 
         def __str__(self) -> str:
             return f'{self.module}::{self.name}'

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -513,6 +513,22 @@ class ObjectTypeCommand(
                         span=self.span,
                     )
 
+        # Internal consistency check: our stdlib and extension types
+        # shouldn't extend std::Object, which is reserved for user
+        # types.
+        if (
+            self.scls.is_material_object_type(schema)
+            and self.classname.get_root_module_name() in s_schema.STD_MODULES
+        ):
+            for base in self.scls.get_bases(schema).objects(schema):
+                name = base.get_name(schema)
+                if name == sn.QualName('std', 'Object'):
+                    raise errors.SchemaDefinitionError(
+                        f"standard lib/extension type '{self.classname}' "
+                        f"cannot extend std::Object",
+                        hint="try BaseObject",
+                    )
+
 
 class CreateObjectType(
     ObjectTypeCommand,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9092,11 +9092,11 @@ type default::Foo {
 
                 create module ext::auth;
 
-                create type ext::auth::Identity {
+                create type ext::auth::Identity extending std::BaseObject {
                     create required property provider: std::str;
                 };
 
-                create type ext::auth::Email {
+                create type ext::auth::Email extending std::BaseObject {
                     create required property primary: std::bool;
                     create required link identity: ext::auth::Identity;
                     create constraint exclusive on ((.identity, .primary));

--- a/tests/test_edgeql_extensions.py
+++ b/tests/test_edgeql_extensions.py
@@ -342,7 +342,7 @@ class TestDDLExtensions(tb.DDLTestCase):
               set code := ' ((__col__) NULLS FIRST)';
           };
 
-          create type ext::varchar::ParentTest {
+          create type ext::varchar::ParentTest extending std::BaseObject {
               create property foo -> str;
           };
           create type ext::varchar::ChildTest

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -390,7 +390,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
         await self.con.execute('''
             configure session set __internal_testmode := true;
             create module ext::_test;
-            create type ext::_test::X;
+            create type ext::_test::X extending std::BaseObject;
             configure session reset __internal_testmode;
         ''')
 


### PR DESCRIPTION
We should reserve Object for genuine user types.
Add a check to the schema to enforce this.

We *could* backport this with a patch but I think we probably
shouldn't?