### PR TITLE
Rust connection pool/Python integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -909,6 +909,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1604,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "statrs"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,9 +1758,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
+ "libc",
+ "mio",
  "num_cpus",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2000,7 +2025,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2008,6 +2033,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"

--- a/edb/server/conn_pool/Cargo.toml
+++ b/edb/server/conn_pool/Cargo.toml
@@ -26,7 +26,7 @@ smart-default = "0"
 
 [dependencies.tokio]
 version = "1"
-features = ["rt", "time", "sync"]
+features = ["rt", "time", "sync", "net"]
 
 [dependencies.derive_more]
 version = "1.0.0-beta.6"

--- a/edb/server/conn_pool/src/algo.rs
+++ b/edb/server/conn_pool/src/algo.rs
@@ -1,9 +1,9 @@
-use scopeguard::defer;
 use std::cell::{Cell, RefCell};
 use tracing::trace;
 
 use crate::{
     block::Name,
+    drain::Drain,
     metrics::{MetricVariant, RollingAverageU32},
 };
 
@@ -199,13 +199,6 @@ pub enum RebalanceOp {
     Close(Name),
 }
 
-/// Determines the shutdown plan based on the current pool state.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ShutdownOp {
-    /// Garbage collect a block.
-    Close(Name),
-}
-
 /// Determines the acquire plan based on the current pool state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AcquireOp {
@@ -215,6 +208,8 @@ pub enum AcquireOp {
     Steal(Name),
     /// Wait for a connection.
     Wait,
+    /// A connection cannot be established due to shutdown.
+    FailInShutdown,
 }
 
 /// Determines the release plan based on the current pool state.
@@ -238,8 +233,6 @@ pub enum ReleaseType {
     Normal,
     /// A release of a poisoned connection.
     Poison,
-    /// A release of a drained connection.
-    Drain,
 }
 
 /// Generic trait to decouple the algorithm from the underlying pool blocks.
@@ -384,6 +377,7 @@ pub trait PoolAlgorithmDataBlock: PoolAlgorithmDataMetrics {
     /// estimated database time statistic we can use for relative
     /// weighting.
     fn demand_score(&self) -> usize {
+        // This gives us an approximate count of incoming connection load during the last period
         let active = self.max(MetricVariant::Active);
         let active_ms = self.avg_ms(MetricVariant::Active).max(MIN_TIME.get());
         let waiting = self.max(MetricVariant::Waiting);
@@ -434,23 +428,42 @@ pub struct PoolConstraints {
     pub max: usize,
 }
 
-impl PoolConstraints {
+/// The algorithm runs against these data structures.
+pub struct AlgoState<'a, V: VisitPoolAlgoData> {
+    pub drain: &'a Drain,
+    pub it: &'a V,
+    pub constraints: &'a PoolConstraints,
+}
+
+impl<'a, V: VisitPoolAlgoData> AlgoState<'a, V> {
     /// Recalculate the quota targets for each block within the pool/
-    pub fn recalculate_shares(&self, it: &impl VisitPoolAlgoData) {
+    fn recalculate_shares(&self, update_demand: bool) {
         // First, compute the overall request load and number of backend targets
         let mut total_demand = 0;
         let mut total_target = 0;
         let mut s = "".to_owned();
 
-        it.with_all(|name, data| {
-            let demand_avg = data.demand();
-
-            if tracing::enabled!(tracing::Level::TRACE) {
-                s += &format!("{name}={demand_avg} ",);
+        self.it.with_all(|name, data| {
+            // Draining targets act like they have demand zero
+            if self.drain.is_draining(name) {
+                if tracing::enabled!(tracing::Level::TRACE) {
+                    s += &format!("{name}=drain ");
+                }
+                return;
             }
 
-            total_demand += demand_avg as usize;
-            if demand_avg > 0 {
+            if update_demand {
+                let demand = data.demand_score();
+                data.insert_demand(demand as _);
+            }
+            let demand = data.demand();
+
+            if tracing::enabled!(tracing::Level::TRACE) {
+                s += &format!("{name}={demand} ");
+            }
+
+            total_demand += demand as usize;
+            if demand > 0 {
                 total_target += 1;
             } else {
                 data.set_target(0);
@@ -461,70 +474,44 @@ impl PoolConstraints {
             trace!("Demand: {total_target} {}", s);
         }
 
-        self.allocate_demand(it, total_target, total_demand);
+        self.allocate_demand(total_target, total_demand);
     }
 
     /// Adjust the quota targets for each block within the pool.
-    pub fn adjust(&self, it: &impl VisitPoolAlgoData) {
+    pub fn adjust(&self) {
+        self.recalculate_shares(true);
+
         // Once we've adjusted the constraints, reset the max settings
-        defer!(it.reset_max());
-
-        // First, compute the overall request load and number of backend targets
-        let mut total_demand = 0_usize;
-        let mut total_target = 0;
-        let mut s = "".to_owned();
-
-        it.with_all(|name, data| {
-            let demand = data.demand_score();
-            data.insert_demand(demand as _);
-            let demand_avg = data.demand();
-
-            if tracing::enabled!(tracing::Level::TRACE) {
-                s += &format!("{name}={demand_avg}/{demand}",);
-            }
-
-            total_demand += demand_avg as usize;
-            if demand_avg > 0 {
-                total_target += 1;
-            } else {
-                data.set_target(0);
-            }
-        });
-
-        if tracing::enabled!(tracing::Level::TRACE) {
-            trace!("Demand: {total_target} {}", s);
-        }
-
-        self.allocate_demand(it, total_target, total_demand);
+        self.it.reset_max();
     }
 
     /// Allocate the calculated demand to target quotas.
-    fn allocate_demand(
-        &self,
-        it: &impl VisitPoolAlgoData,
-        total_target: usize,
-        total_demand: usize,
-    ) {
+    fn allocate_demand(&self, total_target: usize, total_demand: usize) {
         // Empty pool, no math
         if total_target == 0 || total_demand == 0 {
+            self.it.with_all(|_name, data| {
+                data.set_target(0);
+            });
             return;
         }
 
         let mut allocated = 0;
+        let max = self.constraints.max;
         // This is the minimum number of connections we'll allocate to any particular
         // backend regardless of demand if there are less backends than the capacity.
-        let min = (self.max / total_target).min(MAXIMUM_SHARED_TARGET.get());
+        let min = (max / total_target).min(MAXIMUM_SHARED_TARGET.get());
         // The remaining capacity after we allocated the `min` value above.
-        let capacity = self.max - min * total_target;
+        let capacity = max - min * total_target;
 
         if min == 0 {
-            it.with_all(|_name, data| {
+            self.it.with_all(|_name, data| {
                 data.set_target(0);
             });
         } else {
-            it.with_all(|_name, data| {
+            self.it.with_all(|name, data| {
                 let demand = data.demand();
-                if demand == 0 {
+                if demand == 0 || self.drain.is_draining(name) {
+                    data.set_target(0);
                     return;
                 }
 
@@ -539,23 +526,31 @@ impl PoolConstraints {
             });
         }
 
+        if tracing::enabled!(tracing::Level::TRACE) {
+            let mut s = String::new();
+            self.it.with_all(|name, block| {
+                s += &format!("{name}={}/{} ", block.target(), block.total());
+            });
+            trace!("Targets: {s}");
+        }
+
         debug_assert!(
-            allocated <= self.max,
+            allocated <= max,
             "Attempted to allocate more than we were allowed: {allocated} > {} \
                 (req={total_demand}, target={total_target})",
-            self.max
+            max
         );
     }
 
     /// Plan a shutdown.
-    pub fn plan_shutdown(&self, it: &impl VisitPoolAlgoData) -> Vec<ShutdownOp> {
+    fn plan_shutdown(&self) -> Vec<RebalanceOp> {
         let mut ops = vec![];
-        it.with_all(|name, block| {
+        self.it.with_all(|name, block| {
             let idle = block.count(MetricVariant::Idle);
             let failed = block.count(MetricVariant::Failed);
 
             for _ in 0..(idle + failed) {
-                ops.push(ShutdownOp::Close(name.clone()));
+                ops.push(RebalanceOp::Close(name.clone()));
             }
         });
         ops
@@ -563,18 +558,41 @@ impl PoolConstraints {
 
     /// Plan a rebalance to better match the target quotas of the blocks in the
     /// pool.
-    pub fn plan_rebalance(&self, it: &impl VisitPoolAlgoData) -> Vec<RebalanceOp> {
-        let mut current_pool_size = it.total();
-        let max_pool_size = self.max;
+    pub fn plan_rebalance(&self) -> Vec<RebalanceOp> {
+        // In shutdown, we just want to close all idle connections where possible.
+        if self.drain.in_shutdown() {
+            return self.plan_shutdown();
+        }
+
+        let mut current_pool_size = self.it.total();
+        let max_pool_size = self.constraints.max;
+        let mut tasks = vec![];
+
+        // TODO: These could potentially be transferred instead, but
+        // drain/shutdown are pretty unlikely.
+        if self.drain.are_any_draining() {
+            self.it.with_all(|name, data| {
+                if self.drain.is_draining(name) {
+                    for _ in 0..data.count(MetricVariant::Idle) + data.count(MetricVariant::Failed)
+                    {
+                        tasks.push(RebalanceOp::Close(name.clone()))
+                    }
+                }
+            })
+        }
 
         // If there's room in the pool, we can be more aggressive in
         // how we allocate.
         if current_pool_size < max_pool_size {
-            let mut changes = vec![];
             let mut made_changes = false;
 
             for i in 0..MAX_REBALANCE_OPS.get() {
-                it.with_all(|name, block| {
+                self.it.with_all(|name, block| {
+                    // Drains are handled at the start of this function
+                    if self.drain.is_draining(name) {
+                        return;
+                    }
+
                     // If there's room in the block, and room in the pool, and
                     // the block is bumping up against its current headroom, we'll grab
                     // another one.
@@ -584,7 +602,7 @@ impl PoolConstraints {
                             > (block.total() + i)
                                 .saturating_sub(MIN_REBALANCE_HEADROOM_TO_CREATE.get())
                     {
-                        changes.push(RebalanceOp::Create(name.clone()));
+                        tasks.push(RebalanceOp::Create(name.clone()));
                         current_pool_size += 1;
                         made_changes = true;
                     } else if block.total() > block.target()
@@ -596,7 +614,7 @@ impl PoolConstraints {
                         // around, we'll try to keep a few excess connections if
                         // nobody else wants them. Otherwise, we'll just try to close
                         // all the idle connections over time.
-                        changes.push(RebalanceOp::Close(name.clone()));
+                        tasks.push(RebalanceOp::Close(name.clone()));
                         made_changes = true;
                     }
                 });
@@ -605,7 +623,7 @@ impl PoolConstraints {
                 }
             }
 
-            return changes;
+            return tasks;
         }
 
         // For any block with less connections than its quota that has
@@ -617,7 +635,12 @@ impl PoolConstraints {
         let mut s1 = "".to_owned();
         let mut s2 = "".to_owned();
 
-        it.with_all(|name, block| {
+        self.it.with_all(|name, block| {
+            // Drains are handled at the start of this function
+            if self.drain.is_draining(name) {
+                return;
+            }
+
             if let Some(value) = block.hunger_score(false) {
                 if tracing::enabled!(tracing::Level::TRACE) {
                     s1 += &format!("{name}={value} ");
@@ -641,8 +664,6 @@ impl PoolConstraints {
         }
         overloaded.sort();
         hungriest.sort();
-
-        let mut tasks = vec![];
 
         for _ in 0..MAX_REBALANCE_OPS.get() {
             let Some((_, to)) = hungriest.pop() else {
@@ -668,17 +689,24 @@ impl PoolConstraints {
     }
 
     /// Plan a connection acquisition.
-    pub fn plan_acquire(&self, db: &str, it: &impl VisitPoolAlgoData) -> AcquireOp {
-        // If the block is new, we need to perform an initial adjustment to
-        // ensure this block gets some capacity.
-        if it.ensure_block(db, DEMAND_MINIMUM.get() * DEMAND_HISTORY_LENGTH) {
-            self.recalculate_shares(it);
+    pub fn plan_acquire(&self, db: &str) -> AcquireOp {
+        if self.drain.in_shutdown() {
+            return AcquireOp::FailInShutdown;
         }
 
-        let target_block_size = it.target(db);
-        let current_block_size = it.with(db, |data| data.total()).unwrap_or_default();
-        let current_pool_size = it.total();
-        let max_pool_size = self.max;
+        // If the block is new, we need to perform an initial adjustment to
+        // ensure this block gets some capacity.
+        if self
+            .it
+            .ensure_block(db, DEMAND_MINIMUM.get() * DEMAND_HISTORY_LENGTH)
+        {
+            self.recalculate_shares(false);
+        }
+
+        let target_block_size = self.it.target(db);
+        let current_block_size = self.it.with(db, |data| data.total()).unwrap_or_default();
+        let current_pool_size = self.it.total();
+        let max_pool_size = self.constraints.max;
 
         let pool_is_full = current_pool_size >= max_pool_size;
         if !pool_is_full {
@@ -691,7 +719,7 @@ impl PoolConstraints {
         if pool_is_full && block_has_room {
             let mut max = isize::MIN;
             let mut which = None;
-            it.with_all(|name, block| {
+            self.it.with_all(|name, block| {
                 if let Some(overfullness) = block.overfull_score(false) {
                     if overfullness > max {
                         which = Some(name.clone());
@@ -711,33 +739,29 @@ impl PoolConstraints {
     }
 
     /// Plan a connection release.
-    pub fn plan_release(
-        &self,
-        db: &str,
-        release_type: ReleaseType,
-        it: &impl VisitPoolAlgoData,
-    ) -> ReleaseOp {
-        if release_type == ReleaseType::Poison {
-            return ReleaseOp::Reopen;
-        }
-        if release_type == ReleaseType::Drain {
+    pub fn plan_release(&self, db: &str, release_type: ReleaseType) -> ReleaseOp {
+        if self.drain.is_draining(db) {
             return ReleaseOp::Discard;
         }
 
-        let current_pool_size = it.total();
-        let max_pool_size = self.max;
+        if release_type == ReleaseType::Poison {
+            return ReleaseOp::Reopen;
+        }
+
+        let current_pool_size = self.it.total();
+        let max_pool_size = self.constraints.max;
         if current_pool_size < max_pool_size {
             trace!("Pool has room, keeping connection");
             return ReleaseOp::Release;
         }
 
         // We only want to consider a release elsewhere if this block is overfull
-        if let Some(Some(overfull)) = it.with(db, |block| block.overfull_score(true)) {
+        if let Some(Some(overfull)) = self.it.with(db, |block| block.overfull_score(true)) {
             trace!("Block {db} is overfull ({overfull}), trying to release");
             let mut max = isize::MIN;
             let mut which = None;
             let mut s = "".to_owned();
-            it.with_all(|name, block| {
+            self.it.with_all(|name, block| {
                 let is_self = &**name == db;
                 if let Some(mut hunger) = block.hunger_score(is_self) {
                     // Penalize switching by boosting the current database's relative hunger here
@@ -792,29 +816,34 @@ mod tests {
             let connector = BasicConnector::no_delay();
             let config = PoolConfig::suggested_default_for(10);
             let blocks = Blocks::default();
-            let algo = &config.constraints;
+            let drain = Drain::default();
+            let algo = AlgoState {
+                constraints: &config.constraints,
+                drain: &drain,
+                it: &blocks,
+            };
 
             let futures = FuturesUnordered::new();
-            for i in (0..algo.max).map(Name::from) {
-                assert_eq!(algo.plan_acquire(&i, &blocks), AcquireOp::Create);
+            for i in (0..algo.constraints.max).map(Name::from) {
+                assert_eq!(algo.plan_acquire(&i), AcquireOp::Create);
                 futures.push(blocks.create_if_needed(&connector, &i));
             }
             let conns: Vec<_> = futures.collect().await;
             let futures = FuturesUnordered::new();
-            for i in (0..algo.max).map(Name::from) {
-                assert_eq!(algo.plan_acquire(&i, &blocks), AcquireOp::Wait);
+            for i in (0..algo.constraints.max).map(Name::from) {
+                assert_eq!(algo.plan_acquire(&i), AcquireOp::Wait);
                 futures.push(blocks.queue(&i));
             }
             for conn in conns {
                 assert_eq!(
-                    algo.plan_release(&conn?.state.db_name, ReleaseType::Normal, &blocks),
+                    algo.plan_release(&conn?.state.db_name, ReleaseType::Normal),
                     ReleaseOp::Release
                 );
             }
             let conns: Vec<_> = futures.collect().await;
             for conn in conns {
                 assert_eq!(
-                    algo.plan_release(&conn?.state.db_name, ReleaseType::Normal, &blocks),
+                    algo.plan_release(&conn?.state.db_name, ReleaseType::Normal),
                     ReleaseOp::Release
                 );
             }
@@ -831,25 +860,30 @@ mod tests {
         let future = async {
             let connector = BasicConnector::no_delay();
             let config = PoolConfig::suggested_default_for(10);
-            let algo = &config.constraints;
             let blocks = Blocks::default();
+            let drain = Drain::default();
+            let algo = AlgoState {
+                constraints: &config.constraints,
+                drain: &drain,
+                it: &blocks,
+            };
 
             // Room for these
             let futures = FuturesUnordered::new();
             for db in (0..5).map(Name::from) {
-                assert_eq!(algo.plan_acquire(&db, &blocks), AcquireOp::Create);
+                assert_eq!(algo.plan_acquire(&db), AcquireOp::Create);
                 futures.push(blocks.create_if_needed(&connector, &db));
             }
             // ... and these
             let futures2 = FuturesUnordered::new();
             for db in (5..10).map(Name::from) {
-                assert_eq!(algo.plan_acquire(&db, &blocks), AcquireOp::Create);
+                assert_eq!(algo.plan_acquire(&db), AcquireOp::Create);
                 futures2.push(blocks.create_if_needed(&connector, &db));
             }
             // But not these (yet)
             let futures3 = FuturesUnordered::new();
             for db in (10..15).map(Name::from) {
-                assert_eq!(algo.plan_acquire(&db, &blocks), AcquireOp::Wait);
+                assert_eq!(algo.plan_acquire(&db), AcquireOp::Wait);
                 futures3.push(blocks.queue(&db));
             }
             let conns: Vec<_> = futures.collect().await;
@@ -857,7 +891,7 @@ mod tests {
             // These are released to 10..15
             for conn in conns {
                 let conn = conn?;
-                let res = algo.plan_release(&conn.state.db_name, ReleaseType::Normal, &blocks);
+                let res = algo.plan_release(&conn.state.db_name, ReleaseType::Normal);
                 let ReleaseOp::ReleaseTo(to) = res else {
                     panic!("Wrong release: {res:?}");
                 };
@@ -866,7 +900,7 @@ mod tests {
             // These don't have anywhere to go
             for conn in conns2 {
                 let conn = conn?;
-                let res = algo.plan_release(&conn.state.db_name, ReleaseType::Normal, &blocks);
+                let res = algo.plan_release(&conn.state.db_name, ReleaseType::Normal);
                 let ReleaseOp::Release = res else {
                     panic!("Wrong release: {res:?}");
                 };

--- a/edb/server/conn_pool/src/drain.rs
+++ b/edb/server/conn_pool/src/drain.rs
@@ -1,0 +1,139 @@
+use crate::block::Name;
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+};
+
+/// Holds the current drainage and shutdown state for the `Pool`.
+#[derive(Default, Debug)]
+pub struct Drain {
+    drain_all: Cell<usize>,
+    drain: RefCell<HashMap<Name, usize>>,
+    shutdown: Cell<bool>,
+}
+
+impl Drain {
+    pub fn shutdown(&self) {
+        self.shutdown.set(true)
+    }
+
+    pub fn in_shutdown(&self) -> bool {
+        self.shutdown.get()
+    }
+
+    /// Lock all connections for draining.
+    pub fn lock_all<T: AsRef<Drain>>(this: T) -> DrainLock<T> {
+        let drain = this.as_ref();
+        drain.drain_all.set(drain.drain_all.get() + 1);
+        DrainLock {
+            db: None,
+            has_drain: this,
+        }
+    }
+
+    // Lock a specific connection for draining.
+    pub fn lock<T: AsRef<Drain>>(this: T, db: Name) -> DrainLock<T> {
+        {
+            let mut drain = this.as_ref().drain.borrow_mut();
+            drain.entry(db.clone()).and_modify(|v| *v += 1).or_default();
+        }
+        DrainLock {
+            db: Some(db),
+            has_drain: this,
+        }
+    }
+
+    /// Is this connection draining?
+    pub fn is_draining(&self, db: &str) -> bool {
+        self.drain_all.get() > 0 || self.drain.borrow().contains_key(db) || self.shutdown.get()
+    }
+
+    /// Are any connections draining?
+    pub fn are_any_draining(&self) -> bool {
+        !self.drain.borrow().is_empty() || self.shutdown.get() || self.drain_all.get() > 0
+    }
+}
+
+/// Provides a RAII lock for a db- or whole-pool drain operation.
+pub struct DrainLock<T: AsRef<Drain>> {
+    db: Option<Name>,
+    has_drain: T,
+}
+
+impl<T: AsRef<Drain>> Drop for DrainLock<T> {
+    fn drop(&mut self) {
+        if let Some(name) = self.db.take() {
+            let mut drain = self.has_drain.as_ref().drain.borrow_mut();
+            if let Some(count) = drain.get_mut(&name) {
+                if *count >= 1 {
+                    *count -= 1;
+                } else {
+                    drain.remove(&name);
+                }
+            } else {
+                unreachable!()
+            }
+        } else {
+            let this = self.has_drain.as_ref();
+            this.drain_all.set(this.drain_all.get() - 1);
+        }
+    }
+}
+
+impl AsRef<Drain> for Drain {
+    fn as_ref(&self) -> &Drain {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drain_lock_all() {
+        let drain = Drain::default();
+        let l1 = Drain::lock_all(&drain);
+        assert!(drain.are_any_draining());
+        drop(l1);
+        assert!(!drain.are_any_draining());
+    }
+
+    #[test]
+    fn drain_lock_db_one() {
+        let drain = Drain::default();
+        assert!(!drain.are_any_draining());
+        let l1 = Drain::lock(&drain, "db".into());
+        assert!(drain.are_any_draining());
+        drop(l1);
+        assert!(!drain.are_any_draining());
+    }
+
+    #[test]
+    fn drain_lock_db_two() {
+        let drain = Drain::default();
+        let l1 = Drain::lock(&drain, "db".into());
+        assert!(drain.are_any_draining());
+        let l2 = Drain::lock(&drain, "db".into());
+        assert!(drain.are_any_draining());
+        drop((l1, l2));
+        assert!(!drain.are_any_draining());
+    }
+
+    #[test]
+    fn drain_lock_db_mixed_one() {
+        let drain = Drain::default();
+        let l1 = Drain::lock(&drain, "db".into());
+        let l2 = Drain::lock(&drain, "db1".into());
+        drop((l1, l2));
+    }
+
+    #[test]
+    fn drain_lock_db_mixed_two() {
+        let drain = Drain::default();
+        let l1 = Drain::lock(&drain, "db".into());
+        let l2 = Drain::lock(&drain, "db1".into());
+        let l3 = Drain::lock(&drain, "db1".into());
+        drop((l1, l2, l3));
+    }
+}

--- a/edb/server/conn_pool/src/lib.rs
+++ b/edb/server/conn_pool/src/lib.rs
@@ -1,6 +1,7 @@
 pub(crate) mod algo;
 pub(crate) mod block;
 pub(crate) mod conn;
+pub(crate) mod drain;
 pub(crate) mod metrics;
 pub(crate) mod pool;
 pub(crate) mod waitqueue;

--- a/edb/server/conn_pool/src/pool.rs
+++ b/edb/server/conn_pool/src/pool.rs
@@ -136,7 +136,7 @@ impl<C: Connector> Pool<C> {
     fn algo(&self) -> AlgoState<'_, Blocks<C, PoolAlgoTargetData>> {
         AlgoState {
             drain: &self.drain,
-            it: &self.blocks,
+            blocks: &self.blocks,
             constraints: &self.config.constraints,
         }
     }

--- a/edb/server/conn_pool/src/pool.rs
+++ b/edb/server/conn_pool/src/pool.rs
@@ -1,20 +1,16 @@
 use crate::{
     algo::{
-        AcquireOp, PoolAlgoTargetData, PoolAlgorithmDataBlock, PoolAlgorithmDataMetrics,
-        PoolConstraints, RebalanceOp, ReleaseOp, ReleaseType, ShutdownOp, VisitPoolAlgoData,
+        AcquireOp, AlgoState, PoolAlgoTargetData, PoolAlgorithmDataMetrics, PoolConstraints,
+        RebalanceOp, ReleaseOp, ReleaseType,
     },
-    block::{Blocks, Name},
+    block::Blocks,
     conn::{ConnError, ConnHandle, ConnResult, Connector},
+    drain::Drain,
     metrics::{MetricVariant, PoolMetrics},
 };
 use consume_on_drop::{Consume, ConsumeOnDrop};
 use derive_more::Debug;
-use std::{
-    cell::{Cell, RefCell},
-    collections::HashMap,
-    rc::Rc,
-    time::Duration,
-};
+use std::{cell::Cell, rc::Rc, time::Duration};
 use tracing::trace;
 
 #[derive(Debug)]
@@ -131,12 +127,20 @@ impl<C: Connector> Pool<C> {
             blocks: Default::default(),
             connector,
             dirty: Default::default(),
-            drain: Default::default(),
+            drain: Drain::default(),
         })
     }
 }
 
 impl<C: Connector> Pool<C> {
+    fn algo(&self) -> AlgoState<'_, Blocks<C, PoolAlgoTargetData>> {
+        AlgoState {
+            drain: &self.drain,
+            it: &self.blocks,
+            constraints: &self.config.constraints,
+        }
+    }
+
     /// Runs the required async task that takes care of quota management, garbage collection,
     /// and other important async tasks. This should happen only if something has changed in
     /// the pool.
@@ -154,27 +158,8 @@ impl<C: Connector> Pool<C> {
             return;
         }
 
-        if self.drain.shutdown.get() {
-            for op in self.config.constraints.plan_shutdown(&self.blocks) {
-                trace!("Shutdown: {op:?}");
-                match op {
-                    ShutdownOp::Close(name) => {
-                        tokio::task::spawn_local(
-                            self.blocks.task_close_one(&self.connector, &name),
-                        );
-                    }
-                }
-            }
-            return;
-        }
-
-        self.config.constraints.adjust(&self.blocks);
-        let mut s = String::new();
-        self.blocks.with_all(|name, block| {
-            s += &format!("{name}={}/{} ", block.target(), block.len());
-        });
-        trace!("Targets: {s}");
-        for op in self.config.constraints.plan_rebalance(&self.blocks) {
+        self.algo().adjust();
+        for op in self.algo().plan_rebalance() {
             trace!("Rebalance: {op:?}");
             match op {
                 RebalanceOp::Transfer { from, to } => {
@@ -194,11 +179,8 @@ impl<C: Connector> Pool<C> {
     /// controls the lock for the connection and may be dropped to release it
     /// back into the pool.
     pub async fn acquire(self: &Rc<Self>, db: &str) -> ConnResult<PoolHandle<C>, C::Error> {
-        if self.drain.shutdown.get() {
-            return Err(ConnError::Shutdown);
-        }
         self.dirty.set(true);
-        let plan = self.config.constraints.plan_acquire(db, &self.blocks);
+        let plan = self.algo().plan_acquire(db);
         trace!("Acquire {db}: {plan:?}");
         match plan {
             AcquireOp::Create => {
@@ -208,6 +190,9 @@ impl<C: Connector> Pool<C> {
                 tokio::task::spawn_local(self.blocks.task_steal(&self.connector, db, &from));
             }
             AcquireOp::Wait => {}
+            AcquireOp::FailInShutdown => {
+                return Err(ConnError::Shutdown);
+            }
         };
         let conn = self.blocks.queue(db).await?;
 
@@ -218,17 +203,12 @@ impl<C: Connector> Pool<C> {
     fn release(self: Rc<Self>, conn: ConnHandle<C>, poison: bool) {
         let db = &conn.state.db_name;
         self.dirty.set(true);
-        let release_type = if self.drain.is_draining(db) {
-            ReleaseType::Drain
-        } else if poison {
+        let release_type = if poison {
             ReleaseType::Poison
         } else {
             ReleaseType::Normal
         };
-        let plan = self
-            .config
-            .constraints
-            .plan_release(db, release_type, &self.blocks);
+        let plan = self.algo().plan_release(db, release_type);
         trace!("Release: {conn:?} {plan:?}");
         match plan {
             ReleaseOp::Release => {}
@@ -272,6 +252,29 @@ impl<C: Connector> Pool<C> {
 
         let lock = Drain::lock(self.clone(), name);
         while self.blocks.metrics(db).total() > 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        drop(lock);
+    }
+
+    /// Drain all idle connections to the given database. All connections will be
+    /// poisoned on return and this method will return when the given database
+    /// is idle. Multiple calls to this method with the same database are valid,
+    /// and the drain operation will be kept alive as long as one future has not
+    /// been dropped.
+    ///
+    /// It is valid, though unadvisable, to request a connection during this
+    /// period. The connection will be poisoned on return as well.
+    ///
+    /// Dropping this future cancels the drain operation.
+    pub async fn drain_idle(self: Rc<Self>, db: &str) {
+        // If the block doesn't exist, we can return
+        let Some(name) = self.blocks.name(db) else {
+            return;
+        };
+
+        let lock = Drain::lock(self.clone(), name);
+        while self.blocks.metrics(db).get(MetricVariant::Idle) > 0 {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         drop(lock);
@@ -330,73 +333,6 @@ impl<C: Connector> Pool<C> {
 impl<C: Connector> AsRef<Drain> for Rc<Pool<C>> {
     fn as_ref(&self) -> &Drain {
         &self.drain
-    }
-}
-
-/// Holds the current drainage and shutdown state for the `Pool`.
-#[derive(Default, Debug)]
-struct Drain {
-    drain_all: Cell<usize>,
-    drain: RefCell<HashMap<Name, usize>>,
-    shutdown: Cell<bool>,
-}
-
-impl Drain {
-    pub fn shutdown(&self) {
-        self.shutdown.set(true)
-    }
-
-    /// Lock all connections for draining.
-    pub fn lock_all<T: AsRef<Drain>>(this: T) -> DrainLock<T> {
-        let drain = this.as_ref();
-        drain.drain_all.set(drain.drain_all.get() + 1);
-        DrainLock {
-            db: None,
-            has_drain: this,
-        }
-    }
-
-    // Lock a specific connection for draining.
-    pub fn lock<T: AsRef<Drain>>(this: T, db: Name) -> DrainLock<T> {
-        {
-            let mut drain = this.as_ref().drain.borrow_mut();
-            drain.entry(db.clone()).and_modify(|v| *v += 1).or_default();
-        }
-        DrainLock {
-            db: Some(db),
-            has_drain: this,
-        }
-    }
-
-    /// Is this connection draining?
-    fn is_draining(&self, db: &str) -> bool {
-        self.drain_all.get() > 0 || self.drain.borrow().contains_key(db) || self.shutdown.get()
-    }
-}
-
-/// Provides a RAII lock for a db- or whole-pool drain operation.
-struct DrainLock<T: AsRef<Drain>> {
-    db: Option<Name>,
-    has_drain: T,
-}
-
-impl<T: AsRef<Drain>> Drop for DrainLock<T> {
-    fn drop(&mut self) {
-        if let Some(name) = self.db.take() {
-            let mut drain = self.has_drain.as_ref().drain.borrow_mut();
-            if let Some(count) = drain.get_mut(&name) {
-                if *count > 1 {
-                    *count -= 1;
-                } else {
-                    drain.remove(&name);
-                }
-            } else {
-                unreachable!()
-            }
-        } else {
-            let this = self.has_drain.as_ref();
-            this.drain_all.set(this.drain_all.get() - 1);
-        }
     }
 }
 
@@ -570,10 +506,10 @@ mod tests {
         let connect_cost = spec.disconn_cost;
         let conn_failure_percentage = spec.conn_failure_percentage;
         let connector = BasicConnector::delay(move |disconnect| {
-            if conn_failure_percentage > 0 {
-                if thread_rng().gen_range(0..100) > conn_failure_percentage {
-                    return std::result::Result::Err(());
-                }
+            if conn_failure_percentage > 0
+                && thread_rng().gen_range(0..100) > conn_failure_percentage
+            {
+                return std::result::Result::Err(());
             }
             std::result::Result::Ok(if disconnect {
                 disconnect_cost.random_duration()

--- a/edb/server/conn_pool/src/python.rs
+++ b/edb/server/conn_pool/src/python.rs
@@ -1,6 +1,468 @@
-use pyo3::{pymodule, types::PyModule, PyResult, Python};
+use crate::{
+    conn::{ConnError, ConnResult, Connector},
+    pool::{Pool, PoolConfig},
+    PoolHandle,
+};
+use derive_more::{Add, AddAssign};
+use futures::future::poll_fn;
+use pyo3::{exceptions::PyException, prelude::*};
+use std::{
+    cell::{Cell, RefCell},
+    collections::BTreeMap,
+    os::fd::IntoRawFd,
+    pin::Pin,
+    rc::Rc,
+    thread,
+    time::Duration,
+};
+use tokio::{io::AsyncWrite, task::LocalSet};
+use tracing::{error, info, subscriber::DefaultGuard, trace};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+pyo3::create_exception!(_conn_pool, InternalError, PyException);
+
+#[derive(Debug)]
+enum RustToPythonMessage {
+    Acquired(PythonConnId, ConnHandleId),
+    Pruned(PythonConnId),
+
+    PerformConnect(ConnHandleId, String),
+    PerformDisconnect(ConnHandleId),
+    PerformReconnect(ConnHandleId, String),
+
+    Failed(PythonConnId, ConnHandleId),
+}
+
+impl ToPyObject for RustToPythonMessage {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        use RustToPythonMessage::*;
+        match self {
+            Acquired(a, b) => (0, a, b.0).to_object(py),
+            PerformConnect(conn, s) => (1, conn.0, s).to_object(py),
+            PerformDisconnect(conn) => (2, conn.0).to_object(py),
+            PerformReconnect(conn, s) => (3, conn.0, s).to_object(py),
+            Pruned(conn) => (4, conn).to_object(py),
+            Failed(conn, error) => (5, conn, error.0).to_object(py),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum PythonToRustMessage {
+    /// Acquire a connection.
+    Acquire(PythonConnId, String),
+    /// Release a connection.
+    Release(PythonConnId),
+    /// Discard a connection.
+    Discard(PythonConnId),
+    /// Prune connections from a database.
+    Prune(PythonConnId, String),
+    /// Completed an async request made by Rust.
+    CompletedAsync(ConnHandleId),
+    /// Failed an async request made by Rust.
+    FailedAsync(ConnHandleId),
+}
+
+type PipeSender = tokio::net::unix::pipe::Sender;
+
+type PythonConnId = u64;
+#[derive(Debug, Default, Clone, Copy, Add, AddAssign, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct ConnHandleId(u64);
+
+impl Into<Box<(dyn derive_more::Error + std::marker::Send + Sync + 'static)>> for ConnHandleId {
+    fn into(self) -> Box<(dyn derive_more::Error + std::marker::Send + Sync + 'static)> {
+        Box::new(ConnError::Underlying(format!("{self:?}")))
+    }
+}
+
+struct RpcPipe {
+    rust_to_python_notify: RefCell<PipeSender>,
+    rust_to_python: std::sync::mpsc::Sender<RustToPythonMessage>,
+    python_to_rust: RefCell<tokio::sync::mpsc::UnboundedReceiver<PythonToRustMessage>>,
+    handles: RefCell<BTreeMap<PythonConnId, PoolHandle<Rc<RpcPipe>>>>,
+    next_id: Cell<ConnHandleId>,
+    async_ops: RefCell<BTreeMap<ConnHandleId, tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl std::fmt::Debug for RpcPipe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RpcPipe")
+    }
+}
+
+impl RpcPipe {
+    async fn write(&self, msg: RustToPythonMessage) -> ConnResult<(), String> {
+        self.rust_to_python
+            .send(msg)
+            .map_err(|_| ConnError::Shutdown)?;
+        // If we're shutting down, this may fail (but that's OK)
+        poll_fn(|cx| {
+            let pipe = &mut *self.rust_to_python_notify.borrow_mut();
+            let this = Pin::new(pipe);
+            this.poll_write(cx, &[0])
+        })
+        .await
+        .map_err(|_| ConnError::Shutdown)?;
+        Ok(())
+    }
+
+    async fn call<T>(
+        self: Rc<Self>,
+        conn_id: ConnHandleId,
+        ok: T,
+        msg: RustToPythonMessage,
+    ) -> ConnResult<T, ConnHandleId> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.async_ops.borrow_mut().insert(conn_id, tx);
+        self.write(msg).await.map_err(|_| ConnError::Underlying(conn_id))?;
+        if let Ok(_) = rx.await {
+            Err(ConnError::Underlying(conn_id))
+        } else {
+            Ok(ok)
+        }
+    }
+}
+
+impl Connector for Rc<RpcPipe> {
+    type Conn = ConnHandleId;
+    type Error = ConnHandleId;
+
+    fn connect(
+        &self,
+        db: &str,
+    ) -> impl futures::Future<
+        Output = ConnResult<<Self as Connector>::Conn, <Self as Connector>::Error>,
+    > + 'static {
+        let id = self.next_id.get();
+        self.next_id.set(id + ConnHandleId(1));
+        let msg = RustToPythonMessage::PerformConnect(id, db.to_owned());
+        self.clone().call(id, id, msg)
+    }
+
+    fn disconnect(
+        &self,
+        conn: Self::Conn,
+    ) -> impl futures::Future<Output = ConnResult<(), <Self as Connector>::Error>> + 'static {
+        self.clone()
+            .call(conn, (), RustToPythonMessage::PerformDisconnect(conn))
+    }
+
+    fn reconnect(
+        &self,
+        conn: Self::Conn,
+        db: &str,
+    ) -> impl futures::Future<
+        Output = ConnResult<<Self as Connector>::Conn, <Self as Connector>::Error>,
+    > + 'static {
+        self.clone().call(
+            conn,
+            conn,
+            RustToPythonMessage::PerformReconnect(conn, db.to_owned()),
+        )
+    }
+}
+
+#[pyclass]
+struct ConnPool {
+    python_to_rust: tokio::sync::mpsc::UnboundedSender<PythonToRustMessage>,
+    rust_to_python: std::sync::mpsc::Receiver<RustToPythonMessage>,
+    notify_fd: u64,
+}
+
+impl Drop for ConnPool {
+    fn drop(&mut self) {
+        info!("ConnPool dropped");
+    }
+}
+
+fn internal_error(message: &str) -> PyErr {
+    error!("{message}");
+    InternalError::new_err(())
+}
+
+async fn run_and_block(max_capacity: usize, rpc_pipe: RpcPipe) {
+    let rpc_pipe = Rc::new(rpc_pipe);
+
+    let pool = Pool::new(
+        PoolConfig::suggested_default_for(max_capacity),
+        rpc_pipe.clone(),
+    );
+
+    let pool_task = {
+        let pool = pool.clone();
+        tokio::task::spawn_local(async move {
+            loop {
+                pool.run_once();
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+    };
+
+    loop {
+        let Some(rpc) = poll_fn(|cx| rpc_pipe.python_to_rust.borrow_mut().poll_recv(cx)).await
+        else {
+            info!("ConnPool shutting down");
+            pool_task.abort();
+            pool.shutdown().await;
+            break;
+        };
+        let pool = pool.clone();
+        trace!("Received RPC: {rpc:?}");
+        let rpc_pipe = rpc_pipe.clone();
+        tokio::task::spawn_local(async move {
+            use PythonToRustMessage::*;
+            match rpc {
+                Acquire(conn_id, db) => {
+                    let conn = match pool.acquire(&db).await {
+                        Ok(conn) => conn,
+                        Err(ConnError::Underlying(err)) => {
+                            _ = rpc_pipe
+                                .write(RustToPythonMessage::Failed(conn_id, err))
+                                .await;
+                            return;
+                        }
+                        Err(_) => {
+                            // TODO
+                            return;
+                        }
+                    };
+                    let handle = conn.handle();
+                    rpc_pipe.handles.borrow_mut().insert(conn_id, conn);
+                    _ = rpc_pipe
+                        .write(RustToPythonMessage::Acquired(conn_id, handle))
+                        .await;
+                }
+                Release(conn_id) => {
+                    rpc_pipe.handles.borrow_mut().remove(&conn_id);
+                }
+                Discard(conn_id) => {
+                    rpc_pipe
+                        .handles
+                        .borrow_mut()
+                        .remove(&conn_id)
+                        .unwrap()
+                        .poison();
+                }
+                Prune(conn_id, db) => {
+                    pool.drain_idle(&db).await;
+                    _ = rpc_pipe.write(RustToPythonMessage::Pruned(conn_id)).await;
+                }
+                CompletedAsync(handle_id) => {
+                    rpc_pipe.async_ops.borrow_mut().remove(&handle_id);
+                }
+                FailedAsync(handle_id) => {
+                    _ = rpc_pipe
+                        .async_ops
+                        .borrow_mut()
+                        .remove(&handle_id)
+                        .unwrap()
+                        .send(());
+                }
+            }
+        });
+    }
+}
+
+#[pymethods]
+impl ConnPool {
+    /// Create the connection pool and automatically boot a tokio runtime on a
+    /// new thread. When this [`ConnPool`] is GC'd, the thread will be torn down.
+    #[new]
+    fn new(py: Python, max_capacity: usize) -> Self {
+        py.allow_threads(|| {
+            info!("ConnPool::new(max_capacity={max_capacity})");
+            let (txrp, rxrp) = std::sync::mpsc::channel();
+            let (txpr, rxpr) = tokio::sync::mpsc::unbounded_channel();
+            let (txfd, rxfd) = std::sync::mpsc::channel();
+
+            thread::spawn(move || {
+                info!("Rust-side ConnPool thread booted");
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_time()
+                    .enable_io()
+                    .build()
+                    .unwrap();
+                let _guard = rt.enter();
+                let (txn, rxn) = tokio::net::unix::pipe::pipe().unwrap();
+                let fd = rxn.into_nonblocking_fd().unwrap().into_raw_fd() as u64;
+                txfd.send(fd).unwrap();
+                let local = LocalSet::new();
+
+                let rpc_pipe = RpcPipe {
+                    python_to_rust: rxpr.into(),
+                    rust_to_python: txrp,
+                    rust_to_python_notify: txn.into(),
+                    next_id: Default::default(),
+                    handles: Default::default(),
+                    async_ops: Default::default(),
+                };
+
+                local.block_on(&rt, run_and_block(max_capacity, rpc_pipe));
+            });
+
+            let notify_fd = rxfd.recv().unwrap();
+            ConnPool {
+                python_to_rust: txpr,
+                rust_to_python: rxrp,
+                notify_fd,
+            }
+        })
+    }
+
+    #[getter]
+    fn _fd(&self) -> u64 {
+        self.notify_fd
+    }
+
+    fn _acquire(&self, id: u64, db: &str) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::Acquire(id, db.to_owned()))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _release(&self, id: u64) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::Release(id))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _discard(&self, id: u64) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::Discard(id))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _completed(&self, id: u64) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::CompletedAsync(ConnHandleId(id)))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _failed(&self, id: u64, error: PyObject) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::FailedAsync(ConnHandleId(id)))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _prune(&self, id: u64, db: &str) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::Prune(id, db.to_owned()))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _read(&self, py: Python<'_>) -> Py<PyAny> {
+        let Ok(msg) = self.rust_to_python.recv() else {
+            return py.None();
+        };
+        msg.to_object(py)
+    }
+
+    fn _try_read(&self, py: Python<'_>) -> Py<PyAny> {
+        let Ok(msg) = self.rust_to_python.try_recv() else {
+            return py.None();
+        };
+        msg.to_object(py)
+    }
+}
+
+/// Ensure that logging does not outlive the Python runtime.
+#[pyclass]
+struct LoggingGuard {
+    #[allow(unused)]
+    guard: DefaultGuard,
+}
+
+#[pymethods]
+impl LoggingGuard {
+    #[new]
+    fn init_logging(py: Python) -> PyResult<LoggingGuard> {
+        let logging = py.import("logging")?;
+        let logger = logging
+            .getattr("getLogger")?
+            .call(("edb.server.connpool",), None)?;
+        let level = logger
+            .getattr("getEffectiveLevel")?
+            .call((), None)?
+            .extract::<i32>()?;
+        let logger = logger.to_object(py);
+
+        struct PythonSubscriber {
+            logger: Py<PyAny>,
+        }
+
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for PythonSubscriber {
+            fn on_event(
+                &self,
+                event: &tracing::Event,
+                _ctx: tracing_subscriber::layer::Context<S>,
+            ) {
+                let mut message = format!("[{}] ", event.metadata().target());
+                #[derive(Default)]
+                struct Visitor(String);
+                impl tracing::field::Visit for Visitor {
+                    fn record_debug(
+                        &mut self,
+                        field: &tracing::field::Field,
+                        value: &dyn std::fmt::Debug,
+                    ) {
+                        if field.name() == "message" {
+                            self.0 += &format!("{value:?} ");
+                        } else {
+                            self.0 += &format!("{}={:?} ", field.name(), value)
+                        }
+                    }
+                }
+
+                let mut visitor = Visitor::default();
+                event.record(&mut visitor);
+                message += &visitor.0;
+
+                Python::with_gil(|py| {
+                    let Ok(log) = (match *event.metadata().level() {
+                        tracing::Level::TRACE => self.logger.getattr(py, "debug"),
+                        tracing::Level::DEBUG => self.logger.getattr(py, "warning"),
+                        tracing::Level::INFO => self.logger.getattr(py, "info"),
+                        tracing::Level::WARN => self.logger.getattr(py, "warning"),
+                        tracing::Level::ERROR => self.logger.getattr(py, "error"),
+                    }) else {
+                        return;
+                    };
+                    // This may fail
+                    _ = log.call1(py, (message,));
+                });
+            }
+        }
+
+        let level = if level < 10 {
+            tracing_subscriber::filter::LevelFilter::TRACE
+        } else if level <= 10 {
+            tracing_subscriber::filter::LevelFilter::DEBUG
+        } else if level <= 20 {
+            tracing_subscriber::filter::LevelFilter::INFO
+        } else if level <= 30 {
+            tracing_subscriber::filter::LevelFilter::WARN
+        } else if level <= 40 {
+            tracing_subscriber::filter::LevelFilter::ERROR
+        } else {
+            tracing_subscriber::filter::LevelFilter::OFF
+        };
+
+        let subscriber = PythonSubscriber { logger };
+        let guard = tracing_subscriber::registry()
+            .with(level)
+            .with(subscriber)
+            .set_default();
+
+        tracing::info!("ConnPool initialized (level = {level})");
+        Ok(LoggingGuard { guard })
+    }
+}
 
 #[pymodule]
 fn _conn_pool(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<ConnPool>()?;
+    m.add_class::<LoggingGuard>()?;
+    m.add("InternalError", py.get_type::<InternalError>())?;
+
     Ok(())
 }

--- a/edb/server/connpool/config.py
+++ b/edb/server/connpool/config.py
@@ -15,19 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
-from .pool import Pool as Pool1Impl, _NaivePool  # NoQA
-from .pool2 import Pool as Pool2Impl
-
-# During the transition period we allow for the pool to be swapped out. The
-# current default is to use the old pool, however this will be switched to use
-# the new pool once we've fully implemented all required features.
-if os.environ.get("EDGEDB_USE_NEW_CONNPOOL", "") == "1":
-    Pool = Pool2Impl
-    Pool2 = Pool1Impl
-else:
-    # The two pools have the same effective type shape
-    Pool = Pool1Impl  # type: ignore
-    Pool2 = Pool2Impl  # type: ignore
-
-__all__ = ('Pool', 'Pool2')
+MIN_CONN_TIME_THRESHOLD = 0.01
+MIN_QUERY_TIME_THRESHOLD = 0.001
+MIN_LOG_TIME_THRESHOLD = 1
+MIN_IDLE_TIME_BEFORE_GC = 120
+CONNECT_FAILURE_RETRIES = 3

--- a/edb/server/connpool/pool2.py
+++ b/edb/server/connpool/pool2.py
@@ -1,5 +1,360 @@
-import edb.server._conn_pool  # noqa: F401
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import edb.server._conn_pool
+import asyncio
+import typing
+import logging
+import dataclasses
+import os
+
+from . import config
+
+logger = logging.getLogger("edb.server.connpool")
+guard = edb.server._conn_pool.LoggingGuard()
+
+# Connections must be hashable because we use them to reverse-lookup
+# an internal ID.
+C = typing.TypeVar("C", bound=typing.Hashable)
+
+CP1 = typing.TypeVar('CP1', covariant=True)
+CP2 = typing.TypeVar('CP2', contravariant=True)
 
 
-class Pool:
-    pass
+class Connector(typing.Protocol[CP1]):
+
+    def __call__(self, dbname: str) -> typing.Awaitable[CP1]:
+        pass
+
+
+class Disconnector(typing.Protocol[CP2]):
+
+    def __call__(self, conn: CP2) -> typing.Awaitable[None]:
+        pass
+
+
+@dataclasses.dataclass
+class BlockSnapshot:
+    dbname: str
+    nwaiters_avg: int
+    nconns: int
+    npending: int
+    nwaiters: int
+    quota: int
+
+
+@dataclasses.dataclass
+class SnapshotLog:
+    timestamp: float
+    event: str
+    dbname: str
+    value: int
+
+
+@dataclasses.dataclass
+class Snapshot:
+    timestamp: float
+    capacity: int
+    blocks: typing.List[BlockSnapshot]
+    log: typing.List[SnapshotLog]
+
+    failed_connects: int
+    failed_disconnects: int
+    successful_connects: int
+    successful_disconnects: int
+
+
+class StatsCollector(typing.Protocol):
+
+    def __call__(self, stats: Snapshot) -> None:
+        pass
+
+
+class Pool(typing.Generic[C]):
+    _pool: edb.server._conn_pool.ConnPool
+    _next_conn_id: int
+    _failed_connects: int
+    _failed_disconnects: int
+    _successful_connects: int
+    _successful_disconnects: int
+    _cur_capacity: int
+    _max_capacity: int
+    _task: typing.Optional[asyncio.Task[None]]
+    _acquires: dict[int, asyncio.Future[int]]
+    _prunes: dict[int, asyncio.Future[None]]
+    _conns: dict[int, C]
+    _errors: dict[int, BaseException]
+    _conns_held: dict[C, int]
+    _loop: asyncio.AbstractEventLoop
+    _skip_reads: int
+
+    def __init__(self, *, connect: Connector[C],
+                 disconnect: Disconnector[C],
+                 max_capacity: int,
+                 stats_collector: typing.Optional[StatsCollector]=None) -> None:
+        logger.info(f'Creating a connection pool with \
+                    max_capacity={max_capacity}')
+        self._connect = connect
+        self._disconnect = disconnect
+        self._pool = edb.server._conn_pool.ConnPool(max_capacity)
+        self._max_capacity = max_capacity
+        self._cur_capacity = 0
+        self._next_conn_id = 0
+        self._acquires = {}
+        self._conns = {}
+        self._errors = {}
+        self._conns_held = {}
+        self._prunes = {}
+        self._skip_reads = 0
+
+        self._loop = asyncio.get_running_loop()
+        self._task = self._loop.create_task(self._boot(self._loop))
+
+        self._failed_connects = 0
+        self._failed_disconnects = 0
+        self._successful_connects = 0
+        self._successful_disconnects = 0
+
+        if stats_collector:
+            stats_collector(self._build_snapshot(now=0))
+        pass
+
+    def __del__(self) -> None:
+        if self._task:
+            self._task.cancel()
+            self._task = None
+
+    async def close(self) -> None:
+        if self._task:
+            # Cancel the currently-executing futures
+            for acq in self._acquires.values():
+                acq.set_exception(asyncio.CancelledError())
+            for prune in self._prunes.values():
+                prune.set_exception(asyncio.CancelledError())
+            logger.info("Closing connection pool...")
+            task = self._task
+            self._task = None
+            task.cancel()
+            try:
+                await task
+            except asyncio.exceptions.CancelledError:
+                pass
+            self._pool = None
+            logger.info("Closed connection pool")
+
+    async def _boot(self, loop: asyncio.AbstractEventLoop) -> None:
+        logger.info("Python-side connection pool booted")
+        reader = asyncio.StreamReader(loop=loop)
+        reader_protocol = asyncio.StreamReaderProtocol(reader)
+        fd = os.fdopen(self._pool._fd, 'rb')
+        transport, _ = await loop.connect_read_pipe(lambda: reader_protocol, fd)
+        try:
+            while len(await reader.read(1)) == 1:
+                if not self._pool or not self._task:
+                    break
+                if self._skip_reads > 0:
+                    self._skip_reads -= 1
+                    continue
+                msg = self._pool._read()
+                if not msg:
+                    break
+                self._process_message(msg)
+
+        finally:
+            transport.close()
+            fd.close()
+
+    # Allow readers to skip the self-pipe for performing reads which may reduce
+    # latency a small degree. We'll still need to eventually pick up a self-pipe
+    # read but we increment a counter to skip at that point.
+    def _try_read(self) -> None:
+        while msg := self._pool._try_read():
+            self._skip_reads += 1
+            self._process_message(msg)
+
+    def _process_message(self, msg: typing.Any) -> None:
+        # If we're closing, don't dispatch any operations
+        if not self._task:
+            return
+        if msg[0] == 0:
+            if f := self._acquires.pop(msg[1], None):
+                f.set_result(msg[2])
+            else:
+                logger.warning(f"Duplicate result for acquire {msg[1]}")
+        elif msg[0] == 1:
+            self._loop.create_task(self._perform_connect(msg[1], msg[2]))
+        elif msg[0] == 2:
+            self._loop.create_task(self._perform_disconnect(msg[1]))
+        elif msg[0] == 3:
+            self._loop.create_task(self._perform_reconnect(msg[1], msg[2]))
+        elif msg[0] == 4:
+            self._loop.create_task(self._perform_prune(msg[1]))
+        elif msg[0] == 5:
+            # Note that we might end up with duplicated messages at shutdown
+            error = self._errors.pop(msg[2], None)
+            if error:
+                if f := self._acquires.pop(msg[1], None):
+                    f.set_exception(error)
+                else:
+                    logger.warn(f"Duplicate exception for acquire {msg[1]}")
+        else:
+            logger.critical(f'Unexpected message: {msg}')
+
+    async def _perform_connect(self, id: int, db: str) -> None:
+        self._cur_capacity += 1
+        try:
+            self._conns[id] = await self._connect(db)
+            self._successful_connects += 1
+            if self._pool:
+                self._pool._completed(id)
+        except Exception as e:
+            self._errors[id] = e
+            if self._pool:
+                self._pool._failed(id, e)
+
+    async def _perform_disconnect(self, id: int) -> None:
+        try:
+            conn = self._conns.pop(id)
+            await self._disconnect(conn)
+            self._successful_disconnects += 1
+            self._cur_capacity -= 1
+            if self._pool:
+                self._pool._completed(id)
+        except Exception as e:
+            self._cur_capacity -= 1
+            if self._pool:
+                self._pool._failed(id, e)
+
+    async def _perform_reconnect(self, id: int, db: str) -> None:
+        try:
+            # Note that we cannot hold this connection here as there is an
+            # implicit expectation that the connection will GC after disconnect
+            # but before reconnect.
+            conn = self._conns.pop(id)
+            await self._disconnect(conn)
+            self._successful_disconnects += 1
+            try:
+                self._conns[id] = await self._connect(db)
+                self._successful_connects += 1
+                if self._pool:
+                    self._pool._completed(id)
+            except Exception as e:
+                self._errors[id] = e
+                if self._pool:
+                    self._pool._failed(id, e)
+
+        except Exception as e:
+            del self._conns[id]
+            self._cur_capacity -= 1
+            if self._pool:
+                self._pool._failed(id, e)
+
+    async def _perform_prune(self, id: int) -> None:
+        self._prunes[id].set_result(None)
+
+    async def acquire(self, dbname: str) -> C:
+        """Acquire a connection from the database. This connection must be
+        released."""
+        if not self._task:
+            raise asyncio.CancelledError()
+        for i in range(config.CONNECT_FAILURE_RETRIES + 1):
+            id = self._next_conn_id
+            self._next_conn_id += 1
+            acquire: asyncio.Future[int] = asyncio.Future()
+            self._acquires[id] = acquire
+            self._pool._acquire(id, dbname)
+            self._try_read()
+            # This may throw!
+            try:
+                conn = await acquire
+                c = self._conns[conn]
+                self._conns_held[c] = id
+                return c
+            except Exception:
+                # Allow the final exception to escape
+                if i == config.CONNECT_FAILURE_RETRIES:
+                    logger.exception('Failed to acquire connection, will not '
+                                     f'retry {dbname} ({self._cur_capacity}'
+                                     'active)')
+                    raise
+                logger.exception('Failed to acquire connection, will retry: '
+                                 f'{dbname} ({self._cur_capacity} active)')
+        raise AssertionError("Unreachable end of loop")
+
+    def release(self, dbname: str, conn: C, discard: bool = False) -> None:
+        """Releases a connection back into the pool, discarding or returning it
+        in the background."""
+        id = self._conns_held.pop(conn)
+        if discard:
+            self._pool._discard(id)
+        else:
+            self._pool._release(id)
+        self._try_read()
+
+    async def prune_inactive_connections(self, dbname: str) -> None:
+        if not self._task:
+            raise asyncio.CancelledError()
+        id = self._next_conn_id
+        self._next_conn_id += 1
+        self._prunes[id] = asyncio.Future()
+        self._pool._prune(id, dbname)
+        await self._prunes[id]
+        del self._prunes[id]
+
+    async def prune_all_connections(self) -> None:
+        # Brutally close all connections. This is used by HA failover.
+        coros = []
+        for conn in self._conns.values():
+            coros.append(self._disconnect(conn))
+        await asyncio.gather(*coros, return_exceptions=True)
+
+    @property
+    def active_conns(self) -> int:
+        return len(self._conns_held)
+
+    def iterate_connections(self) -> typing.Iterator[C]:
+        for conn in self._conns.values():
+            yield conn
+
+    def _build_snapshot(self, *, now: float) -> Snapshot:
+        return Snapshot(
+            timestamp=now,
+            blocks=[],
+            capacity=self._cur_capacity,
+            log=[],
+
+            failed_connects=self._failed_connects,
+            failed_disconnects=self._failed_disconnects,
+            successful_connects=self._successful_connects,
+            successful_disconnects=self._successful_disconnects,
+        )
+
+    @property
+    def max_capacity(self) -> int:
+        return self._max_capacity
+
+    @property
+    def current_capacity(self) -> int:
+        return self._cur_capacity
+
+    @property
+    def failed_connects(self) -> int:
+        return self._failed_connects
+
+    @property
+    def failed_disconnects(self) -> int:
+        return self._failed_disconnects

--- a/edb/server/connpool/pool2.py
+++ b/edb/server/connpool/pool2.py
@@ -176,7 +176,6 @@ class Pool(typing.Generic[C]):
 
         finally:
             transport.close()
-            fd.close()
 
     # Allow readers to skip the self-pipe for performing reads which may reduce
     # latency a small degree. We'll still need to eventually pick up a self-pipe

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -256,9 +256,7 @@ class Tenant(ha_base.ClusterProtocol):
             )
 
     def get_active_pgcon_num(self) -> int:
-        return (
-            self._pg_pool.current_capacity - self._pg_pool.get_pending_conns()
-        )
+        return self._pg_pool.active_conns
 
     @property
     def client_id(self) -> int:
@@ -531,6 +529,7 @@ class Tenant(ha_base.ClusterProtocol):
             tg = self._task_group
             self._task_group = None
             await tg.__aexit__(*sys.exc_info())
+        await self._pg_pool.close()
 
     def terminate_sys_pgcon(self) -> None:
         if self.__sys_pgcon is not None:


### PR DESCRIPTION
Follow-up work from https://github.com/edgedb/edgedb/pull/7478

Note that running `EDGEDB_USE_NEW_CONNPOOL=1 edb test` fails with a few tests. These will get sorted out as we move forward. The tests unfortunately require the logging to match the expected output from the old pool, which is a small challenge. I'll figure out if it makes sense to rewrite these tests in the next round.

The interaction between Rust and Python is pretty straightforward: we use a cross-thread channel to send messages and we pair that with a self-pipe that we write to to notify the asyncio end that there's a new message. We preemptively read in a few places to reduce latency, and if we manage to pick up a message, reduce the number of messages we expect to read async by one.

As we move forward, these patterns will probably get moved into a more common set of code rather than being adhoc like this.

What's left after this PR:

 - Complete garbage collection work -- connections should not get GC'd too quickly
 - Export metrics/logs

@msullivan I'd recommend looking at the following files:

 - `edb/server/conn_pool/src/python.rs` - the Rust/Python integration strategy
 - `edb/server/connpool/` - the actual Python end of things (and changes required to ensure we can run two connpools side-by-side)

@fantix It would be great if you could take a look at the Rust changes. For the most part they are just refactorings, a small bugfix in the drain code and some light algorithm tweaks. 