### PR TITLE
[Upgrades] Make upgrade finalization failure tolerant

### DIFF
--- a/tests/inplace-testing/test.sh
+++ b/tests/inplace-testing/test.sh
@@ -50,6 +50,12 @@ SPID=
 
 tar cf "$DIR"-prepped.tar "$DIR"
 
+# Try to finalize the upgrade, but inject a failure
+if EDGEDB_UPGRADE_FINALIZE_ERROR_INJECTION=main edb server --bootstrap-only --inplace-upgrade-finalize --data-dir "$DIR"; then
+    echo Unexpected upgrade success despite failure injection
+    exit 4
+fi
+
 # Finalize the upgrade
 edb server --bootstrap-only --inplace-upgrade-finalize --data-dir "$DIR"
 tar cf "$DIR"-cooked.tar "$DIR"


### PR DESCRIPTION
Two parts to this:

1. Test all of the pivots inside rolled-back transactions before
   applying. This ensures that if there is a bug in the pivot
   that prevents a database from being upgraded, we fail before
   any irreversible change is made to any database.
2. Track which databases have been finalized and skip them
   when finalizing. This lets us be resilent to crashes, since
   the finalization can be retried.

Progress on #6697.