### PR TITLE
Unify the Rust python module and feature setup

### DIFF
--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -66,7 +66,7 @@ jobs:
         CARGO_TARGET_DIR: ${{ env.BUILD_TEMP }}/rust/extensions
         CARGO_HOME: ${{ env.BUILD_TEMP }}/rust/extensions/cargo_home
       run:
-        cargo test
+        cargo test --all-features
 
   python-test:
     needs: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,7 +411,7 @@ jobs:
         CARGO_TARGET_DIR: ${{ env.BUILD_TEMP }}/rust/extensions
         CARGO_HOME: ${{ env.BUILD_TEMP }}/rust/extensions/cargo_home
       run:
-        cargo test
+        cargo test --all-features
 
   python-test:
     needs: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,17 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,7 +462,6 @@ dependencies = [
  "snafu",
  "thiserror",
  "unicode-width",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -516,19 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -540,6 +516,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
+ "humantime",
  "log",
 ]
 
@@ -665,12 +642,12 @@ dependencies = [
 
 [[package]]
 name = "genetic_algorithm"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6310c399e71285ca3a06cedd9df0c5c7a53414316579b75883ca3d8521d594e5"
+checksum = "d7afd9309bb75c6ffc975e959a775f0deb92d66dcb505c9f7efcb97a4a7d4c85"
 dependencies = [
  "crossbeam",
- "env_logger 0.9.3",
+ "env_logger",
  "factorial",
  "itertools 0.10.5",
  "log",
@@ -744,15 +721,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1062,7 +1030,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1225,6 +1193,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
+ "serde",
  "unindent",
 ]
 
@@ -1691,21 +1660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-log"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
 dependencies = [
- "env_logger 0.11.3",
+ "env_logger",
  "test-log-macros",
  "tracing-subscriber",
 ]
@@ -1938,62 +1898,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
-dependencies = [
- "cfg-if",
- "serde",
- "serde_json",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
-
-[[package]]
 name = "wide"
 version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,15 +1922,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
+ "bytes",
  "libc",
  "mio",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+pyo3 = { version = "0.20.2", features = ["extension-module", "serde"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync", "net", "io-util"] }
+
 [profile.release]
 debug = true
 lto = true

--- a/edb/edgeql-parser/Cargo.toml
+++ b/edb/edgeql-parser/Cargo.toml
@@ -15,14 +15,11 @@ num-bigint = { version = "0.3.0", features = ["serde"] }
 sha2 = "0.10.2"
 snafu = "0.8.1"
 memchr = "2.5.0"
-wasm-bindgen = { version = "0.2", features = [
-    "serde-serialize"
-], optional = true }
 serde = { version = "1.0.106", features = ["derive"], optional = true }
 thiserror = "1.0.23"
 unicode-width = "0.1.8"
 edgeql-parser-derive = { path = "edgeql-parser-derive", optional = true }
-pyo3 = { version = "0.20.2", optional = true }
+pyo3 = { workspace = true, optional = true }
 indexmap = "1.9.3"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 bumpalo = { version = "3.13.0", features = ["collections"] }
@@ -31,7 +28,6 @@ append-only-vec = "0.1.2"
 
 [features]
 default = []
-wasm-lexer = ["wasm-bindgen", "serde"]
 python = ["pyo3", "serde", "edgeql-parser-derive"]
 
 [lib]

--- a/edb/edgeql-parser/Cargo.toml
+++ b/edb/edgeql-parser/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+pyo3 = { workspace = true, optional = true }
+
 base32 = "0.4.0"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 num-bigint = { version = "0.3.0", features = ["serde"] }
@@ -19,7 +21,6 @@ serde = { version = "1.0.106", features = ["derive"], optional = true }
 thiserror = "1.0.23"
 unicode-width = "0.1.8"
 edgeql-parser-derive = { path = "edgeql-parser-derive", optional = true }
-pyo3 = { workspace = true, optional = true }
 indexmap = "1.9.3"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 bumpalo = { version = "3.13.0", features = ["collections"] }

--- a/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
+++ b/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
@@ -10,8 +10,11 @@ workspace = true
 
 [features]
 python_extension = ["pyo3/extension-module"]
+default = ["python_extension"]
 
 [dependencies]
+pyo3 = { workspace = true, optional = true }
+
 edgeql-parser = { path = "..", features = ["serde"] }
 bytes = "1.0.1"
 num-bigint = "0.4.3"
@@ -21,7 +24,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 indexmap = "1.9.3"
 once_cell = "1.18.0"
-pyo3 = { workspace = true, optional = true }
 bincode = { version = "1.3.3" }
 
 [dependencies.edgedb-protocol]

--- a/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
+++ b/edb/edgeql-parser/edgeql-parser-python/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+python_extension = ["pyo3/extension-module"]
+
 [dependencies]
 edgeql-parser = { path = "..", features = ["serde"] }
 bytes = "1.0.1"
@@ -18,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 indexmap = "1.9.3"
 once_cell = "1.18.0"
-pyo3 = { version = "0.20.2", features = ["extension-module"] }
+pyo3 = { workspace = true, optional = true }
 bincode = { version = "1.3.3" }
 
 [dependencies.edgedb-protocol]

--- a/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(feature="python_extension")]
 mod errors;
 mod hash;
 mod keywords;

--- a/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(feature="python_extension")]
+#![cfg(feature = "python_extension")]
 mod errors;
 mod hash;
 mod keywords;

--- a/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
@@ -1,4 +1,4 @@
-#![cfg(feature="python_extension")]
+#![cfg(feature = "python_extension")]
 use edgeql_parser::tokenizer::Value;
 use edgeql_rust::normalize::{normalize, Variable};
 use num_bigint::BigInt;

--- a/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/tests/normalize.rs
@@ -1,3 +1,4 @@
+#![cfg(feature="python_extension")]
 use edgeql_parser::tokenizer::Value;
 use edgeql_rust::normalize::{normalize, Variable};
 use num_bigint::BigInt;

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -68,8 +68,6 @@ impl Error {
     }
 }
 
-#[cfg_attr(feature="wasm-bindgen",
-    wasm_bindgen::prelude::wasm_bindgen(js_name=TokenKind))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Kind {

--- a/edb/graphql-rewrite/Cargo.toml
+++ b/edb/graphql-rewrite/Cargo.toml
@@ -8,16 +8,17 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+python_extension = ["pyo3/extension-module"]
+
 [dependencies]
+pyo3 = { workspace = true, optional = true }
+
 combine = "3.8"
 thiserror = "1.0.11"
 num-bigint = "0.4.3"
 num-traits = "0.2.11"
 edb-graphql-parser = { git="https://github.com/edgedb/graphql-parser" }
-
-[dependencies.pyo3]
-version = "0.20.2"
-features = ["extension-module"]
 
 [dev-dependencies]
 pretty_assertions = "1.2.0"

--- a/edb/graphql-rewrite/Cargo.toml
+++ b/edb/graphql-rewrite/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [features]
 python_extension = ["pyo3/extension-module"]
+default = ["python_extension"]
 
 [dependencies]
 pyo3 = { workspace = true, optional = true }

--- a/edb/graphql-rewrite/src/lib.rs
+++ b/edb/graphql-rewrite/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(feature="python_extension")]
 mod py_entry;
 mod py_exception;
 mod py_token;

--- a/edb/graphql-rewrite/src/lib.rs
+++ b/edb/graphql-rewrite/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(feature="python_extension")]
+#![cfg(feature = "python_extension")]
 mod py_entry;
 mod py_exception;
 mod py_token;

--- a/edb/graphql-rewrite/src/lib.rs
+++ b/edb/graphql-rewrite/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(feature="python_extension")]
 mod py_entry;
 mod py_exception;
 mod py_token;

--- a/edb/graphql-rewrite/tests/rewrite.rs
+++ b/edb/graphql-rewrite/tests/rewrite.rs
@@ -1,4 +1,4 @@
-#![cfg(feature="python_extension")]
+#![cfg(feature = "python_extension")]
 use std::collections::BTreeMap;
 
 use edb_graphql_parser::Pos;

--- a/edb/graphql-rewrite/tests/rewrite.rs
+++ b/edb/graphql-rewrite/tests/rewrite.rs
@@ -1,3 +1,4 @@
+#![cfg(feature="python_extension")]
 use std::collections::BTreeMap;
 
 use edb_graphql_parser::Pos;

--- a/edb/server/conn_pool/Cargo.toml
+++ b/edb/server/conn_pool/Cargo.toml
@@ -13,9 +13,11 @@ python_extension = ["pyo3/extension-module"]
 optimizer = []
 
 [dependencies]
+pyo3 = { workspace = true, optional = true }
+tokio.workspace = true
+
 futures = "0"
 scopeguard = "1"
-pyo3 = "0"
 itertools = "0"
 thiserror = "1"
 tracing = "0"
@@ -24,15 +26,13 @@ strum = { version = "0.26", features = ["derive"] }
 consume_on_drop = "0"
 smart-default = "0"
 
-[dependencies.tokio]
-version = "1"
-features = ["rt", "time", "sync", "net"]
-
 [dependencies.derive_more]
 version = "1.0.0-beta.6"
 features = ["full"]
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
 pretty_assertions = "1.2.0"
 test-log = { version = "0", features = ["trace"] }
 anyhow = "1"
@@ -41,10 +41,6 @@ rand = "0"
 statrs = "0"
 genetic_algorithm = "0.7.2"
 lru = "0"
-
-[dev-dependencies.tokio]
-version = "1"
-features = ["macros", "rt-multi-thread", "time", "test-util"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/edb/server/conn_pool/Cargo.toml
+++ b/edb/server/conn_pool/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = "1"
 rstest = "0"
 rand = "0"
 statrs = "0"
-genetic_algorithm = "0"
+genetic_algorithm = "0.7.2"
 lru = "0"
 
 [dev-dependencies.tokio]

--- a/edb/server/conn_pool/src/pool.rs
+++ b/edb/server/conn_pool/src/pool.rs
@@ -1286,7 +1286,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "optimizer")]
+    #[cfg(all(feature = "optimizer", never))]
     fn optimizer() {
         use crate::knobs::*;
         use std::sync::atomic::AtomicIsize;

--- a/edb/server/conn_pool/src/python.rs
+++ b/edb/server/conn_pool/src/python.rs
@@ -338,7 +338,7 @@ impl ConnPool {
             .map_err(|_| internal_error("In shutdown"))
     }
 
-    fn _failed(&self, id: u64, error: PyObject) -> PyResult<()> {
+    fn _failed(&self, id: u64, _error: PyObject) -> PyResult<()> {
         self.python_to_rust
             .send(PythonToRustMessage::FailedAsync(ConnHandleId(id)))
             .map_err(|_| internal_error("In shutdown"))

--- a/edb/server/edbrust/Cargo.toml
+++ b/edb/server/edbrust/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "edbrust"
+version = "0.1.0"
+license = "MIT/Apache-2.0"
+authors = ["MagicStack Inc. <hello@magic.io>"]
+edition = "2021"
+
+[lint]
+workspace = true
+
+[features]
+python_extension = ["pyo3/extension-module", "pyo3/serde"]
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+tokio.workspace = true
+
+[dependencies.derive_more]
+version = "1.0.0-beta.6"
+features = ["full"]
+
+[dev-dependencies]
+pretty_assertions = "1.2.0"
+test-log = { version = "0", features = ["trace"] }
+anyhow = "1"
+rstest = "0"
+statrs = "0"
+lru = "0"
+byteorder = "1.5"
+clap = "4"
+clap_derive = "4"
+hex-literal = "0.4"
+
+[dev-dependencies.tokio]
+version = "1"
+features = ["test-util"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+path = "src/lib.rs"

--- a/edb/server/edbrust/edbrust-util/Cargo.toml
+++ b/edb/server/edbrust/edbrust-util/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "edbrust-rust"
+version = "0.1.0"
+license = "MIT/Apache-2.0"
+authors = ["MagicStack Inc. <hello@magic.io>"]
+edition = "2021"
+
+[lint]
+workspace = true
+
+[features]
+python_extension = ["pyo3/extension-module", "pyo3/serde"]
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+tokio.workspace = true
+
+[lib]
+crate-type = ["lib", "cdylib"]
+path = "src/lib.rs"

--- a/setup.py
+++ b/setup.py
@@ -1119,11 +1119,13 @@ setuptools.setup(
         setuptools_rust.RustExtension(
             "edb._edgeql_parser",
             path="edb/edgeql-parser/edgeql-parser-python/Cargo.toml",
+            features=["python_extension"],
             binding=setuptools_rust.Binding.PyO3,
         ),
         setuptools_rust.RustExtension(
             "edb._graphql_rewrite",
             path="edb/graphql-rewrite/Cargo.toml",
+            features=["python_extension"],
             binding=setuptools_rust.Binding.PyO3,
         ),
         setuptools_rust.RustExtension(


### PR DESCRIPTION
Some AOT work to support a PyO3 upgrade and start on the way to a more optimal, monolithic Rust library to provide python services.

 - Start work on upgrading pyo3 by unifying the pyo3 and tokio versions into the workspace root.
 - Create a universal `python_extension` feature for all modules (older modules turn this on by default and the entire module is disabled if using `--no-default-features`). This feature may be adjusted in the future as we upgrade `pyo3` further.
 - Ensure that `cargo test`, `cargo test --all-features`, and `cargo test --no-default-features` all work.
 - The `wasm-bindgen` feature of `edgeql-parser` had rotted and has been removed entirely.
