### PR TITLE
Fix iterators in DML over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -423,7 +423,7 @@ def _uncompile_insert_object_stmt(
         external_rels={
             value_id: (
                 value_rel,
-                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+                (pgce.PathAspect.SOURCE,),
             )
         },
         early_result=context.CompiledDML(
@@ -692,7 +692,7 @@ def _uncompile_insert_pointer_stmt(
         external_rels={
             source_id: (
                 value_rel,
-                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+                (pgce.PathAspect.SOURCE,),
             )
         },
         early_result=context.CompiledDML(
@@ -922,7 +922,7 @@ def _uncompile_delete_object_stmt(
         external_rels={
             value_id: (
                 value_rel,
-                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+                (pgce.PathAspect.SOURCE,),
             )
         },
         early_result=context.CompiledDML(
@@ -1114,7 +1114,7 @@ def _uncompile_delete_pointer_stmt(
         external_rels={
             source_id: (
                 value_rel,
-                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+                (pgce.PathAspect.SOURCE,),
             )
         },
         early_result=context.CompiledDML(
@@ -1369,7 +1369,7 @@ def _uncompile_update_object_stmt(
         external_rels={
             value_id: (
                 value_rel,
-                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+                (pgce.PathAspect.SOURCE,),
             )
         },
         early_result=context.CompiledDML(

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -173,6 +173,9 @@ def _collect_dml_stmts(stmt: pgast.Base) -> List[pgast.DMLQuery]:
     return res
 
 
+ExternalRel = Tuple[pgast.BaseRelation, Tuple[pgce.PathAspect, ...]]
+
+
 @dataclasses.dataclass(kw_only=True, eq=False, repr=False)
 class UncompiledDML:
     # the input DML node
@@ -188,9 +191,7 @@ class UncompiledDML:
     ql_returning_shape: List[qlast.ShapeElement]
     ql_singletons: Set[irast.PathId]
     ql_anchors: Mapping[str, irast.PathId]
-    external_rels: Mapping[
-        irast.PathId, Tuple[pgast.BaseRelation, Tuple[str, ...]]
-    ]
+    external_rels: Mapping[irast.PathId, ExternalRel]
 
     # list of column names of the subject type, along with pointer name
     # these columns will be available within RETURNING clause
@@ -419,7 +420,12 @@ def _uncompile_insert_object_stmt(
         ql_returning_shape=ql_returning_shape,
         ql_singletons={value_id},
         ql_anchors={value_name: value_id},
-        external_rels={value_id: (value_rel, ('source', 'identity'))},
+        external_rels={
+            value_id: (
+                value_rel,
+                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+            )
+        },
         early_result=context.CompiledDML(
             value_cte_name=value_cte_name,
             value_relation_input=value_relation,
@@ -683,7 +689,12 @@ def _uncompile_insert_pointer_stmt(
         ql_returning_shape=ql_returning_shape,
         ql_singletons={source_id},
         ql_anchors={value_name: source_id},
-        external_rels={source_id: (value_rel, ('source', 'identity'))},
+        external_rels={
+            source_id: (
+                value_rel,
+                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+            )
+        },
         early_result=context.CompiledDML(
             value_cte_name=value_cte_name,
             value_relation_input=value_relation,
@@ -908,7 +919,12 @@ def _uncompile_delete_object_stmt(
         ql_returning_shape=ql_returning_shape,
         ql_singletons={value_id},
         ql_anchors={value_name: value_id},
-        external_rels={value_id: (value_rel, ('source', 'identity'))},
+        external_rels={
+            value_id: (
+                value_rel,
+                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+            )
+        },
         early_result=context.CompiledDML(
             value_cte_name=value_cte_name,
             value_relation_input=value_relation,
@@ -1095,7 +1111,12 @@ def _uncompile_delete_pointer_stmt(
         ql_returning_shape=ql_returning_shape,
         ql_singletons={source_id},
         ql_anchors={value_name: source_id},
-        external_rels={source_id: (value_rel, ('source', 'identity'))},
+        external_rels={
+            source_id: (
+                value_rel,
+                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+            )
+        },
         early_result=context.CompiledDML(
             value_cte_name=value_cte_name,
             value_relation_input=value_relation,
@@ -1345,7 +1366,12 @@ def _uncompile_update_object_stmt(
         ql_returning_shape=ql_returning_shape,
         ql_singletons={value_id},
         ql_anchors={value_name: value_id},
-        external_rels={value_id: (value_rel, ('source', 'identity'))},
+        external_rels={
+            value_id: (
+                value_rel,
+                (pgce.PathAspect.SOURCE, pgce.PathAspect.IDENTITY),
+            )
+        },
         early_result=context.CompiledDML(
             value_cte_name=value_cte_name,
             value_relation_input=value_relation,
@@ -1524,7 +1550,7 @@ def _merge_and_prepare_external_rels(
     stmts: List[UncompiledDML],
     stmt_names: List[str],
 ) -> Tuple[
-    Dict[irast.PathId, Tuple[pgast.BaseRelation, Tuple[str, ...]]],
+    Mapping[irast.PathId, ExternalRel],
     List[irast.MutatingStmt],
 ]:
     """Construct external rels used for compiling all DML statements at once."""
@@ -1548,9 +1574,7 @@ def _merge_and_prepare_external_rels(
             continue
         shape_elements_by_name[rptr_name.name] = b.expr.expr
 
-    external_rels: Dict[
-        irast.PathId, Tuple[pgast.BaseRelation, Tuple[str, ...]]
-    ] = {}
+    external_rels: Dict[irast.PathId, ExternalRel] = {}
     ir_stmts = []
     for stmt, name in zip(stmts, stmt_names):
         # find the associated binding (this is real funky)

--- a/tests/test_sql_dml.py
+++ b/tests/test_sql_dml.py
@@ -91,6 +91,11 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             set default := global y;
           };
         };
+
+        create type Document2 {
+            create required property title: str;
+            create link owner: User;
+        };
     """
     ]
 
@@ -797,6 +802,28 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             id,
         )
         self.assertEqual(res, [[id]])
+
+    async def test_sql_dml_insert_36(self):
+        await self.squery_values(
+            f'''
+            INSERT INTO "User" DEFAULT VALUES
+            '''
+        )
+
+        res = await self.scon.execute(
+            f'''
+            INSERT INTO "Document2" (title, owner_id)
+            VALUES ('Raven', (select id FROM "User" LIMIT 1))
+            '''
+        )
+        # self.assertEqual(res, 'INSERT 0 1')
+
+        res = await self.squery_values(
+            '''
+            SELECT title FROM "Document2"
+            '''
+        )
+        self.assertEqual(res, [['Raven']])
 
     async def test_sql_dml_delete_01(self):
         # delete, inspect CommandComplete tag


### PR DESCRIPTION
Test case:

```sql
INSERT INTO "Document" (title) VALUES ('Report'), ('Briefing')
```

Here, the input relation is injected with an iterator (as it is needed for DML), but is is also registered as identity & value.
This causes problems in specific test case, where the iterator will be joined with base
table to compare ids - this produces no results so no objects are inserted.

If I remove the identity/value, the ql compiler will complain because it is
first doing a plain `compile_Set` on the iterator.

