### PR TITLE
Test infrastructure improvements

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2440,7 +2440,7 @@ class _EdgeDBServer:
         self.proc: asyncio.Process = await asyncio.create_subprocess_exec(
             *cmd,
             env=env,
-            stdout=subprocess.PIPE if not self.debug else None,
+            stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             pass_fds=(status_w.fileno(),),
         )
@@ -2451,6 +2451,32 @@ class _EdgeDBServer:
                 timeout=240,
             ),
         )
+
+        output = b''
+
+        async def read_stdout():
+            nonlocal output
+            # Tee the log temporarily to a tempfile that exists as long as the
+            # test is running. This helps debug hanging tests.
+            with tempfile.NamedTemporaryFile(mode='w+t',
+                                             prefix='edgedb-test-log-',
+                                             delete=False) as temp_file:
+                if self.debug:
+                    print(f"Logging to {temp_file.name}")
+                try:
+                    while True:
+                        line = await self.proc.stdout.readline()
+                        if not line:
+                            break
+                        output += line
+                        temp_file.write(line.decode(errors='ignore'))
+                        if self.debug:
+                            print(line.decode(errors='ignore'), end='')
+                finally:
+                    os.remove(temp_file.name)
+
+        stdout_task = asyncio.create_task(read_stdout())
+
         try:
             _, pending = await asyncio.wait(
                 [
@@ -2476,8 +2502,8 @@ class _EdgeDBServer:
             await asyncio.wait(pending, timeout=10)
 
         if self.proc.returncode is not None:
-            output = (await self.proc.stdout.read()).decode().strip()
-            raise edgedb_cluster.ClusterError(output)
+            await stdout_task
+            raise edgedb_cluster.ClusterError(output.decode(errors='ignore'))
         else:
             assert status_task.done()
             data = status_task.result()

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2458,22 +2458,19 @@ class _EdgeDBServer:
             nonlocal output
             # Tee the log temporarily to a tempfile that exists as long as the
             # test is running. This helps debug hanging tests.
-            with tempfile.NamedTemporaryFile(mode='w+t',
-                                             prefix='edgedb-test-log-',
-                                             delete=False) as temp_file:
+            with tempfile.NamedTemporaryFile(
+                mode='w+t',
+                prefix='edgedb-test-log-') as temp_file:
                 if self.debug:
                     print(f"Logging to {temp_file.name}")
-                try:
-                    while True:
-                        line = await self.proc.stdout.readline()
-                        if not line:
-                            break
-                        output += line
-                        temp_file.write(line.decode(errors='ignore'))
-                        if self.debug:
-                            print(line.decode(errors='ignore'), end='')
-                finally:
-                    os.remove(temp_file.name)
+                while True:
+                    line = await self.proc.stdout.readline()
+                    if not line:
+                        break
+                    output += line
+                    temp_file.write(line.decode(errors='ignore'))
+                    if self.debug:
+                        print(line.decode(errors='ignore'), end='')
 
         stdout_task = asyncio.create_task(read_stdout())
 

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -36,6 +36,7 @@ from edb.common import devmode
 from edb.testbase.server import get_test_cases
 from edb.tools.edb import edbcommands
 
+from .decorators import async_timeout
 from .decorators import not_implemented
 from .decorators import _xfail
 from .decorators import xfail
@@ -49,7 +50,8 @@ from . import styles
 from . import results
 
 
-__all__ = ('not_implemented', 'xerror', 'xfail', '_xfail', 'skip')
+__all__ = ('async_timeout', 'not_implemented', 'xerror', 'xfail', '_xfail',
+           'skip')
 
 
 @edbcommands.command()


### PR DESCRIPTION
Various test infrastructure improvements extracted from PR #7544:

 - The test server now properly redirects output to the exceptions, even if `EDGEDB_DEBUG_SERVER` is set
 - Adds a `test.async_timeout` decorator to simplify test timeouts
