### PR TITLE
Remove module from globals' internal alias names.

### DIFF
--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -174,8 +174,17 @@ class AliasLikeCommand(
         return obj
 
     @classmethod
-    def _mangle_name(cls, type_name: sn.QualName) -> sn.QualName:
-        base_name = type_name
+    def _mangle_name(
+        cls,
+        type_name: sn.QualName,
+        *,
+        include_module_in_name: bool,
+    ) -> sn.QualName:
+        base_name = (
+            type_name
+            if include_module_in_name else
+            type_name.get_local_name()
+        )
         quals = (cls.get_schema_metaclass().get_schema_class_displayname(),)
         pnn = sn.get_specialized_name(base_name, str(type_name), *quals)
         name = sn.QualName(name=pnn, module=type_name.module)
@@ -271,7 +280,7 @@ class AliasCommand(
         context: sd.CommandContext,
     ) -> sn.QualName:
         type_name = super()._classname_from_ast(schema, astnode, context)
-        return cls._mangle_name(type_name)
+        return cls._mangle_name(type_name, include_module_in_name=True)
 
     def compile_expr_field(
         self,

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -121,7 +121,7 @@ class GlobalCommand(
 
     @classmethod
     def _get_alias_name(cls, type_name: sn.QualName) -> sn.QualName:
-        return cls._mangle_name(type_name)
+        return cls._mangle_name(type_name, include_module_in_name=False)
 
     @classmethod
     def _is_computable(cls, obj: Global, schema: s_schema.Schema) -> bool:

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -1152,6 +1152,29 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             []
         )
 
+        await self.con.execute('''
+            create module my_mod;
+            create alias my_mod::best_card := 'Dragon';
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'my_mod::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop alias my_mod::best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
     async def test_edgeql_aliases_schema_types_02(self):
         # Object alias adds a type
         await self.con.execute('''
@@ -1169,6 +1192,31 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
 
         await self.con.execute('''
             drop alias best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            create module my_mod;
+            create alias my_mod::best_card := (
+                select Card filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'my_mod::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop alias my_mod::best_card;
         ''')
         await self.assert_query_result(
             r'''
@@ -1202,6 +1250,36 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
 
         await self.con.execute('''
             drop alias best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            create module my_mod;
+            create alias my_mod::best_card := (
+                select Card {name}
+                filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%"
+            order by .name;
+            ''',
+            [
+                {'name': 'my_mod::__best_card__Card'},
+                {'name': 'my_mod::best_card'},
+            ]
+        )
+
+        await self.con.execute('''
+            drop alias my_mod::best_card;
         ''')
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -1127,3 +1127,86 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
                 );
             """
         )
+
+    async def test_edgeql_aliases_schema_types_01(self):
+        # Scalar alias adds a type
+        await self.con.execute('''
+            create alias best_card := 'Dragon';
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'default::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop alias best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+    async def test_edgeql_aliases_schema_types_02(self):
+        # Object alias adds a type
+        await self.con.execute('''
+            create alias best_card := (
+                select Card filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'default::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop alias best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+    async def test_edgeql_aliases_schema_types_03(self):
+        # Object alias with shape adds two types:
+        # - one for the alias
+        # - one for the shape
+        await self.con.execute('''
+            create alias best_card := (
+                select Card {name}
+                filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%"
+            order by .name;
+            ''',
+            [
+                {'name': 'default::__best_card__Card'},
+                {'name': 'default::best_card'},
+            ]
+        )
+
+        await self.con.execute('''
+            drop alias best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -585,3 +585,121 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             self.assertEqual(dres, globs)
         finally:
             await con.aclose()
+
+    async def test_edgeql_globals_schema_types_01(self):
+        # Non-computed globals don't add a schema type
+        await self.con.execute('''
+            create global best_card -> str;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            set global best_card := 'Dragon';
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            drop global best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+    async def test_edgeql_globals_schema_types_02(self):
+        # Computed scalar global adds a type
+        await self.con.execute('''
+            create global best_card := 'Dragon';
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'default::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop global best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+    async def test_edgeql_globals_schema_types_03(self):
+        # Computed object global adds a type
+        await self.con.execute('''
+            create global best_card := (
+                select Card filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'default::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop global best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+    async def test_edgeql_globals_schema_types_04(self):
+        # Computed object global with shape adds two types:
+        # - one for the global
+        # - one for the shape
+        await self.con.execute('''
+            create global best_card := (
+                select Card {name}
+                filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%"
+            order by .name;
+            ''',
+            [
+                {'name': 'default::__best_card'},
+                {'name': 'default::best_card'},
+            ]
+        )
+
+        await self.con.execute('''
+            drop global best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -621,6 +621,40 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             []
         )
 
+        await self.con.execute('''
+            create module my_mod;
+            create global my_mod::best_card -> str;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            set global my_mod::best_card := 'Dragon';
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            drop global my_mod::best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
     async def test_edgeql_globals_schema_types_02(self):
         # Computed scalar global adds a type
         await self.con.execute('''
@@ -636,6 +670,29 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
 
         await self.con.execute('''
             drop global best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            create module my_mod;
+            create global my_mod::best_card := 'Dragon';
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'my_mod::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop global my_mod::best_card;
         ''')
         await self.assert_query_result(
             r'''
@@ -671,6 +728,31 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             []
         )
 
+        await self.con.execute('''
+            create module my_mod;
+            create global my_mod::best_card := (
+                select Card filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            [{'name': 'my_mod::best_card'}]
+        )
+
+        await self.con.execute('''
+            drop global my_mod::best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
     async def test_edgeql_globals_schema_types_04(self):
         # Computed object global with shape adds two types:
         # - one for the global
@@ -695,6 +777,36 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
 
         await self.con.execute('''
             drop global best_card;
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%";
+            ''',
+            []
+        )
+
+        await self.con.execute('''
+            create module my_mod;
+            create global my_mod::best_card := (
+                select Card {name}
+                filter .name = 'Dragon' limit 1
+            );
+        ''')
+        await self.assert_query_result(
+            r'''
+            with module schema select Type { name }
+            filter .name ilike "%best_card%"
+            order by .name;
+            ''',
+            [
+                {'name': 'my_mod::__best_card'},
+                {'name': 'my_mod::best_card'},
+            ]
+        )
+
+        await self.con.execute('''
+            drop global my_mod::best_card;
         ''')
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
Close #7516

Cause of the issue:
- When creating a `global` ie. `CreateGlobal.apply`:
    - During `CreateAliasLike._create_begin`
    - `alias_name` is set to `GlobalCommand._get_alias_name`
        - This mangles `classname`, which adds some `'@'`s in the process
- When compiling the alias expression in `compile_alias_expr`:
    - A persistent type is generated in `_process_view`
    - The `generated_name` is prefixed by `__`
- When updating the schema, in `write_meta_create_object`:
    - During `_build_object_mutation_shape`, when processing `n == 'name'`
    - `target_value` is set to `Object.get_displayname_static(v)`
        - Calls `QualifiedObject.get_shortname_static`
        - Calls `schema.name.shortname_from_fullname`
        - This unmangles the name after splitting by `'@'`, but preserves the module

This PR removes the module from the alias name produced for the global. This allows the unmangled form to not prefix the module with `'__'`.

