### PR TITLE
CI: fix macOS build for recent Homebrew update

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -135,6 +135,16 @@
         ref: master
         path: edgedb-pkg
 
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -136,7 +136,7 @@
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       with:
         components: "cargo,rustc,rust-std"

--- a/.github/workflows.src/ls-build.inc.yml
+++ b/.github/workflows.src/ls-build.inc.yml
@@ -133,7 +133,7 @@
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       with:
         components: "cargo,rustc,rust-std"

--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -129,7 +129,7 @@
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -59,7 +59,7 @@ jobs:
         key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Install rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -978,7 +978,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"
@@ -1036,7 +1036,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -977,6 +977,16 @@ jobs:
         ref: master
         path: edgedb-pkg
 
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
@@ -1034,6 +1044,16 @@ jobs:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
+
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2

--- a/.github/workflows/ls-nightly.yml
+++ b/.github/workflows/ls-nightly.yml
@@ -231,7 +231,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"
@@ -290,7 +290,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -982,6 +982,16 @@ jobs:
         ref: master
         path: edgedb-pkg
 
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
@@ -1039,6 +1049,16 @@ jobs:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
+
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -983,7 +983,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"
@@ -1041,7 +1041,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,6 +524,16 @@ jobs:
         ref: master
         path: edgedb-pkg
 
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
@@ -579,6 +589,16 @@ jobs:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
+
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -525,7 +525,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"
@@ -581,7 +581,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -546,6 +546,16 @@ jobs:
         ref: master
         path: edgedb-pkg
 
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
@@ -602,6 +612,16 @@ jobs:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
+
+    - name: Update Homebrew before installing Rust toolchain
+      run: |
+        # Homebrew renamed `rustup-init` to `rustup`:
+        #   https://github.com/Homebrew/homebrew-core/pull/177840
+        # But the GitHub Action runner is not updated with this change yet.
+        # This caused the later `brew update` in step `Build` to relink Rust
+        # toolchain executables, overwriting the custom toolchain installed by
+        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        brew update
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -547,7 +547,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"
@@ -604,7 +604,7 @@ jobs:
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       if: true
       with:
         components: "cargo,rustc,rust-std"

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -170,7 +170,7 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -155,7 +155,7 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -157,7 +157,7 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -155,7 +155,7 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"

--- a/.github/workflows/tests-pool.yml
+++ b/.github/workflows/tests-pool.yml
@@ -165,7 +165,7 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,7 @@ jobs:
       if: |
         steps.cli-cache.outputs.cache-hit != 'true' ||
         steps.rust-cache.outputs.cache-hit != 'true'
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"
@@ -407,7 +407,7 @@ jobs:
         key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
 
     - name: Install rust toolchain
-      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
       with:
         components: "cargo,rustc,rust-std"
         toolchain: "stable"


### PR DESCRIPTION
Homebrew [renamed](https://github.com/Homebrew/homebrew-core/pull/177840) `rustup-init` to `rustup`. But the GitHub Action runner is not updated with this change yet. This caused the later `brew update` in step `Build` to relink Rust toolchain executables, overwriting the custom toolchain installed by `dtolnay/rust-toolchain`. So let's just run `brew update` early.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/10062770334)

Same fix shall be applied to edgedb-cli too once approved.