### PR TITLE
func cache: fix dropping extension with scalar type

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2832,21 +2832,24 @@ class DeleteScalarType(ScalarTypeMetaCommand,
         cls, scalar: s_scalars.ScalarType, orig_schema: s_schema.Schema
     ) -> dbops.Command:
         ops = dbops.CommandGroup()
-        old_domain_name = common.get_backend_name(
-            orig_schema, scalar, catenate=False)
 
         # The custom scalar types are sometimes included in the function
         # signatures of query cache functions under QueryCacheMode.PgFunc.
         # We need to find such functions through pg_depend and evict the cache
         # before dropping the custom scalar type.
-        drop_func_cache_sql = textwrap.dedent(f'''
-            DO $$
-            DECLARE
-                qc RECORD;
-            BEGIN
-                FOR qc IN
-                    WITH
-                    types AS (
+        pg_type = types.pg_type_from_scalar(orig_schema, scalar)
+        if len(pg_type) == 1:
+            types_cte = f'''
+                        SELECT
+                            pt.oid AS oid
+                        FROM
+                            pg_type pt
+                        WHERE
+                            pt.typname = {ql(pg_type[0])}
+                            OR pt.typname = {ql('_' + pg_type[0])}\
+            '''
+        else:
+            types_cte = f'''
                         SELECT
                             pt.oid AS oid
                         FROM
@@ -2854,11 +2857,20 @@ class DeleteScalarType(ScalarTypeMetaCommand,
                             JOIN pg_namespace pn
                                 ON pt.typnamespace = pn.oid
                         WHERE
-                            pn.nspname = {ql(old_domain_name[0])}
+                            pn.nspname = {ql(pg_type[0])}
                             AND (
-                                pt.typname = {ql(old_domain_name[1])}
-                                OR pt.typname = {ql('_' + old_domain_name[1])}
-                            )
+                                pt.typname = {ql(pg_type[1])}
+                                OR pt.typname = {ql('_' + pg_type[1])}
+                            )\
+            '''
+        drop_func_cache_sql = textwrap.dedent(f'''
+            DO $$
+            DECLARE
+                qc RECORD;
+            BEGIN
+                FOR qc IN
+                    WITH
+                    types AS ({types_cte}
                     ),
                     class AS (
                         SELECT
@@ -2890,6 +2902,8 @@ class DeleteScalarType(ScalarTypeMetaCommand,
         ''')
         ops.add_command(dbops.Query(drop_func_cache_sql))
 
+        old_domain_name = common.get_backend_name(
+            orig_schema, scalar, catenate=False)
         cond: dbops.Condition
         if scalar.is_concrete_enum(orig_schema):
             old_enum_name = old_domain_name

--- a/tests/test_edgeql_vector.py
+++ b/tests/test_edgeql_vector.py
@@ -861,3 +861,22 @@ class TestEdgeQLVector(tb.QueryTestCase):
             'select <int64>_current_setting("hnsw.ef_search")',
             [40],
         )
+
+
+class TestEdgeQLVectorExtension(tb.QueryTestCase):
+    BACKEND_SUPERUSER = True
+    TRANSACTION_ISOLATION = False
+
+    async def test_edgeql_vector_drop_extension_with_func_cache(self):
+        await self.con.execute("create extension pgvector")
+        try:
+            # Run many times to wait for the func cache creation
+            for _i in range(64):
+                await self.con.query(
+                    '''
+                        select <ext::pgvector::vector>[4.2];
+                    '''
+                )
+        finally:
+            # this should drop the cache function of the query above as well
+            await self.con.execute("drop extension pgvector")


### PR DESCRIPTION
Scalar types in extensions may define `sql_type` thus not using `common.get_backend_name()`. Instead, here I think we should use `types.pg_type_from_scalar()` to cover more cases.

This is a follow up fix for https://github.com/edgedb/edgedb/pull/7422/commits/d1b2c4d22ee1cd38fe0bb81bc708e6910e33a6b4, captured in [edgedb-js CI](https://github.com/edgedb/edgedb-js/actions/runs/9959418228/job/27516218887?pr=1054#step:17:20). This should've been caught by https://github.com/edgedb/edgedb/pull/7497, I'll double check why it didn't, and make sure either it does, or write a new test in this PR.

Manually tested for enum tuples as well as the pgvector `vector` type.