### PR TITLE
Add note about removing b64url padding in PKCE

### DIFF
--- a/docs/guides/auth/built_in_ui.rst
+++ b/docs/guides/auth/built_in_ui.rst
@@ -57,6 +57,13 @@ base64url encode the resulting string. This new string is called the
 
 .. note::
 
+   Since ``=`` is not a URL-safe character, if your Base64-URL encoding
+   function adds padding, you should remove the padding before hashing the
+   ``verifier`` to derive the ``challenge`` or when providing the ``verifier``
+   or ``challenge`` in your requests.
+
+.. note::
+
    If you are familiar with PKCE, you will notice some differences from how RFC
    7636 defines PKCE. Our authentication flow is not an OAuth flow, but rather a
    strict server-to-server flow with Proof Key of Code Exchange added for

--- a/docs/guides/auth/email_password.rst
+++ b/docs/guides/auth/email_password.rst
@@ -60,6 +60,13 @@ base64url encode the resulting string. This new string is called the
 
 .. note::
 
+   Since ``=`` is not a URL-safe character, if your Base64-URL encoding
+   function adds padding, you should remove the padding before hashing the
+   ``verifier`` to derive the ``challenge`` or when providing the ``verifier``
+   or ``challenge`` in your requests.
+
+.. note::
+
    If you are familiar with PKCE, you will notice some differences from how RFC
    7636 defines PKCE. Our authentication flow is not an OAuth flow, but rather a
    strict server-to-server flow with Proof Key of Code Exchange added for

--- a/docs/guides/auth/oauth.rst
+++ b/docs/guides/auth/oauth.rst
@@ -60,6 +60,13 @@ base64url encode the resulting string. This new string is called the
 
 .. note::
 
+   Since ``=`` is not a URL-safe character, if your Base64-URL encoding
+   function adds padding, you should remove the padding before hashing the
+   ``verifier`` to derive the ``challenge`` or when providing the ``verifier``
+   or ``challenge`` in your requests.
+
+.. note::
+
    If you are familiar with PKCE, you will notice some differences from how RFC
    7636 defines PKCE. Our authentication flow is not an OAuth flow, but rather a
    strict server-to-server flow with Proof Key of Code Exchange added for


### PR DESCRIPTION
Closes #7596 by updating the documentation. As noted there, the reference implementation in Node.js uses the `Buffer` implementation of base64url encoding which does _not_ pad encoded strings, so there is not a corresponding change in the example code. However, if you use, for instance Python, you'll do something like [what we do in our test suite](https://github.com/edgedb/edgedb/blob/e9e349b25732990a823c3f5093c360d8512b36e6/tests/test_http_ext_auth.py#L3226-L3229).

```py
            verifier = base64.urlsafe_b64encode(os.urandom(43)).rstrip(b'=')
            challenge = base64.urlsafe_b64encode(
                hashlib.sha256(verifier).digest()
            ).rstrip(b'=')
```
