### PR TITLE
Fix event loop leak in test suite

### DIFF
--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -55,15 +55,6 @@ class BaseHttpExtensionTest(server.QueryTestCase):
         return f'/branch/{dbname}/{extpath}'
 
     @classmethod
-    def tearDownClass(cls):
-        # This isn't really necessary but helps test extension dropping
-        for extname in reversed(cls.EXTENSIONS):
-            cls.loop.run_until_complete(
-                cls.con.execute(f'DROP EXTENSION {extname};')
-            )
-        super().tearDownClass()
-
-    @classmethod
     async def _wait_for_db_config(
         cls, config_key, *, server=None, instance_config=False, value=None
     ):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1647,7 +1647,6 @@ class DumpCompatTestCase(
 class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
 
     BASE_TEST_CLASS = True
-    ISOLATED_METHODS = False
     STABLE_DUMP = True
     TRANSACTION_ISOLATION = False
     PARALLELISM_GRANULARITY = 'suite'
@@ -1752,7 +1751,6 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
 class StablePGDumpTestCase(BaseQueryTestCase):
 
     BASE_TEST_CLASS = True
-    ISOLATED_METHODS = False
     TRANSACTION_ISOLATION = False
 
     def run_pg_dump(self, *args, input: Optional[str] = None) -> None:

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9124,6 +9124,30 @@ type default::Foo {
             DROP EXTENSION TestAuthExtension;
         """)
 
+    async def test_edgeql_ddl_all_extensions_01(self):
+        # Install all extensions and then delete them all
+        exts = await self.con.query('''
+            select distinct sys::ExtensionPackage.name
+        ''')
+
+        ext_commands = ''.join(f'using extension {ext};\n' for ext in exts)
+        await self.con.execute(f"""
+            START MIGRATION TO {{
+                {ext_commands}
+                module default {{ }}
+            }};
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)
+
+        await self.con.execute(f"""
+            START MIGRATION TO {{
+                module default {{ }}
+            }};
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)
+
     async def test_edgeql_ddl_role_01(self):
         if not self.has_create_role:
             self.skipTest("create role is not supported by the backend")

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -67,6 +67,7 @@ class TestExtAI(tb.BaseHttpExtensionTest):
     @classmethod
     def tearDownClass(cls):
         cls.mock_server.stop()
+        super().tearDownClass()
 
     @classmethod
     def get_setup_script(cls):

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -1336,7 +1336,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 class TestLinkTargetDeleteMigrations(stb.DDLTestCase):
 
     SCHEMA = pathlib.Path(__file__).parent / 'schemas' / 'link_tgt_del.esdl'
-    ISOLATED_METHODS = False
 
     async def test_link_on_target_delete_migration_01(self):
         async with self._run_and_rollback():


### PR DESCRIPTION
TextExtAI wasn't calling tearDownClass on its superclass.  Just
calling it caused problems, because it tested dropping the extensions,
which assumed the test had no schema. I fixed that by getting rid of
that mechanism.

To make up for the testing lost by removing that mechanism, add a new
test that installs *all* extensions and then drops them all.

Also drop some unused class variables that were briefly red herrings.