### PR TITLE
Add smoke tests for `net` and `net::http` types

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1590,4 +1590,7 @@ def _is_forbidden_stdlib_type_for_mod(
         # Allow people to mess with the baseclass of user-defined objects to
         # their hearts' content
         return False
+    if name.get_module_name() == s_name.UnqualName('net::http'):
+        # Allow users to insert net module types
+        return False
     return t.get_name(schema).get_module_name() in s_schema.STD_MODULES

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1579,9 +1579,10 @@ def _is_forbidden_stdlib_type_for_mod(
                     for ut in union.objects(schema)))
 
     name = t.get_name(schema)
+    mod_name = name.get_module_name()
 
     if (
-        name.get_module_name() == s_name.UnqualName('cfg')
+        mod_name == s_name.UnqualName('cfg')
         and o.in_server_config_op
     ):
         # Config ops include various internally generated statements for cfg::
@@ -1590,7 +1591,7 @@ def _is_forbidden_stdlib_type_for_mod(
         # Allow people to mess with the baseclass of user-defined objects to
         # their hearts' content
         return False
-    if name.get_module_name() == s_name.UnqualName('net::http'):
+    if mod_name == s_name.UnqualName('net::http'):
         # Allow users to insert net module types
         return False
-    return t.get_name(schema).get_module_name() in s_schema.STD_MODULES
+    return mod_name in s_schema.STD_MODULES

--- a/tests/test_edgeql_net_schema.py
+++ b/tests/test_edgeql_net_schema.py
@@ -1,0 +1,110 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2024-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from edb.testbase import server as tb
+
+
+class TestEdgeQLNetSchema(tb.DDLTestCase):
+    '''Tests for net schema.'''
+
+    async def test_edgeql_net_request_state_enum_01(self):
+        await self.assert_query_result(
+            '''
+            select {
+                net::RequestState.Pending,
+                net::RequestState.InProgress,
+                net::RequestState.Completed,
+                net::RequestState.Failed,
+            };
+            ''',
+            ['Pending', 'InProgress', 'Completed', 'Failed'],
+        )
+
+    async def test_edgeql_net_request_state_failure_kind_01(self):
+        await self.assert_query_result(
+            '''
+            select {
+                net::RequestFailureKind.NetworkError,
+                net::RequestFailureKind.Timeout,
+            };
+            ''',
+            ['NetworkError', 'Timeout'],
+        )
+
+    async def test_edgeql_net_http_method_01(self):
+        await self.assert_query_result(
+            '''
+            select {
+                net::http::Method.`GET`,
+                net::http::Method.POST,
+                net::http::Method.PUT,
+                net::http::Method.`DELETE`,
+                net::http::Method.HEAD,
+                net::http::Method.OPTIONS,
+                net::http::Method.PATCH,
+            };
+            ''',
+            ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH'],
+        )
+
+    async def test_edgeql_net_http_request_response_01(self):
+        await self.assert_query_result(
+            '''
+            with
+                nh as module net::http,
+                response := (
+                    insert nh::Response {
+                        created_at := datetime_of_statement(),
+                        status := 200,
+                        headers := [("Content-Type", "text/plain")],
+                        body := to_bytes("hello world"),
+                    }
+                ),
+                request := (
+                    insert nh::ScheduledRequest {
+                        created_at := datetime_of_statement(),
+                        state := net::RequestState.Completed,
+
+                        url := "http://example.com",
+                        method := nh::Method.`GET`,
+                        headers := [("Accept", "text/plain")],
+
+                        response := response,
+                    }
+                ),
+            select request {
+                state,
+                url,
+                method,
+
+                response: {
+                    status,
+                    body_decoded := to_str(.body),
+                }
+            };
+            ''',
+            [{
+                'state': 'Completed',
+                'url': 'http://example.com',
+                'method': 'GET',
+                'response': {
+                    'status': 200,
+                    'body_decoded': 'hello world',
+                },
+            }],
+        )


### PR DESCRIPTION
These tests uncovered the `_is_forbidden_stdlib_type_for_mod` bit, and I wasn't 100% sure if this was the right fix here, but tests pass.