### PR TITLE
Workaround Cython bug under Clang

### DIFF
--- a/edb/server/pgcon/pgcon.pxd
+++ b/edb/server/pgcon/pgcon.pxd
@@ -188,4 +188,4 @@ cdef class PGConnection:
     cdef inline str get_tenant_label(self)
     cpdef set_stmt_cache_size(self, int maxsize)
 
-cdef inline str setting_to_sql(self)
+cdef str setting_to_sql(self)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -3341,7 +3341,7 @@ cdef bytes FLUSH_MESSAGE = bytes(WriteBuffer.new_message(b'H').end_message())
 cdef EdegDBCodecContext DEFAULT_CODEC_CONTEXT = EdegDBCodecContext()
 
 
-cdef inline str setting_to_sql(setting: tuple[str | int | float, ...]):
+cdef str setting_to_sql(setting: tuple[str | int | float, ...]):
     return ', '.join(setting_val_to_sql(v) for v in setting)
 
 


### PR DESCRIPTION
`cimport`-ing an `cdef inline` function is compiled into a CYTHON_INLINE function pointer by Cython (both 0.x and 3.x), which isn't allowed in Clang.

Refs #7747, fixes nightlies on macOS