### PR TITLE
[Upgrades] Support preparing upgrade while still up

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -227,7 +227,8 @@ class ServerConfig(NamedTuple):
     log_level: str
     log_to: str
     bootstrap_only: bool
-    inplace_upgrade: Optional[pathlib.Path]
+    inplace_upgrade_prepare: Optional[pathlib.Path]
+    inplace_upgrade_finalize: bool
     bootstrap_command: str
     bootstrap_command_file: pathlib.Path
     default_branch: Optional[str]
@@ -676,10 +677,15 @@ _server_options = [
         envvar="EDGEDB_SERVER_BOOTSTRAP_ONLY", cls=EnvvarResolver,
         help='bootstrap the database cluster and exit'),
     click.option(
-        '--inplace-upgrade', type=PathPath(),
-        envvar="EDGEDB_SERVER_INPLACE_UPGRADE",
+        '--inplace-upgrade-prepare', type=PathPath(),
+        envvar="EDGEDB_SERVER_INPLACE_UPGRADE_PREPARE",
         cls=EnvvarResolver,  # XXX?
         help='try to do an in-place upgrade with the specified dump file'),
+    click.option(
+        '--inplace-upgrade-finalize', type=bool, is_flag=True,
+        envvar="EDGEDB_SERVER_INPLACE_UPGRADE_FINALIZE",
+        cls=EnvvarResolver,  # XXX?
+        help='finalize an in-place upgrade'),
     click.option(
         '--default-branch', type=str,
         help='the name of the default branch to create'),

--- a/tests/inplace-testing/test.sh
+++ b/tests/inplace-testing/test.sh
@@ -16,12 +16,41 @@ make parsers
 
 tar cf "$DIR".tar "$DIR"
 
-patch -f -p1 < tests/inplace-testing/upgrade.patch
+PORT=12346
+edb server -D "$DIR" -P $PORT &
+SPID=$!
+cleanup() {
+    kill $SPID
+}
+trap cleanup EXIT
 
+# Wait for the server to come up and see it is working
+edgedb -H localhost -P $PORT --tls-security insecure -b select query 'select count(User)' | grep 2
+
+# Upgrade to the new version
+patch -f -p1 < tests/inplace-testing/upgrade.patch
 make parsers
 
-edb server --bootstrap-only --inplace-upgrade "$DIR"/upgrade.json --data-dir "$DIR"
+# Get the DSN from the debug endpoint
+DSN=$(curl -s http://localhost:$PORT/server-info | jq -r '.pg_addr | "postgres:///?user=\(.user)&port=\(.port)&host=\(.host)"')
 
+# Prepare the upgrade, operating against the postgres that the old
+# version server is managing
+edb server --bootstrap-only --inplace-upgrade-prepare "$DIR"/upgrade.json --backend-dsn="$DSN"
+
+# Check the server is still working
+edgedb -H localhost -P $PORT --tls-security insecure -b select query 'select count(User)' | grep 2
+
+# Kill the old version so we can finalize the upgrade
+kill $SPID
+wait $SPID
+SPID=
+
+tar cf "$DIR"-prepped.tar "$DIR"
+
+# Finalize the upgrade
+edb server --bootstrap-only --inplace-upgrade-finalize --data-dir "$DIR"
 tar cf "$DIR"-cooked.tar "$DIR"
 
+# Test!
 edb test --data-dir "$DIR" --use-data-dir-dbs -v "$@"

--- a/tests/inplace-testing/test.sh
+++ b/tests/inplace-testing/test.sh
@@ -20,7 +20,9 @@ PORT=12346
 edb server -D "$DIR" -P $PORT &
 SPID=$!
 cleanup() {
-    kill $SPID
+    if [ -n "$SPID" ]; then
+        kill $SPID
+    fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
This requires splitting up "preparing" the upgrade (which populates
the new namespaces) and "finalizing" the upgrade (which flips all the
trampolines and performs schema fixups).

This also does some more work towards making the upgrade recoverable
(by running the finalizations in transactions, and not committing any until
all are ready), but there are still important TODOs on that front.

Progress on #6697.