### PR TITLE
Configure versioned_stdlib in the compiler properly

### DIFF
--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -75,7 +75,11 @@ def compile_ir_to_sql_tree(
     ] = None,
     backend_runtime_params: Optional[pgparams.BackendRuntimeParams]=None,
     detach_params: bool = False,
+    versioned_stdlib: bool = True,
 ) -> CompileResult:
+    if singleton_mode:
+        versioned_stdlib = False
+
     try:
         # Transform to sql tree
         query_params = []
@@ -122,6 +126,7 @@ def compile_ir_to_sql_tree(
             scope_tree_nodes=scope_tree_nodes,
             external_rvars=external_rvars,
             backend_runtime_params=backend_runtime_params,
+            versioned_stdlib=versioned_stdlib,
         )
 
         ctx = context.CompilerContextLevel(

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -683,7 +683,11 @@ def _compile_config_value(
         cast_name = s_casts.get_cast_fullname_from_names(
             sn.QualName('std', 'bytes'), sn.QualName('std', 'json'))
         val = pgast.FuncCall(
-            name=common.get_cast_backend_name(cast_name, aspect='function'),
+            name=common.get_cast_backend_name(
+                cast_name,
+                aspect='function',
+                versioned=ctx.env.versioned_stdlib,
+            ),
             args=[val],
         )
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -228,7 +228,8 @@ def compile_TypeCast(
         assert expr.cast_name
 
         func_name = common.get_cast_backend_name(
-            expr.cast_name, aspect="function"
+            expr.cast_name, aspect="function",
+            versioned=ctx.env.versioned_stdlib,
         )
 
         args = [pg_expr]
@@ -504,7 +505,8 @@ def compile_operator(
                     lexpr, rexpr, expr.sql_function[1:])
         else:
             func_name = common.get_operator_backend_name(
-                expr.func_shortname, aspect='function')
+                expr.func_shortname, aspect='function',
+                versioned=ctx.env.versioned_stdlib)
 
         args = []
         if lexpr is not None:

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -607,7 +607,9 @@ def serialize_expr_to_json(
             sn.QualName('std', 'json'),
         )
         val = pgast.FuncCall(
-            name=common.get_cast_backend_name(cast_name, aspect='function'),
+            name=common.get_cast_backend_name(
+                cast_name, aspect='function', versioned=env.versioned_stdlib
+            ),
             args=[expr], null_safe=True, ser_safe=True)
         if env.output_format in _JSON_FORMATS:
             val = pgast.TypeCast(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -596,7 +596,9 @@ def new_pointer_rvar(
     ptrref = ir_ptr.ptrref
 
     ptr_info = pg_types.get_ptrref_storage_info(
-        ptrref, resolve_type=False, link_bias=link_bias, allow_missing=True)
+        ptrref, resolve_type=False, link_bias=link_bias, allow_missing=True,
+        versioned=ctx.env.versioned_stdlib,
+    )
 
     if ptr_info and ptr_info.table_type == 'ObjectType':
         # Inline link
@@ -2013,12 +2015,14 @@ def range_for_ptrref(
             # needs to contain any link properties, for one reason.)
             ptr_info = pg_types.get_ptrref_storage_info(
                 src_ptrref, resolve_type=False, link_bias=True,
+                versioned=ctx.env.versioned_stdlib,
             )
             if not ptr_info:
                 assert ptrref.union_components
 
                 ptr_info = pg_types.get_ptrref_storage_info(
                     src_ptrref, resolve_type=False, link_bias=False,
+                    versioned=ctx.env.versioned_stdlib,
                 )
 
             cols = [

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3310,10 +3310,12 @@ def get_func_call_backend_name(
     if expr.func_sql_function:
         # The name might contain a "." if it's one of our
         # metaschema helpers.
+        # XXX: VERSIONING?
         func_name = tuple(expr.func_sql_function.split('.', 1))
     else:
         func_name = common.get_function_backend_name(
-            expr.func_shortname, expr.backend_name)
+            expr.func_shortname, expr.backend_name,
+            versioned=ctx.env.versioned_stdlib)
     return func_name
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1235,6 +1235,7 @@ class FunctionCommand(MetaCommand):
                 schema, func.get_return_type(schema), cache=None),
             output_format=compiler.OutputFormat.NATIVE,
             named_param_prefix=self.get_pgname(func, schema)[-1:],
+            versioned_stdlib=context.stdmode,
         )
 
         return codegen.generate_source(sql_res.ast)

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1892,6 +1892,7 @@ def _compile_ql_query(
         expand_inhviews=options.expand_inhviews,
         detach_params=(use_persistent_cache
                        and cache_mode is config.QueryCacheMode.PgFunc),
+        versioned_stdlib=True,
     )
 
     sql_text = pg_codegen.generate_source(sql_res.ast)


### PR DESCRIPTION
In general, default to using versioned stdlib (`edgedb_vX.`), except
when compiling user functions and indexes/constraints, where we use
trampolined stdlib (`edgedb.`).