### PR TITLE
Add SDL to migrations.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_08_27_00_02
+EDGEDB_CATALOG_VERSION = 2024_08_29_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -779,6 +779,10 @@ class CreateMigration(CreateObject, MigrationCommand):
     parent: typing.Optional[ObjectRef] = None
     metadata_only: bool = False
 
+    # Sometimes the target SDL of a migration can be known in advance.
+    # eg. when doing `start migration to`
+    target_sdl: typing.Optional[str] = None
+
 
 class CommittedSchema(DDL):
     pass

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -38,6 +38,9 @@ CREATE ABSTRACT INHERITABLE ANNOTATION cfg::affects_compilation;
 
 CREATE SCALAR TYPE cfg::memory EXTENDING std::anyscalar;
 CREATE SCALAR TYPE cfg::AllowBareDDL EXTENDING enum<AlwaysAllow, NeverAllow>;
+CREATE SCALAR TYPE cfg::StoreMigrationSDL EXTENDING enum<
+    AlwaysStore, NeverStore,
+>;
 CREATE SCALAR TYPE cfg::ConnectionTransport EXTENDING enum<
     TCP, TCP_PG, HTTP, SIMPLE_HTTP, HTTP_METRICS, HTTP_HEALTH>;
 CREATE SCALAR TYPE cfg::QueryCacheMode EXTENDING enum<
@@ -166,6 +169,13 @@ ALTER TYPE cfg::AbstractConfig {
         CREATE ANNOTATION cfg::affects_compilation := 'true';
         CREATE ANNOTATION std::description :=
             'Whether DDL is allowed to be executed outside a migration.';
+    };
+
+    CREATE PROPERTY store_migration_sdl -> cfg::StoreMigrationSDL {
+        SET default := cfg::StoreMigrationSDL.NeverStore;
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION std::description :=
+            'When to store resulting SDL of a Migration. This may be slow.';
     };
 
     CREATE PROPERTY apply_access_policies -> std::bool {

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -573,6 +573,7 @@ CREATE TYPE schema::Migration
 {
     CREATE MULTI LINK parents -> schema::Migration;
     CREATE REQUIRED PROPERTY script -> str;
+    CREATE PROPERTY sdl -> str;
     CREATE PROPERTY message -> str;
     CREATE PROPERTY generated_by -> schema::MigrationGeneratedBy;
 };

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -661,6 +661,7 @@ def delta_from_ddl(
     stdmode: bool=False,
     testmode: bool=False,
     allow_dml_in_functions: bool=False,
+    store_migration_sdl: bool=False,
     schema_object_ids: Optional[
         Mapping[Tuple[sn.Name, Optional[str]], uuid.UUID]
     ]=None,
@@ -673,6 +674,7 @@ def delta_from_ddl(
         stdmode=stdmode,
         testmode=testmode,
         allow_dml_in_functions=allow_dml_in_functions,
+        store_migration_sdl=store_migration_sdl,
         schema_object_ids=schema_object_ids,
         compat_ver=compat_ver,
     )
@@ -688,6 +690,7 @@ def delta_and_schema_from_ddl(
     internal_schema_mode: bool=False,
     testmode: bool=False,
     allow_dml_in_functions: bool=False,
+    store_migration_sdl: bool=False,
     schema_object_ids: Optional[
         Mapping[Tuple[sn.Name, Optional[str]], uuid.UUID]
     ]=None,
@@ -701,6 +704,7 @@ def delta_and_schema_from_ddl(
         internal_schema_mode=internal_schema_mode,
         testmode=testmode,
         allow_dml_in_functions=allow_dml_in_functions,
+        store_migration_sdl=store_migration_sdl,
         schema_object_ids=schema_object_ids,
         compat_ver=compat_ver,
     )

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1292,6 +1292,7 @@ class CommandContext:
         internal_schema_mode: bool = False,
         disable_dep_verification: bool = False,
         allow_dml_in_functions: bool = False,
+        store_migration_sdl: bool = False,
         descriptive_mode: bool = False,
         schema_object_ids: Optional[
             Mapping[Tuple[sn.Name, Optional[str]], uuid.UUID]
@@ -1314,6 +1315,7 @@ class CommandContext:
         self.descriptive_mode = descriptive_mode
         self.disable_dep_verification = disable_dep_verification
         self.allow_dml_in_functions = allow_dml_in_functions
+        self.store_migration_sdl = store_migration_sdl
         self.renames: Dict[sn.Name, sn.Name] = {}
         self.early_renames: Dict[sn.Name, sn.Name] = {}
         self.renamed_objs: Set[so.Object] = set()

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -222,6 +222,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         ):
             # If target sdl was not known in advance, compute it now.
             new_sdl: str = s_ddl.sdl_text_from_schema(new_schema)
+            new_schema = self.scls.set_field_value(new_schema, 'sdl', new_sdl)
             self.set_attribute_value('sdl', new_sdl)
 
         return new_schema

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -134,9 +134,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         hasher.add_source(ddl_text)
         name = hasher.make_migration_id()
 
-        sdl_text = ''
-        if astnode.target_sdl:
-            sdl_text = astnode.target_sdl
+        sdl_text: Optional[str] = astnode.target_sdl
 
         if specified_name is not None and name != specified_name:
             raise errors.SchemaDefinitionError(
@@ -218,7 +216,10 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
 
         new_schema = super().apply(schema, context)
 
-        if not self.get_attribute_value('sdl'):
+        if (
+            context.store_migration_sdl
+            and not self.get_attribute_value('sdl')
+        ):
             # If target sdl was not known in advance, compute it now.
             new_sdl: str = s_ddl.sdl_text_from_schema(new_schema)
             self.set_attribute_value('sdl', new_sdl)

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -165,6 +165,9 @@ def compile_and_apply_ddl_stmt(
             is_transactional=True,
         )
 
+    if isinstance(stmt, qlast.CreateMigration):
+        stmt.target_sdl = s_ddl.sdl_text_from_schema(new_schema)
+
     # If we are in a migration rewrite, we also don't actually
     # apply the DDL, just record it. (The DDL also needs to be a
     # CreateMigration.)
@@ -822,6 +825,7 @@ def _commit_migration(
             commands=mstate.accepted_cmds  # type: ignore
         ),
         parent=last_migration_ref,
+        target_sdl=s_ddl.sdl_text_from_schema(schema),
     )
 
     current_tx.update_schema(mstate.initial_schema)

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -165,7 +165,11 @@ def compile_and_apply_ddl_stmt(
             is_transactional=True,
         )
 
-    if isinstance(stmt, qlast.CreateMigration):
+    store_migration_sdl = compiler._get_config_val(ctx, 'store_migration_sdl')
+    if (
+        isinstance(stmt, qlast.CreateMigration)
+        and store_migration_sdl == 'AlwaysStore'
+    ):
         stmt.target_sdl = s_ddl.sdl_text_from_schema(new_schema)
 
     # If we are in a migration rewrite, we also don't actually
@@ -298,6 +302,9 @@ def _get_delta_context_args(ctx: compiler.CompileContext) -> dict[str, Any]:
         allow_dml_in_functions=(
             compiler._get_config_val(ctx, 'allow_dml_in_functions')
         ),
+        store_migration_sdl=(
+            compiler._get_config_val(ctx, 'store_migration_sdl')
+        ) == 'AlwaysStore',
         schema_object_ids=ctx.schema_object_ids,
         compat_ver=ctx.compat_ver,
     )
@@ -820,12 +827,17 @@ def _commit_migration(
     else:
         last_migration_ref = None
 
+    target_sdl: Optional[str] = None
+    store_migration_sdl = compiler._get_config_val(ctx, 'store_migration_sdl')
+    if store_migration_sdl == 'AlwaysStore':
+        target_sdl = s_ddl.sdl_text_from_schema(schema)
+
     create_migration = qlast.CreateMigration(  # type: ignore
         body=qlast.NestedQLBlock(
             commands=mstate.accepted_cmds  # type: ignore
         ),
         parent=last_migration_ref,
-        target_sdl=s_ddl.sdl_text_from_schema(schema),
+        target_sdl=target_sdl,
     )
 
     current_tx.update_schema(mstate.initial_schema)


### PR DESCRIPTION
Add a config property `store_migration_sdl` with two options `cfg::StoreMigrationSDL::NeverStore` and `cfg::StoreMigrationSDL::AlwaysStore`.

When this is set to `cfg::StoreMigrationSDL::AlwaysStore`, during migrations or migration rewrites, the stored `schema::Migration` objects will have their resulting SDL saved.

related #7621
