### PR TITLE
Support arbitrary OpenID Connect providers

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -177,8 +177,16 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         };
     };
 
-    create type ext::auth::OpenIDConnectProviderConfig
+    create type ext::auth::OpenIDConnectProvider
         extending ext::auth::OAuthProviderConfig {
+        alter property name {
+            set protected := false;
+        };
+
+        alter property display_name {
+            set protected := false;
+        };
+
         create required property issuer_url: std::str {
             create annotation std::description :=
                 "The issuer URL of the provider.";

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -177,6 +177,37 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         };
     };
 
+    create type ext::auth::OpenIDConnectProviderConfig
+        extending ext::auth::OAuthProviderConfig {
+        create required property issuer_url: std::str {
+            create annotation std::description :=
+                "The issuer URL of the provider.";
+            create constraint exclusive;
+        };
+
+        create property logo_url: std::str {
+            create annotation std::description :=
+                "A url to an image of the provider's logo.";
+        };
+
+        create property dark_logo_url: std::str {
+            create annotation std::description :=
+                "A url to an image of the provider's logo to be used with the \
+                dark theme.";
+        };
+
+        create property brand_color: std::str {
+            create annotation std::description :=
+                "The brand color of the provider as a hex string.";
+        };
+
+        create property dark_brand_color: std::str {
+            create annotation std::description :=
+                "The brand color of the provider as a hex string to be used \
+                with the dark theme.";
+        };
+    };
+
     create type ext::auth::AppleOAuthProvider
         extending ext::auth::OAuthProviderConfig {
         alter property name {

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -190,7 +190,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property issuer_url: std::str {
             create annotation std::description :=
                 "The issuer URL of the provider.";
-            create constraint exclusive;
         };
 
         create property logo_url: std::str {
@@ -214,6 +213,8 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
                 "The brand color of the provider as a hex string to be used \
                 with the dark theme.";
         };
+
+        create constraint exclusive on ((.issuer_url, .client_id));
     };
 
     create type ext::auth::AppleOAuthProvider

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -197,23 +197,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
                 "A url to an image of the provider's logo.";
         };
 
-        create property dark_logo_url: std::str {
-            create annotation std::description :=
-                "A url to an image of the provider's logo to be used with the \
-                dark theme.";
-        };
-
-        create property brand_color: std::str {
-            create annotation std::description :=
-                "The brand color of the provider as a hex string.";
-        };
-
-        create property dark_brand_color: std::str {
-            create annotation std::description :=
-                "The brand color of the provider as a hex string to be used \
-                with the dark theme.";
-        };
-
         create constraint exclusive on ((.issuer_url, .client_id));
     };
 

--- a/edb/server/protocol/auth_ext/apple.py
+++ b/edb/server/protocol/auth_ext/apple.py
@@ -30,7 +30,6 @@ class AppleProvider(base.OpenIDProvider):
             "apple",
             "https://appleid.apple.com",
             *args,
-            content_type=base.ContentType.FORM_ENCODED,
             **kwargs,
         )
 

--- a/edb/server/protocol/auth_ext/apple.py
+++ b/edb/server/protocol/auth_ext/apple.py
@@ -24,7 +24,7 @@ import urllib.parse
 from . import base
 
 
-class AppleProvider(base.OpenIDProvider):
+class AppleProvider(base.OpenIDConnectProvider):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(
             "apple",

--- a/edb/server/protocol/auth_ext/azure.py
+++ b/edb/server/protocol/auth_ext/azure.py
@@ -28,6 +28,5 @@ class AzureProvider(base.OpenIDProvider):
             "azure",
             "https://login.microsoftonline.com/common/v2.0",
             *args,
-            content_type=base.ContentType.FORM_ENCODED,
             **kwargs,
         )

--- a/edb/server/protocol/auth_ext/azure.py
+++ b/edb/server/protocol/auth_ext/azure.py
@@ -22,7 +22,7 @@ from typing import Any
 from . import base
 
 
-class AzureProvider(base.OpenIDProvider):
+class AzureProvider(base.OpenIDConnectProvider):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(
             "azure",

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -75,12 +75,10 @@ class OpenIDProvider(BaseProvider):
         self,
         name: str,
         issuer_url: str,
-        *args: Any,
-        content_type: ContentType = ContentType.JSON,
-        **kwargs: Any,
+        *args,
+        **kwargs,
     ):
         super().__init__(name, issuer_url, *args, **kwargs)
-        self.content_type = content_type
 
     async def get_code_url(
         self, state: str, redirect_uri: str, additional_scope: str
@@ -114,23 +112,16 @@ class OpenIDProvider(BaseProvider):
                 "redirect_uri": redirect_uri,
             }
             headers = {"Accept": ContentType.JSON.value}
-            if self.content_type == ContentType.JSON:
-                resp = await client.post(
-                    token_endpoint.path,
-                    json=request_body,
-                    headers=headers,
-                )
-            else:
-                resp = await client.post(
-                    token_endpoint.path,
-                    data=request_body,
-                    headers=headers,
-                )
+            resp = await client.post(
+                token_endpoint.path,
+                data=request_body,
+                headers=headers,
+            )
             if resp.status_code >= 400:
                 raise errors.OAuthProviderFailure(
                     f"Failed to exchange code: {resp.text}"
                 )
-            content_type = resp.headers.get('Content-Type', self.content_type)
+            content_type = resp.headers.get('Content-Type')
             if content_type.startswith(str(ContentType.JSON)):
                 response_body = resp.json()
             else:

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -70,13 +70,13 @@ class ContentType(enum.StrEnum):
     FORM_ENCODED = "application/x-www-form-urlencoded"
 
 
-class OpenIDProvider(BaseProvider):
+class OpenIDConnectProvider(BaseProvider):
     def __init__(
         self,
         name: str,
         issuer_url: str,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ):
         super().__init__(name, issuer_url, *args, **kwargs)
 

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -54,6 +54,7 @@ class OAuthProviderConfig(ProviderConfig):
     secret: str
     additional_scope: Optional[str]
     issuer_url: Optional[str]
+    logo_url: Optional[str]
 
 
 class WebAuthnProviderConfig(ProviderConfig):

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -53,6 +53,7 @@ class OAuthProviderConfig(ProviderConfig):
     client_id: str
     secret: str
     additional_scope: Optional[str]
+    issuer_url: Optional[str]
 
 
 class WebAuthnProviderConfig(ProviderConfig):

--- a/edb/server/protocol/auth_ext/google.py
+++ b/edb/server/protocol/auth_ext/google.py
@@ -22,7 +22,7 @@ from typing import Any
 from . import base
 
 
-class GoogleProvider(base.OpenIDProvider):
+class GoogleProvider(base.OpenIDConnectProvider):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(
             "google", "https://accounts.google.com", *args, **kwargs

--- a/edb/server/protocol/auth_ext/http_client.py
+++ b/edb/server/protocol/auth_ext/http_client.py
@@ -50,7 +50,7 @@ class HttpClient(httpx.AsyncClient):
         **kwargs: Any,
     ) -> httpx.Response:
         if self.edgedb_orig_base_url:
-            path = f'{self.edgedb_orig_base_url}/{path}'
+            path = f'{self.edgedb_orig_base_url}{path}'
         return await super().post(
             path, *args, **kwargs
         )
@@ -62,5 +62,5 @@ class HttpClient(httpx.AsyncClient):
         **kwargs: Any,
     ) -> httpx.Response:
         if self.edgedb_orig_base_url:
-            path = f'{self.edgedb_orig_base_url}/{path}'
+            path = f'{self.edgedb_orig_base_url}{path}'
         return await super().get(path, *args, **kwargs)

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -19,7 +19,7 @@
 
 import json
 
-from typing import cast, Any, Type
+from typing import cast, Any
 from edb.server.protocol import execute
 
 from . import github, google, azure, apple, discord, slack
@@ -48,34 +48,46 @@ class Client:
             "additional_scope": provider_config.additional_scope,
         }
 
-        provider_class: Type[base.BaseProvider]
         match (provider_name, provider_config.issuer_url):
             case ("builtin::oauth_github", _):
-                provider_class = github.GitHubProvider
+                self.provider = github.GitHubProvider(
+                    *provider_args,
+                    **provider_kwargs,
+                )
             case ("builtin::oauth_google", _):
-                provider_class = google.GoogleProvider
+                self.provider = google.GoogleProvider(
+                    *provider_args,
+                    **provider_kwargs,
+                )
             case ("builtin::oauth_azure", _):
-                provider_class = azure.AzureProvider
+                self.provider = azure.AzureProvider(
+                    *provider_args,
+                    **provider_kwargs,
+                )
             case ("builtin::oauth_apple", _):
-                provider_class = apple.AppleProvider
+                self.provider = apple.AppleProvider(
+                    *provider_args,
+                    **provider_kwargs,
+                )
             case ("builtin::oauth_discord", _):
-                provider_class = discord.DiscordProvider
+                self.provider = discord.DiscordProvider(
+                    *provider_args,
+                    **provider_kwargs,
+                )
             case ("builtin::oauth_slack", _):
-                provider_class = slack.SlackProvider
+                self.provider = slack.SlackProvider(
+                    *provider_args,
+                    **provider_kwargs,
+                )
             case (provider_name, str(issuer_url)):
-                provider_args = (
+                self.provider = base.OpenIDConnectProvider(
                     provider_name,
                     issuer_url,
                     *provider_args,
+                    **provider_kwargs,
                 )
-                provider_class = base.OpenIDConnectProvider
             case _:
                 raise errors.InvalidData(f"Invalid provider: {provider_name}")
-
-        self.provider = provider_class(
-            *provider_args,
-            **provider_kwargs,  # type: ignore[arg-type]
-        )
 
     async def get_authorize_url(self, state: str, redirect_uri: str) -> str:
         return await self.provider.get_code_url(

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -39,7 +39,10 @@ class Client:
         )
 
         provider_config = self._get_provider_config(provider_name)
-        provider_args = (provider_config.client_id, provider_config.secret)
+        provider_args: tuple[str, str] | tuple[str, str, str, str] = (
+            provider_config.client_id,
+            provider_config.secret,
+        )
         provider_kwargs = {
             "http_factory": http_factory,
             "additional_scope": provider_config.additional_scope,

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -146,7 +146,8 @@ select {
                     client_id=cfg.client_id,
                     secret=cfg.secret,
                     additional_scope=cfg.additional_scope,
-                    issuer_url=getattr(cfg, 'issuer_url', None)
+                    issuer_url=getattr(cfg, 'issuer_url', None),
+                    logo_url=getattr(cfg, 'logo_url', None),
                 )
 
         raise errors.MissingConfiguration(

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -139,6 +139,7 @@ select {
                     client_id=cfg.client_id,
                     secret=cfg.secret,
                     additional_scope=cfg.additional_scope,
+                    issuer_url=getattr(cfg, 'issuer_url', None)
                 )
 
         raise errors.MissingConfiguration(

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -46,19 +46,26 @@ class Client:
         }
 
         provider_class: Type[base.BaseProvider]
-        match provider_name:
-            case "builtin::oauth_github":
+        match (provider_name, provider_config.issuer_url):
+            case ("builtin::oauth_github", _):
                 provider_class = github.GitHubProvider
-            case "builtin::oauth_google":
+            case ("builtin::oauth_google", _):
                 provider_class = google.GoogleProvider
-            case "builtin::oauth_azure":
+            case ("builtin::oauth_azure", _):
                 provider_class = azure.AzureProvider
-            case "builtin::oauth_apple":
+            case ("builtin::oauth_apple", _):
                 provider_class = apple.AppleProvider
-            case "builtin::oauth_discord":
+            case ("builtin::oauth_discord", _):
                 provider_class = discord.DiscordProvider
-            case "builtin::oauth_slack":
+            case ("builtin::oauth_slack", _):
                 provider_class = slack.SlackProvider
+            case (provider_name, str(issuer_url)):
+                provider_args = (
+                    provider_name,
+                    issuer_url,
+                    *provider_args,
+                )
+                provider_class = base.OpenIDConnectProvider
             case _:
                 raise errors.InvalidData(f"Invalid provider: {provider_name}")
 
@@ -121,7 +128,7 @@ select {
 
         return (
             data.Identity(**result_json[0]['identity']),
-            result_json[0]['new']
+            result_json[0]['new'],
         )
 
     def _get_provider_config(

--- a/edb/server/protocol/auth_ext/slack.py
+++ b/edb/server/protocol/auth_ext/slack.py
@@ -28,6 +28,5 @@ class SlackProvider(base.OpenIDProvider):
             "slack",
             "https://slack.com",
             *args,
-            content_type=base.ContentType.FORM_ENCODED,
             **kwargs,
         )

--- a/edb/server/protocol/auth_ext/slack.py
+++ b/edb/server/protocol/auth_ext/slack.py
@@ -22,7 +22,7 @@ from typing import Any
 from . import base
 
 
-class SlackProvider(base.OpenIDProvider):
+class SlackProvider(base.OpenIDConnectProvider):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(
             "slack",

--- a/edb/server/protocol/auth_ext/ui/components.py
+++ b/edb/server/protocol/auth_ext/ui/components.py
@@ -148,16 +148,21 @@ def _oauth_button(
     *,
     label_prefix: str,
 ) -> str:
-    href = '../authorize?' + urllib.parse.urlencode({
-        'provider': provider.name,
-        **params
-    })
-    img = (
-        f'''<img src="_static/icon_{provider.name[15:]}.svg"
-            alt="{provider.display_name} Icon" />'''
-        if provider.name in known_oauth_provider_names
-        else ''
+    href = '../authorize?' + urllib.parse.urlencode(
+        {'provider': provider.name, **params}
     )
+    if (
+        provider.name.startswith('builtin::')
+        and provider.name in known_oauth_provider_names
+    ):
+        img = f'''<img src="_static/icon_{provider.name[15:]}.svg"
+            alt="{provider.display_name} Icon" />'''
+    elif provider.logo_url is not None:
+        img = f'''<img src="{provider.logo_url}"
+            alt="{provider.display_name} Icon" />'''
+    else:
+        img = ''
+
     label = f'{label_prefix} {provider.display_name}'
     return f'''
         <a href={href} title="{label}">

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -656,7 +656,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://github.com",
-                "/login/oauth/access_token",
+                "login/oauth/access_token",
             )
             self.mock_provider.register_route_handler(*token_request)(
                 (
@@ -671,7 +671,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
-            user_request = ("GET", "https://api.github.com", "/user")
+            user_request = ("GET", "https://api.github.com", "user")
             self.mock_provider.register_route_handler(*user_request)(
                 (
                     json.dumps(
@@ -831,7 +831,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://github.com",
-                "/login/oauth/access_token",
+                "login/oauth/access_token",
             )
             self.mock_provider.register_route_handler(*token_request)(
                 (
@@ -897,7 +897,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://github.com",
-                "/login/oauth/access_token",
+                "login/oauth/access_token",
             )
             self.mock_provider.register_route_handler(*token_request)(
                 (
@@ -1038,7 +1038,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://discord.com",
-                "/api/oauth2/token",
+                "api/oauth2/token",
             )
             self.mock_provider.register_route_handler(*token_request)(
                 (
@@ -1053,7 +1053,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
             )
 
-            user_request = ("GET", "https://discord.com/api/v10", "/users/@me")
+            user_request = ("GET", "https://discord.com/api/v10", "users/@me")
             self.mock_provider.register_route_handler(*user_request)(
                 (
                     json.dumps(
@@ -1216,7 +1216,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://accounts.google.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -1229,7 +1229,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             jwks_request = (
                 "GET",
                 "https://www.googleapis.com",
-                "/oauth2/v3/certs",
+                "oauth2/v3/certs",
             )
             # Generate a JWK Set
             k = jwk.JWK.generate(kty='RSA', size=4096)
@@ -1249,7 +1249,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://oauth2.googleapis.com",
-                "/token",
+                "token",
             )
             id_token_claims = {
                 "iss": "https://accounts.google.com",
@@ -1377,7 +1377,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://accounts.google.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -1447,7 +1447,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://login.microsoftonline.com/common/v2.0",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -1521,7 +1521,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://login.microsoftonline.com/common/v2.0",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -1533,7 +1533,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             jwks_request = (
                 "GET",
                 "https://login.microsoftonline.com",
-                "/common/discovery/v2.0/keys",
+                "common/discovery/v2.0/keys",
             )
             # Generate a JWK Set
             k = jwk.JWK.generate(kty='RSA', size=4096)
@@ -1553,7 +1553,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://login.microsoftonline.com",
-                "/common/oauth2/v2.0/token",
+                "common/oauth2/v2.0/token",
             )
             id_token_claims = {
                 "iss": "https://login.microsoftonline.com/common/v2.0",
@@ -1665,7 +1665,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://appleid.apple.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -1737,7 +1737,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://appleid.apple.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -1749,7 +1749,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             jwks_request = (
                 "GET",
                 "https://appleid.apple.com",
-                "/auth/keys",
+                "auth/keys",
             )
             # Generate a JWK Set
             k = jwk.JWK.generate(kty='RSA', size=4096)
@@ -1769,7 +1769,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://appleid.apple.com",
-                "/auth/token",
+                "auth/token",
             )
             id_token_claims = {
                 "iss": "https://appleid.apple.com",
@@ -1881,7 +1881,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://appleid.apple.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -1893,7 +1893,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             jwks_request = (
                 "GET",
                 "https://appleid.apple.com",
-                "/auth/keys",
+                "auth/keys",
             )
             # Generate a JWK Set
             k = jwk.JWK.generate(kty='RSA', size=4096)
@@ -1913,7 +1913,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://appleid.apple.com",
-                "/auth/token",
+                "auth/token",
             )
             id_token_claims = {
                 "iss": "https://appleid.apple.com",
@@ -2029,7 +2029,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://slack.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -2042,7 +2042,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             jwks_request = (
                 "GET",
                 "https://slack.com",
-                "/openid/connect/keys",
+                "openid/connect/keys",
             )
             # Generate a JWK Set
             k = jwk.JWK.generate(kty='RSA', size=4096)
@@ -2062,7 +2062,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             token_request = (
                 "POST",
                 "https://slack.com",
-                "/api/openid.connect.token",
+                "api/openid.connect.token",
             )
             id_token_claims = {
                 "iss": "https://slack.com",
@@ -2190,7 +2190,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://slack.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (
@@ -2268,7 +2268,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             discovery_request = (
                 "GET",
                 "https://example.com",
-                "/.well-known/openid-configuration",
+                ".well-known/openid-configuration",
             )
             self.mock_provider.register_route_handler(*discovery_request)(
                 (

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3763,6 +3763,11 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertIn(APP_NAME, body_str)
             self.assertIn(LOGO_URL, body_str)
             self.assertIn(BRAND_COLOR, body_str)
+
+            # Check for OAuth buttons
+            self.assertIn("Sign in with Google", body_str)
+            self.assertIn("Sign in with GitHub", body_str)
+            self.assertIn("Sign in with My Generic OIDC Provider", body_str)
             self.assertEqual(status, 200)
 
     async def test_http_auth_ext_webauthn_register_options(self):

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -1291,13 +1291,13 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_token = self.mock_provider.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)
             self.assertEqual(
-                json.loads(requests_for_token[0]["body"]),
+                urllib.parse.parse_qs(requests_for_token[0]["body"]),
                 {
-                    "grant_type": "authorization_code",
-                    "code": "abc123",
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "redirect_uri": f"{self.http_addr}/callback",
+                    "grant_type": ["authorization_code"],
+                    "code": ["abc123"],
+                    "client_id": [client_id],
+                    "client_secret": [client_secret],
+                    "redirect_uri": [f"{self.http_addr}/callback"],
                 },
             )
 


### PR DESCRIPTION
Adds support for arbitrary well-behaved OpenID Connect providers that support discovery. Does not include a PKCE session, which some providers might require. It uses a direct code exchange with a shared client secret. Tested using Google OpenID Connect.