### PR TITLE
Fix nightlies by configuring instance-name in `start_edgedb_server`

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2376,6 +2376,9 @@ class _EdgeDBServer:
             cmd += ['--jwt-revocation-list-file',
                     self.jwt_revocation_list_file]
 
+        if not self.multitenant_config:
+            cmd += ['--instance-name=localtest']
+
         if self.extra_args:
             cmd.extend(self.extra_args)
 

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -381,7 +381,6 @@ class TestServerAuth(tb.ConnectedTestCase):
         async with tb.start_edgedb_server(
             jws_key_file=pathlib.Path(jwk_file),
             default_auth_method=args.ServerAuthMethod.JWT,
-            extra_args=["--instance-name=localtest"],
         ) as sd:
             base_sk = secretkey.generate_secret_key(jwk)
             conn = await sd.connect(secret_key=base_sk)
@@ -607,7 +606,6 @@ class TestServerAuth(tb.ConnectedTestCase):
                     args.ServerAuthMethod.JWT,
                 ],
             }),
-            extra_args=["--instance-name=localtest"],
         ) as sd:
             base_sk = secretkey.generate_secret_key(jwk)
             conn = await sd.connect(secret_key=base_sk)

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -712,7 +712,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
     async def test_server_ops_cache_recompile_01(self):
         ckey = (
             'edgedb_server_edgeql_query_compilations_total'
-            '{tenant="_localdev",path="compiler"}'
+            '{tenant="localtest",path="compiler"}'
         )
         qry = 'select schema::Object { name }'
 


### PR DESCRIPTION
Otherwise, the instance-name was `_localdev` in dev test runs but
`_unknown` in our nightly tests, which was leading to a nightly failure.
Make it `localtest`, to match what `BaseCluster` does for tests.

(Should `BaseCluster` and `start_edgedb_server` be merged?)