### PR TITLE
Fix tests in --use-data-dir-dbs mode

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2594,12 +2594,14 @@ def start_edgedb_server(
     extra_args: Optional[List[str]] = None,
     default_branch: Optional[str] = None,
 ):
-    if not devmode.is_in_dev_mode() and not runstate_dir:
+    if (not devmode.is_in_dev_mode() or adjacent_to) and not runstate_dir:
         if backend_dsn or adjacent_to:
+            import traceback
             # We don't want to implicitly "fix the issue" for the test author
             print('WARNING: starting an EdgeDB server with the default '
                   'runstate_dir; the test is likely to fail or hang. '
                   'Consider specifying the runstate_dir parameter.')
+            print('\n'.join(traceback.format_stack(limit=5)))
 
     if mt_conf := os.environ.get("EDGEDB_SERVER_MULTITENANT_CONFIG_FILE"):
         if multitenant_config is None and max_allowed_connections == 10:

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2073,6 +2073,7 @@ class TestServerProtoMigration(tb.QueryTestCase):
             ['123']
         )
 
+
 class TestServerProtoDdlPropagation(tb.QueryTestCase):
 
     TRANSACTION_ISOLATION = False
@@ -2117,7 +2118,8 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
             123
         )
 
-        async with tb.start_edgedb_server(**self.get_adjacent_server_args()) as sd:
+        server_args = self.get_adjacent_server_args()
+        async with tb.start_edgedb_server(**server_args) as sd:
 
             con2 = await sd.connect(
                 user=conargs.get('user'),
@@ -2210,7 +2212,8 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
 
         conargs = self.get_connect_args()
 
-        async with tb.start_edgedb_server(**self.get_adjacent_server_args()) as sd:
+        server_args = self.get_adjacent_server_args()
+        async with tb.start_edgedb_server(**server_args) as sd:
 
             # Run twice to make sure there is no lingering accessibility state
             for _ in range(2):
@@ -2291,7 +2294,8 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
             'Authorization': self.make_auth_header(),
         }
 
-        async with tb.start_edgedb_server(**self.get_adjacent_server_args()) as sd:
+        server_args = self.get_adjacent_server_args()
+        async with tb.start_edgedb_server(**server_args) as sd:
 
             await self.con.execute("CREATE EXTENSION notebook;")
 


### PR DESCRIPTION
Fixes #7707 by specifying a `runstate_dir` for tests that were flaking often under `--use-data-dir-dbs`.