### PR TITLE
Revert "Skip rebuilding query string if normalization didn't extract variables (#7237)"

### DIFF
--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -188,6 +188,14 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
     }
 
     all_variables.push(variables);
+    // N.B: We always serialize the tokens to produce
+    // processed_source, even when no changes have been made. This is
+    // because when Source gets serialized, it always uses a
+    // PackedEntry, which will result in it being normalized *there*,
+    // and so if we don't do it *here*, then we won't be able to hit
+    // the persistent cache in cases where we didn't reserialize the
+    // tokens.
+    // TODO: Rework the caching to avoid needing to do this.
     let processed_source = serialize_tokens(&rewritten_tokens[..]);
     Ok(Entry {
         hash: hash(&processed_source),

--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -159,9 +159,10 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
                 matches!(kw, "configure"|"create"|"alter"|"drop"|"start"|"analyze")
                 || (last_was_set && kw == "global")
             ) => {
+                let processed_source = serialize_tokens(&tokens);
                 return Ok(Entry {
-                    hash: hash(text),
-                    processed_source: text.to_string(),
+                    hash: hash(&processed_source),
+                    processed_source,
                     tokens,
                     variables: Vec::new(),
                     named_args: false,
@@ -187,13 +188,7 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
     }
 
     all_variables.push(variables);
-    let processed_source = if counter <= var_idx {
-        // Just use the original text when there is no literal to extract,
-        // in order to save the time calling `serialize_tokens()`
-        text.to_string()
-    } else {
-        serialize_tokens(&rewritten_tokens[..])
-    };
+    let processed_source = serialize_tokens(&rewritten_tokens[..]);
     Ok(Entry {
         hash: hash(&processed_source),
         processed_source,

--- a/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
@@ -7,8 +7,8 @@ use num_bigint::BigInt;
 fn test_verbatim() {
     let entry = normalize(r###"
         SELECT $1 + $2
-    "###.trim()).unwrap();
-    assert_eq!(entry.processed_source, "SELECT $1 + $2");
+    "###).unwrap();
+    assert_eq!(entry.processed_source, "SELECT$1+$2");
     assert_eq!(entry.variables, vec![vec![]]);
 }
 
@@ -16,8 +16,8 @@ fn test_verbatim() {
 fn test_configure() {
     let entry = normalize(r###"
         CONFIGURE INSTANCE SET some_setting := 7
-    "###.trim()).unwrap();
-    assert_eq!(entry.processed_source, "CONFIGURE INSTANCE SET some_setting := 7");
+    "###).unwrap();
+    assert_eq!(entry.processed_source, "CONFIGURE INSTANCE SET some_setting:=7");
     assert_eq!(entry.variables, vec![] as Vec<Vec<Variable>>);
 }
 


### PR DESCRIPTION
This reverts commit 6aef9f57908cb2c0627fa29a187318dcc431f701.

Reverting this for now because it breaks the persistent cache for
queries that don't have any constants extracted. This is because the
serialized source uses a PackedEntry, which always works by
serializing tokens, and so it won't match the non-normalized queries.