### PR TITLE
Cleanup a few parser edgecases

### DIFF
--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -220,7 +220,7 @@ fn is_operator(token: &Token) -> bool {
         | OpenBrace | CloseBrace | Dot | Semicolon | Colon | Add | Sub | Mul | Div | Modulo
         | Pow | Less | Greater | Eq | Ampersand | Pipe | At => true,
         DecimalConst | FloatConst | IntConst | BigIntConst | BinStr | Parameter
-        | ParameterAndType | Str | BacktickName | Keyword(_) | Ident | Substitution | EOF | EOI
+        | ParameterAndType | Str | BacktickName | Keyword(_) | Ident | Substitution | EOI
         | Epsilon | StartBlock | StartExtension | StartFragment | StartMigration
         | StartSDLDocument => false,
     }
@@ -232,7 +232,7 @@ fn serialize_tokens(tokens: &[Token]) -> String {
     let mut buf = String::new();
     let mut needs_space = false;
     for token in tokens {
-        if matches!(token.kind, Kind::EOF | Kind::EOI) {
+        if matches!(token.kind, Kind::EOI) {
             break;
         }
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/parser.rs
@@ -24,7 +24,7 @@ pub fn parse(
     let context = parser::Context::new(spec);
     let (cst, errors) = parser::parse(&tokens, &context);
 
-    let cst = cst.map(|c| to_py_cst(c, py)).transpose()?;
+    let cst = cst.map(|c| to_py_cst(&c, py)).transpose()?;
 
     let errors = errors
         .into_iter()
@@ -84,12 +84,6 @@ fn downcast_tokens(
         let token = token.borrow().inner.clone();
 
         buf.push(parser::Terminal::from_token(token));
-    }
-
-    // adjust the span of the starting token for nicer error message spans
-    if buf.len() >= 2 {
-        buf[0].span.start = buf[1].span.start;
-        buf[0].span.end = buf[1].span.start;
     }
 
     Ok(buf)

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -123,8 +123,7 @@ pub enum Kind {
     Keyword(Keyword),
 
     Ident,
-    EOF,
-    EOI,     // <$> (needed for LR parser)
+    EOI,     // end of input
     Epsilon, // <e> (needed for LR parser)
 
     StartBlock,
@@ -1056,7 +1055,6 @@ impl Kind {
         use Kind::*;
         Some(match self {
             Ident => "identifier",
-            EOF => "end of file",
             EOI => "end of input",
 
             BinStr => "binary constant",

--- a/edb/edgeql-parser/src/validation.rs
+++ b/edb/edgeql-parser/src/validation.rs
@@ -239,7 +239,7 @@ impl<'a> Iterator for WithEof<'a> {
             let pos = self.inner.current_pos().offset;
 
             Some(Ok(Token {
-                kind: Kind::EOF,
+                kind: Kind::EOI,
                 text: "".into(),
                 value: None,
                 span: Span {

--- a/edb/edgeql/parser/grammar/start.py
+++ b/edb/edgeql/parser/grammar/start.py
@@ -44,29 +44,23 @@ from .config import *  # NOQA
 class EdgeQLGrammar(Nonterm):
     "%start"
 
-    @parsing.inline(1)
-    def reduce_STARTBLOCK_EdgeQLBlock_EOF(self, *kids):
-        pass
+    def reduce_STARTBLOCK_EdgeQLBlock_EOI(self, *kids):
+        self.val = kids[1].val
 
-    @parsing.inline(1)
-    def reduce_STARTEXTENSION_CreateExtensionPackageCommandsBlock_EOF(self, *k):
-        pass
+    def reduce_STARTEXTENSION_CreateExtensionPackageCommandsBlock_EOI(self, *k):
+        self.val = k[1].val
 
-    @parsing.inline(1)
-    def reduce_STARTMIGRATION_CreateMigrationCommandsBlock_EOF(self, *kids):
-        pass
+    def reduce_STARTMIGRATION_CreateMigrationCommandsBlock_EOI(self, *kids):
+        self.val = kids[1].val
 
-    @parsing.inline(1)
-    def reduce_STARTFRAGMENT_ExprStmt_EOF(self, *kids):
-        pass
+    def reduce_STARTFRAGMENT_ExprStmt_EOI(self, *kids):
+        self.val = kids[1].val
 
-    @parsing.inline(1)
-    def reduce_STARTFRAGMENT_Expr_EOF(self, *kids):
-        pass
+    def reduce_STARTFRAGMENT_Expr_EOI(self, *kids):
+        self.val = kids[1].val
 
-    @parsing.inline(1)
-    def reduce_STARTSDLDOCUMENT_SDLDocument(self, *kids):
-        pass
+    def reduce_STARTSDLDOCUMENT_SDLDocument_EOI(self, *kids):
+        self.val = kids[1].val
 
 
 class EdgeQLBlock(Nonterm):
@@ -110,12 +104,12 @@ class StatementBlock(
 
 
 class SDLDocument(Nonterm):
-    def reduce_OptSemicolons_EOF(self, *kids):
+    def reduce_OptSemicolons(self, *kids):
         self.val = qlast.Schema(declarations=[])
 
     def reduce_statement_without_semicolons(self, *kids):
         r"""%reduce \
-            OptSemicolons SDLShortStatement EOF
+            OptSemicolons SDLShortStatement
         """
         declarations = [kids[1].val]
         commondl._validate_declarations(declarations)
@@ -124,18 +118,18 @@ class SDLDocument(Nonterm):
     def reduce_statements_without_optional_trailing_semicolons(self, *kids):
         r"""%reduce \
             OptSemicolons SDLStatements \
-            OptSemicolons SDLShortStatement EOF
+            OptSemicolons SDLShortStatement
         """
         declarations = kids[1].val + [kids[3].val]
         commondl._validate_declarations(declarations)
         self.val = qlast.Schema(declarations=declarations)
 
-    def reduce_OptSemicolons_SDLStatements_EOF(self, *kids):
+    def reduce_OptSemicolons_SDLStatements(self, *kids):
         declarations = kids[1].val
         commondl._validate_declarations(declarations)
         self.val = qlast.Schema(declarations=declarations)
 
-    def reduce_OptSemicolons_SDLStatements_Semicolons_EOF(self, *kids):
+    def reduce_OptSemicolons_SDLStatements_Semicolons(self, *kids):
         declarations = kids[1].val
         commondl._validate_declarations(declarations)
         self.val = qlast.Schema(declarations=declarations)

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -268,7 +268,7 @@ class T_IDENT(Token):
     pass
 
 
-class T_EOF(Token):
+class T_EOI(Token):
     pass
 
 

--- a/edb/tools/parser_demo.py
+++ b/edb/tools/parser_demo.py
@@ -89,9 +89,11 @@ def main():
                         assert isinstance(x, qlast.Base)
                         x.dump_edgeql()
                         x.dump()
+                        print(x.span.start, x.span.end)
                 elif isinstance(ast, qlast.Base):
                     ast.dump_edgeql()
                     ast.dump()
+                    print(ast.span.start, ast.span.end)
                 else:
                     print(ast)
 
@@ -380,4 +382,12 @@ QUERIES = [
     '''
         START MIGRATION TO BadLang $$type Foo$$;
     ''',
+    '''
+        SELECT Issue{
+            name,
+            related_to *5,
+        };
+    ''',
+    '''sdl# comment
+    '''
 ]

--- a/edb/tools/parser_demo.py
+++ b/edb/tools/parser_demo.py
@@ -31,7 +31,7 @@ from edb.tools.edb import edbcommands
 def main():
     qlparser.preload_spec()
 
-    for q in QUERIES[-1:]:
+    for q in QUERIES[-8:]:
         sdl = q.startswith('sdl')
         if sdl:
             q = q[3:]
@@ -64,7 +64,7 @@ def main():
             )
             print(
                 ' ' * (start.column - 1)
-                + '^' * (end.column - start.column)
+                + '^' * (max(1, end.column - start.column))
                 + ' '
                 + message
             )
@@ -349,6 +349,35 @@ QUERIES = [
     }
     ''',
     '''
-    select { a := 1, b := false }
+    SELECT __type__;
+    ''',
+    '''
+    INSERT Foo GROUP BY Foo.bar;
+    ''',
+    '''
+    WITH MODULE welp
+    CREATE DATABASE sample;
+    ''',
+    '''
+    WITH MODULE welp
+    DROP DATABASE sample;
+    ''',
+    '''
+    SELECT (1, a := 2);
+    ''',
+    '''
+        SELECT Issue{
+            name,
+            related_to *$var,
+        };
+    ''',
+    '''
+        SELECT Issue{
+            name,
+            related_to *5,
+        };
+    ''',
+    '''
+        START MIGRATION TO BadLang $$type Foo$$;
     ''',
 ]

--- a/edb/tools/test/results.py
+++ b/edb/tools/test/results.py
@@ -261,18 +261,18 @@ def render_result(
 
     # counts
     counts = [
-        ('tests ran', result.testsRun),
-        ('failures', len(result.failures)),
-        ('errors', len(result.errors)),
-        ('expected failures', len(result.expected_failures)),
-        ('not implemented', len(result.not_implemented)),
-        ('unexpected successes', len(result.unexpected_successes)),
-        ('skipped', len(result.skipped)),
+        ('tests ran', result.testsRun, None),
+        ('failures', len(result.failures), 'red'),
+        ('errors', len(result.errors), 'red'),
+        ('unexpected successes', len(result.unexpected_successes), 'red'),
+        ('not implemented', len(result.not_implemented), 'yellow'),
+        ('skipped', len(result.skipped), 'yellow'),
+        ('expected failures', len(result.expected_failures), None),
     ]
-    for bit, count in counts:
+    for name, count, fg in counts:
         if not count:
             continue
-        _echo(file, f'  {bit}: ', nl=False)
+        _echo(file, f'  {name}: ', nl=False, fg=fg)
         _echo(file, f'{count}', bold=True)
 
     # running times

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1998,7 +1998,7 @@ aa';
         # TODO: parser error quality regression
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing ','", line=2, col=21)
+                  "Unexpected ':='", line=2, col=22)
     def test_edgeql_syntax_struct_10(self):
         """
         SELECT (1, a := 2);
@@ -2780,7 +2780,9 @@ aa';
         OFFSET 2 LIMIT 5;
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=9)
+    @tb.must_fail(
+        errors.EdgeQLSyntaxError, 'Missing keyword \'SELECT\'', line=1, col=1
+    )
     def test_edgeql_syntax_select_07(self):
         """
         (SELECT User.name) OFFSET 2;
@@ -2825,7 +2827,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Missing keyword 'SELECT'", line=2, col=9)
+                  r"Missing keyword 'SELECT'", line=1, col=1)
     def test_edgeql_syntax_select_13(self):
         """
         default::Movie.name;
@@ -3077,7 +3079,9 @@ aa';
         SELECT ((SELECT Foo) UNION (SELECT Bar));
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=9)
+    @tb.must_fail(
+        errors.EdgeQLSyntaxError, 'Missing keyword \'SELECT\'', line=1, col=1
+    )
     def test_edgeql_syntax_set_03(self):
         """
         (SELECT Foo) UNION (SELECT Bar);
@@ -6477,7 +6481,7 @@ aa';
         # just the first one.
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing keyword 'SELECT'", line=2, col=9)
+                  "Missing keyword 'SELECT'", line=1, col=1)
     def test_edgeql_syntax_ddl_02(self):
         """
         sys::get_version();

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -1957,8 +1957,12 @@ abstract property test::foo {
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, r"Missing keyword 'ABSTRACT'",
-                  line=2, col=1)
+    @tb.must_fail(
+        errors.EdgeQLSyntaxError,
+        r"Missing keyword 'ABSTRACT'",
+        line=1,
+        col=1
+    )
     def test_eschema_syntax_annotation_15(self):
         """
 annotation test::foo;


### PR DESCRIPTION
When I ported the parser to Rust, I did not fully understand all of the edge cases, so there was an occasionally assertion failure in the `finish` function.

This PR merges EOI and EOF tokens and unifies start token handling.
