### PR TITLE
Fix inconsistent prepared statement in script

### DIFF
--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -92,6 +92,7 @@ jobs:
     - name: Test
       env:
         SHARD: ${{ matrix.shard }}
+        EDGEDB_TEST_REPEATS: 1
       run: |
         mkdir -p .results/
         cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
@@ -118,6 +119,7 @@ jobs:
     - name: Generate complete list of tests for verification
       env:
         SHARD: ${{ matrix.shard }}
+        EDGEDB_TEST_REPEATS: 1
       run: |
         edb test --list > .tmp/all_tests.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -576,6 +576,7 @@ jobs:
     - name: Test
       env:
         SHARD: ${{ matrix.shard }}
+        EDGEDB_TEST_REPEATS: 1
       run: |
         mkdir -p .results/
         cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
@@ -738,6 +739,7 @@ jobs:
     - name: Generate complete list of tests for verification
       env:
         SHARD: ${{ matrix.shard }}
+        EDGEDB_TEST_REPEATS: 1
       run: |
         edb test --list > .tmp/all_tests.txt
 


### PR DESCRIPTION
This fixes the "prepared statement ... already exists" issue, by doing all `CLOSE` at the beginning of `send_query_unit_group()`.

Before:

```
CLOSE stmt1
PARSE stmt1
EXECUTE stmt1
CLOSE stmt2
PARSE stmt2
EXECUTE stmt2
SYNC
```

After:

```
CLOSE stmt1
CLOSE stmt2
PARSE stmt1
EXECUTE stmt1
PARSE stmt2
EXECUTE stmt2
SYNC
```

Please refer to the test for a detailed explanation of the issue.

Fixes #5246 