### PR TITLE
func cache: drop dependant cache function of tuple type

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2026,7 +2026,7 @@ def _build_cache_function(
                     ir.expr.typeref.base_type or ir.expr.typeref
                 )
                 if ir.stype.is_tuple(ir.schema):
-                    returns_record = True
+                    returns_record = return_type == ('record',)
 
         case enums.OutputFormat.JSON:
             return_type = ("json",)


### PR DESCRIPTION
Thanks @msullivan for the finding:

> ```
> _localdev:x> create function lol() -> SET OF tuple<str, str> using (('x', 'y'));
> OK: CREATE None
> _localdev:x> select lol();
> {('x', 'y')}
> _localdev:x> drop function lol();
> edgedb error: InternalServerError: cannot drop type edgedbpub."3c3402fb-4fa5-11ef-b513-13b3bfaae634_t" because other objects depend on it
>   Server traceback:
>       edb.errors.InternalServerError: cannot drop type edgedbpub."3c3402fb-4fa5-11ef-b513-13b3bfaae634_t" because other objects depend on it
> ```