### PR TITLE
Fix some potentially nondeterministic tests

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_08_22_00_00
+EDGEDB_CATALOG_VERSION = 2024_08_23_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -371,6 +371,13 @@ std::_current_setting(sqlname: str) -> OPTIONAL std::str {
 };
 
 
+create function std::_set_config(sqlname: std::str, val: std::str) -> std::str {
+    using sql $$
+      select set_config(sqlname, val, true)
+    $$;
+};
+
+
 CREATE MODULE std::_test;
 
 

--- a/tests/schemas/explain_setup.edgeql
+++ b/tests/schemas/explain_setup.edgeql
@@ -133,14 +133,6 @@ SET {
 };
 
 
-# Add a function that disables sequential scan.
-create function _set_seqscan(val: std::str) -> std::str {
-    using sql $$
-      select set_config('enable_seqscan', val, true)
-    $$;
-};
-
-
 # Generate some data ...
 for i in range_unpack(range(1, 10)) union (
   with u := (insert User { name := <str>i }),

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -43,9 +43,3 @@ type Stuff extending Astronomy {
 type Star extending Astronomy;
 
 type Supernova extending Star;
-
-function _set_seqscan(val: std::str) -> std::str {
-    using sql $$
-      select set_config('enable_seqscan', val, true)
-    $$;
-};

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -57,7 +57,9 @@ class TestEdgeQLExplain(tb.QueryTestCase):
         con = (con or self.con)
         # Disable sequential scan so that we hit the index even on small
         # datasets.
-        await con.query_single('select _set_seqscan("off")')
+        await self.con.query_single(
+            'select _set_config("enable_seqscan", "off")'
+        )
         no_ex = '(execute := False) ' if not execute else ''
         return json.loads(await con.query_single(
             f'analyze {no_ex}{query}'

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2462,7 +2462,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                         name,
                         owners: {
                             name
-                        },
+                        } ORDER BY .name,
                     } ORDER BY .name
                 } FILTER .name = 'Alice';
             """,
@@ -3929,10 +3929,10 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 filter .name = 'Djinn';
             ''',
             [
-                {"name": "Djinn", "owners": [
-                    {"name": "Carol"}, {"name": "Dave"}]},
-                {"name": "Djinn", "owners": [
-                    {"name": "Carol"}, {"name": "Dave"}]}
+                {"name": "Djinn", "owners": tb.bag([
+                    {"name": "Carol"}, {"name": "Dave"}])},
+                {"name": "Djinn", "owners": tb.bag([
+                    {"name": "Carol"}, {"name": "Dave"}])},
             ],
         )
 

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -3979,27 +3979,27 @@ class TestUpdate(tb.QueryTestCase):
             [
                 {
                     'name': 'update-test1',
-                    'weighted_tags': [
+                    'weighted_tags': tb.bag([
                         {'name': 'fun', '@note': 'a'},
                         {'name': 'boring', '@note': 'a'},
                         {'name': 'wow', '@note': 'a'}
-                    ],
+                    ]),
                 },
                 {
                     'name': 'update-test2',
-                    'weighted_tags': [
+                    'weighted_tags': tb.bag([
                         {'name': 'fun', '@note': 'a'},
                         {'name': 'boring', '@note': 'a'},
                         {'name': 'wow', '@note': 'a'}
-                    ],
+                    ]),
                 },
                 {
                     'name': 'update-test3',
-                    'weighted_tags': [
+                    'weighted_tags': tb.bag([
                         {'name': 'fun', '@note': 'a'},
                         {'name': 'boring', '@note': 'a'},
                         {'name': 'wow', '@note': 'a'}
-                    ],
+                    ]),
                 },
             ],
         )

--- a/tests/test_edgeql_vector.py
+++ b/tests/test_edgeql_vector.py
@@ -706,6 +706,10 @@ class TestEdgeQLVector(tb.QueryTestCase):
             else:
                 return False
 
+        await self.con.query_single(
+            'select _set_config("enable_seqscan", "off")'
+        )
+
         plan = await self.con.query_json(f'analyze {query}', *args)
         if not look(json.loads(plan)):
             raise AssertionError(f'query did not use {index_type} index')

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -338,7 +338,9 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                 return False
 
         async with self._run_and_rollback():
-            await self.con.execute('select _set_seqscan("off");')
+            await self.con.query_single(
+                'select _set_config("enable_seqscan", "off")'
+            )
             plan = await self.con.query_json(f'analyze {query};', *args)
         if not look(json.loads(plan)):
             raise AssertionError(f'query did not use ext::ai::index index')


### PR DESCRIPTION
One involved needing to disable seqscans when analyzing, so I made a
_testmode function for that instead of needing to duplicate it in
every test suite that needs it.