### PR TITLE
Store module name instead of dynamic look-up

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1579,9 +1579,10 @@ def _is_forbidden_stdlib_type_for_mod(
                     for ut in union.objects(schema)))
 
     name = t.get_name(schema)
+    mod_name = name.get_module_name()
 
     if (
-        name.get_module_name() == s_name.UnqualName('cfg')
+        mod_name == s_name.UnqualName('cfg')
         and o.in_server_config_op
     ):
         # Config ops include various internally generated statements for cfg::
@@ -1590,7 +1591,7 @@ def _is_forbidden_stdlib_type_for_mod(
         # Allow people to mess with the baseclass of user-defined objects to
         # their hearts' content
         return False
-    if name.get_module_name() == s_name.UnqualName('net::http'):
+    if mod_name == s_name.UnqualName('net::http'):
         # Allow users to insert net module types
         return False
-    return t.get_name(schema).get_module_name() in s_schema.STD_MODULES
+    return mod_name in s_schema.STD_MODULES


### PR DESCRIPTION
The value should be stable across all of these invocations