### PR TITLE
Add a auto_rebuild_query_cache_timeout config

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_06_26_00_00
+EDGEDB_CATALOG_VERSION = 2024_07_01_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -194,6 +194,12 @@ ALTER TYPE cfg::AbstractConfig {
             'Recompile all cached queries on DDL if enabled.';
     };
 
+    CREATE PROPERTY auto_rebuild_query_cache_timeout -> std::duration {
+        CREATE ANNOTATION std::description :=
+            'Maximum time to spend recompiling cached queries on DDL.';
+        SET default := <std::duration>'60 seconds';
+    };
+
     CREATE PROPERTY query_cache_mode -> cfg::QueryCacheMode {
         SET default := cfg::QueryCacheMode.Default;
         CREATE ANNOTATION cfg::affects_compilation := 'true';

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -697,13 +697,21 @@ def _call_system_api(
         con.close()
 
 
+def parse_metrics(metrics: str) -> dict[str, float]:
+    res = {}
+    for line in metrics.splitlines():
+        if line.startswith('#') or ' ' not in line:
+            continue
+        key, _, val = line.partition(' ')
+        res[key] = float(val)
+    return res
+
+
 def _extract_background_errors(metrics: str) -> str | None:
     non_zero = []
 
-    for line in metrics.splitlines():
-        if line.startswith('edgedb_server_background_errors_total'):
-            label, _, total = line.rpartition(' ')
-            total = float(total)
+    for label, total in parse_metrics(metrics).items():
+        if label.startswith('edgedb_server_background_errors_total'):
             if total:
                 non_zero.append(
                     f'non-zero {label!r} metric: {total}'


### PR DESCRIPTION
Allow configuring a timeout for query cache recompilation.

Also add a test that tests this behavior and some other basic cache behavior.