### PR TITLE
Improve casting to regclass over SQL adapter

### DIFF
--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -976,6 +976,31 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         )
         self.assertEqual(res, [[None]])
 
+    async def test_sql_query_static_eval_06(self):
+        # pg_relation_size requires regclass argument
+
+        res = await self.squery_values(
+            """
+            SELECT relname, pg_relation_size(tables.oid)
+            FROM pg_catalog.pg_class AS tables
+            JOIN pg_namespace pn ON (pn.oid = tables.relnamespace)
+            WHERE tables.relkind = 'r' AND pn.nspname = 'public'
+            ORDER BY relname;
+            """
+        )
+        self.assertEqual(res, [
+            ["Book", 8192],
+            ["Book.chapters", 8192],
+            ["Content", 8192],
+            ["Genre", 8192],
+            ["Movie", 8192],
+            ["Movie.actors", 8192],
+            ["Movie.director", 8192],
+            ["Person", 8192],
+            ["novel", 8192],
+            ["novel.chapters", 0],
+        ])
+
     async def test_sql_query_be_state(self):
         con = await self.connect(database=self.con.dbname)
         try:


### PR DESCRIPTION
EdgeDB has a limited support for casting into `regclass`, since a general solution would require parsing and resolving SQL identifiers *at runtime*. 

Instead, we have a "static casting into regclass from string". It basically parses and resolves the identifier and then looks-up the name in our introspection tables to get the oid.

We also have "static casting from integers" since that is basically just a cast into oid.

This PR adds "non-static casting from integer types", by assuming that any complex expression is of type integer and throwing a runtime exception if it isn't.

This allows us to support queries like this:
```sql
SELECT oid::regclass FROM pg_class;
```
