### PR TITLE
Stop using catalog version for the default tenant id

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_08_23_00_00
+EDGEDB_CATALOG_VERSION = 2024_08_23_00_01
 EDGEDB_MAJOR_VERSION = 6
 
 
@@ -585,8 +585,7 @@ def get_cache_src_dirs():
 
 
 def get_default_tenant_id() -> str:
-    catver = EDGEDB_CATALOG_VERSION
-    return f'V{catver:x}'
+    return 'E'
 
 
 def get_version_line() -> str:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -625,7 +625,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
             runstate_dir=None if devmode.is_in_dev_mode() else td,
             reset_auth=True,
             ignore_other_tenants=True,
-            env={'EDGEDB_TEST_CATALOG_VERSION': '3022_01_07_00_00'},
+            env={'EDGEDB_SERVER_TENANT_ID': 'asdf'},
         ) as sd:
             con = await sd.connect()
             await con.aclose()


### PR DESCRIPTION
I don't think it ever is really helpful, except maybe in some dev
situations where we don't actually use it.

Anybody relying on tenant ids almost certainly needs to be specifying
them explicitly to get anything to work.

Just use `'E`' as the tenant id. This will give us nice predictible
database names and eases inplace upgrades.