### PR TITLE
Tweak how we test index scans.

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1163,7 +1163,10 @@ class ConnectedTestCase(ClusterTestCase):
 
     async def assert_index_use(self, query, *args, index_type):
         def look(obj):
-            if isinstance(obj, dict) and obj.get('plan_type') == "IndexScan":
+            if (
+                isinstance(obj, dict)
+                and "IndexScan" in obj.get('plan_type', '')
+            ):
                 return any(
                     prop['title'] == 'index_name'
                     and index_type in prop['value']


### PR DESCRIPTION
When testing whether a query plan involves an index "IndexScan" as well as "BitmapIndexScan" are both acceptable.