### PR TITLE
Rust connpool: Implement an explicit reconnection phase

### DIFF
--- a/edb/server/conn_pool/src/conn.rs
+++ b/edb/server/conn_pool/src/conn.rs
@@ -135,9 +135,9 @@ impl<C: Connector> Conn<C> {
             ConnInner::Idle(_t, conn, ..) | ConnInner::Active(_t, conn, ..) => {
                 from.inc_all_time(MetricVariant::Disconnecting);
                 from.inc_all_time(MetricVariant::Closed);
-                to.insert(MetricVariant::Connecting);
+                to.insert(MetricVariant::Reconnecting);
                 let f = connector.reconnect(conn, db).boxed_local();
-                ConnInner::Connecting(Instant::now(), f)
+                ConnInner::Reconnecting(Instant::now(), f)
             }
             _ => unreachable!(),
         });
@@ -167,30 +167,38 @@ impl<C: Connector> Conn<C> {
         to: MetricVariant,
     ) -> Poll<ConnResult<()>> {
         let mut lock = self.inner.borrow_mut();
+        debug_assert!(
+            to == MetricVariant::Active || to == MetricVariant::Idle || to == MetricVariant::Closed
+        );
 
         let res = match &mut *lock {
             ConnInner::Idle(..) => Ok(()),
-            ConnInner::Connecting(t, f) => match ready!(f.poll_unpin(cx)) {
-                Ok(c) => {
-                    debug_assert!(to == MetricVariant::Active || to == MetricVariant::Idle);
-                    metrics.transition(MetricVariant::Connecting, to, t.elapsed());
-                    if to == MetricVariant::Active {
-                        *lock = ConnInner::Active(Instant::now(), c);
-                    } else {
-                        *lock = ConnInner::Idle(Instant::now(), c);
+            ConnInner::Connecting(t, f) | ConnInner::Reconnecting(t, f) => {
+                match ready!(f.poll_unpin(cx)) {
+                    Ok(c) => {
+                        let elapsed = t.elapsed();
+                        let from = (&std::mem::replace(&mut *lock, ConnInner::Transition)).into();
+                        metrics.transition(from, to, elapsed);
+                        if to == MetricVariant::Active {
+                            *lock = ConnInner::Active(Instant::now(), c);
+                        } else if to == MetricVariant::Idle {
+                            *lock = ConnInner::Idle(Instant::now(), c);
+                        } else {
+                            unreachable!()
+                        }
+                        Ok(())
                     }
-                    Ok(())
+                    Err(err) => {
+                        metrics.transition(
+                            MetricVariant::Connecting,
+                            MetricVariant::Failed,
+                            t.elapsed(),
+                        );
+                        *lock = ConnInner::Failed;
+                        Err(err)
+                    }
                 }
-                Err(err) => {
-                    metrics.transition(
-                        MetricVariant::Connecting,
-                        MetricVariant::Failed,
-                        t.elapsed(),
-                    );
-                    *lock = ConnInner::Failed;
-                    Err(err)
-                }
-            },
+            }
             ConnInner::Disconnecting(t, f) => match ready!(f.poll_unpin(cx)) {
                 Ok(_) => {
                     debug_assert_eq!(to, MetricVariant::Closed);
@@ -238,7 +246,8 @@ impl<C: Connector> Conn<C> {
             ConnInner::Active(t, _)
             | ConnInner::Idle(t, _)
             | ConnInner::Connecting(t, _)
-            | ConnInner::Disconnecting(t, _) => metrics.remove_time(self.variant(), t.elapsed()),
+            | ConnInner::Disconnecting(t, _)
+            | ConnInner::Reconnecting(t, _) => metrics.remove_time(self.variant(), t.elapsed()),
             other => metrics.remove(other.into()),
         }
     }
@@ -256,6 +265,8 @@ enum ConnInner<C: Connector> {
     Connecting(Instant, Pin<Box<dyn Future<Output = ConnResult<C::Conn>>>>),
     /// Disconnecting connections hold a spot in the pool as they count towards quotas
     Disconnecting(Instant, Pin<Box<dyn Future<Output = ConnResult<()>>>>),
+    /// Reconnecting hold a spot in the pool as they count towards quotas
+    Reconnecting(Instant, Pin<Box<dyn Future<Output = ConnResult<C::Conn>>>>),
     /// The connection is alive, but it is not being held.
     Idle(Instant, C::Conn),
     /// The connection is alive, and is being held.
@@ -274,6 +285,7 @@ impl<C: Connector> From<&ConnInner<C>> for MetricVariant {
         match val {
             ConnInner::Connecting(..) => MetricVariant::Connecting,
             ConnInner::Disconnecting(..) => MetricVariant::Disconnecting,
+            ConnInner::Reconnecting(..) => MetricVariant::Reconnecting,
             ConnInner::Idle(..) => MetricVariant::Idle,
             ConnInner::Active(..) => MetricVariant::Active,
             ConnInner::Failed => MetricVariant::Failed,

--- a/edb/server/conn_pool/src/metrics.rs
+++ b/edb/server/conn_pool/src/metrics.rs
@@ -12,6 +12,7 @@ use crate::block::Name;
 pub enum MetricVariant {
     Connecting,
     Disconnecting,
+    Reconnecting,
     Idle,
     Active,
     Failed,

--- a/edb/server/conn_pool/src/pool.rs
+++ b/edb/server/conn_pool/src/pool.rs
@@ -298,9 +298,9 @@ impl<C: Connector> Pool<C> {
         if cfg!(debug_assertions) {
             let all_time = &pool.metrics().all_time;
             assert_eq!(
-                all_time[MetricVariant::Connecting],
+                all_time[MetricVariant::Connecting] + all_time[MetricVariant::Reconnecting],
                 all_time[MetricVariant::Disconnecting],
-                "Connecting != Disconnecting"
+                "Connecting + Reconnecting != Disconnecting"
             );
             assert_eq!(
                 all_time[MetricVariant::Disconnecting],


### PR DESCRIPTION
We want to track reconnections for QoS and algorithm purposes -- we want to account for the time spend disconnecting and reconnecting when calculating the expense of switching connections.