### PR TITLE
Improve SET multi-ref parsing over SQL adapter

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -513,7 +513,7 @@ class UpdateTarget(ImmutableBaseExpr):
     """Query update target."""
 
     # column names
-    name: str | typing.List[str]
+    name: str
     # value expression to assign
     val: BaseExpr
     # subscripts, field names and '*'

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -893,7 +893,7 @@ class MultiAssignRef(ImmutableBase):
     # row-valued expression
     source: BaseExpr
     # list of columns to assign to
-    columns: typing.List[ColumnRef]
+    columns: typing.List[str]
 
 
 class SortBy(ImmutableBase):

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -498,8 +498,6 @@ class ResTarget(ImmutableBaseExpr):
 
     # Column name (optional)
     name: typing.Optional[str] = None
-    # subscripts, field names and '*'
-    indirection: typing.Optional[typing.List[IndirectionOp]] = None
     # value expression to compute
     val: BaseExpr
 

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -617,6 +617,8 @@ class Query(ReturningQuery):
 
     @property
     def ser_safe(self):
+        if not self.target_list:
+            return False
         return all(t.ser_safe for t in self.target_list)
 
     def append_cte(self, cte: CommonTableExpr) -> None:

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -563,7 +563,10 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_MultiAssignRef(self, node: pgast.MultiAssignRef) -> None:
         self.write('(')
-        self.visit_list(node.columns, newlines=False)
+        for index, col in enumerate(node.columns):
+            if index > 0:
+                self.write(', ')
+            self.write(common.quote_col(col))
         self.write(') = ')
         self.visit(node.source)
 

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -442,6 +442,8 @@ class SQLSourceGenerator(codegen.SourceGenerator):
                 self.write('(')
                 self.visit(node.select_stmt)
                 self.write(')')
+        else:
+            self.write('DEFAULT VALUES')
 
         if node.on_conflict:
             self.new_lines = 1

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -572,8 +572,6 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_ResTarget(self, node: pgast.ResTarget) -> None:
         self.visit(node.val)
-        if node.indirection:
-            self._visit_indirection_ops(node.indirection)
         if node.name:
             self.write(' AS ' + common.quote_col(node.name))
 

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -162,7 +162,7 @@ def compile_ConfigSet(
                 ),
                 target_list=[
                     pgast.MultiAssignRef(
-                        columns=[pgast.ColumnRef(name=['value'])],
+                        columns=['value'],
                         source=pgast.RowExpr(
                             args=[
                                 val,
@@ -227,7 +227,7 @@ def compile_ConfigSet(
                 ),
                 target_list=[
                     pgast.MultiAssignRef(
-                        columns=[pgast.ColumnRef(name=['value'])],
+                        columns=['value'],
                         source=pgast.RowExpr(
                             args=[
                                 val,
@@ -785,7 +785,7 @@ def top_output_as_config_op(
                 ),
                 target_list=[
                     pgast.MultiAssignRef(
-                        columns=[pgast.ColumnRef(name=['value'])],
+                        columns=['value'],
                         source=pgast.RowExpr(
                             args=[
                                 upd_val,

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1788,10 +1788,7 @@ def process_update_body(
             from_clause=[contents_rvar],
             targets=[
                 pgast.MultiAssignRef(
-                    columns=[
-                        pgast.ColumnRef(name=not_none(value.name))
-                        for value, _ in values
-                    ],
+                    columns=[not_none(value.name) for value, _ in values],
                     source=pgast.SelectStmt(
                         target_list=[
                             pgast.ResTarget(
@@ -2779,9 +2776,9 @@ def process_link_update(
         ]
 
         target_cols = [
-            col
+            col.name[0]
             for col in cols
-            if col.name[0] not in conflict_cols
+            if isinstance(col.name[0], str) and col.name[0] not in conflict_cols
         ]
 
         if len(target_cols) == 0:
@@ -2794,7 +2791,7 @@ def process_link_update(
         else:
             conflict_data = pgast.RowExpr(
                 args=[
-                    pgast.ColumnRef(name=['excluded', col.name[0]])
+                    pgast.ColumnRef(name=['excluded', col])
                     for col in target_cols
                 ],
             )

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1787,9 +1787,12 @@ def process_update_body(
             ),
             from_clause=[contents_rvar],
             targets=[
-                pgast.UpdateTarget(
-                    name=[not_none(value.name) for value, _ in values],
-                    val=pgast.SelectStmt(
+                pgast.MultiAssignRef(
+                    columns=[
+                        pgast.ColumnRef(name=not_none(value.name))
+                        for value, _ in values
+                    ],
+                    source=pgast.SelectStmt(
                         target_list=[
                             pgast.ResTarget(
                                 val=pgast.ColumnRef(

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -294,7 +294,7 @@ def _build_insert_stmt(n: Node, c: Context) -> pgast.InsertStmt:
     return pgast.InsertStmt(
         relation=_build_rel_range_var(n["relation"], c),
         returning_list=(
-            _maybe_list(n, c, "returningList", _build_res_target) or None
+            _maybe_list(n, c, "returningList", _build_res_target) or []
         ),
         cols=_maybe_list(n, c, "cols", _build_insert_target),
         select_stmt=_maybe(n, c, "selectStmt", _build_stmt),
@@ -1074,7 +1074,6 @@ def _build_res_target(n: Node, c: Context) -> pgast.ResTarget:
     n = _unwrap(n, "ResTarget")
     return pgast.ResTarget(
         name=_maybe(n, c, "name", _build_str),
-        indirection=_maybe_list(n, c, "indirection", _build_indirection_op),
         val=_build_base_expr(n["val"], c),
         span=_build_span(n, c),
     )

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -311,6 +311,9 @@ def _build_update_stmt(n: Node, c: Context) -> pgast.UpdateStmt:
         from_clause=(
             _maybe_list(n, c, "fromClause", _build_base_range_var) or []
         ),
+        returning_list=(
+            _maybe_list(n, c, "returningList", _build_res_target) or []
+        ),
         ctes=_maybe(n, c, "withClause", _build_ctes),
     )
 

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -294,11 +294,11 @@ def _build_insert_stmt(n: Node, c: Context) -> pgast.InsertStmt:
     return pgast.InsertStmt(
         relation=_build_rel_range_var(n["relation"], c),
         returning_list=(
-            _maybe_list(n, c, "returningList", _build_res_target) or []
+            _maybe_list(n, c, "returningList", _build_res_target) or None
         ),
         cols=_maybe_list(n, c, "cols", _build_insert_target),
         select_stmt=_maybe(n, c, "selectStmt", _build_stmt),
-        on_conflict=_maybe(n, c, "on_conflict", _build_on_conflict),
+        on_conflict=_maybe(n, c, "onConflictClause", _build_on_conflict),
         ctes=_maybe(n, c, "withClause", _build_ctes),
     )
 
@@ -306,7 +306,7 @@ def _build_insert_stmt(n: Node, c: Context) -> pgast.InsertStmt:
 def _build_update_stmt(n: Node, c: Context) -> pgast.UpdateStmt:
     return pgast.UpdateStmt(
         relation=_build_rel_range_var(n["relation"], c),
-        targets=_build_targets(n, c, "targetList") or [],
+        targets=_maybe(n, c, "targetList", _build_update_targets) or [],
         where_clause=_maybe(n, c, "whereClause", _build_base_expr),
         from_clause=(
             _maybe_list(n, c, "fromClause", _build_base_range_var) or []
@@ -1088,7 +1088,48 @@ def _build_insert_target(n: Node, c: Context) -> pgast.InsertTarget:
     )
 
 
-def _build_update_target(n: Node, c: Context) -> pgast.UpdateTarget:
+def _build_update_targets(
+    target_list: List[Node], c: Context
+) -> List[pgast.UpdateTarget | pgast.MultiAssignRef]:
+    targets: List[pgast.UpdateTarget | pgast.MultiAssignRef] = []
+    while len(target_list) > 0:
+        val: dict = target_list[0]["ResTarget"]["val"]
+        if first_mar := val.get("MultiAssignRef", None):
+            ncolumns = first_mar['ncolumns']
+
+            columns: List[pgast.ColumnRef] = []
+            for _ in range(ncolumns):
+                target = target_list.pop(0)
+                mar = target['ResTarget']
+
+                if 'indirection' in mar:
+                    raise PSqlUnsupportedError(
+                        val, f"multi-assign SET with indirection"
+                    )
+
+                columns.append(_as_column_ref(mar['name']))
+
+            targets.append(_build_multi_assign_ref(first_mar, columns, c))
+        else:
+            target = target_list.pop(0)
+            targets.append(_build_update_target(target, c))
+
+    return targets
+
+
+def _build_multi_assign_ref(
+    n: Node, columns: List[pgast.ColumnRef], c: Context
+) -> pgast.MultiAssignRef:
+    return pgast.MultiAssignRef(
+        source=_build_base_expr(n['source'], c),
+        columns=columns,
+        span=_build_span(n, c),
+    )
+
+
+def _build_update_target(
+    n: Node, c: Context
+) -> pgast.UpdateTarget | pgast.MultiAssignRef:
     n = _unwrap(n, "ResTarget")
     return pgast.UpdateTarget(
         name=_build_str(n['name'], c),
@@ -1133,29 +1174,6 @@ def _build_sort_order(n: Node, _c: Context) -> qlast.SortOrder:
     return qlast.SortOrder.Asc
 
 
-def _build_targets(
-    n: Node, c: Context, key: str
-) -> Optional[List[pgast.UpdateTarget | pgast.MultiAssignRef]]:
-    if _probe(n, [key, 0, "ResTarget", "val", "MultiAssignRef"]):
-        return [_build_multi_assign_ref(n[key], c)]
-    else:
-        return _maybe_list(n, c, key, _build_update_target)
-
-
-def _build_multi_assign_ref(
-    targets: List[Node], c: Context
-) -> pgast.MultiAssignRef:
-    mar = targets[0]['ResTarget']['val']['MultiAssignRef']
-
-    return pgast.MultiAssignRef(
-        source=_build_base_expr(mar['source'], c),
-        columns=[
-            _as_column_ref(target['ResTarget']['name']) for target in targets
-        ],
-        span=_build_span(targets[0]['ResTarget'], c),
-    )
-
-
 def _build_column_ref(n: Node, c: Context) -> pgast.ColumnRef:
     return pgast.ColumnRef(
         name=_list(n, c, "fields", _build_string_or_star),
@@ -1175,21 +1193,12 @@ def _build_infer_clause(n: Node, c: Context) -> pgast.InferClause:
 
 def _build_on_conflict(n: Node, c: Context) -> pgast.OnConflictClause:
     return pgast.OnConflictClause(
-        action=_build_str(n["action"], c),
+        action=_build_str(n["action"], c).removeprefix('ONCONFLICT_'),
         infer=_maybe(n, c, "infer", _build_infer_clause),
-        target_list=_build_on_conflict_targets(n, c, "targetList"),
+        target_list=_maybe(n, c, "targetList", _build_update_targets) or [],
         where=_maybe(n, c, "where", _build_base_expr),
         span=_build_span(n, c),
     )
-
-
-def _build_on_conflict_targets(
-    n: Node, c: Context, key: str
-) -> Optional[List[pgast.InsertTarget | pgast.MultiAssignRef]]:
-    if _probe(n, [key, 0, "ResTarget", "val", "MultiAssignRef"]):
-        return [_build_multi_assign_ref(n[key], c)]
-    else:
-        return _maybe_list(n, c, key, _build_insert_target)
 
 
 def _build_star(_n: Node, _c: Context) -> pgast.Star | str:

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -1096,7 +1096,7 @@ def _build_update_targets(
         if first_mar := val.get("MultiAssignRef", None):
             ncolumns = first_mar['ncolumns']
 
-            columns: List[pgast.ColumnRef] = []
+            columns: List[str] = []
             for _ in range(ncolumns):
                 target = target_list.pop(0)
                 mar = target['ResTarget']
@@ -1106,7 +1106,7 @@ def _build_update_targets(
                         val, f"multi-assign SET with indirection"
                     )
 
-                columns.append(_as_column_ref(mar['name']))
+                columns.append(mar['name'])
 
             targets.append(_build_multi_assign_ref(first_mar, columns, c))
         else:
@@ -1117,7 +1117,7 @@ def _build_update_targets(
 
 
 def _build_multi_assign_ref(
-    n: Node, columns: List[pgast.ColumnRef], c: Context
+    n: Node, columns: List[str], c: Context
 ) -> pgast.MultiAssignRef:
     return pgast.MultiAssignRef(
         source=_build_base_expr(n['source'], c),

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -269,8 +269,7 @@ def _preprocess_subject_columns(
 def _preprocess_insert_stmt(
     stmt: pgast.InsertStmt, *, ctx: Context
 ) -> PreprocessedDML:
-    # determine the subject object we are inserting into
-    # (this can either be an ObjectType or a Pointer for link tables)
+    # determine the subject object
     sub_table, sub = _preprocess_dml_subject(stmt.relation, ctx=ctx)
 
     expected_columns = _pull_columns_from_table(

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -663,6 +663,11 @@ class TestSQLParse(tb.BaseDocTest):
         (board[1:3][1:3], finished) = ('{{,,},{,,},{,,}}', FALSE)
         """
 
+    def test_sql_parse_update_13(self):
+        """
+        UPDATE tictactoe SET a = a RETURNING *
+        """
+
     def test_sql_parse_delete(self):
         """
         DELETE FROM dataset USING table_one

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -464,6 +464,13 @@ class TestSQLParse(tb.BaseDocTest):
         SELECT -1; SELECT 0; SELECT 1
         """
 
+    def test_sql_parse_select_61(self):
+        """
+        SELECT a[1:3], b.x
+% OK %
+        SELECT (a)[1:3], b.x
+        """
+
     def test_sql_parse_insert_00(self):
         """
         INSERT INTO my_table (id, name) VALUES (1, 'some')
@@ -546,6 +553,15 @@ class TestSQLParse(tb.BaseDocTest):
         INSERT INTO films DEFAULT VALUES
         ON CONFLICT DO UPDATE
         SET (a, b) = ('a', 'b'), c = 'c', (d, e) = ('d', 'e')
+        """
+
+    def test_sql_parse_insert_12(self):
+        """
+        INSERT INTO foo DEFAULT VALUES
+        RETURNING a[1:3] AS a, b.x AS b
+% OK %
+        INSERT INTO foo DEFAULT VALUES
+        RETURNING (a)[1:3] AS a, b.x AS b
         """
 
     def test_sql_parse_update_00(self):

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -541,6 +541,13 @@ class TestSQLParse(tb.BaseDocTest):
         INSERT INTO films (code, title, did) VALUES ($1, $2, $3)
         """
 
+    def test_sql_parse_insert_11(self):
+        """
+        INSERT INTO films DEFAULT VALUES
+        ON CONFLICT DO UPDATE
+        SET (a, b) = ('a', 'b'), c = 'c', (d, e) = ('d', 'e')
+        """
+
     def test_sql_parse_update_00(self):
         """
         UPDATE my_table SET the_value = DEFAULT
@@ -626,6 +633,18 @@ class TestSQLParse(tb.BaseDocTest):
     def test_sql_parse_update_10(self):
         """
         UPDATE x SET z = now()
+        """
+
+    def test_sql_parse_update_11(self):
+        """
+        UPDATE x SET (a, b) = ('a', 'b'), c = 'c', (d, e) = ('d', 'e')
+        """
+
+    @test.xerror('unsupported')
+    def test_sql_parse_update_12(self):
+        """
+        UPDATE tictactoe SET
+        (board[1:3][1:3], finished) = ('{{,,},{,,},{,,}}', FALSE)
         """
 
     def test_sql_parse_delete(self):


### PR DESCRIPTION
I've only now realized the full extent of syntax of SET clause within UPDATE and ON CONFLICT:

```sql
UPDATE x SET (a, b) = ('a', 'b'), c = 'c', (d, e) = ('d', 'e')

UPDATE tictactoe SET (board[1:3][1:3], finished) = ('{{,,},{,,},{,,}}', FALSE)
```