### PR TITLE
Fix dump tests after CLI breakage

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1652,12 +1652,13 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
     PARALLELISM_GRANULARITY = 'suite'
 
     async def check_dump_restore_single_db(self, check_method):
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.TemporaryDirectory() as f:
+            fname = os.path.join(f, 'dump')
             dbname = edgedb_defines.EDGEDB_SUPERUSER_DB
-            await asyncio.to_thread(self.run_cli, '-d', dbname, 'dump', f.name)
+            await asyncio.to_thread(self.run_cli, '-d', dbname, 'dump', fname)
             await self.tearDownSingleDB()
             await asyncio.to_thread(
-                self.run_cli, '-d', dbname, 'restore', f.name
+                self.run_cli, '-d', dbname, 'restore', fname
             )
 
         # Cycle the connection to avoid state mismatches
@@ -1673,15 +1674,16 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
         src_dbname = self.get_database_name()
         tgt_dbname = f'{src_dbname}_restored'
         q_tgt_dbname = qlquote.quote_ident(tgt_dbname)
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.TemporaryDirectory() as f:
+            fname = os.path.join(f, 'dump')
             await asyncio.to_thread(
-                self.run_cli, '-d', src_dbname, 'dump', f.name
+                self.run_cli, '-d', src_dbname, 'dump', fname
             )
 
             await self.con.execute(f'CREATE DATABASE {q_tgt_dbname}')
             try:
                 await asyncio.to_thread(
-                    self.run_cli, '-d', tgt_dbname, 'restore', f.name
+                    self.run_cli, '-d', tgt_dbname, 'restore', fname
                 )
                 con2 = await self.connect(database=tgt_dbname)
             except Exception:

--- a/tests/test_dump_basic.py
+++ b/tests/test_dump_basic.py
@@ -87,12 +87,13 @@ class TestDumpBasics(tb.DatabaseTestCase, tb.CLITestCaseMixin):
         dbname = self.get_database_name()
         restored_dbname = f'{dbname}_restored'
 
-        with tempfile.NamedTemporaryFile() as f:
-            self.run_cli('-d', dbname, 'dump', f.name)
+        with tempfile.TemporaryDirectory() as f:
+            fname = os.path.join(f, 'dump')
+            self.run_cli('-d', dbname, 'dump', fname)
 
             await self.con.execute(f'CREATE DATABASE {restored_dbname}')
             try:
-                self.run_cli('-d', restored_dbname, 'restore', f.name)
+                self.run_cli('-d', restored_dbname, 'restore', fname)
                 con2 = await self.connect(database=restored_dbname)
             except Exception:
                 await tb.drop_db(self.con, restored_dbname)

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1249,9 +1249,10 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
 
         try:
             # Dump and restore should trigger a re-introspection in sd2
-            with tempfile.NamedTemporaryFile() as f:
+            with tempfile.TemporaryDirectory() as f:
+                fname = os.path.join(f, 'dump')
                 await asyncio.to_thread(
-                    self.run_cli_on_connection, conn_args, "dump", f.name
+                    self.run_cli_on_connection, conn_args, "dump", fname
                 )
                 await asyncio.to_thread(
                     self.run_cli_on_connection,
@@ -1259,7 +1260,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
                     "-d",
                     "restore_signal",
                     "restore",
-                    f.name
+                    fname
                 )
 
             # The re-introspection has a delay, but should eventually happen


### PR DESCRIPTION
edgedb/edgedb-cli#1184 made dump refuse to overwrite files by default,
which broke our dump tests.

We could fix it by passing the flag to allow overwriting to the CLI,
but it seems more natural to make a temp *directory* instead of
overwriting a temp file.