### PR TITLE
Improve ir ast compatibility with NodeTransformer.

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -261,7 +261,7 @@ class AST:
         self.__dict__ = kwargs
 
     def __copy__(self):
-        copied = self.__class__()
+        copied = self._init_copy()
         for field, value in iter_fields(self, include_meta=True):
             try:
                 object.__setattr__(copied, field, value)
@@ -271,10 +271,13 @@ class AST:
         return copied
 
     def __deepcopy__(self, memo):
-        copied = self.__class__()
+        copied = self._init_copy()
         for field, value in iter_fields(self, include_meta=True):
             object.__setattr__(copied, field, copy.deepcopy(value, memo))
         return copied
+
+    def _init_copy(self):
+        return self.__class__()
 
     def replace(self: T, **changes) -> T:
         copied = copy.copy(self)

--- a/edb/common/ast/transformer.py
+++ b/edb/common/ast/transformer.py
@@ -60,16 +60,34 @@ class NodeTransformer(visitor.NodeVisitor):
     """
 
     def generic_visit(self, node):
-        for field, old_value in base.iter_fields(node, include_meta=False):
-            old_value = getattr(node, field, None)
+        if isinstance(node, base.ImmutableASTMixin):
+            changes: dict[str, base.AST] = {}
 
-            if typeutils.is_container(old_value):
-                new_values = old_value.__class__(self.visit(old_value))
-                setattr(node, field, old_value.__class__(new_values))
+            for field, old_value in base.iter_fields(node, include_meta=False):
+                old_value = getattr(node, field, None)
 
-            elif isinstance(old_value, base.AST):
-                new_node = self.visit(old_value)
-                if new_node is not old_value:
-                    setattr(node, field, new_node)
+                if typeutils.is_container(old_value):
+                    new_values = old_value.__class__(self.visit(old_value))
+                    changes[field] = old_value.__class__(new_values)
+
+                elif isinstance(old_value, base.AST):
+                    new_node = self.visit(old_value)
+                    if new_node is not old_value:
+                        changes[field] = new_node
+
+            node = node.replace(changes=changes)
+
+        else:
+            for field, old_value in base.iter_fields(node, include_meta=False):
+                old_value = getattr(node, field, None)
+
+                if typeutils.is_container(old_value):
+                    new_values = old_value.__class__(self.visit(old_value))
+                    setattr(node, field, old_value.__class__(new_values))
+
+                elif isinstance(old_value, base.AST):
+                    new_node = self.visit(old_value)
+                    if new_node is not old_value:
+                        setattr(node, field, new_node)
 
         return node

--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -121,12 +121,22 @@ class NodeVisitor:
         return visitor.visit(node)
 
     def container_visit(self, node):
-        result = []
-        for elem in (node.values() if isinstance(node, dict) else node):
-            if base.is_ast_node(elem) or typeutils.is_container(elem):
-                result.append(self.visit(elem))
-            else:
-                result.append(elem)
+        if isinstance(node, dict):
+            result = {}
+            for key, value in node.items():
+                if base.is_ast_node(value) or typeutils.is_container(value):
+                    result[key] = self.visit(value)
+                else:
+                    result[key] = value
+
+        else:
+            result = []
+            for elem in node:
+                if base.is_ast_node(elem) or typeutils.is_container(elem):
+                    result.append(self.visit(elem))
+                else:
+                    result.append(elem)
+
         return result
 
     def repeated_node_visit(self, node):

--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -260,6 +260,8 @@ class SpanPropagator(ast.NodeVisitor):
                     pass
                 elif isinstance(span, list):
                     span_list.extend(span)
+                elif isinstance(span, dict):
+                    span_list.extend(span.values())
                 else:
                     span_list.append(span)
         return span_list

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1809,6 +1809,8 @@ class GraphQLTranslator:
             for res in results:
                 if isinstance(res, Field):
                     flattened.append(res)
+                elif isinstance(res, dict):
+                    flattened.extend(res.values())
                 elif typeutils.is_container(res):
                     flattened.extend(res)
                 else:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -829,6 +829,9 @@ class BaseConstant(ConstExpr, ImmutableExpr):
         if self.value is None:
             raise ValueError('cannot create irast.Constant without a value')
 
+    def _init_copy(self) -> BaseConstant:
+        return self.__class__(typeref=self.typeref, value=self.value)
+
 
 class BaseStrConstant(BaseConstant):
     __abstract_node__ = True

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -304,10 +304,11 @@ class ContainsDMLVisitor(ast.NodeVisitor):
         super().__init__()
         self.skip_bindings = skip_bindings
 
-    def combine_field_results(self, xs: List[Optional[bool]]) -> bool:
+    def combine_field_results(self, xs: Iterable[Optional[bool]]) -> bool:
         return any(
             x is True
             or (isinstance(x, list) and self.combine_field_results(x))
+            or (isinstance(x, dict) and self.combine_field_results(x.values()))
             for x in xs
         )
 
@@ -420,6 +421,8 @@ class FindPotentiallyVisibleVisitor(FindPathScopes):
         for x in xs:
             if isinstance(x, list):
                 x = self.combine_field_results(x)
+            if isinstance(x, dict):
+                x = self.combine_field_results(x.values())
             if x:
                 if isinstance(x, set):
                     out.update(x)


### PR DESCRIPTION
- Change `container_visit` to return a dict if the node is also a dict
- Fix `NodeTransformer` errors when visiting an immutable node.