### PR TITLE
Remove inhviews

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3088,7 +3088,6 @@ class CompositeMetaCommand(MetaCommand):
         self.table_name = None
         self._multicommands = {}
         self.update_search_indexes = None
-        self.inhview_updates = set()
         self.post_inhview_update_commands = []
         self.constraint_trigger_updates = set()
 
@@ -3279,19 +3278,6 @@ class CompositeMetaCommand(MetaCommand):
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> None:
-        if self.inhview_updates:
-            to_recreate = {k for k, r in self.inhview_updates if r}
-            to_alter = {
-                k for k, _ in self.inhview_updates if k not in to_recreate}
-
-            for s in to_recreate:
-                if types.has_table(s, schema):
-                    self.update_if_cfg_view(schema, context, s)
-
-            for s in to_alter:
-                if types.has_table(s, schema):
-                    self.update_if_cfg_view(schema, context, s)
-
         for post_cmd in self.post_inhview_update_commands:
             if callable(post_cmd):
                 if op := post_cmd(schema, context):

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -104,7 +104,6 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
         *,
         constraint,
         exprdata: list[schemamech.ExprData],
-        origin_exprdata: list[schemamech.ExprData],
         relative_exprdata: list[schemamech.ExprData],
         scope,
         type,
@@ -115,7 +114,6 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
         ConstraintCommon.__init__(self, constraint, schema)
         dbops.TableConstraint.__init__(self, table_name, None)
         self._exprdata = exprdata
-        self._origin_exprdata = origin_exprdata
         self._relative_exprdata = relative_exprdata
         self._scope = scope
         self._type = type

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4282,7 +4282,7 @@ class GetPgTypeForEdgeDBTypeFunction2(trampoline.VersionedFunction):
                         "kind" = 'schema::Array'
                          AND (
                             typ.typname = "elemid"::text || '_domain'
-                            OR typ.typname = "elemid"::text || '_t'
+                            OR typ.typname = "elemid"::text
                             OR typ.oid = (
                                 SELECT
                                     st.backend_id

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1129,23 +1129,6 @@ async def create_branch(
     '''.encode('utf-8')
     await conn.sql_execute(copy_cfg_query)
 
-    # std::Object and std::BaseObject depend on user tables, so we
-    # need to dump those and patch them to OR REPLACE, now that we
-    # have created the user tables.
-    std_views = [
-        pg_common.get_backend_name(
-            schema, schema.get(name), catenate=True, aspect='inhview'
-        )
-        for name in ('std::Object', 'std::BaseObject', 'cfg::ExtensionConfig')
-    ]
-    views_dump = await cluster.dump_database(
-        src_dbname,
-        include_tables=std_views,
-        schema_only=True,
-    )
-    views_dump = views_dump.replace(b'CREATE VIEW', b'CREATE OR REPLACE VIEW')
-    await conn.sql_execute(views_dump)
-
     # HACK: Empty out all schema multi property tables. This is
     # because the original template has the stdschema in it, and so we
     # use --on-conflict-do-nothing to avoid conflicts since the dump


### PR DESCRIPTION
- Removed remaining uses of inhviews:
    - Enforcing constraint ops
    - Type trampolines
    - View dumps when creating a branch
- Remove inhview create, alter, recreate, drop, and update related functions.
- Modified `get_pg_type_for_edgedb_type` to check the object's base table when looking for the oid of an array of objects.
- Where necessary, added `update_if_cfg_view` to update fake cfg views.

related #7410