### PR TITLE
Allow for GC interval in Rust connection pool

### DIFF
--- a/edb/server/conn_pool/src/block.rs
+++ b/edb/server/conn_pool/src/block.rs
@@ -14,6 +14,7 @@ use std::{
     collections::HashMap,
     future::{poll_fn, ready, Future},
     rc::Rc,
+    time::Duration,
 };
 use tracing::trace;
 
@@ -434,6 +435,10 @@ impl<C: Connector> PoolAlgorithmDataBlock for Block<C, PoolAlgoTargetData> {
     #[inline(always)]
     fn demand(&self) -> u32 {
         self.data.demand()
+    }
+    #[inline(always)]
+    fn count_older(&self, variant: MetricVariant, than: Duration) -> usize {
+        self.conns.count_older(variant, than)
     }
     #[inline(always)]
     fn oldest_ms(&self, variant: MetricVariant) -> usize {

--- a/edb/server/connpool/pool.py
+++ b/edb/server/connpool/pool.py
@@ -1292,6 +1292,7 @@ class _NaivePool(BasePool[C]):
         disconnect: Disconnector[C],
         max_capacity: int,
         stats_collector: typing.Optional[StatsCollector]=None,
+        min_idle_time_before_gc: float = config.MIN_IDLE_TIME_BEFORE_GC,
     ) -> None:
         super().__init__(
             connect=connect,

--- a/edb/server/connpool/pool2.py
+++ b/edb/server/connpool/pool2.py
@@ -105,12 +105,15 @@ class Pool(typing.Generic[C]):
     def __init__(self, *, connect: Connector[C],
                  disconnect: Disconnector[C],
                  max_capacity: int,
-                 stats_collector: typing.Optional[StatsCollector]=None) -> None:
+                 stats_collector: typing.Optional[StatsCollector]=None,
+                 min_idle_time_before_gc: float = config.MIN_IDLE_TIME_BEFORE_GC
+        ) -> None:
         logger.info(f'Creating a connection pool with \
                     max_capacity={max_capacity}')
         self._connect = connect
         self._disconnect = disconnect
-        self._pool = edb.server._conn_pool.ConnPool(max_capacity)
+        self._pool = edb.server._conn_pool.ConnPool(max_capacity,
+                                                    min_idle_time_before_gc)
         self._max_capacity = max_capacity
         self._cur_capacity = 0
         self._next_conn_id = 0

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -530,7 +530,7 @@ class SimulatedCase(unittest.TestCase, metaclass=SimulatedCaseMeta):
                 sim, spec.disconn_cost_base, spec.disconn_cost_var),
             stats_collector=on_stats if collect_stats else None,
             max_capacity=spec.capacity,
-            min_idle_time_before_gc= 0.1 * TIME_SCALE,
+            min_idle_time_before_gc = 0.1 * TIME_SCALE,
         )
         print(f"Simulating {pool.__class__}")
 

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -530,7 +530,7 @@ class SimulatedCase(unittest.TestCase, metaclass=SimulatedCaseMeta):
                 sim, spec.disconn_cost_base, spec.disconn_cost_var),
             stats_collector=on_stats if collect_stats else None,
             max_capacity=spec.capacity,
-            min_idle_time_before_gc = 0.1 * TIME_SCALE,
+            min_idle_time_before_gc=0.1 * TIME_SCALE,
         )
         print(f"Simulating {pool.__class__}")
 

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -530,10 +530,9 @@ class SimulatedCase(unittest.TestCase, metaclass=SimulatedCaseMeta):
                 sim, spec.disconn_cost_base, spec.disconn_cost_var),
             stats_collector=on_stats if collect_stats else None,
             max_capacity=spec.capacity,
+            min_idle_time_before_gc= 0.1 * TIME_SCALE,
         )
         print(f"Simulating {pool.__class__}")
-        if hasattr(pool, '_gc_interval'):
-            pool._gc_interval = 0.1 * TIME_SCALE
 
         started_at = time.monotonic()
         async with asyncio.TaskGroup() as g:


### PR DESCRIPTION
Instead of aggressively closing all connections when idle, we now perform regular GC sweeps of the pool and scan for any idle connection older than the GC age.