### PR TITLE
Unbreak cache recompilation after a restart

### DIFF
--- a/edb/server/compiler/rpc.pxd
+++ b/edb/server/compiler/rpc.pxd
@@ -46,4 +46,4 @@ cdef class CompilationRequest:
         object cache_key
 
     cdef _serialize(self)
-    cdef _deserialize_v0(self, bytes data, str query_text)
+    cdef _deserialize_v0_v1(self, bytes data, str query_text, char version)

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -159,8 +159,11 @@ cdef class CompilationRequest:
         return self
 
     def deserialize(self, bytes data, str query_text) -> CompilationRequest:
-        if data[0] == 0:
-            self._deserialize_v0(data, query_text)
+        cdef:
+            char version
+        version = data[0]
+        if version == 0 or version == 1:
+            self._deserialize_v0_v1(data, query_text, version)
         else:
             raise errors.UnsupportedProtocolVersionError(
                 f"unsupported compile cache: version {data[0]}"
@@ -178,10 +181,10 @@ cdef class CompilationRequest:
         return self.cache_key
 
     cdef _serialize(self):
-        # Please see _deserialize_v0 for the format doc
+        # Please see _deserialize_v0_v1 for the format doc
 
         cdef:
-            char version = 0, flags
+            char version = 1, flags
             WriteBuffer out = WriteBuffer.new()
 
         out.write_byte(version)
@@ -219,6 +222,10 @@ cdef class CompilationRequest:
         out.write_bytes(type_id.bytes)
         out.write_len_prefixed_bytes(desc)
 
+        # Must set_schema_version() before serializing compilation request
+        assert self.schema_version is not None
+        out.write_bytes(self.schema_version.bytes)
+
         hash_obj = hashlib.blake2b(memoryview(out), digest_size=16)
         hash_obj.update(self.source.cache_key())
 
@@ -238,10 +245,6 @@ cdef class CompilationRequest:
         )
         hash_obj.update(serialized_comp_config)
 
-        # Must set_schema_version() before serializing compilation request
-        assert self.schema_version is not None
-        hash_obj.update(self.schema_version.bytes)
-
         cache_key_bytes = hash_obj.digest()
         self.cache_key = uuidgen.from_bytes(cache_key_bytes)
 
@@ -249,10 +252,10 @@ cdef class CompilationRequest:
         out.write_bytes(cache_key_bytes)
         self.serialized_cache = bytes(out)
 
-    cdef _deserialize_v0(self, bytes data, str query_text):
+    cdef _deserialize_v0_v1(self, bytes data, str query_text, char version):
         # Format:
         #
-        # * 1 byte of version (0)
+        # * 1 byte of version (0 or 1)
         # * 1 byte of bit flags:
         #   * json_parameters
         #   * expect_one
@@ -271,6 +274,7 @@ cdef class CompilationRequest:
         # * Session config type descriptor
         #   * 16 bytes type ID
         #   * int32-length-prefixed serialized type descriptor
+        # * In v1, the schema_version.
         # * Session config: int32-length-prefixed serialized data
         # * Serialized Source or NormalizedSource without the original query
         #   string
@@ -280,6 +284,7 @@ cdef class CompilationRequest:
         #    * Except that the serialized session config is replaced by
         #      serialized combined config (session -> database -> system)
         #      that only affects compilation.
+        #    * In v0, the schema_version.
 
         cdef char flags
 
@@ -287,7 +292,7 @@ cdef class CompilationRequest:
 
         buf = ReadBuffer.new_message_parser(data)
 
-        assert buf.read_byte() == 0  # version
+        assert buf.read_byte() == version  # version
 
         flags = buf.read_byte()
         self.json_parameters = flags & MASK_JSON_PARAMETERS > 0
@@ -323,6 +328,9 @@ cdef class CompilationRequest:
                 type_id, buf.read_len_prefixed_bytes(), defines.CURRENT_PROTOCOL
             )
             self._serializer = serializer
+
+        if version > 0:
+            self.schema_version = uuidgen.from_bytes(buf.read_bytes(16))
 
         data = buf.read_len_prefixed_bytes()
         if data:


### PR DESCRIPTION
In #7099, I made it so we only recompile when the schema_version of a 
request matches the current schema_version. Unfortunately, we don't 
serialize the schema_version out, so it was always None.

Bump the CompilationRequest serialization version number and include 
schema_version.