### PR TITLE
Create all trampolines at the *end* of bootstrap

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_07_29_00_00
+EDGEDB_CATALOG_VERSION = 2024_07_30_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -82,10 +82,12 @@ def compile_ir_to_sql_tree(
     ] = None,
     backend_runtime_params: Optional[pgparams.BackendRuntimeParams]=None,
     detach_params: bool = False,
+    alias_generator: Optional[aliases.AliasGenerator] = None,
     versioned_stdlib: bool = True,
-    alias_generator: Optional[aliases.AliasGenerator] = None
+    # HACK?
+    versioned_singleton: bool = False,
 ) -> CompileResult:
-    if singleton_mode:
+    if singleton_mode and not versioned_singleton:
         versioned_stdlib = False
 
     try:

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -331,6 +331,8 @@ def _process_delta(
 
     # Generate SQL DDL for the delta.
     pgdelta.generate(block)  # type: ignore
+    # XXX: We would prefer for there to not be trampolines ever after bootstrap
+    pgdelta.create_trampolines.generate(block)  # type: ignore
 
     # Generate schema storage SQL (DML into schema storage tables).
     subblock = block.add_block()


### PR DESCRIPTION
This ensures that nothing during bootstrap relies on them, and is a
prereq to being able to create a new stdlib in parallel.