### PR TITLE
Fix DML with Execute limit over SQL adapter

### DIFF
--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1796,7 +1796,7 @@ cdef class PGConnection:
                     pass
                 elif isinstance(
                     action.query_unit.command_complete_tag,
-                    dbstate.TagUnpackRow,
+                    (dbstate.TagCountMessages, dbstate.TagUnpackRow),
                 ):
                     # when executing TagUnpackRow, don't pass the limit through
                     msg_buf = WriteBuffer.new_message(b'E')

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1792,7 +1792,19 @@ cdef class PGConnection:
                     # on this connection, so there's nothing to DEALLOCATE.
                     action.frontend_only = True
 
-                if not action.is_frontend_only():
+                if action.is_frontend_only():
+                    pass
+                elif isinstance(
+                    action.query_unit.command_complete_tag,
+                    dbstate.TagUnpackRow,
+                ):
+                    # when executing TagUnpackRow, don't pass the limit through
+                    msg_buf = WriteBuffer.new_message(b'E')
+                    msg_buf.write_bytestring(action.portal_name)
+                    msg_buf.write_int32(0)
+                    buf.write_buffer(msg_buf.end_message())
+                else:
+                    # base case
                     msg_buf = WriteBuffer.new_message(b'E')
                     msg_buf.write_bytestring(action.portal_name)
                     msg_buf.write_int32(action.args)
@@ -2054,8 +2066,7 @@ cdef class PGConnection:
                     if self.debug:
                         self.debug_print('END OF DESCRIBE', mtype)
                     if (
-                        mtype == b'T' and 
-                        action.action == PGAction.DESCRIBE_STMT_ROWS and
+                        mtype == b'T' and
                         isinstance(
                             action.query_unit.command_complete_tag,
                             dbstate.TagUnpackRow,
@@ -2068,10 +2079,9 @@ cdef class PGConnection:
                         # that col.
                         is_binary_format = data[-1] == 1
 
-                        if is_binary_format:
-                            # TagUnpackRow converts RowDescription into NoData
-                            msg_buf = WriteBuffer.new_message(b'n')
-                            buf.write_buffer(msg_buf.end_message())
+                        # TagUnpackRow converts RowDescription into NoData
+                        msg_buf = WriteBuffer.new_message(b'n')
+                        buf.write_buffer(msg_buf.end_message())
 
                     elif not action.is_injected() and not (
                         mtype == b'n' and
@@ -2153,7 +2163,6 @@ cdef class PGConnection:
 
                     if (
                         not action.is_injected()
-                        and mtype == b'C'
                         and action.query_unit.command_complete_tag
                     ):
                         tag = action.query_unit.command_complete_tag


### PR DESCRIPTION
This PR sets row limit in `Execute` command over SQL adapter to 0 when we are injecting `CommandComplete` tags.

### Background

For queries like this one:
```
INSERT INTO X VALUES ... RETURNING ...
```
... we count number of rows returned and add a `CommandComplete("INSERT 0 n")` where `n` is the number of rows in response.

Because of this, we must not set result row limit in `Execute` command message, since that would change the number of reported modified rows.
