### PR TITLE
Some more cleanup of implicit limits

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -906,7 +906,7 @@ def _cast_range(
         )
 
         if el_type.contains_json(subctx.env.schema):
-            subctx.inhibit_implicit_limit = True
+            subctx.implicit_limit = 0
 
         return dispatch.compile(cast, ctx=subctx)
 
@@ -975,7 +975,7 @@ def _cast_multirange(
         )
 
         if el_type.contains_json(subctx.env.schema):
-            subctx.inhibit_implicit_limit = True
+            subctx.implicit_limit = 0
 
         return dispatch.compile(cast, ctx=subctx)
 
@@ -1272,7 +1272,7 @@ def _cast_array(
             correlated_query = qlast.SelectQuery(result=correlated_elements)
 
             if el_type.contains_json(subctx.env.schema):
-                subctx.inhibit_implicit_limit = True
+                subctx.implicit_limit = 0
 
             array_ir = dispatch.compile(correlated_query, ctx=subctx)
             assert isinstance(array_ir, irast.Set)

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -529,9 +529,6 @@ class ContextLevel(compiler.ContextLevel):
     implicit_limit: int
     """Implicit LIMIT clause in SELECT statements."""
 
-    inhibit_implicit_limit: bool
-    """Whether implicit limit injection should be inhibited."""
-
     special_computables_in_mutation_shape: FrozenSet[str]
     """A set of "special" computable pointers allowed in mutation shape."""
 
@@ -622,7 +619,6 @@ class ContextLevel(compiler.ContextLevel):
             self.implicit_tid_in_shapes = False
             self.implicit_tname_in_shapes = False
             self.implicit_limit = 0
-            self.inhibit_implicit_limit = False
             self.special_computables_in_mutation_shape = frozenset()
             self.empty_result_type_hint = None
             self.defining_view = None
@@ -667,7 +663,6 @@ class ContextLevel(compiler.ContextLevel):
             self.implicit_tid_in_shapes = prevlevel.implicit_tid_in_shapes
             self.implicit_tname_in_shapes = prevlevel.implicit_tname_in_shapes
             self.implicit_limit = prevlevel.implicit_limit
-            self.inhibit_implicit_limit = prevlevel.inhibit_implicit_limit
             self.special_computables_in_mutation_shape = \
                 prevlevel.special_computables_in_mutation_shape
             self.empty_result_type_hint = prevlevel.empty_result_type_hint

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -767,7 +767,7 @@ def compile_TypeCast(
         if target_stype.contains_json(subctx.env.schema):
             # JSON wants type shapes and acts as an output sink.
             subctx.expr_exposed = context.Exposure.EXPOSED
-            subctx.inhibit_implicit_limit = True
+            subctx.implicit_limit = 0
             subctx.implicit_id_in_shapes = False
             subctx.implicit_tid_in_shapes = False
             subctx.implicit_tname_in_shapes = False

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -939,7 +939,6 @@ def finalize_args(
                 and ctx.implicit_limit
                 and isinstance(arg_val.expr, irast.SelectStmt)
                 and arg_val.expr.limit is None
-                and not ctx.inhibit_implicit_limit
             ):
                 arg_val.expr.limit = dispatch.compile(
                     qlast.Constant.integer(ctx.implicit_limit),

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -623,7 +623,7 @@ def compile_arg(
                 result=arg_ql, span=arg_ql.span,
                 implicit=True, rptr_passthrough=True)
 
-        argctx.inhibit_implicit_limit = True
+        argctx.implicit_limit = 0
 
         arg_ir = dispatch.compile(arg_ql, ctx=argctx)
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1319,24 +1319,6 @@ def compile_result_clause(
             # `SELECT foo := expr` is equivalent to
             # `WITH foo := expr SELECT foo`
             rexpr = astutils.ensure_ql_select(result)
-            if (
-                sctx.implicit_limit
-                and rexpr.limit is None
-                and not sctx.inhibit_implicit_limit
-            ):
-                # Inline alias is special: it's both "exposed",
-                # but also subject for further processing, so
-                # make sure we don't mangle it with an implicit
-                # limit.
-                rexpr.limit = qlast.TypeCast(
-                    expr=qlast.Set(elements=[]),
-                    type=qlast.TypeName(
-                        maintype=qlast.ObjectRef(
-                            module='__std__',
-                            name='int64',
-                        )
-                    )
-                )
 
             stmtctx.declare_view(
                 rexpr,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1533,7 +1533,7 @@ def _normalize_view_ptr_expr(
                 qlexpr.limit = shape_el.limit
 
             if (
-                (ctx.expr_exposed or ctx.stmt is ctx.toplevel_stmt)
+                ctx.expr_exposed
                 and ctx.implicit_limit
                 and not base_is_singleton
             ):
@@ -1656,7 +1656,7 @@ def _normalize_view_ptr_expr(
             qlexpr = astutils.ensure_ql_select(qlexpr)
 
         if (
-            (ctx.expr_exposed or ctx.stmt is ctx.toplevel_stmt)
+            ctx.expr_exposed
             and ctx.implicit_limit
         ):
             qlexpr = qlast.SelectQuery(result=qlexpr, implicit=True)


### PR DESCRIPTION
Drop inhibit_implicit_limit in favor of setting implicit_limit to 0
(which we already do in several places).

Drop some now-dead code in the aliased SELECT path.

Drop some extra conditionals in viewgen.