### PR TITLE
Use async context managers for connections

### DIFF
--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -702,18 +702,17 @@ async def parse_execute_json(
     )
 
     tenant = db.tenant
-    pgcon = await tenant.acquire_pgcon(db.name)
-    try:
-        return await execute_json(
-            pgcon,
-            dbv,
-            compiled,
-            variables=variables,
-            globals_=globals_,
-        )
-    finally:
-        tenant.release_pgcon(db.name, pgcon)
-        tenant.remove_dbview(dbv)
+    async with tenant.with_pgcon(db.name) as pgcon:
+        try:
+            return await execute_json(
+                pgcon,
+                dbv,
+                compiled,
+                variables=variables,
+                globals_=globals_,
+            )
+        finally:
+            tenant.remove_dbview(dbv)
 
 
 async def execute_json(


### PR DESCRIPTION
We can switch connection acquisition in `Tenant` and `FrontendConnection` to using async context managers which has a few positive side-effects:

1. All use of connections can be easily found by searching for `with_.*pgcon`.
2. We no longer need an explicit cleanup step -- with the exception of the pinned connection in the frontend

This should simplify further refactoring down the line as we move more code to Rust.