### PR TITLE
CI: don't use hidden dir for shared artifacts

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -112,7 +112,7 @@
         <%- endif %>
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -194,7 +194,7 @@
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -208,7 +208,7 @@
     runs-on: << tgt.runs_on if tgt.runs_on else "ubuntu-latest" >>
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -241,7 +241,7 @@
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -286,7 +286,7 @@
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -310,7 +310,7 @@
     runs-on: << tgt.runs_on if tgt.runs_on else "ubuntu-latest" >>
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -352,7 +352,7 @@
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>

--- a/.github/workflows.src/ls-build.inc.yml
+++ b/.github/workflows.src/ls-build.inc.yml
@@ -109,7 +109,7 @@
         <%- endif %>
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -175,7 +175,7 @@
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -201,7 +201,7 @@
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -226,7 +226,7 @@
     runs-on: << tgt.runs_on if tgt.runs_on else "ubuntu-latest" >>
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -269,7 +269,7 @@
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>

--- a/.github/workflows.src/tests-managed-pg.tpl.yml
+++ b/.github/workflows.src/tests-managed-pg.tpl.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -100,7 +100,7 @@ jobs:
       << setup_aws_creds()|indent(2) >>
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds
@@ -112,7 +112,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -135,7 +135,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -155,7 +155,7 @@ jobs:
       run: terraform init
 
     - name: Restore Terraform state
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: do-database-tfstate
         path: .github/do-database
@@ -210,7 +210,7 @@ jobs:
       << setup_terraform()|indent(2) >>
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: do-database-tfstate
           path: .github/do-database
@@ -221,7 +221,7 @@ jobs:
           TF_VAR_do_token: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -248,7 +248,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -287,7 +287,7 @@ jobs:
       << setup_gcp_creds()|indent(2) >>
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql
@@ -298,7 +298,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -327,7 +327,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -366,7 +366,7 @@ jobs:
       << setup_aws_creds()|indent(2) >>
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora
@@ -379,7 +379,7 @@ jobs:
           TF_VAR_vpc_id: ${{ secrets.AWS_VPC_ID }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -403,7 +403,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate
@@ -423,7 +423,7 @@ jobs:
       run: terraform init
 
     - name: Restore Terraform state
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: heroku-postgres-tfstate
         path: .github/heroku-postgres
@@ -457,7 +457,7 @@ jobs:
       << setup_aws_creds()|indent(2) >>
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres
@@ -469,7 +469,7 @@ jobs:
           HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate

--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -60,7 +60,7 @@
     << caller() >>
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -338,7 +338,7 @@
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts

--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -63,7 +63,7 @@
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -80,7 +80,7 @@
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -89,7 +89,7 @@
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -160,7 +160,7 @@
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -195,7 +195,7 @@
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -219,7 +219,7 @@
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -292,7 +292,7 @@
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 
@@ -303,19 +303,19 @@
 <%- endmacro %>
 
 <% macro calc_cache_key() -%>
-    mkdir -p .tmp
-    python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-    python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-    python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-    python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-    python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-    python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-    echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-    python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-    echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-    echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-    echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-    echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+    mkdir -p shared-artifacts
+    python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+    python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+    python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+    python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+    python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+    python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+    echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+    python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+    echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+    echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+    echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+    echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
     echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
     echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 <%- endmacro %>
@@ -341,13 +341,13 @@
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -365,21 +365,21 @@
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -400,7 +400,7 @@
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -94,18 +94,18 @@ jobs:
         SHARD: ${{ matrix.shard }}
         EDGEDB_TEST_REPEATS: 1
       run: |
-        mkdir -p .results/
-        cp shared-artifacts/time_stats.csv .results/running_times_${SHARD}.csv
+        mkdir -p results/
+        cp shared-artifacts/time_stats.csv results/running_times_${SHARD}.csv
         edb test --jobs 2 --verbose --shard ${SHARD}/16 \
-          --running-times-log=.results/running_times_${SHARD}.csv \
-          --result-log=.results/result_${SHARD}.json
+          --running-times-log=results/running_times_${SHARD}.csv \
+          --result-log=results/result_${SHARD}.json
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: python-test-results-${{ matrix.shard }}
-        path: .results
+        path: results
         retention-days: 1
 
   python-test-list:
@@ -153,12 +153,12 @@ jobs:
         with:
           pattern: python-test-results-*
           merge-multiple: true
-          path: .results
+          path: results
 
       # Render results and exit if they were unsuccessful
       - name: Render results
         run: |
-          python edb/tools/test/results.py '.results/result_*.json'
+          python edb/tools/test/results.py 'results/result_*.json'
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v4
@@ -197,7 +197,7 @@ jobs:
                   assert line not in all_tests, "duplicate test name in this run!"
                   all_tests.add(line.strip())
 
-          for new_file in glob.glob(".results/running_times_*.csv"):
+          for new_file in glob.glob("results/running_times_*.csv"):
               with open(new_file) as f:
                   for name, t, c in csv.reader(f):
                       if int(c) > orig.get(name, (0, 0))[1]:

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -42,7 +42,7 @@ jobs:
     << install_python_requirements() >>
 
     - name: Download cache key
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -101,7 +101,7 @@ jobs:
           --result-log=results/result_${SHARD}.json
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       if: ${{ always() }}
       with:
         name: python-test-results-${{ matrix.shard }}
@@ -124,7 +124,7 @@ jobs:
         edb test --list > shared-artifacts/all_tests.txt
 
     - name: Upload list of tests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: test-list
         path: shared-artifacts
@@ -149,7 +149,7 @@ jobs:
           submodules: false
 
       - name: Download python-test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           pattern: python-test-results-*
           merge-multiple: true
@@ -161,13 +161,13 @@ jobs:
           python edb/tools/test/results.py 'results/result_*.json'
 
       - name: Download shared artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: shared-artifacts
           path: shared-artifacts
 
       - name: Download test list
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: test-list
           path: shared-artifacts

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -30,7 +30,7 @@ jobs:
           -u edgedb-ci:$GIST_TOKEN \
           https://api.github.com/gists/8b722a65397f7c4c0df72f5394efa04c \
         | jq '.files."time_stats.csv".raw_url' \
-        | xargs curl > .tmp/time_stats.csv
+        | xargs curl > shared-artifacts/time_stats.csv
     <%- endcall %>
 
   cargo-test:
@@ -45,7 +45,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Generate environment variables
       run: |
@@ -56,7 +56,7 @@ jobs:
       id: rust-cache
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
@@ -95,7 +95,7 @@ jobs:
         EDGEDB_TEST_REPEATS: 1
       run: |
         mkdir -p .results/
-        cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
+        cp shared-artifacts/time_stats.csv .results/running_times_${SHARD}.csv
         edb test --jobs 2 --verbose --shard ${SHARD}/16 \
           --running-times-log=.results/running_times_${SHARD}.csv \
           --result-log=.results/result_${SHARD}.json
@@ -121,13 +121,13 @@ jobs:
         SHARD: ${{ matrix.shard }}
         EDGEDB_TEST_REPEATS: 1
       run: |
-        edb test --list > .tmp/all_tests.txt
+        edb test --list > shared-artifacts/all_tests.txt
 
     - name: Upload list of tests
       uses: actions/upload-artifact@v4
       with:
         name: test-list
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
   test-conclusion:
@@ -164,13 +164,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: shared-artifacts
-          path: .tmp
+          path: shared-artifacts
 
       - name: Download test list
         uses: actions/download-artifact@v4
         with:
           name: test-list
-          path: .tmp
+          path: shared-artifacts
 
       - name: Merge stats and verify tests completion
         shell: python
@@ -187,12 +187,12 @@ jobs:
           orig = {}
           new = {}
           all_tests = set()
-          with open(".tmp/time_stats.csv") as f:
+          with open("shared-artifacts/time_stats.csv") as f:
               for name, t, c in csv.reader(f):
                   assert name not in orig, "duplicate test name in original stats!"
                   orig[name] = (t, int(c))
 
-          with open(".tmp/all_tests.txt") as f:
+          with open("shared-artifacts/all_tests.txt") as f:
               for line in f:
                   assert line not in all_tests, "duplicate test name in this run!"
                   all_tests.add(line.strip())

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -448,7 +448,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -472,7 +472,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -496,7 +496,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -520,7 +520,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -544,7 +544,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -568,7 +568,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -592,7 +592,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -616,7 +616,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -640,7 +640,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -664,7 +664,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -688,7 +688,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -712,7 +712,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -736,7 +736,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -760,7 +760,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -784,7 +784,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -808,7 +808,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -832,7 +832,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -856,7 +856,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -881,7 +881,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -906,7 +906,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -932,7 +932,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -958,7 +958,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -1029,7 +1029,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -1100,7 +1100,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -1110,7 +1110,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1131,7 +1131,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1152,7 +1152,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1173,7 +1173,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1194,7 +1194,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1215,7 +1215,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1236,7 +1236,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1257,7 +1257,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -1278,7 +1278,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -1299,7 +1299,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -1320,7 +1320,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -1341,7 +1341,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -1362,7 +1362,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -1383,7 +1383,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -1404,7 +1404,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -1425,7 +1425,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -1446,7 +1446,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -1467,7 +1467,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -1488,7 +1488,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -1509,7 +1509,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -1530,7 +1530,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -1551,7 +1551,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -1578,7 +1578,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -1607,7 +1607,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/ls-nightly.yml
+++ b/.github/workflows/ls-nightly.yml
@@ -131,7 +131,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -157,7 +157,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -184,7 +184,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -211,7 +211,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -266,7 +266,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -321,7 +321,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -352,7 +352,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -385,7 +385,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -406,7 +406,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -439,7 +439,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -460,7 +460,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -493,7 +493,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -514,7 +514,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -547,7 +547,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -578,7 +578,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -453,7 +453,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -477,7 +477,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -501,7 +501,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -525,7 +525,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -549,7 +549,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -573,7 +573,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -597,7 +597,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -621,7 +621,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -645,7 +645,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -669,7 +669,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -693,7 +693,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -717,7 +717,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -741,7 +741,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -765,7 +765,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -789,7 +789,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -813,7 +813,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -837,7 +837,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -861,7 +861,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -886,7 +886,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -911,7 +911,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -937,7 +937,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -963,7 +963,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -1034,7 +1034,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -1105,7 +1105,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -1115,7 +1115,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1136,7 +1136,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1157,7 +1157,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1178,7 +1178,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1199,7 +1199,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1220,7 +1220,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1241,7 +1241,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1262,7 +1262,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -1283,7 +1283,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -1304,7 +1304,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -1325,7 +1325,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -1346,7 +1346,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -1367,7 +1367,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -1388,7 +1388,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -1409,7 +1409,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -1430,7 +1430,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -1451,7 +1451,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -1472,7 +1472,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -1493,7 +1493,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -1514,7 +1514,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -1535,7 +1535,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -1556,7 +1556,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -1583,7 +1583,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -1612,7 +1612,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -1630,7 +1630,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1650,7 +1650,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1682,7 +1682,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1702,7 +1702,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1734,7 +1734,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1754,7 +1754,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1786,7 +1786,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1806,7 +1806,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1838,7 +1838,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1858,7 +1858,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1890,7 +1890,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1910,7 +1910,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1942,7 +1942,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1962,7 +1962,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1994,7 +1994,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -2014,7 +2014,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -2046,7 +2046,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -2066,7 +2066,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -2098,7 +2098,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -2118,7 +2118,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -2150,7 +2150,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -2170,7 +2170,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -2202,7 +2202,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -2222,7 +2222,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -2254,7 +2254,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -2274,7 +2274,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -2306,7 +2306,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -2326,7 +2326,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -2358,7 +2358,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -2378,7 +2378,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -2410,7 +2410,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -2430,7 +2430,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -2462,7 +2462,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -2482,7 +2482,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -2514,7 +2514,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -2534,7 +2534,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -2566,7 +2566,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -2586,7 +2586,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -2618,7 +2618,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -2638,7 +2638,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -2670,7 +2670,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -2690,7 +2690,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -2722,7 +2722,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -2742,7 +2742,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -2774,7 +2774,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -2804,7 +2804,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -61,7 +61,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -83,7 +83,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -105,7 +105,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -127,7 +127,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -149,7 +149,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -171,7 +171,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -193,7 +193,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -215,7 +215,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -237,7 +237,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -259,7 +259,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -281,7 +281,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -303,7 +303,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -325,7 +325,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -347,7 +347,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -369,7 +369,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -391,7 +391,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -413,7 +413,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -436,7 +436,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -459,7 +459,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -483,7 +483,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -507,7 +507,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -576,7 +576,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -645,7 +645,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -655,7 +655,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -675,7 +675,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -695,7 +695,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -715,7 +715,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -735,7 +735,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -755,7 +755,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -775,7 +775,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -795,7 +795,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -815,7 +815,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -835,7 +835,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -855,7 +855,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -875,7 +875,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -895,7 +895,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -915,7 +915,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -935,7 +935,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -955,7 +955,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -975,7 +975,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -995,7 +995,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -1015,7 +1015,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -1035,7 +1035,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -1055,7 +1055,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -1075,7 +1075,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -1101,7 +1101,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -1129,7 +1129,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -1175,7 +1175,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1194,7 +1194,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1225,7 +1225,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1244,7 +1244,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1275,7 +1275,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1294,7 +1294,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1325,7 +1325,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1344,7 +1344,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1375,7 +1375,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1394,7 +1394,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1425,7 +1425,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1444,7 +1444,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1475,7 +1475,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1494,7 +1494,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1525,7 +1525,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -1544,7 +1544,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -1575,7 +1575,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -1594,7 +1594,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -1625,7 +1625,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -1644,7 +1644,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -1675,7 +1675,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -1694,7 +1694,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -1725,7 +1725,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -1744,7 +1744,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -1775,7 +1775,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -1794,7 +1794,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -1825,7 +1825,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -1844,7 +1844,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -1875,7 +1875,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -1894,7 +1894,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -1925,7 +1925,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -1944,7 +1944,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -1975,7 +1975,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -1994,7 +1994,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -2025,7 +2025,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -2044,7 +2044,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -2075,7 +2075,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -2094,7 +2094,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -2125,7 +2125,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -2144,7 +2144,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -2175,7 +2175,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -2194,7 +2194,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -2225,7 +2225,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -2244,7 +2244,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -2275,7 +2275,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -2304,7 +2304,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -63,7 +63,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -86,7 +86,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -109,7 +109,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -132,7 +132,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -155,7 +155,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -178,7 +178,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -201,7 +201,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -224,7 +224,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -247,7 +247,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -270,7 +270,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -293,7 +293,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -316,7 +316,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -339,7 +339,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -362,7 +362,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -385,7 +385,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -408,7 +408,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -431,7 +431,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -455,7 +455,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -479,7 +479,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -504,7 +504,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -529,7 +529,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -599,7 +599,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -669,7 +669,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -679,7 +679,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -700,7 +700,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -721,7 +721,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -742,7 +742,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -763,7 +763,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -784,7 +784,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -805,7 +805,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -826,7 +826,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -847,7 +847,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -868,7 +868,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -889,7 +889,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -910,7 +910,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -931,7 +931,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -952,7 +952,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -973,7 +973,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -994,7 +994,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -1015,7 +1015,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -1036,7 +1036,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -1057,7 +1057,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -1078,7 +1078,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -1099,7 +1099,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -1120,7 +1120,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -1147,7 +1147,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -1176,7 +1176,7 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
@@ -1223,7 +1223,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1243,7 +1243,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -1275,7 +1275,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1295,7 +1295,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -1327,7 +1327,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1347,7 +1347,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -1379,7 +1379,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1399,7 +1399,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -1431,7 +1431,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1451,7 +1451,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -1483,7 +1483,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1503,7 +1503,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -1535,7 +1535,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1555,7 +1555,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -1587,7 +1587,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -1607,7 +1607,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -1639,7 +1639,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -1659,7 +1659,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -1691,7 +1691,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -1711,7 +1711,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -1743,7 +1743,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -1763,7 +1763,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -1795,7 +1795,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -1815,7 +1815,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -1847,7 +1847,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -1867,7 +1867,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-x86_64
         path: artifacts/ubuntu-noble
@@ -1899,7 +1899,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -1919,7 +1919,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-ubuntu-noble-aarch64
         path: artifacts/ubuntu-noble
@@ -1951,7 +1951,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -1971,7 +1971,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -2003,7 +2003,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -2023,7 +2023,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -2055,7 +2055,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -2075,7 +2075,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -2107,7 +2107,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -2127,7 +2127,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -2159,7 +2159,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -2179,7 +2179,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -2211,7 +2211,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -2231,7 +2231,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -2263,7 +2263,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -2283,7 +2283,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -2315,7 +2315,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -2335,7 +2335,7 @@ jobs:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -2367,7 +2367,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -2397,7 +2397,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -101,7 +101,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -392,7 +392,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -84,19 +84,19 @@ jobs:
       env:
         GIST_TOKEN: ${{ secrets.CI_BOT_GIST_TOKEN }}
       run: |
-        mkdir -p .tmp
-        python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-        python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-        python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-        python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-        python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-        python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-        python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        mkdir -p shared-artifacts
+        python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+        python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+        python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+        python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+        python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+        python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+        python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -104,7 +104,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -121,7 +121,7 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -130,7 +130,7 @@ jobs:
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -201,7 +201,7 @@ jobs:
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -236,7 +236,7 @@ jobs:
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -260,7 +260,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -333,7 +333,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 
@@ -395,13 +395,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -419,21 +419,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -454,7 +454,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |

--- a/.github/workflows/tests-inplace.yml
+++ b/.github/workflows/tests-inplace.yml
@@ -86,7 +86,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -377,7 +377,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts

--- a/.github/workflows/tests-inplace.yml
+++ b/.github/workflows/tests-inplace.yml
@@ -69,19 +69,19 @@ jobs:
 
     - name: Compute cache keys
       run: |
-        mkdir -p .tmp
-        python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-        python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-        python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-        python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-        python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-        python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-        python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        mkdir -p shared-artifacts
+        python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+        python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+        python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+        python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+        python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+        python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+        python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -89,7 +89,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -106,7 +106,7 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -115,7 +115,7 @@ jobs:
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -186,7 +186,7 @@ jobs:
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -221,7 +221,7 @@ jobs:
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -245,7 +245,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -318,7 +318,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 
@@ -380,13 +380,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -404,21 +404,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -439,7 +439,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -86,7 +86,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -363,7 +363,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -423,7 +423,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -552,7 +552,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds
@@ -564,7 +564,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -596,7 +596,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -651,7 +651,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -752,7 +752,7 @@ jobs:
       run: terraform init
 
     - name: Restore Terraform state
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: do-database-tfstate
         path: .github/do-database
@@ -816,7 +816,7 @@ jobs:
         run: terraform init
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: do-database-tfstate
           path: .github/do-database
@@ -827,7 +827,7 @@ jobs:
           TF_VAR_do_token: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -867,7 +867,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -927,7 +927,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -1055,7 +1055,7 @@ jobs:
           export_default_credentials: true
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql
@@ -1066,7 +1066,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -1109,7 +1109,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -1169,7 +1169,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -1298,7 +1298,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora
@@ -1311,7 +1311,7 @@ jobs:
           TF_VAR_vpc_id: ${{ secrets.AWS_VPC_ID }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -1344,7 +1344,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate
@@ -1399,7 +1399,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -1500,7 +1500,7 @@ jobs:
       run: terraform init
 
     - name: Restore Terraform state
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: heroku-postgres-tfstate
         path: .github/heroku-postgres
@@ -1548,7 +1548,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Restore Terraform state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres
@@ -1560,7 +1560,7 @@ jobs:
           HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -69,19 +69,19 @@ jobs:
 
     - name: Compute cache keys
       run: |
-        mkdir -p .tmp
-        python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-        python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-        python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-        python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-        python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-        python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-        python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        mkdir -p shared-artifacts
+        python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+        python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+        python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+        python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+        python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+        python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+        python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -89,7 +89,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -106,7 +106,7 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -115,7 +115,7 @@ jobs:
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -186,7 +186,7 @@ jobs:
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -221,7 +221,7 @@ jobs:
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -245,7 +245,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -318,7 +318,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 
@@ -426,13 +426,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -450,21 +450,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -485,7 +485,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |
@@ -654,13 +654,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -678,21 +678,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -713,7 +713,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |
@@ -930,13 +930,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -954,21 +954,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -989,7 +989,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |
@@ -1172,13 +1172,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -1196,21 +1196,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -1231,7 +1231,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |
@@ -1402,13 +1402,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -1426,21 +1426,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -1461,7 +1461,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -88,7 +88,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -392,7 +392,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -71,19 +71,19 @@ jobs:
 
     - name: Compute cache keys
       run: |
-        mkdir -p .tmp
-        python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-        python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-        python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-        python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-        python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-        python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-        python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        mkdir -p shared-artifacts
+        python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+        python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+        python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+        python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+        python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+        python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+        python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -91,7 +91,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -108,7 +108,7 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -117,7 +117,7 @@ jobs:
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -188,7 +188,7 @@ jobs:
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -223,7 +223,7 @@ jobs:
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -247,7 +247,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -320,7 +320,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 
@@ -395,13 +395,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -419,21 +419,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -454,7 +454,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -69,19 +69,19 @@ jobs:
 
     - name: Compute cache keys
       run: |
-        mkdir -p .tmp
-        python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-        python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-        python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-        python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-        python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-        python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-        python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        mkdir -p shared-artifacts
+        python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+        python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+        python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+        python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+        python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+        python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+        python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -89,7 +89,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -106,7 +106,7 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -115,7 +115,7 @@ jobs:
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -186,7 +186,7 @@ jobs:
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -221,7 +221,7 @@ jobs:
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -245,7 +245,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -318,7 +318,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 
@@ -419,13 +419,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -443,21 +443,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -478,7 +478,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -86,7 +86,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -416,7 +416,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts

--- a/.github/workflows/tests-pool.yml
+++ b/.github/workflows/tests-pool.yml
@@ -79,19 +79,19 @@ jobs:
 
     - name: Compute cache keys
       run: |
-        mkdir -p .tmp
-        python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-        python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-        python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-        python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-        python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-        python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-        python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        mkdir -p shared-artifacts
+        python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+        python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+        python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+        python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+        python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+        python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+        python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -99,7 +99,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -116,7 +116,7 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -125,7 +125,7 @@ jobs:
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -196,7 +196,7 @@ jobs:
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -231,7 +231,7 @@ jobs:
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -255,7 +255,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -328,7 +328,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 

--- a/.github/workflows/tests-pool.yml
+++ b/.github/workflows/tests-pool.yml
@@ -96,7 +96,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,19 +74,19 @@ jobs:
       env:
         GIST_TOKEN: ${{ secrets.CI_BOT_GIST_TOKEN }}
       run: |
-        mkdir -p .tmp
-        python setup.py -q ci_helper --type cli > .tmp/edgedbcli_git_rev.txt
-        python setup.py -q ci_helper --type rust >.tmp/rust_cache_key.txt
-        python setup.py -q ci_helper --type ext >.tmp/ext_cache_key.txt
-        python setup.py -q ci_helper --type parsers >.tmp/parsers_cache_key.txt
-        python setup.py -q ci_helper --type postgres >.tmp/postgres_git_rev.txt
-        python setup.py -q ci_helper --type libpg_query >.tmp/libpg_query_git_rev.txt
-        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >.tmp/stolon_git_rev.txt
-        python setup.py -q ci_helper --type bootstrap >.tmp/bootstrap_cache_key.txt
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo LIBPG_QUERY_GIT_REV=$(cat .tmp/libpg_query_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        mkdir -p shared-artifacts
+        python setup.py -q ci_helper --type cli > shared-artifacts/edgedbcli_git_rev.txt
+        python setup.py -q ci_helper --type rust >shared-artifacts/rust_cache_key.txt
+        python setup.py -q ci_helper --type ext >shared-artifacts/ext_cache_key.txt
+        python setup.py -q ci_helper --type parsers >shared-artifacts/parsers_cache_key.txt
+        python setup.py -q ci_helper --type postgres >shared-artifacts/postgres_git_rev.txt
+        python setup.py -q ci_helper --type libpg_query >shared-artifacts/libpg_query_git_rev.txt
+        echo 'f8cd94309eaccbfba5dea7835b88c78377608a37' >shared-artifacts/stolon_git_rev.txt
+        python setup.py -q ci_helper --type bootstrap >shared-artifacts/bootstrap_cache_key.txt
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo LIBPG_QUERY_GIT_REV=$(cat shared-artifacts/libpg_query_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -95,13 +95,13 @@ jobs:
           -u edgedb-ci:$GIST_TOKEN \
           https://api.github.com/gists/8b722a65397f7c4c0df72f5394efa04c \
         | jq '.files."time_stats.csv".raw_url' \
-        | xargs curl > .tmp/time_stats.csv
+        | xargs curl > shared-artifacts/time_stats.csv
 
     - name: Upload shared artifacts
       uses: actions/upload-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
     # Restore binary cache
@@ -118,7 +118,7 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-v4-
 
@@ -127,7 +127,7 @@ jobs:
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Handle cached PostgreSQL build
       uses: actions/cache@v4
@@ -198,7 +198,7 @@ jobs:
       if: steps.rust-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
         restore-keys: |
           edb-rust-build-v1-
 
@@ -233,7 +233,7 @@ jobs:
       if: steps.ext-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/edb
-        key: edb-ext-build-v3-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-build-v3-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Build Cython extensions
       env:
@@ -257,7 +257,7 @@ jobs:
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
         restore-keys: |
           edb-parsers-v3-
 
@@ -330,7 +330,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
         restore-keys: |
           edb-bootstrap-v2-
 
@@ -390,7 +390,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Generate environment variables
       run: |
@@ -401,7 +401,7 @@ jobs:
       id: rust-cache
       with:
         path: ${{ env.BUILD_TEMP }}/rust/extensions
-        key: edb-rust-build-v1-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-build-v1-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Install Rust toolchain
       uses: dsherret/rust-toolchain-file@v1
@@ -475,13 +475,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -499,21 +499,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -534,7 +534,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |
@@ -576,7 +576,7 @@ jobs:
         EDGEDB_TEST_REPEATS: 1
       run: |
         mkdir -p .results/
-        cp .tmp/time_stats.csv .results/running_times_${SHARD}.csv
+        cp shared-artifacts/time_stats.csv .results/running_times_${SHARD}.csv
         edb test --jobs 2 --verbose --shard ${SHARD}/16 \
           --running-times-log=.results/running_times_${SHARD}.csv \
           --result-log=.results/result_${SHARD}.json
@@ -641,13 +641,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: shared-artifacts
-        path: .tmp
+        path: shared-artifacts
 
     - name: Set environment variables
       run: |
-        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
-        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
-        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo EDGEDBCLI_GIT_REV=$(cat shared-artifacts/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
         echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
@@ -665,21 +665,21 @@ jobs:
       id: rust-cache
       with:
         path: build/rust_extensions
-        key: edb-rust-v4-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
 
     - name: Restore cached Cython extensions
       uses: actions/cache@v4
       id: ext-cache
       with:
         path: build/extensions
-        key: edb-ext-v5-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+        key: edb-ext-v5-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
 
     - name: Restore compiled parsers cache
       uses: actions/cache@v4
       id: parsers-cache
       with:
         path: build/lib
-        key: edb-parsers-v3-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
 
     - name: Restore cached PostgreSQL build
       uses: actions/cache@v4
@@ -700,7 +700,7 @@ jobs:
       id: bootstrap-cache
       with:
         path: build/cache
-        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
 
     - name: Stop if we cannot retrieve the cache
       if: |
@@ -738,13 +738,13 @@ jobs:
         SHARD: ${{ matrix.shard }}
         EDGEDB_TEST_REPEATS: 1
       run: |
-        edb test --list > .tmp/all_tests.txt
+        edb test --list > shared-artifacts/all_tests.txt
 
     - name: Upload list of tests
       uses: actions/upload-artifact@v4
       with:
         name: test-list
-        path: .tmp
+        path: shared-artifacts
         retention-days: 1
 
   test-conclusion:
@@ -781,13 +781,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: shared-artifacts
-          path: .tmp
+          path: shared-artifacts
 
       - name: Download test list
         uses: actions/download-artifact@v4
         with:
           name: test-list
-          path: .tmp
+          path: shared-artifacts
 
       - name: Merge stats and verify tests completion
         shell: python
@@ -804,12 +804,12 @@ jobs:
           orig = {}
           new = {}
           all_tests = set()
-          with open(".tmp/time_stats.csv") as f:
+          with open("shared-artifacts/time_stats.csv") as f:
               for name, t, c in csv.reader(f):
                   assert name not in orig, "duplicate test name in original stats!"
                   orig[name] = (t, int(c))
 
-          with open(".tmp/all_tests.txt") as f:
+          with open("shared-artifacts/all_tests.txt") as f:
               for line in f:
                   assert line not in all_tests, "duplicate test name in this run!"
                   all_tests.add(line.strip())

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
         | xargs curl > shared-artifacts/time_stats.csv
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -387,7 +387,7 @@ jobs:
       run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
 
     - name: Download cache key
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -472,7 +472,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -582,7 +582,7 @@ jobs:
           --result-log=results/result_${SHARD}.json
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       if: ${{ always() }}
       with:
         name: python-test-results-${{ matrix.shard }}
@@ -638,7 +638,7 @@ jobs:
     # Restore the artifacts and environment variables
 
     - name: Download shared artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: shared-artifacts
         path: shared-artifacts
@@ -741,7 +741,7 @@ jobs:
         edb test --list > shared-artifacts/all_tests.txt
 
     - name: Upload list of tests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
         name: test-list
         path: shared-artifacts
@@ -766,7 +766,7 @@ jobs:
           submodules: false
 
       - name: Download python-test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           pattern: python-test-results-*
           merge-multiple: true
@@ -778,13 +778,13 @@ jobs:
           python edb/tools/test/results.py 'results/result_*.json'
 
       - name: Download shared artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: shared-artifacts
           path: shared-artifacts
 
       - name: Download test list
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
         with:
           name: test-list
           path: shared-artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -575,18 +575,18 @@ jobs:
         SHARD: ${{ matrix.shard }}
         EDGEDB_TEST_REPEATS: 1
       run: |
-        mkdir -p .results/
-        cp shared-artifacts/time_stats.csv .results/running_times_${SHARD}.csv
+        mkdir -p results/
+        cp shared-artifacts/time_stats.csv results/running_times_${SHARD}.csv
         edb test --jobs 2 --verbose --shard ${SHARD}/16 \
-          --running-times-log=.results/running_times_${SHARD}.csv \
-          --result-log=.results/result_${SHARD}.json
+          --running-times-log=results/running_times_${SHARD}.csv \
+          --result-log=results/result_${SHARD}.json
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: python-test-results-${{ matrix.shard }}
-        path: .results
+        path: results
         retention-days: 1
 
   python-test-list:
@@ -770,12 +770,12 @@ jobs:
         with:
           pattern: python-test-results-*
           merge-multiple: true
-          path: .results
+          path: results
 
       # Render results and exit if they were unsuccessful
       - name: Render results
         run: |
-          python edb/tools/test/results.py '.results/result_*.json'
+          python edb/tools/test/results.py 'results/result_*.json'
 
       - name: Download shared artifacts
         uses: actions/download-artifact@v4
@@ -814,7 +814,7 @@ jobs:
                   assert line not in all_tests, "duplicate test name in this run!"
                   all_tests.add(line.strip())
 
-          for new_file in glob.glob(".results/running_times_*.csv"):
+          for new_file in glob.glob("results/running_times_*.csv"):
               with open(new_file) as f:
                   for name, t, c in csv.reader(f):
                       if int(c) > orig.get(name, (0, 0))[1]:


### PR DESCRIPTION
[actions/upload-artifact@v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) dropped support for hidden paths (e.g., with a leading dot `.results`), which breaks our CI when using such paths - fix so that we don't.

Also, pinned such action versions so that breakage won't happen accidentally.