### PR TITLE
Handle input token limits for different providers

### DIFF
--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -165,6 +165,9 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         ext::ai::embedding_model_max_input_tokens;
 
     create abstract inheritable annotation
+        ext::ai::embedding_model_max_batch_tokens;
+
+    create abstract inheritable annotation
         ext::ai::embedding_model_max_output_dimensions;
 
     create abstract inheritable annotation
@@ -175,6 +178,8 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
     {
         create annotation
             ext::ai::embedding_model_max_input_tokens := "<must override>";
+        create annotation
+            ext::ai::embedding_model_max_batch_tokens := "<must override>";
         create annotation
             ext::ai::embedding_model_max_output_dimensions := "<must override>";
         create annotation
@@ -203,6 +208,8 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         alter annotation
             ext::ai::embedding_model_max_input_tokens := "8191";
         alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "8191";
+        alter annotation
             ext::ai::embedding_model_max_output_dimensions := "1536";
         alter annotation
             ext::ai::embedding_model_supports_shortening := "true";
@@ -217,6 +224,8 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             ext::ai::model_provider := "builtin::openai";
         alter annotation
             ext::ai::embedding_model_max_input_tokens := "8191";
+        alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "8191";
         # Note: ext::pgvector is currently limited to 2000 dimensions,
         # so returned embeddings will be automatically truncated if
         # pgvector is used as the index implementation.
@@ -235,6 +244,8 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             ext::ai::model_provider := "builtin::openai";
         alter annotation
             ext::ai::embedding_model_max_input_tokens := "8191";
+        alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "8191";
         alter annotation
             ext::ai::embedding_model_max_output_dimensions := "1536";
     };
@@ -270,7 +281,9 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         alter annotation
             ext::ai::model_provider := "builtin::mistral";
         alter annotation
-            ext::ai::embedding_model_max_input_tokens := "16384";
+            ext::ai::embedding_model_max_input_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "16384";
         alter annotation
             ext::ai::embedding_model_max_output_dimensions := "1024";
     };

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -359,6 +359,7 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             = ext::ai::IndexType.HNSW,
         named only index_parameters: tuple<m: int64, ef_construction: int64>
             = (m := 32, ef_construction := 100),
+        named only truncate_to_max: bool = False,
     ) {
         create annotation std::description :=
             "Semantic similarity index.";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     'webauthn~=2.0.0',
     'argon2-cffi~=23.1.0',
     'aiosmtplib~=2.0',
+    'tiktoken~=0.7.0',
+    'mistral_common~=1.2.1',
 ]
 
 [project.scripts]

--- a/tests/schemas/dump_v5_default.esdl
+++ b/tests/schemas/dump_v5_default.esdl
@@ -30,6 +30,7 @@ type TestEmbeddingModel
     annotation ext::ai::model_name := "text-embedding-test";
     annotation ext::ai::model_provider := "custom::test";
     annotation ext::ai::embedding_model_max_input_tokens := "8191";
+    annotation ext::ai::embedding_model_max_batch_tokens := "16384";
     annotation ext::ai::embedding_model_max_output_dimensions := "10";
     annotation ext::ai::embedding_model_supports_shortening := "true";
 };

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -23,6 +23,7 @@ type TestEmbeddingModel
     annotation ext::ai::model_name := "text-embedding-test";
     annotation ext::ai::model_provider := "custom::test";
     annotation ext::ai::embedding_model_max_input_tokens := "8191";
+    annotation ext::ai::embedding_model_max_batch_tokens := "16384";
     annotation ext::ai::embedding_model_max_output_dimensions := "10";
     annotation ext::ai::embedding_model_supports_shortening := "true";
 };

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12442,6 +12442,7 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             {
                 annotation ext::ai::model_name := "text-embedding-test";
                 annotation ext::ai::model_provider := "custom::test";
+                annotation ext::ai::embedding_model_max_batch_tokens := "16384";
                 annotation ext::ai::embedding_model_max_output_dimensions
                   := "10";
                 annotation ext::ai::embedding_model_supports_shortening
@@ -12484,6 +12485,8 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
                     annotation ext::ai::model_provider := "custom::test";
                     annotation ext::ai::embedding_model_max_input_tokens
                       := "8191";
+                    annotation ext::ai::embedding_model_max_batch_tokens
+                      := "16384";
                     annotation ext::ai::embedding_model_max_output_dimensions
                       := "10";
                     annotation ext::ai::embedding_model_supports_shortening
@@ -12510,6 +12513,8 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
                     annotation ext::ai::model_provider := "custom::test";
                     annotation ext::ai::embedding_model_max_input_tokens
                       := "8191";
+                    annotation ext::ai::embedding_model_max_batch_tokens
+                      := "16384";
                     annotation ext::ai::embedding_model_max_output_dimensions
                       := "20";
                     annotation ext::ai::embedding_model_supports_shortening
@@ -12544,6 +12549,8 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
                     annotation ext::ai::model_provider := "custom::test";
                     annotation ext::ai::embedding_model_max_input_tokens
                       := "8191";
+                    annotation ext::ai::embedding_model_max_batch_tokens
+                      := "16384";
                     annotation ext::ai::embedding_model_max_output_dimensions
                       := "10";
                     annotation ext::ai::embedding_model_supports_shortening
@@ -12570,6 +12577,8 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
                     annotation ext::ai::model_provider := "custom::test";
                     annotation ext::ai::embedding_model_max_input_tokens
                       := "8191";
+                    annotation ext::ai::embedding_model_max_batch_tokens
+                      := "16384";
                     annotation ext::ai::embedding_model_max_output_dimensions
                       := "10";
                     annotation ext::ai::embedding_model_supports_shortening
@@ -12607,6 +12616,8 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
                     annotation ext::ai::model_provider := "custom::test";
                     annotation ext::ai::embedding_model_max_input_tokens
                       := "8191";
+                    annotation ext::ai::embedding_model_max_batch_tokens
+                      := "16384";
                     annotation ext::ai::embedding_model_max_output_dimensions
                       := "10";
                     annotation ext::ai::embedding_model_supports_shortening


### PR DESCRIPTION
- Add `truncate_to_max` parameter to `ext::ai::Index`
- Add `embedding_model_max_batch_tokens` to `ext::ai::EmbeddingModel`
    - This represents the maximum token count for all inputs given in a single request. For Mistral, this is greater than the max input tokens.
- Add `Tokenizer` classes to count input text tokens
- Remove any inputs which would exceed `embedding_model_max_input_tokens`
    - These inputs will be processed again if the `truncate_to_max` flag is set.
- Group input tokens in blocks which will not exceed the maximum batch size

Related #7438