### PR TITLE
Fix single row optimization

### DIFF
--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -694,8 +694,10 @@ def _preprocess_insert_pointer_stmt(
 
 
 def _has_at_most_one_row(query: pgast.Query | None) -> bool:
+    if not query:
+        return True
     return isinstance(query, pgast.SelectStmt) and (
-        (query.values and len(query.values) == 1)
+        (query.values and len(query.values) <= 1)
         or (
             isinstance(query.limit_count, pgast.NumericConstant)
             and query.limit_count.val == '1'


### PR DESCRIPTION
For SQL INSERTs, we have an optimization for inserting a single row, which skips the whole for-loop & iterator shenanigans. It was not applied for DEFAULT VALUES, which is basically a relation with 1 row and 0 columns, but is represented by `None` instead of `pgast.SelectStmt`.