### PR TITLE
Fix ast transformer not working with sets of tuples of nodes.

### DIFF
--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -19,7 +19,9 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Type, TypeVar, AbstractSet, Collection
+from typing import (
+    AbstractSet, Any, Callable, Collection, Optional, Iterable, Type, TypeVar
+)
 
 from edb.common import typeutils
 
@@ -120,22 +122,29 @@ class NodeVisitor:
         visitor = cls(**kwargs)
         return visitor.visit(node)
 
-    def container_visit(self, node):
+    def container_visit(self, node) -> dict[Any, Any] | Iterable[Any]:
+        def _visit_element(elem):
+            if base.is_ast_node(elem) or typeutils.is_container(elem):
+                return self.visit(elem)
+            else:
+                return elem
+
+        result: dict[Any, Any] | Iterable[Any]
+
         if isinstance(node, dict):
             result = {}
             for key, value in node.items():
-                if base.is_ast_node(value) or typeutils.is_container(value):
-                    result[key] = self.visit(value)
-                else:
-                    result[key] = value
+                result[key] = _visit_element(value)
+
+        elif isinstance(node, tuple):
+            result = ()
+            for elem in node:
+                result += (_visit_element(elem),)
 
         else:
             result = []
             for elem in node:
-                if base.is_ast_node(elem) or typeutils.is_container(elem):
-                    result.append(self.visit(elem))
-                else:
-                    result.append(elem)
+                result.append(_visit_element(elem))
 
         return result
 

--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -251,14 +251,14 @@ class SpanPropagator(ast.NodeVisitor):
         return self.memo[node]
 
     def container_visit(self, node) -> List[Span | None]:
-        span_list = []
+        span_list: list[Span | None] = []
         for el in node:
             if isinstance(el, ast.AST) or typeutils.is_container(el):
                 span = self.visit(el)
 
                 if not span:
                     pass
-                elif isinstance(span, list):
+                elif isinstance(span, (list, tuple)):
                     span_list.extend(span)
                 elif isinstance(span, dict):
                     span_list.extend(span.values())

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -307,7 +307,7 @@ class ContainsDMLVisitor(ast.NodeVisitor):
     def combine_field_results(self, xs: Iterable[Optional[bool]]) -> bool:
         return any(
             x is True
-            or (isinstance(x, list) and self.combine_field_results(x))
+            or (isinstance(x, (list, tuple)) and self.combine_field_results(x))
             or (isinstance(x, dict) and self.combine_field_results(x.values()))
             for x in xs
         )
@@ -419,7 +419,7 @@ class FindPotentiallyVisibleVisitor(FindPathScopes):
     def combine_field_results(self, xs: Any) -> Set[irast.Set]:
         out = set()
         for x in xs:
-            if isinstance(x, list):
+            if isinstance(x, (list, tuple)):
                 x = self.combine_field_results(x)
             if isinstance(x, dict):
                 x = self.combine_field_results(x.values())


### PR DESCRIPTION
Followup to #7716
Related #7692

Some fields are sets of tuples. The current visit implementation will produce attempt to produce a set of lists, however, lists are not hashable. This causes `NodeTransformer.generic_visit` visit to fail to create the new field data.

The return type should not be modified in `NodeVisitor.container_visit` since most visitors are not expected to return the exact type of the node when visiting. It is possible to override the function in `NodeTransformer`, but this change is minimal.