### PR TITLE
CI: fix Rust toolchain on macOS

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -129,12 +129,6 @@
 <% endif %>
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -142,12 +136,25 @@
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -971,12 +971,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -984,12 +978,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -1035,12 +1042,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -1048,12 +1049,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -976,12 +976,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -989,12 +983,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -1040,12 +1047,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -1053,12 +1054,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -518,12 +518,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -531,12 +525,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -580,12 +587,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -593,12 +594,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -540,12 +540,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -553,12 +547,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -603,12 +610,6 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - name: Update Homebrew before installing Rust toolchain
       run: |
         # Homebrew renamed `rustup-init` to `rustup`:
@@ -616,12 +617,25 @@ jobs:
         # But the GitHub Action runner is not updated with this change yet.
         # This caused the later `brew update` in step `Build` to relink Rust
         # toolchain executables, overwriting the custom toolchain installed by
-        # `dtolnay/rust-toolchain`. So let's just run `brew update` early.
+        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
         brew update
+
+    - uses: actions/checkout@v4
+      if: true
+      with:
+        sparse-checkout: |
+          rust-toolchain.toml
+        sparse-checkout-cone-mode: false
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
       if: true
+
+    - uses: actions/checkout@v4
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-pkg
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
Thanks @mmastrac for the fix. Looks like the toolchain.toml checkout should go before the edgedb-pkg checkout, or the latter will get overwritten.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/10510224013)