### PR TITLE
Recompile constraint triggers

### DIFF
--- a/edb/pgsql/dbops/triggers.py
+++ b/edb/pgsql/dbops/triggers.py
@@ -186,14 +186,16 @@ class DropTrigger(ddl.DropObject):
     def __init__(self, object, *, conditional=False, **kwargs):
         super().__init__(object, **kwargs)
         self.trigger = object
+        self.conditional = conditional
         if conditional:
             self.conditions.add(
                 TriggerExists(self.trigger.name, self.trigger.table_name)
             )
 
     def code(self, block: base.PLBlock) -> str:
+        ifexists = ' IF EXISTS' if self.conditional else ''
         return (
-            f'DROP TRIGGER {qi(self.trigger.name)} '
+            f'DROP TRIGGER{ifexists} {qi(self.trigger.name)} '
             f'ON {qn(*self.trigger.table_name)}'
         )
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2043,8 +2043,7 @@ class ConstraintCommand(MetaCommand):
                 bconstr = schemamech.compile_constraint(
                     subject, base, schema, span
                 )
-                op.add_command(bconstr.alter_ops(
-                    bconstr, only_modify_enabled=True))
+                op.add_command(bconstr.update_trigger_ops())
 
         return op
 

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -609,24 +609,12 @@ class AlterTableDropConstraint(AlterTableConstraintBase):
 
 
 class AlterTableUpdateConstraintTrigger(AlterTableConstraintBase):
-    def __init__(
-        self,
-        name: Tuple[str, ...],
-        *,
-        constraint: SchemaConstraintTableConstraint,
-        orig_constraint: Optional[SchemaConstraintTableConstraint],
-        **kwargs,
-    ):
-        super().__init__(name, constraint=constraint, **kwargs)
-        self._orig_constraint = orig_constraint
-
     def __repr__(self):
         return '<{}.{} {!r}>'.format(
             self.__class__.__module__, self.__class__.__name__,
             self._constraint)
 
     def generate(self, block):
-        if self._orig_constraint is not None:
-            self.drop_constraint_trigger_and_fuction(self._orig_constraint)
+        self.drop_constraint_trigger_and_fuction(self._constraint)
         self.create_constraint_trigger_and_fuction(self._constraint)
         super().generate(block)

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -576,11 +576,10 @@ class AlterTableAddConstraint(AlterTableConstraintBase):
 
 class AlterTableAlterConstraint(AlterTableConstraintBase):
     def __init__(
-        self, name, *, constraint, new_constraint, only_modify_enabled, **kwargs
+        self, name, *, constraint, new_constraint, **kwargs
     ):
         super().__init__(name, constraint=constraint, **kwargs)
         self._new_constraint = new_constraint
-        self._only_modify_enabled = only_modify_enabled
 
     def __repr__(self):
         return '<{}.{} {!r}>'.format(
@@ -588,10 +587,7 @@ class AlterTableAlterConstraint(AlterTableConstraintBase):
             self._constraint)
 
     def generate(self, block):
-        if self._only_modify_enabled:
-            self.update_constraint_enabled(self._new_constraint)
-        else:
-            self.alter_constraint(self._constraint, self._new_constraint)
+        self.alter_constraint(self._constraint, self._new_constraint)
         super().generate(block)
 
 
@@ -604,4 +600,15 @@ class AlterTableDropConstraint(AlterTableConstraintBase):
     def generate(self, block):
         if not self._constraint.delegated:
             self.drop_constraint(self._constraint)
+        super().generate(block)
+
+
+class AlterTableUpdateConstraintTrigger(AlterTableConstraintBase):
+    def __repr__(self):
+        return '<{}.{} {!r}>'.format(
+            self.__class__.__module__, self.__class__.__name__,
+            self._constraint)
+
+    def generate(self, block):
+        self.update_constraint_enabled(self._constraint)
         super().generate(block)

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -205,7 +205,7 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
             origin_exprdata = origin_expr.exprdata
 
             except_data = self._except_data
-            origin_except_data = origin_expr.origin_except_data
+            origin_except_data = origin_expr.except_data
 
             if self._except_data:
                 except_part = f'''
@@ -229,7 +229,7 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
                 if self._table_type == 'link' else ''
             )
 
-            schemaname, tablename = origin_expr.origin_subject_db_name
+            schemaname, tablename = origin_expr.subject_db_name
             text = '''
                 PERFORM
                     TRUE

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -434,7 +434,10 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
     ) -> List[dbops.DDLOperation]:
         ins_trigger, upd_trigger = self._get_triggers(table_name, constraint)
 
-        return [dbops.DropTrigger(ins_trigger), dbops.DropTrigger(upd_trigger)]
+        return [
+            dbops.DropTrigger(ins_trigger, conditional=True),
+            dbops.DropTrigger(upd_trigger, conditional=True),
+        ]
 
     def enable_constr_trigger(
         self,
@@ -481,7 +484,7 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
         return [dbops.CreateFunction(func, or_replace=True)]
 
     def drop_constr_trigger_function(self, proc_name: Tuple[str, ...]):
-        return [dbops.DropFunction(name=proc_name, args=())]
+        return [dbops.DropFunction(name=proc_name, args=(), if_exists=True)]
 
     def create_constraint(self, constraint: SchemaConstraintTableConstraint):
         # Add the constraint normally to our table
@@ -491,8 +494,6 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
         my_alter.add_command(add_constr)
 
         self.add_command(my_alter)
-
-        self.create_constraint_trigger_and_fuction(constraint)
 
     def create_constraint_trigger_and_fuction(
         self, constraint: SchemaConstraintTableConstraint

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -609,12 +609,24 @@ class AlterTableDropConstraint(AlterTableConstraintBase):
 
 
 class AlterTableUpdateConstraintTrigger(AlterTableConstraintBase):
+    def __init__(
+        self,
+        name: Tuple[str, ...],
+        *,
+        constraint: SchemaConstraintTableConstraint,
+        orig_constraint: Optional[SchemaConstraintTableConstraint],
+        **kwargs,
+    ):
+        super().__init__(name, constraint=constraint, **kwargs)
+        self._orig_constraint = orig_constraint
+
     def __repr__(self):
         return '<{}.{} {!r}>'.format(
             self.__class__.__module__, self.__class__.__name__,
             self._constraint)
 
     def generate(self, block):
-        self.drop_constraint_trigger_and_fuction(self._constraint)
+        if self._orig_constraint is not None:
+            self.drop_constraint_trigger_and_fuction(self._orig_constraint)
         self.create_constraint_trigger_and_fuction(self._constraint)
         super().generate(block)

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -505,9 +505,7 @@ class SchemaDomainConstraint:
         ops = dbops.CommandGroup()
         return ops
 
-    def update_trigger_ops(
-        self, orig_constr: Optional[SchemaConstraint]
-    ):
+    def update_trigger_ops(self) -> dbops.CommandGroup:
         ops = dbops.CommandGroup()
         return ops
 
@@ -655,22 +653,13 @@ class SchemaTableConstraint:
 
         return ops
 
-    def update_trigger_ops(
-        self, orig_constr: Optional[SchemaConstraint]
-    ) -> dbops.CommandGroup:
+    def update_trigger_ops(self) -> dbops.CommandGroup:
         ops = dbops.CommandGroup()
 
         tabconstr = self._table_constraint(self)
-        orig_tabconstr = (
-            self._table_constraint(orig_constr)
-            if orig_constr is not None else
-            None
-        )
-
         add_constr = deltadbops.AlterTableUpdateConstraintTrigger(
             name=tabconstr.get_subject_name(quote=False),
             constraint=tabconstr,
-            orig_constraint=orig_tabconstr,
         )
 
         ops.add_command(add_constr)

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -85,8 +85,8 @@ class ExprData:
     exprdata: ExprDataSources
     is_multicol: bool
     is_trivial: bool
-    origin_subject_db_name: Optional[Tuple[str, str]] = None
-    origin_except_data: Optional[ExprDataSources] = None
+    subject_db_name: Optional[Tuple[str, str]] = None
+    except_data: Optional[ExprDataSources] = None
 
 
 @dataclasses.dataclass(kw_only=True, repr=False, eq=False, slots=True)
@@ -335,8 +335,8 @@ def _get_compiled_constraint_expr_data(
         exprdata = _edgeql_ref_to_pg_constr(
             primary_subject, constraint_subject, ref
         )
-        exprdata.origin_subject_db_name = constraint_data.subject_db_name
-        exprdata.origin_except_data = constraint_data.except_data
+        exprdata.subject_db_name = constraint_data.subject_db_name
+        exprdata.except_data = constraint_data.except_data
         exprdatas.append(exprdata)
 
     return exprdatas
@@ -434,8 +434,8 @@ def compile_constraint(
         exprdata = _edgeql_ref_to_pg_constr(
             subject, origin_data.subject, constraint_data.ir
         )
-        exprdata.origin_subject_db_name = origin_data.subject_db_name
-        exprdata.origin_except_data = origin_data.except_data
+        exprdata.subject_db_name = origin_data.subject_db_name
+        exprdata.except_data = origin_data.except_data
 
         pg_constr_data.expressions.append(exprdata)
 
@@ -600,8 +600,8 @@ class SchemaTableConstraint:
             old_expr = origin_exprdata.old
             new_expr = exprdata.new
 
-            assert origin_expr.origin_subject_db_name
-            schemaname, tablename = origin_expr.origin_subject_db_name
+            assert origin_expr.subject_db_name
+            schemaname, tablename = origin_expr.subject_db_name
             real_tablename = tabconstr.get_subject_name(quote=False)
 
             errmsg = 'duplicate key value violates unique ' \
@@ -619,7 +619,7 @@ class SchemaTableConstraint:
                 key = "id"
 
             except_data = tabconstr._except_data
-            origin_except_data = origin_expr.origin_except_data
+            origin_except_data = origin_expr.except_data
 
             if except_data:
                 assert origin_except_data

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -485,7 +485,7 @@ class SchemaDomainConstraint:
         return ops
 
     def alter_ops(
-        self, orig_constr: SchemaConstraint, only_modify_enabled: bool = False
+        self, orig_constr: SchemaConstraint
     ):
         ops = dbops.CommandGroup()
         return ops
@@ -502,6 +502,10 @@ class SchemaDomainConstraint:
         return ops
 
     def enforce_ops(self):
+        ops = dbops.CommandGroup()
+        return ops
+
+    def update_trigger_ops(self):
         ops = dbops.CommandGroup()
         return ops
 
@@ -549,7 +553,7 @@ class SchemaTableConstraint:
         return ops
 
     def alter_ops(
-        self, orig_constr: SchemaConstraint, only_modify_enabled=False
+        self, orig_constr: SchemaConstraint
     ):
         ops = dbops.CommandGroup()
 
@@ -558,8 +562,9 @@ class SchemaTableConstraint:
 
         alter_constr = deltadbops.AlterTableAlterConstraint(
             name=tabconstr.get_subject_name(quote=False),
-            constraint=orig_tabconstr, new_constraint=tabconstr,
-            only_modify_enabled=only_modify_enabled)
+            constraint=orig_tabconstr,
+            new_constraint=tabconstr,
+        )
 
         ops.add_command(alter_constr)
 
@@ -645,6 +650,19 @@ class SchemaTableConstraint:
                 '''
             )
             ops.add_command(check)
+
+        return ops
+
+    def update_trigger_ops(self) -> dbops.CommandGroup:
+        ops = dbops.CommandGroup()
+
+        tabconstr = self._table_constraint(self)
+        add_constr = deltadbops.AlterTableUpdateConstraintTrigger(
+            name=tabconstr.get_subject_name(quote=False),
+            constraint=tabconstr,
+        )
+
+        ops.add_command(add_constr)
 
         return ops
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -505,7 +505,9 @@ class SchemaDomainConstraint:
         ops = dbops.CommandGroup()
         return ops
 
-    def update_trigger_ops(self):
+    def update_trigger_ops(
+        self, orig_constr: Optional[SchemaConstraint]
+    ):
         ops = dbops.CommandGroup()
         return ops
 
@@ -653,13 +655,22 @@ class SchemaTableConstraint:
 
         return ops
 
-    def update_trigger_ops(self) -> dbops.CommandGroup:
+    def update_trigger_ops(
+        self, orig_constr: Optional[SchemaConstraint]
+    ) -> dbops.CommandGroup:
         ops = dbops.CommandGroup()
 
         tabconstr = self._table_constraint(self)
+        orig_tabconstr = (
+            self._table_constraint(orig_constr)
+            if orig_constr is not None else
+            None
+        )
+
         add_constr = deltadbops.AlterTableUpdateConstraintTrigger(
             name=tabconstr.get_subject_name(quote=False),
             constraint=tabconstr,
+            orig_constraint=orig_tabconstr,
         )
 
         ops.add_command(add_constr)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1425,6 +1425,19 @@ class CommandContext:
                    and getattr(ctx.op, 'scls', None) == obj
                    for ctx in self.stack)
 
+    def is_altering(self, obj: so.Object) -> bool:
+        """Return True if *obj* is being altered in this context.
+
+        :param obj:
+            The object in question.
+
+        :returns:
+            True if *obj* is being altered in this context.
+        """
+        return any(isinstance(ctx.op, AlterObject)
+                   and getattr(ctx.op, 'scls', None) == obj
+                   for ctx in self.stack)
+
     def push(self, token: CommandContextToken[Command]) -> None:
         self.stack.append(token)
 


### PR DESCRIPTION
- In `delta`, create a mechanism to schedule updates to triggers after all other changes to the schema (`schedule_constraint_trigger_update`)
    - Ensure that any `create_ops` or `alter_ops`, also schedule updating triggers.
    - If a constraint becomes a relative or stops being the relative of another, also update its triggers.
    - Update mechanism similar to existing post inhview updates.
- Implement the trigger updates using new `schemamech.SchemaTableConstraint.update_trigger_ops` and `deltadbops.AlterTableUpdateConstraintTrigger`
- In `dbops`, remove all create trigger and trigger function ops from create and alter ops.
    - Add `if exists` to any drop trigger and trigger function ops since a trigger may be dropped multiple times by a single command.
- Add tests to check that constraints work after changes to schema.
- Fixed a bug where when changing the bases of an abstract link (either removing or adding), it's triggers and those of its relatives (new and old) are not correctly updated.

Related #7410