### PR TITLE
Move edgedb's fixed internal types to a edgedbt schema

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_07_01_00_00
+EDGEDB_CATALOG_VERSION = 2024_07_09_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -345,8 +345,8 @@ std::_datetime_range_buckets(
     SET volatility := 'Stable';
     USING SQL $$
     SELECT
-        lo::edgedb.timestamptz_t,
-        hi::edgedb.timestamptz_t
+        lo::edgedbt.timestamptz_t,
+        hi::edgedbt.timestamptz_t
     FROM
         (SELECT
             series AS lo,

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -48,7 +48,7 @@ cal::to_local_datetime(s: std::str, fmt: OPTIONAL str={})
             edgedb.local_datetime_in("s")
         WHEN "fmt" = '' THEN
             edgedb.raise(
-                NULL::edgedb.timestamp_t,
+                NULL::edgedbt.timestamp_t,
                 'invalid_parameter_value',
                 msg => (
                     'to_local_datetime(): '
@@ -82,7 +82,7 @@ cal::to_local_datetime(year: std::int64, month: std::int64, day: std::int64,
     SELECT make_timestamp(
         "year"::int, "month"::int, "day"::int,
         "hour"::int, "min"::int, "sec"
-    )::edgedb.timestamp_t
+    )::edgedbt.timestamp_t
     $$;
 };
 
@@ -96,7 +96,7 @@ cal::to_local_datetime(dt: std::datetime, zone: std::str)
     # The version of timezone with these arguments is IMMUTABLE.
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT timezone("zone", "dt")::edgedb.timestamp_t;
+    SELECT timezone("zone", "dt")::edgedbt.timestamp_t;
     $$;
 };
 
@@ -112,7 +112,7 @@ cal::to_local_date(s: std::str, fmt: OPTIONAL str={}) -> cal::local_date
             edgedb.local_date_in("s")
         WHEN "fmt" = '' THEN
             edgedb.raise(
-                NULL::edgedb.date_t,
+                NULL::edgedbt.date_t,
                 'invalid_parameter_value',
                 msg => (
                     'to_local_date(): '
@@ -121,7 +121,7 @@ cal::to_local_date(s: std::str, fmt: OPTIONAL str={}) -> cal::local_date
             )
         ELSE
             edgedb.raise_on_null(
-                edgedb.to_local_datetime("s", "fmt")::edgedb.date_t,
+                edgedb.to_local_datetime("s", "fmt")::edgedbt.date_t,
                 'invalid_parameter_value',
                 msg => (
                     'to_local_date(): format ''' || "fmt" || ''' is invalid'
@@ -141,7 +141,7 @@ cal::to_local_date(dt: std::datetime, zone: std::str)
     # The version of timezone with these arguments is IMMUTABLE.
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT timezone("zone", "dt")::edgedb.date_t;
+    SELECT timezone("zone", "dt")::edgedbt.date_t;
     $$;
 };
 
@@ -153,7 +153,7 @@ cal::to_local_date(year: std::int64, month: std::int64, day: std::int64)
     CREATE ANNOTATION std::description := 'Create a `cal::local_date` value.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT make_date("year"::int, "month"::int, "day"::int)::edgedb.date_t
+    SELECT make_date("year"::int, "month"::int, "day"::int)::edgedbt.date_t
     $$;
 };
 
@@ -258,7 +258,7 @@ cal::to_relative_duration(
             "seconds"
         ) +
         (microseconds::text || ' microseconds')::interval
-    )::edgedb.relative_duration_t
+    )::edgedbt.relative_duration_t
     $$;
 };
 
@@ -278,7 +278,7 @@ cal::to_date_duration(
         "months"::int,
         0,
         "days"::int
-    )::edgedb.date_duration_t
+    )::edgedbt.date_duration_t
     $$;
 };
 
@@ -392,7 +392,7 @@ std::`+` (l: std::datetime, r: cal::relative_duration) -> std::datetime {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamptz_t
+        SELECT ("l" + "r")::edgedbt.timestamptz_t
     $$
 };
 
@@ -407,7 +407,7 @@ std::`+` (l: cal::relative_duration, r: std::datetime) -> std::datetime {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamptz_t
+        SELECT ("l" + "r")::edgedbt.timestamptz_t
     $$
 };
 
@@ -421,7 +421,7 @@ std::`-` (l: std::datetime, r: cal::relative_duration) -> std::datetime {
     # should affect this.
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT ("l" - "r")::edgedb.timestamptz_t
+        SELECT ("l" - "r")::edgedbt.timestamptz_t
     $$
 };
 
@@ -525,7 +525,7 @@ std::`+` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -538,7 +538,7 @@ std::`+` (l: std::duration, r: cal::local_datetime) -> cal::local_datetime {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -550,7 +550,7 @@ std::`-` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
         'Time interval and date/time subtraction.';
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT ("l" - "r")::edgedb.timestamp_t
+        SELECT ("l" - "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -563,7 +563,7 @@ std::`+` (l: cal::local_datetime, r: cal::relative_duration) -> cal::local_datet
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -576,7 +576,7 @@ std::`+` (l: cal::relative_duration, r: cal::local_datetime) -> cal::local_datet
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -588,7 +588,7 @@ std::`-` (l: cal::local_datetime, r: cal::relative_duration) -> cal::local_datet
         'Time interval and date/time subtraction.';
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT ("l" - "r")::edgedb.timestamp_t
+        SELECT ("l" - "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -704,7 +704,7 @@ std::`+` (l: cal::local_date, r: std::duration) -> cal::local_datetime
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -719,7 +719,7 @@ std::`+` (l: std::duration, r: cal::local_date) -> cal::local_datetime
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -733,7 +733,7 @@ std::`-` (l: cal::local_date, r: std::duration) -> cal::local_datetime
     SET volatility := 'Immutable';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" - "r")::edgedb.timestamp_t
+        SELECT ("l" - "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -748,7 +748,7 @@ std::`+` (l: cal::local_date, r: cal::relative_duration) -> cal::local_datetime
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -763,7 +763,7 @@ std::`+` (l: cal::relative_duration, r: cal::local_date) -> cal::local_datetime
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamp_t
+        SELECT ("l" + "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -777,7 +777,7 @@ std::`-` (l: cal::local_date, r: cal::relative_duration) -> cal::local_datetime
     SET volatility := 'Immutable';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" - "r")::edgedb.timestamp_t
+        SELECT ("l" - "r")::edgedbt.timestamp_t
     $$;
 };
 
@@ -792,7 +792,7 @@ std::`+` (l: cal::local_date, r: cal::date_duration) -> cal::local_date
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.date_t
+        SELECT ("l" + "r")::edgedbt.date_t
     $$;
 };
 
@@ -807,7 +807,7 @@ std::`+` (l: cal::date_duration, r: cal::local_date) -> cal::local_date
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.date_t
+        SELECT ("l" + "r")::edgedbt.date_t
     $$;
 };
 
@@ -821,7 +821,7 @@ std::`-` (l: cal::local_date, r: cal::date_duration) -> cal::local_date
     SET volatility := 'Immutable';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT ("l" - "r")::edgedb.date_t
+        SELECT ("l" - "r")::edgedbt.date_t
     $$;
 };
 
@@ -834,7 +834,7 @@ std::`-` (l: cal::local_date, r: cal::local_date) -> cal::date_duration
     SET volatility := 'Immutable';
     SET force_return_cast := true;
     USING SQL $$
-        SELECT make_interval(0, 0, 0, "l" - "r")::edgedb.date_duration_t
+        SELECT make_interval(0, 0, 0, "l" - "r")::edgedbt.date_duration_t
     $$;
 };
 
@@ -1105,7 +1105,7 @@ std::`+` (l: cal::relative_duration, r: cal::relative_duration) -> cal::relative
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-    SELECT ("l"::interval + "r"::interval)::edgedb.relative_duration_t;
+    SELECT ("l"::interval + "r"::interval)::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1117,7 +1117,7 @@ std::`-` (l: cal::relative_duration, r: cal::relative_duration) -> cal::relative
         'Time interval subtraction.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT ("l"::interval - "r"::interval)::edgedb.relative_duration_t;
+    SELECT ("l"::interval - "r"::interval)::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1130,7 +1130,7 @@ std::`+` (l: cal::date_duration, r: cal::date_duration) -> cal::date_duration {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-    SELECT ("l" + "r")::edgedb.date_duration_t;
+    SELECT ("l" + "r")::edgedbt.date_duration_t;
     $$;
 };
 
@@ -1142,7 +1142,7 @@ std::`-` (l: cal::date_duration, r: cal::date_duration) -> cal::date_duration {
         'Time interval subtraction.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT ("l" - "r")::edgedb.date_duration_t;
+    SELECT ("l" - "r")::edgedbt.date_duration_t;
     $$;
 };
 
@@ -1155,7 +1155,7 @@ std::`+` (l: std::duration, r: cal::relative_duration) -> cal::relative_duration
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-    SELECT ("l"::interval + "r"::interval)::edgedb.relative_duration_t;
+    SELECT ("l"::interval + "r"::interval)::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1168,7 +1168,7 @@ std::`+` (l: cal::relative_duration, r: std::duration) -> cal::relative_duration
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-    SELECT ("l"::interval + "r"::interval)::edgedb.relative_duration_t;
+    SELECT ("l"::interval + "r"::interval)::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1180,7 +1180,7 @@ std::`-` (l: std::duration, r: cal::relative_duration) -> cal::relative_duration
         'Time interval subtraction.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT ("l"::interval - "r"::interval)::edgedb.relative_duration_t;
+    SELECT ("l"::interval - "r"::interval)::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1192,7 +1192,7 @@ std::`-` (l: cal::relative_duration, r: std::duration) -> cal::relative_duration
         'Time interval subtraction.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT ("l"::interval - "r"::interval)::edgedb.relative_duration_t;
+    SELECT ("l"::interval - "r"::interval)::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1204,7 +1204,7 @@ std::`-` (v: cal::relative_duration) -> cal::relative_duration {
         'Time interval negation.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT (-"v"::interval)::edgedb.relative_duration_t;
+    SELECT (-"v"::interval)::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1253,7 +1253,7 @@ CREATE CAST FROM std::str TO cal::local_time {
 CREATE CAST FROM std::str TO cal::relative_duration {
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT val::edgedb.relative_duration_t;
+    SELECT val::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1375,7 +1375,7 @@ CREATE CAST FROM std::json TO cal::relative_duration {
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(
         val, 'string', detail => detail
-    )::interval::edgedb.relative_duration_t;
+    )::interval::edgedbt.relative_duration_t;
     $$;
 };
 
@@ -1536,12 +1536,12 @@ std::duration_truncate(
     USING SQL $$
     SELECT CASE WHEN "unit" IN (
             'days', 'weeks', 'months', 'years', 'decades', 'centuries')
-        THEN date_trunc("unit", "dt")::edgedb.relative_duration_t
+        THEN date_trunc("unit", "dt")::edgedbt.relative_duration_t
         WHEN "unit" = 'quarters'
-        THEN date_trunc('quarter', "dt")::edgedb.relative_duration_t
+        THEN date_trunc('quarter', "dt")::edgedbt.relative_duration_t
         ELSE
             edgedb.raise(
-                NULL::edgedb.relative_duration_t,
+                NULL::edgedbt.relative_duration_t,
                 'invalid_datetime_format',
                 msg => (
                     'invalid unit for std::duration_truncate: '
@@ -1571,12 +1571,12 @@ std::duration_truncate(
             'microseconds', 'milliseconds', 'seconds',
             'minutes', 'hours', 'days', 'weeks', 'months',
             'years', 'decades', 'centuries')
-        THEN date_trunc("unit", "dt")::edgedb.relative_duration_t
+        THEN date_trunc("unit", "dt")::edgedbt.relative_duration_t
         WHEN "unit" = 'quarters'
-        THEN date_trunc('quarter', "dt")::edgedb.relative_duration_t
+        THEN date_trunc('quarter', "dt")::edgedbt.relative_duration_t
         ELSE
             edgedb.raise(
-                NULL::edgedb.relative_duration_t,
+                NULL::edgedbt.relative_duration_t,
                 'invalid_datetime_format',
                 msg => (
                     'invalid unit for std::duration_truncate: '
@@ -1719,7 +1719,7 @@ std::to_datetime(local: cal::local_datetime, zone: std::str)
     # The version of timezone with these arguments is IMMUTABLE.
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT timezone("zone", "local")::edgedb.timestamptz_t;
+    SELECT timezone("zone", "local")::edgedbt.timestamptz_t;
     $$;
 };
 
@@ -1996,7 +1996,7 @@ std::range_unpack(
 {
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT d::edgedb.timestamp_t
+        SELECT d::edgedbt.timestamp_t
         FROM
             generate_series(
                 (
@@ -2013,7 +2013,7 @@ std::range_unpack(
                 step::interval
             ) AS d
         WHERE
-            upper_inc(val) OR d::edgedb.timestamp_t < upper(val)
+            upper_inc(val) OR d::edgedbt.timestamp_t < upper(val)
     $$;
 };
 
@@ -2044,7 +2044,7 @@ std::range_unpack(
                     )
                 )::timestamp,
                 'P1D'::interval
-            )::edgedb.date_t
+            )::edgedbt.date_t
     $$;
 };
 
@@ -2076,11 +2076,11 @@ std::range_unpack(
                     )
                 )::timestamp,
                 step::interval
-            )::edgedb.date_t
+            )::edgedbt.date_t
     $$;
 };
 
-# Need to cast edgedb.date_t to date in order for the @> operator to work.
+# Need to cast edgedbt.date_t to date in order for the @> operator to work.
 CREATE FUNCTION std::contains(
     haystack: range<cal::local_date>,
     needle: cal::local_date

--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -2166,7 +2166,7 @@ std::`//` (n: std::bigint, d: std::bigint) -> std::bigint
     USING SQL $$
         SELECT floor(
             1.0::numeric * "n"::numeric / "d"::numeric
-        )::edgedb.bigint_t;
+        )::edgedbt.bigint_t;
     $$;
 };
 
@@ -2297,7 +2297,7 @@ std::`%` (n: std::bigint, d: std::bigint) -> std::bigint
     SET volatility := 'Immutable';
     USING SQL OPERATOR r'%(numeric,numeric)';
     USING SQL $$
-        SELECT (((n % d) + d) % d)::edgedb.bigint_t;
+        SELECT (((n % d) + d) % d)::edgedbt.bigint_t;
     $$;
 };
 
@@ -2508,7 +2508,7 @@ CREATE CAST FROM std::decimal TO std::float32 {
 
 CREATE CAST FROM std::decimal TO std::bigint {
     SET volatility := 'Immutable';
-    USING SQL 'SELECT round($1)::edgedb.bigint_t';
+    USING SQL 'SELECT round($1)::edgedbt.bigint_t';
 };
 
 
@@ -2532,7 +2532,7 @@ CREATE CAST FROM std::float32 TO std::int64 {
 
 CREATE CAST FROM std::float32 TO std::bigint {
     SET volatility := 'Immutable';
-    USING SQL 'SELECT round($1)::edgedb.bigint_t';
+    USING SQL 'SELECT round($1)::edgedbt.bigint_t';
 };
 
 
@@ -2580,7 +2580,7 @@ CREATE CAST FROM std::float64 TO std::int64 {
 
 CREATE CAST FROM std::float64 TO std::bigint {
     SET volatility := 'Immutable';
-    USING SQL 'SELECT round($1)::edgedb.bigint_t';
+    USING SQL 'SELECT round($1)::edgedbt.bigint_t';
 };
 
 

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -100,12 +100,12 @@ std::datetime_truncate(dt: std::datetime, unit: std::str) -> std::datetime
             'microseconds', 'milliseconds', 'seconds',
             'minutes', 'hours', 'days', 'weeks', 'months',
             'years', 'decades', 'centuries')
-        THEN date_trunc("unit", "dt")::edgedb.timestamptz_t
+        THEN date_trunc("unit", "dt")::edgedbt.timestamptz_t
         WHEN "unit" = 'quarters'
-        THEN date_trunc('quarter', "dt")::edgedb.timestamptz_t
+        THEN date_trunc('quarter', "dt")::edgedbt.timestamptz_t
         ELSE
             edgedb.raise(
-                NULL::edgedb.timestamptz_t,
+                NULL::edgedbt.timestamptz_t,
                 'invalid_datetime_format',
                 msg => (
                     'invalid unit for std::datetime_truncate: '
@@ -162,10 +162,10 @@ std::duration_truncate(dt: std::duration, unit: std::str) -> std::duration
     USING SQL $$
     SELECT CASE WHEN "unit" in ('microseconds', 'milliseconds',
                                 'seconds', 'minutes', 'hours')
-        THEN date_trunc("unit", "dt")::edgedb.duration_t
+        THEN date_trunc("unit", "dt")::edgedbt.duration_t
         ELSE
             edgedb.raise(
-                NULL::edgedb.duration_t,
+                NULL::edgedbt.duration_t,
                 'invalid_datetime_format',
                 msg => (
                     'invalid unit for std::duration_truncate: '
@@ -295,7 +295,7 @@ std::`+` (l: std::datetime, r: std::duration) -> std::datetime {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamptz_t
+        SELECT ("l" + "r")::edgedbt.timestamptz_t
     $$
 };
 
@@ -310,7 +310,7 @@ std::`+` (l: std::duration, r: std::datetime) -> std::datetime {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-        SELECT ("l" + "r")::edgedb.timestamptz_t
+        SELECT ("l" + "r")::edgedbt.timestamptz_t
     $$
 };
 
@@ -324,7 +324,7 @@ std::`-` (l: std::datetime, r: std::duration) -> std::datetime {
     # should affect this.
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT ("l" - "r")::edgedb.timestamptz_t
+        SELECT ("l" - "r")::edgedbt.timestamptz_t
     $$
 };
 
@@ -337,7 +337,7 @@ std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
     # should affect this.
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT EXTRACT(epoch FROM "l" - "r")::text::edgedb.duration_t
+        SELECT EXTRACT(epoch FROM "l" - "r")::text::edgedbt.duration_t
     $$
 };
 
@@ -441,7 +441,7 @@ std::`+` (l: std::duration, r: std::duration) -> std::duration {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
-    SELECT ("l"::interval + "r"::interval)::edgedb.duration_t;
+    SELECT ("l"::interval + "r"::interval)::edgedbt.duration_t;
     $$;
 };
 
@@ -453,7 +453,7 @@ std::`-` (l: std::duration, r: std::duration) -> std::duration {
         'Time interval subtraction.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT ("l"::interval - "r"::interval)::edgedb.duration_t;
+    SELECT ("l"::interval - "r"::interval)::edgedbt.duration_t;
     $$;
 };
 
@@ -465,7 +465,7 @@ std::`-` (v: std::duration) -> std::duration {
         'Time interval negation.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT (-"v"::interval)::edgedb.duration_t;
+    SELECT (-"v"::interval)::edgedbt.duration_t;
     $$;
 };
 

--- a/edb/lib/std/31-rangefuncs.edgeql
+++ b/edb/lib/std/31-rangefuncs.edgeql
@@ -239,7 +239,7 @@ std::range_unpack(
 {
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT d::edgedb.timestamptz_t
+        SELECT d::edgedbt.timestamptz_t
         FROM
             generate_series(
                 (
@@ -256,7 +256,7 @@ std::range_unpack(
                 step::interval
             ) AS d
         WHERE
-            upper_inc(val) OR d::edgedb.timestamptz_t < upper(val)
+            upper_inc(val) OR d::edgedbt.timestamptz_t < upper(val)
     $$;
 };
 

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -382,7 +382,7 @@ std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
             edgedb.datetime_in("s")
         WHEN "fmt" = '' THEN
             edgedb.raise(
-                NULL::edgedb.timestamptz_t,
+                NULL::edgedbt.timestamptz_t,
                 'invalid_parameter_value',
                 msg => (
                     'to_datetime(): "fmt" argument must be a non-empty string'
@@ -412,7 +412,7 @@ std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
     SELECT make_timestamptz(
         "year"::int, "month"::int, "day"::int,
         "hour"::int, "min"::int, "sec", "timezone"
-    )::edgedb.timestamptz_t
+    )::edgedbt.timestamptz_t
     $$;
 };
 
@@ -423,7 +423,7 @@ std::to_datetime(epochseconds: std::float64) -> std::datetime
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
+    SELECT to_timestamp("epochseconds")::edgedbt.timestamptz_t
     $$;
 };
 
@@ -434,7 +434,7 @@ std::to_datetime(epochseconds: std::int64) -> std::datetime
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
+    SELECT to_timestamp("epochseconds")::edgedbt.timestamptz_t
     $$;
 };
 
@@ -445,7 +445,7 @@ std::to_datetime(epochseconds: std::decimal) -> std::datetime
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
+    SELECT to_timestamp("epochseconds")::edgedbt.timestamptz_t
     $$;
 };
 
@@ -472,7 +472,7 @@ std::to_duration(
             "seconds"
         ) +
         (microseconds::text || ' microseconds')::interval
-    )::edgedb.duration_t
+    )::edgedbt.duration_t
     $$;
 };
 
@@ -488,7 +488,7 @@ std::to_bigint(s: std::str, fmt: OPTIONAL str={}) -> std::bigint
             edgedb.str_to_bigint("s")
         WHEN "fmt" = '' THEN
             edgedb.raise(
-                NULL::edgedb.bigint_t,
+                NULL::edgedbt.bigint_t,
                 'invalid_parameter_value',
                 msg => (
                     'to_bigint(): "fmt" argument must be a non-empty string'
@@ -496,7 +496,7 @@ std::to_bigint(s: std::str, fmt: OPTIONAL str={}) -> std::bigint
             )
         ELSE
             edgedb.raise_on_null(
-                to_number("s", "fmt")::edgedb.bigint_t,
+                to_number("s", "fmt")::edgedbt.bigint_t,
                 'invalid_parameter_value',
                 msg => 'to_bigint(): format ''' || "fmt" || ''' is invalid'
             )

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4658,6 +4658,7 @@ async def bootstrap(
 ) -> None:
     cmds = [
         dbops.CreateSchema(name='edgedb'),
+        dbops.CreateSchema(name='edgedbt'),
         dbops.CreateSchema(name='edgedbpub'),
         dbops.CreateSchema(name='edgedbstd'),
         dbops.CreateSchema(name='edgedbsql'),
@@ -5984,7 +5985,8 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
             ctid
         FROM pg_namespace
         WHERE nspname IN ('pg_catalog', 'pg_toast', 'information_schema',
-                          'edgedb', 'edgedbstd', 'edgedb_VER', 'edgedbstd_VER')
+                          'edgedb', 'edgedbstd', 'edgedbt',
+                          'edgedb_VER', 'edgedbstd_VER')
         UNION ALL
 
         -- virtual schemas
@@ -6037,7 +6039,7 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
         WHERE
             nspname IN ('pg_catalog', 'pg_toast', 'information_schema',
                         'edgedb', 'edgedbstd', 'edgedb_VER', 'edgedbstd_VER',
-                        'edgedbpub')
+                        'edgedbpub', 'edgedbt')
         """.format(
                 ",".join(
                     f"pt.{col}"

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -264,11 +264,11 @@ class BigintDomain(dbops.Domain):
     """
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'bigint_t'),
+            name=('edgedbt', 'bigint_t'),
             base='numeric',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'bigint_t'),
+                    domain_name=('edgedbt', 'bigint_t'),
                     expr=("scale(VALUE) = 0 AND VALUE != 'NaN'"),
                 ),
             ),
@@ -278,7 +278,7 @@ class BigintDomain(dbops.Domain):
 class ConfigMemoryDomain(dbops.Domain):
     """Represents the cfg::memory type. Stores number of bytes.
 
-    Defined just as edgedb.bigint_t:
+    Defined just as edgedbt.bigint_t:
 
     * numeric is used to ensure we can comfortably represent huge amounts
       of data beyond petabytes;
@@ -286,11 +286,11 @@ class ConfigMemoryDomain(dbops.Domain):
     """
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'memory_t'),
+            name=('edgedbt', 'memory_t'),
             base='int8',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'memory_t'),
+                    domain_name=('edgedbt', 'memory_t'),
                     expr=("VALUE >= 0"),
                 ),
             ),
@@ -306,11 +306,11 @@ class TimestampTzDomain(dbops.Domain):
     """
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'timestamptz_t'),
+            name=('edgedbt', 'timestamptz_t'),
             base='timestamptz',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'timestamptz_t'),
+                    domain_name=('edgedbt', 'timestamptz_t'),
                     expr=("EXTRACT(years from VALUE) BETWEEN 1 AND 9999"),
                 ),
             ),
@@ -326,11 +326,11 @@ class TimestampDomain(dbops.Domain):
     """
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'timestamp_t'),
+            name=('edgedbt', 'timestamp_t'),
             base='timestamp',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'timestamp_t'),
+                    domain_name=('edgedbt', 'timestamp_t'),
                     expr=("EXTRACT(years from VALUE) BETWEEN 1 AND 9999"),
                 ),
             ),
@@ -346,11 +346,11 @@ class DateDomain(dbops.Domain):
     """
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'date_t'),
+            name=('edgedbt', 'date_t'),
             base='date',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'date_t'),
+                    domain_name=('edgedbt', 'date_t'),
                     expr=("EXTRACT(years from VALUE) BETWEEN 1 AND 9999"),
                 ),
             ),
@@ -360,11 +360,11 @@ class DateDomain(dbops.Domain):
 class DurationDomain(dbops.Domain):
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'duration_t'),
+            name=('edgedbt', 'duration_t'),
             base='interval',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'duration_t'),
+                    domain_name=('edgedbt', 'duration_t'),
                     expr=r'''
                         EXTRACT(months from VALUE) = 0 AND
                         EXTRACT(years from VALUE) = 0 AND
@@ -378,11 +378,11 @@ class DurationDomain(dbops.Domain):
 class RelativeDurationDomain(dbops.Domain):
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'relative_duration_t'),
+            name=('edgedbt', 'relative_duration_t'),
             base='interval',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'relative_duration_t'),
+                    domain_name=('edgedbt', 'relative_duration_t'),
                     expr="true",
                 ),
             ),
@@ -392,11 +392,11 @@ class RelativeDurationDomain(dbops.Domain):
 class DateDurationDomain(dbops.Domain):
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'date_duration_t'),
+            name=('edgedbt', 'date_duration_t'),
             base='interval',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'date_duration_t'),
+                    domain_name=('edgedbt', 'date_duration_t'),
                     expr=r'''
                         EXTRACT(hour from VALUE) = 0 AND
                         EXTRACT(minute from VALUE) = 0 AND
@@ -427,16 +427,16 @@ class Float64Range(dbops.Range):
 class DatetimeRange(dbops.Range):
     def __init__(self) -> None:
         super().__init__(
-            name=types.type_to_range_name_map[('edgedb', 'timestamptz_t')],
-            subtype=('edgedb', 'timestamptz_t'),
+            name=types.type_to_range_name_map[('edgedbt', 'timestamptz_t')],
+            subtype=('edgedbt', 'timestamptz_t'),
         )
 
 
 class LocalDatetimeRange(dbops.Range):
     def __init__(self) -> None:
         super().__init__(
-            name=types.type_to_range_name_map[('edgedb', 'timestamp_t')],
-            subtype=('edgedb', 'timestamp_t'),
+            name=types.type_to_range_name_map[('edgedbt', 'timestamp_t')],
+            subtype=('edgedbt', 'timestamp_t'),
         )
 
 
@@ -660,7 +660,7 @@ class StrToConfigMemoryFunction(trampoline.VersionedFunction):
                                 )
                             )
                     END
-            END)::edgedb.memory_t
+            END)::edgedbt.memory_t
         FROM LATERAL (
             SELECT regexp_match(
                 "val", '^(\d+)([[:alpha:]]+)$') AS v
@@ -673,7 +673,7 @@ class StrToConfigMemoryFunction(trampoline.VersionedFunction):
             args=[
                 ('val', ('text',)),
             ],
-            returns=('edgedb', 'memory_t'),
+            returns=('edgedbt', 'memory_t'),
             strict=True,
             volatility='immutable',
             language='sql',
@@ -722,7 +722,7 @@ class ConfigMemoryToStrFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'cfg_memory_to_str'),
             args=[
-                ('val', ('edgedb', 'memory_t')),
+                ('val', ('edgedbt', 'memory_t')),
             ],
             returns=('text',),
             volatility='immutable',
@@ -878,7 +878,7 @@ class StrToBigint(trampoline.VersionedFunction):
     """Parse bigint from text."""
 
     # The plpgsql execption handling nonsense is actually just so that
-    # we can produce an exception that mentions edgedb.bigint_t
+    # we can produce an exception that mentions edgedbt.bigint_t
     # instead of numeric, and thus produce the right user-facing
     # exception. As a nice side effect it is like twice as fast
     # as the previous code too.
@@ -894,13 +894,13 @@ class StrToBigint(trampoline.VersionedFunction):
             END;
 
             IF scale(v) = 0 THEN
-                RETURN v::edgedb.bigint_t;
+                RETURN v::edgedbt.bigint_t;
             ELSE
                 EXECUTE edgedb_VER.raise(
                     NULL::numeric,
                     'invalid_text_representation',
                     msg => (
-                        'invalid input syntax for type edgedb.bigint_t: '
+                        'invalid input syntax for type edgedbt.bigint_t: '
                         || quote_literal(val)
                     )
                 );
@@ -912,7 +912,7 @@ class StrToBigint(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'str_to_bigint'),
             args=[('val', ('text',))],
-            returns=('edgedb', 'bigint_t'),
+            returns=('edgedbt', 'bigint_t'),
             language='plpgsql',
             volatility='immutable',
             strict=True,
@@ -2285,7 +2285,7 @@ class DatetimeInFunction(trampoline.VersionedFunction):
                 )
             THEN
                 edgedb_VER.raise(
-                    NULL::edgedb.timestamptz_t,
+                    NULL::edgedbt.timestamptz_t,
                     'invalid_datetime_format',
                     msg => (
                         'invalid input syntax for type timestamptz: '
@@ -2299,7 +2299,7 @@ class DatetimeInFunction(trampoline.VersionedFunction):
                     )
                 )
             ELSE
-                val::edgedb.timestamptz_t
+                val::edgedbt.timestamptz_t
             END;
     '''
 
@@ -2307,7 +2307,7 @@ class DatetimeInFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'datetime_in'),
             args=[('val', ('text',))],
-            returns=('edgedb', 'timestamptz_t'),
+            returns=('edgedbt', 'timestamptz_t'),
             # Same volatility as raise() (stable)
             volatility='stable',
             text=self.text)
@@ -2323,7 +2323,7 @@ class DurationInFunction(trampoline.VersionedFunction):
                 EXTRACT(DAY FROM v.column1) != 0
             THEN
                 edgedb_VER.raise(
-                    NULL::edgedb.duration_t,
+                    NULL::edgedbt.duration_t,
                     'invalid_datetime_format',
                     msg => (
                         'invalid input syntax for type std::duration: '
@@ -2334,7 +2334,7 @@ class DurationInFunction(trampoline.VersionedFunction):
                         || 'for std::duration."}'
                     )
                 )
-            ELSE v.column1::edgedb.duration_t
+            ELSE v.column1::edgedbt.duration_t
             END
         FROM
             (VALUES (
@@ -2346,7 +2346,7 @@ class DurationInFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'duration_in'),
             args=[('val', ('text',))],
-            returns=('edgedb', 'duration_t'),
+            returns=('edgedbt', 'duration_t'),
             volatility='immutable',
             text=self.text,
         )
@@ -2365,7 +2365,7 @@ class DateDurationInFunction(trampoline.VersionedFunction):
                 EXTRACT(SECOND FROM v.column1) != 0
             THEN
                 edgedb_VER.raise(
-                    NULL::edgedb.date_duration_t,
+                    NULL::edgedbt.date_duration_t,
                     'invalid_datetime_format',
                     msg => (
                         'invalid input syntax for type cal::date_duration: '
@@ -2376,7 +2376,7 @@ class DateDurationInFunction(trampoline.VersionedFunction):
                         || 'for cal::date_duration."}'
                     )
                 )
-            ELSE v.column1::edgedb.date_duration_t
+            ELSE v.column1::edgedbt.date_duration_t
             END
         FROM
             (VALUES (
@@ -2388,7 +2388,7 @@ class DateDurationInFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'date_duration_in'),
             args=[('val', ('text',))],
-            returns=('edgedb', 'date_duration_t'),
+            returns=('edgedbt', 'date_duration_t'),
             volatility='immutable',
             text=self.text,
         )
@@ -2408,7 +2408,7 @@ class LocalDatetimeInFunction(trampoline.VersionedFunction):
                 )
             THEN
                 edgedb_VER.raise(
-                    NULL::edgedb.timestamp_t,
+                    NULL::edgedbt.timestamp_t,
                     'invalid_datetime_format',
                     msg => (
                         'invalid input syntax for type timestamp: '
@@ -2422,7 +2422,7 @@ class LocalDatetimeInFunction(trampoline.VersionedFunction):
                     )
                 )
             ELSE
-                val::edgedb.timestamp_t
+                val::edgedbt.timestamp_t
             END;
     '''
 
@@ -2430,7 +2430,7 @@ class LocalDatetimeInFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'local_datetime_in'),
             args=[('val', ('text',))],
-            returns=('edgedb', 'timestamp_t'),
+            returns=('edgedbt', 'timestamp_t'),
             volatility='immutable',
             text=self.text)
 
@@ -2447,7 +2447,7 @@ class LocalDateInFunction(trampoline.VersionedFunction):
                 )
             THEN
                 edgedb_VER.raise(
-                    NULL::edgedb.date_t,
+                    NULL::edgedbt.date_t,
                     'invalid_datetime_format',
                     msg => (
                         'invalid input syntax for type date: '
@@ -2461,7 +2461,7 @@ class LocalDateInFunction(trampoline.VersionedFunction):
                     )
                 )
             ELSE
-                val::edgedb.date_t
+                val::edgedbt.date_t
             END;
     '''
 
@@ -2469,7 +2469,7 @@ class LocalDateInFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'local_date_in'),
             args=[('val', ('text',))],
-            returns=('edgedb', 'date_t'),
+            returns=('edgedbt', 'date_t'),
             volatility='immutable',
             text=self.text)
 
@@ -2576,7 +2576,7 @@ class ToTimestampTZCheck(trampoline.VersionedFunction):
                     DETAIL = '';
             END IF;
 
-            RETURN result::edgedb.timestamptz_t;
+            RETURN result::edgedbt.timestamptz_t;
         END;
     '''
 
@@ -2585,7 +2585,7 @@ class ToTimestampTZCheck(trampoline.VersionedFunction):
             name=('edgedb', '_to_timestamptz_check'),
             args=[('val', ('text',)), ('fmt', ('text',)),
                   ('hastz', ('bool',))],
-            returns=('edgedb', 'timestamptz_t'),
+            returns=('edgedbt', 'timestamptz_t'),
             # We're relying on changing settings, so it's volatile.
             volatility='volatile',
             language='plpgsql',
@@ -2606,7 +2606,7 @@ class ToDatetimeFunction(trampoline.VersionedFunction):
                 )
             THEN
                 edgedb_VER.raise(
-                    NULL::edgedb.timestamptz_t,
+                    NULL::edgedbt.timestamptz_t,
                     'invalid_datetime_format',
                     msg => (
                         'missing required time zone in format: '
@@ -2626,7 +2626,7 @@ class ToDatetimeFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'to_datetime'),
             args=[('val', ('text',)), ('fmt', ('text',))],
-            returns=('edgedb', 'timestamptz_t'),
+            returns=('edgedbt', 'timestamptz_t'),
             # Same as _to_timestamptz_check.
             volatility='volatile',
             text=self.text)
@@ -2645,7 +2645,7 @@ class ToLocalDatetimeFunction(trampoline.VersionedFunction):
                 )
             THEN
                 edgedb_VER.raise(
-                    NULL::edgedb.timestamp_t,
+                    NULL::edgedbt.timestamp_t,
                     'invalid_datetime_format',
                     msg => (
                         'unexpected time zone in format: '
@@ -2654,7 +2654,7 @@ class ToLocalDatetimeFunction(trampoline.VersionedFunction):
                 )
             ELSE
                 edgedb_VER._to_timestamptz_check(val, fmt, false)
-                    ::edgedb.timestamp_t
+                    ::edgedbt.timestamp_t
             END;
     '''
 
@@ -2662,7 +2662,7 @@ class ToLocalDatetimeFunction(trampoline.VersionedFunction):
         super().__init__(
             name=('edgedb', 'to_local_datetime'),
             args=[('val', ('text',)), ('fmt', ('text',))],
-            returns=('edgedb', 'timestamp_t'),
+            returns=('edgedbt', 'timestamp_t'),
             # Same as _to_timestamptz_check.
             volatility='volatile',
             text=self.text)
@@ -4148,7 +4148,7 @@ class GetPgTypeForEdgeDBTypeFunction(trampoline.VersionedFunction):
                         -- For ranges, we need to do the lookup based on
                         -- our internal map of elem names to range names,
                         -- because we use the builtin daterange as the range
-                        -- for edgedb.date_t.
+                        -- for edgedbt.date_t.
                         AND rng.rngtypid = (
                             SELECT
                                 rn::regtype::oid
@@ -4173,7 +4173,7 @@ class GetPgTypeForEdgeDBTypeFunction(trampoline.VersionedFunction):
                         -- For multiranges, we need to do the lookup based on
                         -- our internal map of elem names to range names,
                         -- because we use the builtin daterange as the range
-                        -- for edgedb.date_t.
+                        -- for edgedbt.date_t.
                         AND rng.rngmultitypid = (
                             SELECT
                                 rn::regtype::oid

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -48,25 +48,25 @@ base_type_name_map = {
     s_obj.get_known_type_id('std::int32'): ('int4',),
     s_obj.get_known_type_id('std::int16'): ('int2',),
     s_obj.get_known_type_id('std::decimal'): ('numeric',),
-    s_obj.get_known_type_id('std::bigint'): ('edgedb', 'bigint_t'),
+    s_obj.get_known_type_id('std::bigint'): ('edgedbt', 'bigint_t'),
     s_obj.get_known_type_id('std::bool'): ('bool',),
     s_obj.get_known_type_id('std::float64'): ('float8',),
     s_obj.get_known_type_id('std::float32'): ('float4',),
     s_obj.get_known_type_id('std::uuid'): ('uuid',),
-    s_obj.get_known_type_id('std::datetime'): ('edgedb', 'timestamptz_t'),
-    s_obj.get_known_type_id('std::duration'): ('edgedb', 'duration_t',),
+    s_obj.get_known_type_id('std::datetime'): ('edgedbt', 'timestamptz_t'),
+    s_obj.get_known_type_id('std::duration'): ('edgedbt', 'duration_t',),
     s_obj.get_known_type_id('std::bytes'): ('bytea',),
     s_obj.get_known_type_id('std::json'): ('jsonb',),
 
-    s_obj.get_known_type_id('cal::local_datetime'): ('edgedb', 'timestamp_t'),
-    s_obj.get_known_type_id('cal::local_date'): ('edgedb', 'date_t'),
+    s_obj.get_known_type_id('cal::local_datetime'): ('edgedbt', 'timestamp_t'),
+    s_obj.get_known_type_id('cal::local_date'): ('edgedbt', 'date_t'),
     s_obj.get_known_type_id('cal::local_time'): ('time',),
     s_obj.get_known_type_id('cal::relative_duration'):
-        ('edgedb', 'relative_duration_t'),
+        ('edgedbt', 'relative_duration_t'),
     s_obj.get_known_type_id('cal::date_duration'):
-        ('edgedb', 'date_duration_t'),
+        ('edgedbt', 'date_duration_t'),
 
-    s_obj.get_known_type_id('cfg::memory'): ('edgedb', 'memory_t'),
+    s_obj.get_known_type_id('cfg::memory'): ('edgedbt', 'memory_t'),
 }
 
 type_to_range_name_map = {
@@ -75,15 +75,15 @@ type_to_range_name_map = {
     ('numeric',): ('numrange',),
     ('float4',): ('edgedb', 'float32_range_t'),
     ('float8',): ('edgedb', 'float64_range_t'),
-    ('edgedb', 'timestamptz_t'): ('edgedb', 'datetime_range_t'),
-    ('edgedb', 'timestamp_t'): ('edgedb', 'local_datetime_range_t'),
+    ('edgedbt', 'timestamptz_t'): ('edgedb', 'datetime_range_t'),
+    ('edgedbt', 'timestamp_t'): ('edgedb', 'local_datetime_range_t'),
     # cal::local_date uses the built-in daterange instead of a custom
-    # one that actually uses edgedb.date_t as its subtype. This is
+    # one that actually uses edgedbt.date_t as its subtype. This is
     # because cal::local_date is discrete, and its range type should
     # get canonicalized. Defining a canonicalization function for a
     # custom range is a big hassle, and daterange already has the
     # correct canonicalization function
-    ('edgedb', 'date_t'): ('daterange',),
+    ('edgedbt', 'date_t'): ('daterange',),
 }
 
 # Construct a multirange map based on type_to_range_name_map by replacing
@@ -103,7 +103,7 @@ base_type_name_map_r = {
     'character': sn.QualName('std', 'str'),
     'text': sn.QualName('std', 'str'),
     'numeric': sn.QualName('std', 'decimal'),
-    'edgedb.bigint_t': sn.QualName('std', 'bigint'),
+    'edgedbt.bigint_t': sn.QualName('std', 'bigint'),
     'bigint_t': sn.QualName('std', 'bigint'),
     'int4': sn.QualName('std', 'int32'),
     'integer': sn.QualName('std', 'int32'),
@@ -119,28 +119,28 @@ base_type_name_map_r = {
     'float4': sn.QualName('std', 'float32'),
     'uuid': sn.QualName('std', 'uuid'),
     'timestamp with time zone': sn.QualName('std', 'datetime'),
-    'edgedb.timestamptz_t': sn.QualName('std', 'datetime'),
+    'edgedbt.timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz': sn.QualName('std', 'datetime'),
     'duration_t': sn.QualName('std', 'duration'),
-    'edgedb.duration_t': sn.QualName('std', 'duration'),
+    'edgedbt.duration_t': sn.QualName('std', 'duration'),
     'interval': sn.QualName('std', 'duration'),
     'bytea': sn.QualName('std', 'bytes'),
     'jsonb': sn.QualName('std', 'json'),
 
     'timestamp': sn.QualName('cal', 'local_datetime'),
     'timestamp_t': sn.QualName('cal', 'local_datetime'),
-    'edgedb.timestamp_t': sn.QualName('cal', 'local_datetime'),
+    'edgedbt.timestamp_t': sn.QualName('cal', 'local_datetime'),
     'date': sn.QualName('cal', 'local_date'),
     'date_t': sn.QualName('cal', 'local_date'),
-    'edgedb.date_t': sn.QualName('cal', 'local_date'),
+    'edgedbt.date_t': sn.QualName('cal', 'local_date'),
     'time': sn.QualName('cal', 'local_time'),
     'relative_duration_t': sn.QualName('cal', 'relative_duration'),
-    'edgedb.relative_duration_t': sn.QualName('cal', 'relative_duration'),
+    'edgedbt.relative_duration_t': sn.QualName('cal', 'relative_duration'),
     'date_duration_t': sn.QualName('cal', 'date_duration'),
-    'edgedb.date_duration_t': sn.QualName('cal', 'date_duration'),
+    'edgedbt.date_duration_t': sn.QualName('cal', 'date_duration'),
 
-    'edgedb.memory_t': sn.QualName('cfg', 'memory'),
+    'edgedbt.memory_t': sn.QualName('cfg', 'memory'),
     'memory_t': sn.QualName('cfg', 'memory'),
 }
 

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -117,7 +117,7 @@ constraint_res = {
     'id': re.compile(r'^.*"(?:\w+)_data_pkey".*$'),
     'link_target_del': re.compile(r'^.*link target policy$'),
     'scalar': re.compile(
-        r'^value for domain (\w+) violates check constraint "(.+)"'
+        r'^value for domain ([\w\.]+) violates check constraint "(.+)"'
     ),
 }
 


### PR DESCRIPTION
Our internal domains are specifically not versioned, so let's start
making that clear by putting them in an unversioned schema.