### PR TITLE
Fix interaction of implicit limit with explicit OFFSET

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -275,6 +275,10 @@ def compile_ast_to_ir(
 
     ctx = stmtctx_mod.init_context(schema=schema, options=options)
 
+    if isinstance(tree, qlast.Expr) and ctx.implicit_limit:
+        tree = qlast.SelectQuery(result=tree, implicit=True)
+        tree.limit = qlast.Constant.integer(ctx.implicit_limit)
+
     if not script_info:
         script_info = stmtctx_mod.preprocess_script([tree], ctx=ctx)
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -127,14 +127,6 @@ def compile_SelectQuery(
             )
         )
 
-        if (
-            (ctx.expr_exposed or sctx.stmt is ctx.toplevel_stmt)
-            and ctx.implicit_limit
-            and expr.limit is None
-            and not ctx.inhibit_implicit_limit
-        ):
-            expr.limit = qlast.Constant.integer(ctx.implicit_limit)
-
         stmt.result = compile_result_clause(
             expr.result,
             view_scls=ctx.view_scls,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1534,7 +1534,6 @@ def _normalize_view_ptr_expr(
 
             if (
                 (ctx.expr_exposed or ctx.stmt is ctx.toplevel_stmt)
-                and not qlexpr.limit
                 and ctx.implicit_limit
                 and not base_is_singleton
             ):
@@ -1659,10 +1658,6 @@ def _normalize_view_ptr_expr(
         if (
             (ctx.expr_exposed or ctx.stmt is ctx.toplevel_stmt)
             and ctx.implicit_limit
-            and isinstance(qlexpr, (
-                qlast.SelectQuery, qlast.DeleteQuery, qlast.ShapeElement
-            ))
-            and not qlexpr.limit
         ):
             qlexpr = qlast.SelectQuery(result=qlexpr, implicit=True)
             qlexpr.limit = qlast.Constant.integer(ctx.implicit_limit)


### PR DESCRIPTION
Currently, we will inject a LIMIT at any exposed SELECT, which results
in us applying implicit LIMIT before OFFSET, which is wrong.

Drop the injection inside of SelectStmt compilation and inject the
LIMIT at the top-level instead directly.

This also fixes an issue that always annoyed me where limits would be
inserted multiple redundant times.

Fixes #3627.