### PR TITLE
Fix tenant shutdown in multi-tenant mode

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -89,3 +89,7 @@ _TLS_CERT_RELOAD_EXP_INTERVAL = 0.1
 
 PGEXT_POSTGRES_VERSION = "13.9"
 PGEXT_POSTGRES_VERSION_NUM = 130009
+
+# The time in seconds the EdgeDB server will wait for a tenant to be gracefully
+# shutdown when removed from a multi-tenant host.
+MULTITENANT_TENANT_DESTROY_TIMEOUT = 30

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -273,6 +273,10 @@ class MultiTenantServer(server.BaseServer):
 
     async def _destroy_tenant(self, tenant: edbtenant.Tenant):
         try:
+            if tenant.is_online():
+                tenant.set_readiness_state(
+                    srvargs.ReadinessState.Offline, "tenant is removed"
+                )
             tenant.stop_accepting_connections()
             tenant.stop()
             try:

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1310,6 +1310,10 @@ class Tenant(ha_base.ClusterProtocol):
 
         self._accepting_connections = self.is_online()
 
+    def set_readiness_state(self, state: srvargs.ReadinessState, reason: str):
+        self._readiness = state
+        self._readiness_reason = reason
+
     def reload(self):
         # In multi-tenant mode, the file paths for the following states may be
         # unset in a reload, while it's impossible in a regular server.

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -527,6 +527,7 @@ class Tenant(ha_base.ClusterProtocol):
         self._accept_new_tasks = False
         self._cluster.stop_watching()
         self._stop_watching_files()
+        self._server.request_frontend_stop(self)
 
     def _stop_watching_files(self):
         while self._file_watch_finalizers:


### PR DESCRIPTION
1. Request frontend connections to stop
2. Add a timeout to interrupt if they don't stop in time