### PR TITLE
Load `net` module and fix issues

### DIFF
--- a/edb/lib/net.edgeql
+++ b/edb/lib/net.edgeql
@@ -42,36 +42,39 @@ CREATE SCALAR TYPE net::http::Method EXTENDING std::enum<
     PATCH
 >;
 
+CREATE TYPE net::http::Response EXTENDING std::BaseObject {
+    CREATE REQUIRED PROPERTY created_at: std::datetime;
+    CREATE PROPERTY status: std::int16;
+    CREATE PROPERTY headers: std::array<std::tuple<name: std::str, value: std::str>>;
+    CREATE PROPERTY body: std::bytes;
+};
+
 CREATE TYPE net::http::ScheduledRequest extending std::BaseObject {
     CREATE REQUIRED PROPERTY state: net::RequestState;
     CREATE REQUIRED PROPERTY created_at: std::datetime;
     CREATE PROPERTY failure: tuple<kind: net::RequestFailureKind, message: str>;
 
-    CREATE REQUIRED PROPERTY url: str;
+    CREATE REQUIRED PROPERTY url: std::str;
     CREATE REQUIRED PROPERTY method: net::http::Method;
-    CREATE PROPERTY headers: array<tuple<name: str, value: str>>;
-    CREATE PROPERTY body: bytes;
+    CREATE PROPERTY headers: std::array<std::tuple<name: std::str, value: std::str>>;
+    CREATE PROPERTY body: std::bytes;
 
     CREATE LINK response: net::http::Response {
-        CREATE CONSTRAINT EXCLUSIVE;
+        CREATE CONSTRAINT exclusive;
     };
 };
 
-CREATE TYPE net::http::Response EXTENDING std::BaseObject {
-    CREATE REQUIRED PROPERTY created_at: datetime;
-    CREATE PROPERTY status: int16;
-    CREATE PROPERTY headers: array<tuple<name: str, value: str>>;
-    CREATE PROPERTY body: bytes;
-    CREATE PROPERTY request: .<response[is net::http::ScheduledRequest];
+ALTER TYPE net::http::Response {
+    CREATE LINK request := .<response[is net::http::ScheduledRequest];
 };
 
 CREATE FUNCTION
 net::http::schedule_request(
     url: str,
-    named only body: optional bytes,
-    named only method: net::HttpMethod = net::HttpMethod::`GET`,
-    named only headers: optional array<tuple<name: str, value: str>>,
-) -> net::http::ScheduledRequest
+    named only body: optional std::bytes,
+    named only method: net::http::Method = net::http::Method.`GET`,
+    named only headers: optional std::array<std::tuple<name: std::str, value: std::str>>,
+) -> std::int16
 {
     USING SQL $$
         SELECT 42;

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -5809,7 +5809,9 @@ def _generate_sql_information_schema() -> List[dbops.Command]:
         FROM all_tables at
         JOIN edgedb_VER."_SchemaModule" sm ON sm.name = at.module_name
         LEFT JOIN pg_type pt ON pt.typname = at.id::text
-        WHERE schema_name not in ('cfg', 'sys', 'schema', 'std')
+        WHERE schema_name not in (
+            'cfg', 'sys', 'schema', 'std', 'net', 'net::http'
+        )
         '''
     )
     # A few tables in here were causing problems, so let's hide them as an

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -109,6 +109,7 @@ STD_SOURCES = (
     sn.UnqualName('enc'),
     sn.UnqualName('pg'),
     sn.UnqualName('fts'),
+    sn.UnqualName('net'),
 )
 TESTMODE_SOURCES = (
     sn.UnqualName('_testmode'),


### PR DESCRIPTION
In #7676, we were not actually loading the `net.edgeql` module. Once we began loading it, we discovered many issues with syntax and DDL ordering which are fixed here.