### PR TITLE
Add _cqa_rust_ to rust code quality tests

### DIFF
--- a/tests/test_sourcecode.py
+++ b/tests/test_sourcecode.py
@@ -108,7 +108,7 @@ class TestCodeQuality(unittest.TestCase):
                 raise AssertionError(
                     f'mypy validation failed:\n{output}') from None
 
-    def test_clippy(self):
+    def test_cqa_rust_clippy(self):
         edgepath = find_edgedb_root()
         config_path = os.path.join(edgepath, 'Cargo.toml')
         if not os.path.exists(config_path):
@@ -134,7 +134,7 @@ class TestCodeQuality(unittest.TestCase):
             raise AssertionError(
                 f'clippy validation failed:\n{output}') from None
 
-    def test_rustfmt(self):
+    def test_cqa_rust_rustfmt(self):
         edgepath = find_edgedb_root()
         config_path = os.path.join(edgepath, 'Cargo.toml')
         if not os.path.exists(config_path):


### PR DESCRIPTION
This fixes the build (e.g. nightly) CI.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/10494864841)