### PR TITLE
[4.x] Use ON CONFLICT to implement UNLESS CONFLICT more often (#7472)

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 from typing import *
+
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
@@ -305,10 +306,17 @@ class ContainsDMLVisitor(ast.NodeVisitor):
         return bool(self.generic_visit(node))
 
 
-def contains_dml(stmt: irast.Base, *, skip_bindings: bool=False) -> bool:
+def contains_dml(
+    stmt: irast.Base,
+    *,
+    skip_bindings: bool = False,
+    skip_nodes: Iterable[irast.Base] = (),
+) -> bool:
     """Check whether a statement contains any DML in a subtree."""
     # TODO: Make this caching.
     visitor = ContainsDMLVisitor(skip_bindings=skip_bindings)
+    for node in skip_nodes:
+        visitor._memo[node] = False
     res = visitor.visit(stmt) is True
     return res
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1325,16 +1325,8 @@ def insert_needs_conflict_cte(
 ) -> bool:
     # We need to generate a conflict CTE if it is possible that
     # the query might generate two conflicting objects.
-    # For now, we calculate that conservatively and generate a conflict
-    # CTE if there are iterators or other DML statements that we have
-    # seen already.
-    # A more fine-grained scheme would check if there are enclosing
-    # iterators or INSERT/UPDATEs to types that could conflict.
     if on_conflict.else_fail:
         return False
-
-    if ctx.dml_stmts:
-        return True
 
     if on_conflict.always_check or ir_stmt.conflict_checks:
         return True
@@ -1366,7 +1358,11 @@ def insert_needs_conflict_cte(
         if (
             ptr_info.table_type == 'ObjectType'
             and shape_el.expr
-            and irutils.contains_dml(shape_el.expr, skip_bindings=True)
+            and irutils.contains_dml(
+                shape_el.expr,
+                skip_bindings=True,
+                skip_nodes=(ir_stmt.subject,),
+            )
         ):
             return True
 

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -333,3 +333,54 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             sql,
             "typeid injection shouldn't joining ObjectType table",
         )
+
+    def test_codegen_unless_conflict_01(self):
+        # Should have no conflict check because it has no subtypes
+        sql = self._compile('''
+            insert User { name := "test" }
+            unless conflict
+        ''')
+
+        self.assertIn(
+            "ON CONFLICT", sql,
+            "insert unless conflict not using ON CONFLICT"
+        )
+
+    def test_codegen_unless_conflict_02(self):
+        # Should have no conflict check because it has no subtypes
+        sql = self._compile('''
+            insert User { name := "test" }
+            unless conflict on (.name)
+            else (User)
+        ''')
+
+        self.assertIn(
+            "ON CONFLICT", sql,
+            "insert unless conflict not using ON CONFLICT"
+        )
+
+    SCHEMA_asdf = r'''
+        type Tgt;
+        type Tgt2;
+        type Src {
+            name: str { constraint exclusive; }
+            tgt: Tgt;
+            multi tgts: Tgt2;
+        };
+    '''
+
+    def test_codegen_unless_conflict_03(self):
+        # Should have no conflict check because it has no subtypes
+        sql = self._compile('''
+        WITH MODULE asdf
+        INSERT Src {
+            name := 'asdf',
+            tgt := (select Tgt limit 1),
+            tgts := (insert Tgt2),
+        } UNLESS CONFLICT
+        ''')
+
+        self.assertIn(
+            "ON CONFLICT", sql,
+            "insert unless conflict not using ON CONFLICT"
+        )


### PR DESCRIPTION
We were being too strict in detecting whether a single pointer
specified in an INSERT contained DML (it was picking up DML in other
fields of the insert through the source).

Also drop an old and overly conservative check that uses a conflict
CTE whenever DML statements have already been compiled. We now already
do the more fine-grained stuff that the comment was talking about.