### PR TITLE
Include secrets in config objects when dumping with --include-secrets

### DIFF
--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -420,8 +420,12 @@ def value_from_json(spec, setting, value: str):
     return value_from_json_value(spec, setting, json.loads(value))
 
 
-def value_to_edgeql_const(type: type | types.ConfigTypeSpec, value: Any) -> str:
-    ql = s_utils.const_ast_from_python(value)
+def value_to_edgeql_const(
+    type: type | types.ConfigTypeSpec,
+    value: Any,
+    with_secrets: bool,
+) -> str:
+    ql = s_utils.const_ast_from_python(value, with_secrets=with_secrets)
     return qlcodegen.generate_source(ql)
 
 
@@ -498,11 +502,15 @@ def to_edgeql(
                 # a subtype could have a secret that the parent doesn't.
                 if x._tspec.has_secret and not with_secrets:
                     continue
-                val = value_to_edgeql_const(setting.type, x)
+                val = value_to_edgeql_const(
+                    setting.type, x, with_secrets=with_secrets
+                )
                 stmt = f'CONFIGURE {value.scope.to_edgeql()}\n{val};'
                 stmts.append(stmt)
         else:
-            val = value_to_edgeql_const(setting.type, value.value)
+            val = value_to_edgeql_const(
+                setting.type, value.value, with_secrets=with_secrets
+            )
             stmt = f'CONFIGURE {value.scope.to_edgeql()} SET {name} := {val};'
             stmts.append(stmt)
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1707,7 +1707,9 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
 
         await check_method(self)
 
-    async def check_dump_restore(self, check_method):
+    async def check_dump_restore(
+        self, check_method, include_secrets: bool=False
+    ):
         if not self.has_create_database:
             return await self.check_dump_restore_single_db(check_method)
 
@@ -1716,8 +1718,9 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
         q_tgt_dbname = qlquote.quote_ident(tgt_dbname)
         with tempfile.TemporaryDirectory() as f:
             fname = os.path.join(f, 'dump')
+            extra = ['--include-secrets'] if include_secrets else []
             await asyncio.to_thread(
-                self.run_cli, '-d', src_dbname, 'dump', fname
+                self.run_cli, '-d', src_dbname, 'dump', fname, *extra
             )
 
             await self.con.execute(f'CREATE DATABASE {q_tgt_dbname}')


### PR DESCRIPTION
We were incorrectly including objects with the secrets but failing to
plumb the flag into the code path that handled the fields inside the
object.