### PR TITLE
Fix migration creation when adding a new base class with certain constraints

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -1228,13 +1228,14 @@ class RebaseInheritingObject(
         fields.update(self.EXTRA_INHERITED_FIELDS)
 
         for field in fields:
-            if field not in result:
-                if (
-                    inherit
-                    and bool(new_bases[0].get_explicit_field_value(
-                        schema, field, None))
-                ):
-                    result[field] = True
+            if (
+                inherit
+                and field not in result
+                and bool(
+                    new_bases[0].get_explicit_field_value(schema, field, None)
+                )
+            ):
+                result[field] = True
 
         return result
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -1229,11 +1229,12 @@ class RebaseInheritingObject(
 
         for field in fields:
             if field not in result:
-                result[field] = (
+                if (
                     inherit
                     and bool(new_bases[0].get_explicit_field_value(
                         schema, field, None))
-                )
+                ):
+                    result[field] = True
 
         return result
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6102,6 +6102,39 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             ]
         )
 
+    def test_schema_migrations_equivalence_constr_rebase_01(self):
+        self._assert_migration_equivalence(
+            [
+            r"""
+            abstract type Foo;
+
+            type Bar {
+              required property baz -> str {
+                constraint max_len_value(280);
+              }
+            }
+            """,
+            r"""
+            abstract type Foo;
+
+            type Bar extending Foo {
+              required property baz -> str {
+                constraint max_len_value(280);
+              }
+            }
+            """,
+            r"""
+            abstract type Foo;
+
+            type Bar {
+              required property baz -> str {
+                constraint max_len_value(280);
+              }
+            }
+            """,
+            ]
+        )
+
     def test_schema_migrations_equivalence_compound_01(self):
         # Check that union types can be referenced in computables
         # Bug #2002.


### PR DESCRIPTION
If constraints that have an inherited subjectexpr have a new base type
added to the type they are on, we were losing 'subjectexpr' as an
inherited field, because a code path that was intended to only be able
to make fields inherited was sometimes clearing them.