### PR TITLE
Create a task for each DB to ensure we generate the correct load

### DIFF
--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -234,7 +234,7 @@ class LatencyRatio(PercentileBasedScoreMethod):
         ratio = dividend_percentile / divisor_percentile
         score = self._calculate(ratio)
         sim.record_scoring(
-            f'{self.percentile} ratio {self.divisor}/{self.dividend}',
+            f'{self.percentile} ratio {self.dividend}/{self.divisor}',
             ratio, score, self.weight
         )
         return score * self.weight

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -191,20 +191,12 @@ class LatencyDistribution(ScoreMethod):
 class ConnectionOverhead(ScoreMethod):
     # Calculate the score based on the total number of connects and disconnects
 
-    use_time_scale: bool = True
-
     def calculate(self, sim: Simulation) -> float:
-        if self.use_time_scale:
-            self.v90 = self.v100 + (self.v90 - self.v100) * TIME_SCALE
-            self.v60 = self.v100 + (self.v60 - self.v100) * TIME_SCALE
-            self.v0 = self.v100 + (self.v0 - self.v100) * TIME_SCALE
-        value = (
-            sim.stats[-1]["successful_connects"]
-            + sim.stats[-1]["successful_disconnects"]
-        )
+        total = sum(map(lambda x: len(x), sim.latencies.values()))
+        value = sim.stats[-1]["successful_disconnects"] / total
         score = self._calculate(value)
         sim.record_scoring(
-            'Num of (dis-)connects', value, score, self.weight
+            'Num of disconnects/query', value, score, self.weight
         )
         return score * self.weight
 
@@ -786,7 +778,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
                     v100=0.2, v90=0.45, v60=0.7, v0=2
                 ),
                 ConnectionOverhead(
-                    weight=0.06, v100=40, v90=160, v60=200, v0=300
+                    weight=0.06, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[
@@ -848,7 +840,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
                     v100=0.55, v90=0.75, v60=1.0, v0=2
                 ),
                 ConnectionOverhead(
-                    weight=0.15, v100=500, v90=510, v60=800, v0=1500
+                    weight=0.15, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[
@@ -897,7 +889,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
                     weight=0.85, group=range(6), v100=0, v90=0.1, v60=0.2, v0=2
                 ),
                 ConnectionOverhead(
-                    weight=0.15, v100=200, v90=250, v60=300, v0=600
+                    weight=0.15, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[
@@ -930,7 +922,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
                     weight=0.9, group=range(6), v100=0, v90=0.1, v60=0.2, v0=2
                 ),
                 ConnectionOverhead(
-                    weight=0.1, v100=100, v90=220, v60=300, v0=500
+                    weight=0.1, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[
@@ -985,7 +977,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
                     v100=30, v90=5, v60=2, v0=1,
                 ),
                 ConnectionOverhead(
-                    weight=0.15, v100=50, v90=100, v60=150, v0=200
+                    weight=0.15, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
                 EndingCapacity(
                     weight=0.1, v100=6, v90=5, v60=4, v0=3
@@ -1034,7 +1026,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
             conn_cost_var=0.05,
             score=[
                 ConnectionOverhead(
-                    weight=0.9, v100=6, v90=7, v60=12, v0=13
+                    weight=0.9, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[
@@ -1081,7 +1073,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
                     v100=200, v90=100, v60=20, v0=1,
                 ),
                 ConnectionOverhead(
-                    weight=0.4, v100=14, v90=22, v60=30, v0=50
+                    weight=0.4, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[
@@ -1128,8 +1120,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
             conn_cost_var=0,
             score=[
                 ConnectionOverhead(
-                    weight=1, v100=25, v90=50, v60=90, v0=200,
-                    use_time_scale=False,
+                    weight=1, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[
@@ -1189,8 +1180,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
                     v100=0.0001, v90=0.0002, v60=0.0004, v0=0.005
                 ),
                 ConnectionOverhead(
-                    weight=0.6, v100=50, v90=90, v60=100, v0=200,
-                    use_time_scale=False,
+                    weight=0.6, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -189,7 +189,8 @@ class LatencyDistribution(ScoreMethod):
 
 @dataclasses.dataclass
 class ConnectionOverhead(ScoreMethod):
-    # Calculate the score based on the total number of connects and disconnects
+    # Calculate the score based on the number of disconnects required to service
+    # a query on average.
 
     def calculate(self, sim: Simulation) -> float:
         total = sum(map(lambda x: len(x), sim.latencies.values()))
@@ -1026,7 +1027,7 @@ class TestServerConnpoolSimulation(SimulatedCase):
             conn_cost_var=0.05,
             score=[
                 ConnectionOverhead(
-                    weight=0.9, v100=0, v90=0.1, v60=0.2, v0=0.5
+                    weight=1.0, v100=0, v90=0.1, v60=0.2, v0=0.5
                 ),
             ],
             dbs=[


### PR DESCRIPTION
The previous QoS tests were "slipping" and generating an insufficient amount of load when the overhead of the pool was too high. This modifies the query generation to create one task per DB and sleep an appropriate amount of time. The tests were unable to hit the query/sec numbers requested and this was causing the QoS numbers to be lower than they should have been. The QoS output for the various tests change to reflect this, but the overall behaviour of the pool is identical.

Note that this had the side-effect of increasing the total number of queries run in most of the tests, which lowering most of the `ConnectionOverhead` scores. The `ConnectionOverhead` scoring now uses "# of disconnections / # of queries" which is a more stable number and can be more easily compared across tests.

Additional fixes:

 - The `LatencyRatio` ratio output was incorrect -- it printed `divisor` twice
 - One test only had a total weight of 0.9, fixed
