### PR TITLE
test: fix remaining failing scalar type drops due to cache

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12119,6 +12119,7 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
             ['wontfix'],
         )
 
+        # Retry for https://github.com/edgedb/edgedb/issues/7553
         async for tr in self.try_until_succeeds(
             ignore_regexp="cannot drop type .* "
                           "because other objects depend on it",

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2968,9 +2968,15 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
             self.assertEqual(result, 'b')
         finally:
-            await self.con.execute('''
-                DROP SCALAR TYPE tid_prop_02;
-            ''')
+            # Retry for https://github.com/edgedb/edgedb/issues/7553
+            async for tr in self.try_until_succeeds(
+                ignore_regexp="cannot drop type .* "
+                              "because other objects depend on it",
+            ):
+                async with tr:
+                    await self.con.execute('''
+                        DROP SCALAR TYPE tid_prop_02;
+                    ''')
 
     async def test_server_proto_backend_tid_propagation_03(self):
         try:
@@ -2991,9 +2997,15 @@ class TestServerProtoDDL(tb.DDLTestCase):
             self.assertEqual(result, 'B')
 
         finally:
-            await self.con.execute('''
-                DROP SCALAR TYPE tid_prop_03;
-            ''')
+            # Retry for https://github.com/edgedb/edgedb/issues/7553
+            async for tr in self.try_until_succeeds(
+                ignore_regexp="cannot drop type .* "
+                              "because other objects depend on it",
+            ):
+                async with tr:
+                    await self.con.execute('''
+                        DROP SCALAR TYPE tid_prop_03;
+                    ''')
 
     async def test_server_proto_backend_tid_propagation_04(self):
         try:
@@ -3057,6 +3069,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
             self.assertEqual(result, 'b')
         finally:
+            # Retry for https://github.com/edgedb/edgedb/issues/7553
             async for tr in self.try_until_succeeds(
                 ignore_regexp="cannot drop type .* "
                               "because other objects depend on it",
@@ -3099,9 +3112,15 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
         finally:
             await self.con.query('ROLLBACK')
-            await self.con.execute('''
-                DROP SCALAR TYPE tid_prop_081;
-            ''')
+            # Retry for https://github.com/edgedb/edgedb/issues/7553
+            async for tr in self.try_until_succeeds(
+                ignore_regexp="cannot drop type .* "
+                              "because other objects depend on it",
+            ):
+                async with tr:
+                    await self.con.execute('''
+                        DROP SCALAR TYPE tid_prop_081;
+                    ''')
 
     async def test_server_proto_backend_tid_propagation_09(self):
         try:
@@ -3137,16 +3156,10 @@ class TestServerProtoDDL(tb.DDLTestCase):
             self.assertEqual(result, 'Z')
 
         finally:
-            # HACK: this retry is added to temporarily avoid an unresolved
-            # issue in https://github.com/edgedb/edgedb/pull/7422/commits/
-            # d1b2c4d22ee1cd38fe0bb81bc708e6910e33a6b4 that, when the func
-            # cache creation is done in parallel with the drop of the scalar
-            # types below which are used in those function parameter types,
-            # the eviction added in the commit above is not triggered because
-            # the dropping transaction can't see the function as a dependency
-            # in `pg_depend` yet.
+            # Retry for https://github.com/edgedb/edgedb/issues/7553
             async for tr in self.try_until_succeeds(
-                ignore=edgedb.InternalServerError, timeout=30
+                ignore_regexp="cannot drop type .* "
+                              "because other objects depend on it",
             ):
                 async with tr:
                     await self.con.execute('''


### PR DESCRIPTION
Also, add references to #7553 in test code.

Refs #7598, #7552

This fixes https://github.com/edgedb/edgedb/actions/runs/10119762610/job/27989898688