### PR TITLE
Require extension modules to live in ext::

### DIFF
--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -369,6 +369,17 @@ class CreateExtension(
 
         if not context.canonical:
             package = self.scls.get_package(schema)
+
+            module = package.get_ext_module(schema)
+            if module:
+                module_name = sn.UnqualName(module)
+                if module_name.get_root_module_name() != s_schema.EXT_MODULE:
+                    raise errors.SchemaError(
+                        f'built-in extension {self.classname} has invalid '
+                        f'module "{module}": '
+                        f'extension modules must begin with "ext::"'
+                    )
+
             script = package.get_script(schema)
             if script:
                 block, _ = qlparser.parse_extension_package_body_block(script)

--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
         def get_local_name(self) -> UnqualName:
             ...
 
+        def get_root_module_name(self) -> UnqualName:
+            ...
+
         def __lt__(self, other: Any) -> bool:
             ...
 
@@ -90,9 +93,6 @@ if TYPE_CHECKING:
             ...
 
         def get_module_name(self) -> Name:
-            ...
-
-        def get_root_module_name(self) -> UnqualName:
             ...
 
     class UnqualName(Name):
@@ -172,6 +172,9 @@ else:
 
         def get_local_name(self) -> UnqualName:
             return self
+
+        def get_root_module_name(self) -> UnqualName:
+            return UnqualName(self.name.partition('::')[0])
 
         def __str__(self) -> str:
             return self.name


### PR DESCRIPTION
We assume this in some places but one of our tests violated it.