### PR TITLE
Bump PyO3 to 0.22.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,12 +170,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
@@ -387,7 +381,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
  "unicode-xid",
 ]
 
@@ -433,7 +427,7 @@ version = "0.6.0"
 source = "git+https://github.com/edgedb/edgedb-rust#3e08a284abf97e09414b0a3e9bd71edf0e5a84be"
 dependencies = [
  "bigdecimal",
- "bitflags 2.4.2",
+ "bitflags",
  "bytes",
  "edgedb-errors",
  "num-bigint 0.4.4",
@@ -591,7 +585,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -809,16 +803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,7 +897,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1056,29 +1040,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.5",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,7 +1075,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1171,24 +1132,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1199,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1209,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1219,27 +1180,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1318,15 +1279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,7 +1354,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.52",
+ "syn 2.0.75",
  "unicode-ident",
 ]
 
@@ -1471,7 +1423,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1548,7 +1500,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1569,7 +1521,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1622,7 +1574,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1644,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1678,7 +1630,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1698,7 +1650,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1736,7 +1688,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1775,7 +1727,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2101,5 +2053,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.75",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-pyo3 = { version = "0.20.2", features = ["extension-module", "serde"] }
+pyo3 = { version = "0.22.2", features = ["extension-module", "serde"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync", "net", "io-util"] }
 
 [profile.release]

--- a/edb/edgeql-parser/edgeql-parser-derive/src/lib.rs
+++ b/edb/edgeql-parser/edgeql-parser-derive/src/lib.rs
@@ -143,7 +143,7 @@ fn impl_struct_into_python(struct_: &mut syn::ItemStruct) -> TokenStream {
             ) -> cpython::PyResult<cpython::PyObject> {
                 use crate::into_python::IntoPython;
 
-                let kw_args = parent_kw_args.unwrap_or_else(|| cpython::PyDict::new(py));
+                let kw_args = parent_kw_args.unwrap_or_else(|| cPython::PyDict::new_bound(py));
                 #(#property_assigns)*
 
                 #init

--- a/edb/edgeql-parser/edgeql-parser-python/src/errors.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/errors.rs
@@ -20,16 +20,16 @@ pub struct ParserResult {
 #[pymethods]
 impl ParserResult {
     fn pack(&self, py: Python) -> PyResult<PyObject> {
-        let tokens: &PyList = self.out.downcast(py)?;
+        let tokens = self.out.downcast_bound::<PyList>(py)?;
         let mut rv = Vec::with_capacity(tokens.len());
         for token in tokens {
-            let token: &PyCell<OpaqueToken> = token.downcast()?;
+            let token: &Bound<OpaqueToken> = token.downcast()?;
             rv.push(token.borrow().inner.clone());
         }
         let mut buf = vec![0u8]; // type and version
         bincode::serialize_into(&mut buf, &rv)
             .map_err(|e| PyValueError::new_err(format!("Failed to pack: {e}")))?;
-        Ok(PyBytes::new(py, buf.as_slice()).into())
+        Ok(PyBytes::new_bound(py, buf.as_slice()).into())
     }
 }
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/hash.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/hash.rs
@@ -13,14 +13,14 @@ pub struct Hasher {
 #[pymethods]
 impl Hasher {
     #[staticmethod]
-    fn start_migration(parent_id: &PyString) -> PyResult<Hasher> {
+    fn start_migration(parent_id: &Bound<PyString>) -> PyResult<Hasher> {
         let hasher = hash::Hasher::start_migration(parent_id.to_str()?);
         Ok(Hasher {
             _hasher: RefCell::new(Some(hasher)),
         })
     }
 
-    fn add_source(&self, py: Python, data: &PyString) -> PyResult<PyObject> {
+    fn add_source(&self, py: Python, data: &Bound<PyString>) -> PyResult<PyObject> {
         let text = data.to_str()?;
         let mut cell = self._hasher.borrow_mut();
         let hasher = cell

--- a/edb/edgeql-parser/edgeql-parser-python/src/keywords.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/keywords.rs
@@ -13,28 +13,34 @@ pub struct AllKeywords {
 }
 
 pub fn get_keywords(py: Python) -> PyResult<AllKeywords> {
-    let intern = py.import("sys")?.getattr("intern")?;
-    let frozen = py.import("builtins")?.getattr("frozenset")?;
+    let intern = py.import_bound("sys")?.getattr("intern")?;
+    let frozen = py.import_bound("builtins")?.getattr("frozenset")?;
 
-    let current = prepare_keywords(py, keywords::CURRENT_RESERVED_KEYWORDS.iter(), intern)?;
-    let unreserved = prepare_keywords(py, keywords::UNRESERVED_KEYWORDS.iter(), intern)?;
-    let future = prepare_keywords(py, keywords::FUTURE_RESERVED_KEYWORDS.iter(), intern)?;
-    let partial = prepare_keywords(py, keywords::PARTIAL_RESERVED_KEYWORDS.iter(), intern)?;
+    let current = prepare_keywords(py, keywords::CURRENT_RESERVED_KEYWORDS.iter(), &intern)?;
+    let unreserved = prepare_keywords(py, keywords::UNRESERVED_KEYWORDS.iter(), &intern)?;
+    let future = prepare_keywords(py, keywords::FUTURE_RESERVED_KEYWORDS.iter(), &intern)?;
+    let partial = prepare_keywords(py, keywords::PARTIAL_RESERVED_KEYWORDS.iter(), &intern)?;
     Ok(AllKeywords {
-        current: frozen.call((PyList::new(py, &current),), None)?.into(),
-        unreserved: frozen.call((PyList::new(py, &unreserved),), None)?.into(),
-        future: frozen.call((PyList::new(py, &future),), None)?.into(),
-        partial: frozen.call((PyList::new(py, &partial),), None)?.into(),
+        current: frozen
+            .call((PyList::new_bound(py, &current),), None)?
+            .into(),
+        unreserved: frozen
+            .call((PyList::new_bound(py, &unreserved),), None)?
+            .into(),
+        future: frozen.call((PyList::new_bound(py, &future),), None)?.into(),
+        partial: frozen
+            .call((PyList::new_bound(py, &partial),), None)?
+            .into(),
     })
 }
 
 fn prepare_keywords<'py, I: Iterator<Item = &'py &'static str>>(
     py: Python<'py>,
     keyword_set: I,
-    intern: &'py PyAny,
-) -> Result<Vec<&'py PyAny>, PyErr> {
+    intern: &'py Bound<'py, PyAny>,
+) -> Result<Vec<Bound<'py, PyAny>>, PyErr> {
     keyword_set
         .cloned()
-        .map(|s: &str| intern.call((PyString::new(py, s),), None))
+        .map(|s: &str| intern.call((PyString::new_bound(py, s),), None))
         .collect()
 }

--- a/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/lib.rs
@@ -13,9 +13,9 @@ use pyo3::prelude::*;
 
 /// Rust bindings to the edgeql-parser crate
 #[pymodule]
-fn _edgeql_parser(py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("SyntaxError", py.get_type::<errors::SyntaxError>())?;
-    m.add("ParserResult", py.get_type::<errors::ParserResult>())?;
+fn _edgeql_parser(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+    m.add("SyntaxError", py.get_type_bound::<errors::SyntaxError>())?;
+    m.add("ParserResult", py.get_type_bound::<errors::ParserResult>())?;
 
     m.add_class::<hash::Hasher>()?;
 
@@ -36,7 +36,7 @@ fn _edgeql_parser(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<parser::Terminal>()?;
 
     m.add_function(wrap_pyfunction!(position::offset_of_line, m)?)?;
-    m.add("SourcePoint", py.get_type::<position::SourcePoint>())?;
+    m.add("SourcePoint", py.get_type_bound::<position::SourcePoint>())?;
 
     m.add_class::<tokenizer::OpaqueToken>()?;
     m.add_function(wrap_pyfunction!(tokenizer::tokenize, m)?)?;

--- a/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
@@ -10,8 +10,8 @@ use crate::pynormalize::value_to_py_object;
 use crate::tokenizer::OpaqueToken;
 
 #[pyfunction]
-pub fn parse<'py>(
-    py: Python<'py>,
+pub fn parse(
+    py: Python,
     start_token_name: &Bound<PyString>,
     tokens: PyObject,
 ) -> PyResult<(ParserResult, PyObject)> {

--- a/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
@@ -10,9 +10,9 @@ use crate::pynormalize::value_to_py_object;
 use crate::tokenizer::OpaqueToken;
 
 #[pyfunction]
-pub fn parse(
-    py: Python,
-    start_token_name: &PyString,
+pub fn parse<'py>(
+    py: Python<'py>,
+    start_token_name: &Bound<PyString>,
     tokens: PyObject,
 ) -> PyResult<(ParserResult, PyObject)> {
     let start_token_name = start_token_name.to_string();
@@ -30,14 +30,14 @@ pub fn parse(
         .into_iter()
         .map(|e| parser_error_into_tuple(py, e))
         .collect::<Vec<_>>();
-    let errors = PyList::new(py, &errors);
+    let errors = PyList::new_bound(py, &errors);
 
     let res = ParserResult {
         out: cst.into_py(py),
         errors: errors.into(),
     };
 
-    Ok((res, productions.clone()))
+    Ok((res, productions.to_object(py)))
 }
 
 #[pyclass]
@@ -75,12 +75,12 @@ fn downcast_tokens(
     start_token_name: &str,
     token_list: PyObject,
 ) -> PyResult<Vec<parser::Terminal>> {
-    let tokens: &PyList = token_list.downcast(py)?;
+    let tokens = token_list.downcast_bound::<PyList>(py)?;
 
     let mut buf = Vec::with_capacity(tokens.len() + 1);
     buf.push(parser::Terminal::from_start_name(start_token_name));
     for token in tokens.iter() {
-        let token: &PyCell<OpaqueToken> = token.downcast()?;
+        let token: &Bound<OpaqueToken> = token.downcast()?;
         let token = token.borrow().inner.clone();
 
         buf.push(parser::Terminal::from_token(token));
@@ -105,7 +105,7 @@ fn get_spec() -> PyResult<&'static (parser::Spec, PyObject)> {
 
 /// Loads the grammar specification from file and caches it in memory.
 #[pyfunction]
-pub fn preload_spec(py: Python, spec_filepath: &PyString) -> PyResult<()> {
+pub fn preload_spec(py: Python, spec_filepath: &Bound<PyString>) -> PyResult<()> {
     if PARSER_SPECS.get().is_some() {
         return Ok(());
     }
@@ -127,7 +127,7 @@ pub fn preload_spec(py: Python, spec_filepath: &PyString) -> PyResult<()> {
 ///
 /// Called from setup.py.
 #[pyfunction]
-pub fn save_spec(spec_json: &PyString, dst: &PyString) -> PyResult<()> {
+pub fn save_spec(spec_json: &Bound<PyString>, dst: &Bound<PyString>) -> PyResult<()> {
     let spec_json = spec_json.to_string();
     let spec: parser::SpecSerializable = serde_json::from_str(&spec_json)
         .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {e}")))?;
@@ -142,15 +142,15 @@ pub fn save_spec(spec_json: &PyString, dst: &PyString) -> PyResult<()> {
 
 fn load_productions(py: Python<'_>, spec: &parser::Spec) -> PyResult<PyObject> {
     let grammar_name = "edb.edgeql.parser.grammar.start";
-    let grammar_mod = py.import(grammar_name)?;
+    let grammar_mod = py.import_bound(grammar_name)?;
     let load_productions = py
-        .import("edb.common.parsing")?
+        .import_bound("edb.common.parsing")?
         .getattr("load_spec_productions")?;
 
     let production_names: Vec<_> = spec
         .production_names
         .iter()
-        .map(|(a, b)| PyTuple::new(py, [a, b]))
+        .map(|(a, b)| PyTuple::new_bound(py, [a, b]))
         .collect();
 
     let productions = load_productions.call((production_names, grammar_mod), None)?;
@@ -180,7 +180,7 @@ fn to_py_cst<'a>(cst: &'a parser::CSTNode<'a>, py: Python) -> PyResult<CSTNode> 
         parser::CSTNode::Production(prod) => CSTNode {
             production: Production {
                 id: prod.id,
-                args: PyList::new(
+                args: PyList::new_bound(
                     py,
                     prod.args
                         .iter()

--- a/edb/edgeql-parser/edgeql-parser-python/src/position.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/position.rs
@@ -14,7 +14,7 @@ pub struct SourcePoint {
 #[pymethods]
 impl SourcePoint {
     #[staticmethod]
-    fn from_offsets(py: Python, data: &PyBytes, offsets: PyObject) -> PyResult<PyObject> {
+    fn from_offsets(py: Python, data: &Bound<PyBytes>, offsets: PyObject) -> PyResult<PyObject> {
         let mut list: Vec<usize> = offsets.extract(py)?;
         let data: &[u8] = data.as_bytes();
         list.sort();

--- a/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/unpack.rs
@@ -8,7 +8,7 @@ use crate::pynormalize::Entry;
 use crate::tokenizer::tokens_to_py;
 
 #[pyfunction]
-pub fn unpack(py: Python<'_>, serialized: &PyBytes) -> PyResult<PyObject> {
+pub fn unpack(py: Python<'_>, serialized: &Bound<PyBytes>) -> PyResult<PyObject> {
     let buf = serialized.as_bytes();
     match buf[0] {
         0u8 => {

--- a/edb/edgeql-parser/src/into_python.rs
+++ b/edb/edgeql-parser/src/into_python.rs
@@ -51,7 +51,7 @@ impl<T: IntoPython> IntoPython for Vec<T> {
         for x in self {
             elements.push(x.into_python(py, None)?);
         }
-        Ok(PyList::new(py, elements.as_slice()).into_object())
+        Ok(PyList::new_bound(py, elements.as_slice()).into_object())
     }
 }
 
@@ -76,13 +76,13 @@ impl<T1: IntoPython, T2: IntoPython> IntoPython for (T1, T2) {
         let mut elements = Vec::new();
         elements.push(self.0.into_python(py, None)?);
         elements.push(self.1.into_python(py, None)?);
-        Ok(PyTuple::new(py, elements.as_slice()).into_object())
+        Ok(PyTuple::new_bound(py, elements.as_slice()).into_object())
     }
 }
 
 impl<K: IntoPython, V: IntoPython> IntoPython for IndexMap<K, V> {
     fn into_python(self, py: Python<'_>, _: Option<PyDict>) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
+        let dict = PyDict::new_bound(py);
         for (key, value) in self {
             let key = key.into_python(py, None)?;
             let value = value.into_python(py, None)?;
@@ -94,7 +94,7 @@ impl<K: IntoPython, V: IntoPython> IntoPython for IndexMap<K, V> {
 
 impl IntoPython for Vec<u8> {
     fn into_python(self, py: Python<'_>, _: Option<PyDict>) -> PyResult<PyObject> {
-        Ok(PyBytes::new(py, self.as_slice()).into_object())
+        Ok(PyBytes::new_bound(py, self.as_slice()).into_object())
     }
 }
 
@@ -109,7 +109,7 @@ pub fn init_ast_class(
     class_name: &'static str,
     kw_args: PyDict,
 ) -> Result<PyObject, cpython::PyErr> {
-    let locals = PyDict::new(py);
+    let locals = PyDict::new_bound(py);
     locals.set_item(py, "kw_args", kw_args)?;
 
     let code = format!("qlast.{class_name}(**kw_args)");

--- a/edb/graphql-rewrite/src/lib.rs
+++ b/edb/graphql-rewrite/src/lib.rs
@@ -13,14 +13,14 @@ use pyo3::{prelude::*, types::PyString};
 
 /// Rust optimizer for graphql queries
 #[pymodule]
-fn _graphql_rewrite(py: Python, m: &PyModule) -> PyResult<()> {
+fn _graphql_rewrite(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_rewrite, m)?)?;
     m.add_class::<py_entry::Entry>()?;
-    m.add("LexingError", py.get_type::<LexingError>())?;
-    m.add("SyntaxError", py.get_type::<SyntaxError>())?;
-    m.add("NotFoundError", py.get_type::<NotFoundError>())?;
-    m.add("AssertionError", py.get_type::<AssertionError>())?;
-    m.add("QueryError", py.get_type::<QueryError>())?;
+    m.add("LexingError", py.get_type_bound::<LexingError>())?;
+    m.add("SyntaxError", py.get_type_bound::<SyntaxError>())?;
+    m.add("NotFoundError", py.get_type_bound::<NotFoundError>())?;
+    m.add("AssertionError", py.get_type_bound::<AssertionError>())?;
+    m.add("QueryError", py.get_type_bound::<QueryError>())?;
     Ok(())
 }
 
@@ -28,8 +28,8 @@ fn _graphql_rewrite(py: Python, m: &PyModule) -> PyResult<()> {
 #[pyo3(signature = (operation, text))]
 fn py_rewrite(
     py: Python<'_>,
-    operation: Option<&PyString>,
-    text: &PyString,
+    operation: Option<&Bound<PyString>>,
+    text: &Bound<PyString>,
 ) -> PyResult<py_entry::Entry> {
     // convert args
     let operation = operation.map(|x| x.to_string());

--- a/edb/graphql-rewrite/src/py_entry.rs
+++ b/edb/graphql-rewrite/src/py_entry.rs
@@ -29,14 +29,14 @@ impl Entry {
 
 pub fn convert_entry(py: Python<'_>, entry: rewrite::Entry) -> PyResult<Entry> {
     // import decimal
-    let decimal_cls = PyModule::import(py, "decimal")?.getattr("Decimal")?;
+    let decimal_cls = PyModule::import_bound(py, "decimal")?.getattr("Decimal")?;
 
-    let vars = PyDict::new(py);
-    let substitutions = PyDict::new(py);
+    let vars = PyDict::new_bound(py);
+    let substitutions = PyDict::new_bound(py);
     for (idx, var) in entry.variables.iter().enumerate() {
         let s = format!("_edb_arg__{}", idx).to_object(py);
 
-        vars.set_item(s.clone_ref(py), value_to_py(py, &var.value, decimal_cls)?)?;
+        vars.set_item(s.clone_ref(py), value_to_py(py, &var.value, &decimal_cls)?)?;
 
         substitutions.set_item(
             s.clone_ref(py),
@@ -48,9 +48,9 @@ pub fn convert_entry(py: Python<'_>, entry: rewrite::Entry) -> PyResult<Entry> {
         )?;
     }
     for (name, var) in &entry.defaults {
-        vars.set_item(name.into_py(py), value_to_py(py, &var.value, decimal_cls)?)?
+        vars.set_item(name.into_py(py), value_to_py(py, &var.value, &decimal_cls)?)?
     }
-    let key_vars = PyList::new(
+    let key_vars = PyList::new_bound(
         py,
         entry
             .key_vars
@@ -59,7 +59,7 @@ pub fn convert_entry(py: Python<'_>, entry: rewrite::Entry) -> PyResult<Entry> {
             .collect::<Vec<_>>(),
     );
     Ok(Entry {
-        key: PyString::new(py, &entry.key).into(),
+        key: PyString::new_bound(py, &entry.key).into(),
         key_vars: key_vars.into(),
         variables: vars.into_py(py),
         substitutions: substitutions.into(),
@@ -68,16 +68,16 @@ pub fn convert_entry(py: Python<'_>, entry: rewrite::Entry) -> PyResult<Entry> {
     })
 }
 
-fn value_to_py(py: Python, value: &Value, decimal_cls: &PyAny) -> PyResult<PyObject> {
+fn value_to_py(py: Python, value: &Value, decimal_cls: &Bound<PyAny>) -> PyResult<PyObject> {
     let v = match value {
-        Value::Str(ref v) => PyString::new(py, v).into(),
+        Value::Str(ref v) => PyString::new_bound(py, v).into(),
         Value::Int32(v) => v.into_py(py),
         Value::Int64(v) => v.into_py(py),
         Value::Decimal(v) => decimal_cls
-            .call(PyTuple::new(py, &[v.into_py(py)]), None)?
+            .call(PyTuple::new_bound(py, &[v.into_py(py)]), None)?
             .into(),
-        Value::BigInt(ref v) => PyType::new::<PyLong>(py)
-            .call(PyTuple::new(py, &[v.into_py(py)]), None)?
+        Value::BigInt(ref v) => PyType::new_bound::<PyLong>(py)
+            .call(PyTuple::new_bound(py, &[v.into_py(py)]), None)?
             .into(),
         Value::Boolean(b) => b.into_py(py),
     };

--- a/edb/graphql-rewrite/src/py_token.rs
+++ b/edb/graphql-rewrite/src/py_token.rs
@@ -125,7 +125,7 @@ pub fn convert_tokens(
         0u32.into_py(py),
         py.None(),
     ];
-    elems.push(PyTuple::new(py, &start_of_file).into());
+    elems.push(PyTuple::new_bound(py, &start_of_file).into());
 
     for token in tokens {
         let (kind, value) = match token.kind {
@@ -173,10 +173,10 @@ pub fn convert_tokens(
             token.position.map(|x| x.column).into_py(py),
             value,
         ];
-        elems.push(PyTuple::new(py, &token_tuple).into());
+        elems.push(PyTuple::new_bound(py, &token_tuple).into());
     }
     elems.push(
-        PyTuple::new(
+        PyTuple::new_bound(
             py,
             &[
                 eof.clone_ref(py),
@@ -189,5 +189,5 @@ pub fn convert_tokens(
         )
         .into(),
     );
-    Ok(PyList::new(py, &elems[..]).into())
+    Ok(PyList::new_bound(py, &elems[..]).into())
 }

--- a/edb/server/conn_pool/src/python.rs
+++ b/edb/server/conn_pool/src/python.rs
@@ -376,7 +376,7 @@ struct LoggingGuard {
 impl LoggingGuard {
     #[new]
     fn init_logging(py: Python) -> PyResult<LoggingGuard> {
-        let logging = py.import("logging")?;
+        let logging = py.import_bound("logging")?;
         let logger = logging
             .getattr("getLogger")?
             .call(("edb.server.connpool",), None)?;
@@ -459,7 +459,7 @@ impl LoggingGuard {
 }
 
 #[pymodule]
-fn _conn_pool(py: Python, m: &PyModule) -> PyResult<()> {
+fn _conn_pool(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<ConnPool>()?;
     m.add_class::<LoggingGuard>()?;
     m.add("InternalError", py.get_type_bound::<InternalError>())?;

--- a/edb/server/conn_pool/src/python.rs
+++ b/edb/server/conn_pool/src/python.rs
@@ -462,7 +462,7 @@ impl LoggingGuard {
 fn _conn_pool(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ConnPool>()?;
     m.add_class::<LoggingGuard>()?;
-    m.add("InternalError", py.get_type::<InternalError>())?;
+    m.add("InternalError", py.get_type_bound::<InternalError>())?;
 
     Ok(())
 }


### PR DESCRIPTION
Requires migration of Python reference type to `Bound<...>`, ie: `&PyAny` -> `Bound<PyAny>`