### PR TITLE
Validation of object ids of prior DML over SQL

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -582,6 +582,8 @@ class UpdateQuery(Query):
 
     where: typing.Optional[Expr] = None
 
+    sql_mode_link_only: bool = False
+
 
 class DeleteQuery(Query):
     subject: Expr

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -733,9 +733,11 @@ def declare_view(
             cached_view_set = ctx.env.expr_view_cache.get((expr, alias))
             # Detach the view namespace and record the prefix
             # in the parent statement's fence node.
-            view_path_id_ns = ctx.aliases.get('ns')
-            subctx.path_id_namespace |= {view_path_id_ns}
-            ctx.path_scope.add_namespaces({view_path_id_ns})
+            view_path_id_ns = {ctx.aliases.get('ns')}
+            # if view_path_id_ns == {'ns~3'}:
+            #     view_path_id_ns = set()
+            subctx.path_id_namespace |= view_path_id_ns
+            ctx.path_scope.add_namespaces(view_path_id_ns)
         else:
             cached_view_set = None
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1313,6 +1313,8 @@ class UpdateStmt(MutatingStmt, FilteredStmt):
         assert self._material_type
         return self._material_type
 
+    sql_mode_link_only: bool = False
+
 
 class DeleteStmt(MutatingStmt, FilteredStmt):
     _material_type: TypeRef | None = None

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -173,6 +173,11 @@ class EdgeQLPathInfo(Base):
     # A subset of paths necessary to perform joining.
     path_bonds: typing.Set[tuple[irast.PathId, bool]] = ast.field(factory=set)
 
+    # Whether to ignore namespaces when looking at path outputs.
+    # TODO: Maybe instead, Relation should have a way of specifying
+    # output by PointerRef instead.
+    strip_output_namespaces: bool = False
+
     # Map of res target names corresponding to paths.
     path_outputs: typing.Dict[
         typing.Tuple[irast.PathId, PathAspect], OutputVar

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1141,6 +1141,7 @@ def _get_rel_path_output(
         result = pgast.ColumnRef(name=[name], nullable=True)
     else:
         if ptrref is None or ptr_info is None:
+            breakpoint()
             raise LookupError(
                 f'could not resolve trailing pointer class for {path_id}')
 
@@ -1221,6 +1222,10 @@ def get_path_output(
 
     if isinstance(rel, pgast.Query) and flavor == 'normal':
         path_id = map_path_id(path_id, rel.view_path_id_map)
+
+    # XXX: This is a haaaaack.
+    if rel.strip_output_namespaces:
+        path_id = path_id.strip_namespace(path_id.namespace)
 
     return _get_path_output(rel, path_id=path_id, aspect=aspect,
                             disable_output_fusion=disable_output_fusion,

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1141,7 +1141,6 @@ def _get_rel_path_output(
         result = pgast.ColumnRef(name=[name], nullable=True)
     else:
         if ptrref is None or ptr_info is None:
-            breakpoint()
             raise LookupError(
                 f'could not resolve trailing pointer class for {path_id}')
 

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -616,8 +616,8 @@ def _construct_cast_from_uuid_to_obj_type(
 
 
 def _add_pointer(
-    name: str,
     source: s_objtypes.ObjectType,
+    name: str,
     target_scls: s_types.Type,
     *,
     ctx: Context,
@@ -690,8 +690,8 @@ def _uncompile_insert_pointer_stmt(
         transient=True,
     )
 
-    src_ptr = _add_pointer('__source__', dummy_ty, sub_source, ctx=ctx)
-    tgt_ptr = _add_pointer('__target__', dummy_ty, sub_target, ctx=ctx)
+    src_ptr = _add_pointer(dummy_ty, '__source__', sub_source, ctx=ctx)
+    tgt_ptr = _add_pointer(dummy_ty, '__target__', sub_target, ctx=ctx)
 
     # prepare anchors for inserted value columns
     value_name = ctx.alias_generator.get('ins_val')
@@ -736,7 +736,7 @@ def _uncompile_insert_pointer_stmt(
             ptr = sub.maybe_get_ptr(ctx.schema, sn.UnqualName(ptr_name))
             assert ptr
             lprop_tgt = not_none(ptr.get_target(ctx.schema))
-            lprop_ptr = _add_pointer(ptr_name, dummy_ty, lprop_tgt, ctx=ctx)
+            lprop_ptr = _add_pointer(dummy_ty, ptr_name, lprop_tgt, ctx=ctx)
             ptr_id = _get_ptr_id(base_id, lprop_ptr, ctx=ctx)
 
             is_link = False

--- a/edb/tools/test/results.py
+++ b/edb/tools/test/results.py
@@ -244,13 +244,13 @@ def render_result(
     _echo(file)
 
     # cases
-    for case in result.warnings:
+    for case in sorted(result.warnings, key=lambda c: c.id):
         _print_case_result(file, case, 'WARNING', 'yellow')
-    for case in result.errors:
+    for case in sorted(result.errors, key=lambda c: c.id):
         _print_case_result(file, case, 'ERROR', 'red')
-    for case in result.failures:
+    for case in sorted(result.failures, key=lambda c: c.id):
         _print_case_result(file, case, 'FAIL', 'red')
-    for case in result.unexpected_successes:
+    for case in sorted(result.unexpected_successes, key=lambda c: c.id):
         _print_case_result(file, case, 'UNEXPECTED SUCCESS', 'red')
 
     # outcome

--- a/tests/test_sql_dml.py
+++ b/tests/test_sql_dml.py
@@ -1652,7 +1652,7 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
         await self.squery_values(
             'INSERT INTO "Document" DEFAULT VALUES',
         )
-        
+
         res = await self.scon.execute(
             '''
             WITH
@@ -1693,20 +1693,20 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             'SELECT id, title FROM "Document" ORDER BY title',
         )
         self.assertEqual(len(res), 2)
-        inserted_id, inserted_title = res[0]
-        top_level = res[1]
+        existing_id, existing_title = res[0]
+        _inserted_id, inserted_title = res[1]
 
-        self.assertEqual(inserted_title, 'Report (updated)')
+        self.assertEqual(existing_title, 'Report (updated)')
         self.assertEqual(
-            top_level[1],
-            'X' + str(inserted_id) + ',' + inserted_title + ' (new)',
+            inserted_title,
+            'X' + str(existing_id) + ',' + existing_title + ' (new)',
         )
 
     async def test_sql_dml_update_16(self):
         [[doc_id]] = await self.squery_values(
             'INSERT INTO "Document" DEFAULT VALUES RETURNING id'
         )
-        
+
         res = await self.squery_values(
             '''
             WITH
@@ -1719,14 +1719,24 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             '''
         )
         user_id = res[0][1]
-        self.assertEqual(res, [[doc_id, user_id], ])
+        self.assertEqual(
+            res,
+            [
+                [doc_id, user_id],
+            ],
+        )
 
         res = await self.squery_values(
             '''
             SELECT id, owner_id FROM "Document"
             '''
         )
-        self.assertEqual(res, [[doc_id, user_id], ])
+        self.assertEqual(
+            res,
+            [
+                [doc_id, user_id],
+            ],
+        )
 
     async def test_sql_dml_01(self):
         # update/delete only

--- a/tests/test_sql_dml.py
+++ b/tests/test_sql_dml.py
@@ -92,6 +92,11 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             set default := global y;
           };
         };
+
+        create type Document2 {
+            create required property title: str;
+            create link owner: User;
+        };
     """
     ]
 
@@ -854,6 +859,28 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             ''',
         )
         self.assertEqual(res, 'INSERT 0 1')
+
+    async def test_sql_dml_insert_40(self):
+        await self.squery_values(
+            f'''
+            INSERT INTO "User" DEFAULT VALUES
+            '''
+        )
+
+        res = await self.scon.execute(
+            f'''
+            INSERT INTO "Document2" (title, owner_id)
+            VALUES ('Raven', (select id FROM "User" LIMIT 1))
+            '''
+        )
+        self.assertEqual(res, 'INSERT 0 1')
+
+        res = await self.squery_values(
+            '''
+            SELECT title FROM "Document2"
+            '''
+        )
+        self.assertEqual(res, [['Raven']])
 
     async def test_sql_dml_delete_01(self):
         # delete, inspect CommandComplete tag


### PR DESCRIPTION
Ref #7294

## Problem

Such SQL queries:
```SQL
WITH inserted as (INSERT INTO "User" (name) VALUES ('aljaz') RETURNING id)
INSERT INTO "Document" (owner_id) SELECT id FROM inserted
```
... and uncompiled into this EdgeQL:
```
with
  dml_0 := (
    for x in `ins_val~0` union
      insert User { name := x.name }
  ),
  dml_1 := (
    for x in `ins_val~1` union
      insert Document { owner := (select User filter .id = x.owner.id) }
  )
select { dml_0, dml_1 }
```
... where `ins_val~0` and `ins_val~1` are `IRAnchor`s which are provided by the SQL query.

The problem is that with dml_1, `select User` will not contain the object inserted in dml_0.
It would error out, saying that `User` with this id does not exists.

This is a known limitation of EdgeQL (and has its reasons). But it cannot be justified in the original SQL, because there are no SELECT from base tables.

## Solution

This PR replaces `(select User filter .id = x.owner.id)` with `select {User, dml_0} filter .id = x.owner.id`. To be precise, it is replaced with:

```
if exists x.owner
  select {User, dml_0}
  filter .id = x.owner.id
  limit 1
else
  {}
```

---

Currently this is done for links in object insert/updates only.

TODO:
- [x] fix single row optimization,
- [x] inserting link's source,
- [x] inserting link's target,
- [x] ~deleting object's id~ [not needed as this cannot happen because of Postgres rules around DML](https://github.com/edgedb/edgedb/pull/7672#issuecomment-2411320341),
- [x] ~deleting link's source~ ditto,
- [x] ~updating object's id~ ditto,

---

This PR also contains additional minor changes:
- test result sorting,
- cleanup to remove `detached` in DML (it is apparently not needed anymore),
- fix for scope tree's find_visible_ex (that give me problems in prior attempts at this),