### PR TITLE
Allow complex types as function params.

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -226,7 +226,6 @@ class ParameterDesc(ParameterLike):
                 subtypes=[paramt_ast],
             )
 
-        assert isinstance(paramt_ast, qlast.TypeName)
         paramt = utils.ast_to_type_shell(
             paramt_ast,
             metaclass=s_types.Type,


### PR DESCRIPTION
Allow functions such as `create function foo(x: A | B) -> int64 using (x.n);`