### PR TITLE
multitenant: fix health prober API

### DIFF
--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -117,7 +117,9 @@ class MultiTenantServer(server.BaseServer):
         return self._sys_config
 
     def _sni_callback(self, sslobj, server_name, _sslctx):
-        if tenant := self._tenants.get(server_name):
+        if server_name is None:
+            self._tenants_by_sslobj[sslobj] = edbtenant.host_tenant
+        elif tenant := self._tenants.get(server_name):
             self._tenants_by_sslobj[sslobj] = tenant
 
     def get_default_tenant(self) -> edbtenant.Tenant:

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -40,6 +40,7 @@ from edb.common.log import current_tenant
 from edb.pgsql.parser import exceptions as parser_errors
 from edb.server import args as srvargs
 from edb.server import defines, metrics
+from edb.server import tenant as edbtenant
 from edb.server.compiler import dbstate
 from edb.server.pgcon import errors as pgerror
 from edb.server.pgcon.pgcon cimport PGAction, PGMessage
@@ -491,9 +492,12 @@ cdef class PgConnection(frontend.FrontendConnection):
                         self.sslctx,
                         server_side=True,
                     )
-                    self.tenant = self.server.retrieve_tenant(
+                    tenant = self.server.retrieve_tenant(
                         self._transport.get_extra_info("ssl_object")
                     )
+                    if tenant is edbtenant.host_tenant:
+                        tenant = None
+                    self.tenant = tenant
                     if self.tenant is not None:
                         current_tenant.set(self.tenant.get_instance_name())
                     self.is_tls = True

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -68,6 +68,7 @@ cdef class HttpProtocol:
         object binary_endpoint_security
         object http_endpoint_security
         object tenant
+        bint is_tenant_host
         object connection_made_at
 
         HttpRequest current_request

--- a/edb/server/protocol/system_api.py
+++ b/edb/server/protocol/system_api.py
@@ -37,19 +37,25 @@ async def handle_request(
     path_parts,
     server,
     tenant,
+    is_tenant_host,
 ):
     try:
         if tenant is None:
             try:
                 tenant = server.get_default_tenant()
             except Exception:
-                # Multi-tenant server doesn't have default tenant,
-                # only check server status instead
+                # Multi-tenant server doesn't have default tenant
                 pass
-        if path_parts == ['status', 'ready'] and request.method == b'GET':
+        if tenant is None and not is_tenant_host:
+            _response(
+                response,
+                http.HTTPStatus.NOT_FOUND,
+                b'"No such tenant configured"',
+                True,
+            )
+        elif path_parts == ['status', 'ready'] and request.method == b'GET':
             if tenant is None:
-                # TODO(fantix): test the compiler pool
-                _response_ok(response, b"OK")
+                await handle_compiler_query(server, response)
             else:
                 await tenant.create_task(
                     handle_readiness_query(request, response, tenant),
@@ -57,19 +63,19 @@ async def handle_request(
                 )
         elif path_parts == ['status', 'alive'] and request.method == b'GET':
             if tenant is None:
-                # TODO(fantix): test the compiler pool
-                _response_ok(response, b"OK")
+                await handle_compiler_query(server, response)
             else:
                 await tenant.create_task(
                     handle_liveness_query(request, response, tenant),
                     interruptable=False,
                 )
         else:
-            response.body = b'Unknown path'
-            response.status = http.HTTPStatus.NOT_FOUND
-            response.close_connection = True
-
-        return
+            _response(
+                response,
+                http.HTTPStatus.NOT_FOUND,
+                b'"Unknown path"',
+                True,
+            )
     except errors.BackendUnavailableError as ex:
         _response_error(
             response, http.HTTPStatus.SERVICE_UNAVAILABLE, str(ex), type(ex)
@@ -98,16 +104,18 @@ def _response_error(response, status, message, ex_type):
         'type': str(ex_type.__name__),
         'code': ex_type.get_code(),
     }
+    _response(response, status, json.dumps({'error': err_dct}).encode(), True)
 
-    response.body = json.dumps({'error': err_dct}).encode()
+
+def _response(response, status, message, close_connection):
+    response.body = message
     response.status = status
-    response.close_connection = True
+    response.content_type = b'application/json'
+    response.close_connection = close_connection
 
 
 def _response_ok(response, message):
-    response.status = http.HTTPStatus.OK
-    response.content_type = b'application/json'
-    response.body = message
+    _response(response, http.HTTPStatus.OK, message, False)
 
 
 async def _ping(tenant):
@@ -126,6 +134,23 @@ async def _ping(tenant):
         cached_globally=True,
         use_metrics=False,
     )
+
+
+async def handle_compiler_query(server, response):
+    try:
+        # This is just testing if the RPC to the compiler is healthy
+        await server.get_compiler_pool().make_compilation_config_serializer()
+    except Exception as ex:
+        if debug.flags.server:
+            markup.dump(ex)
+        _response_error(
+            response,
+            http.HTTPStatus.INTERNAL_SERVER_ERROR,
+            str(ex),
+            errors.InternalServerError,
+        )
+    else:
+        _response_ok(response, b'"OK"')
 
 
 async def handle_liveness_query(

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1739,3 +1739,7 @@ class Tenant(ha_base.ClusterProtocol):
     def iter_dbs(self) -> Iterator[dbview.Database]:
         if self._dbindex is not None:
             yield from self._dbindex.iter_dbs()
+
+
+# sentinel Tenant object to indicate an empty SNI
+host_tenant = Tenant.__new__(Tenant)


### PR DESCRIPTION
* Report 404 if tenant is not found
* Add compiler check calling tenant host

  Requests to `https://<int-ip>:<port>/server/status/ready` or `.../alive` will now check the healthiness of the compiler pool for a multi-tenant host.

---

[FIXED] Even though this is not a breaking change, theoretically, this is not ideal because it may report a false healthy status for tenants that haven't been added to the host. @nsidnev I think this will break your use case, so maybe we should still separate the paths of 1) checking if the multitenant host itself is healthy and 2) checking if a particular tenant is healthy. Or find some way to tell why the tenant is `None` and report an error properly for case (2).

---

~This allows requests from non-tenant clients to check tenant aliveness/readiness on a multi-tenant host with URLs like:~

~`https://<int-ip>:<port>/server/status/ready/inst--org.c-00.i.aws.edgedb.cloud` ✅~

~This doesn't allow unauthorized access from tenant clients like:~

~`https://inst--org.c-00.i.aws.edgedb.cloud/server/status/ready/inst2--org2.c-00.i.aws.edgedb.cloud` ❌~