### PR TITLE
Increase timeout in ensure_database_not_connected

### DIFF
--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -856,7 +856,7 @@ class Tenant(ha_base.ClusterProtocol):
         )
 
         rloop = retryloop.RetryLoop(
-            timeout=10.0,
+            timeout=30.0,
             ignore=errors.ExecutionError,
         )
 


### PR DESCRIPTION
I've seen some flakes that this might mitigate.