### PR TITLE
Make the extension makefiles closer to being able to build against a nightly

### DIFF
--- a/edb/tools/config.py
+++ b/edb/tools/config.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import click
 
 from edb import buildmeta
+from edb.common import devmode
 from edb.tools.edb import edbcommands
 
 
@@ -41,10 +42,12 @@ def config(make_include: bool, pg_config: bool) -> None:
     '''Query certain parameters about an edgedb environment'''
     if make_include:
         share = buildmeta.get_extension_dir_path()
+        base = share.parent.parent.parent
         # XXX: It should not be here.
+        if not devmode.is_in_dev_mode():
+            base = base / 'data'
         mk = (
-            share.parent.parent.parent / 'tests' /
-            'extension-testing' / 'exts.mk'
+            base / 'tests' / 'extension-testing' / 'exts.mk'
         )
         print(mk)
     if pg_config:

--- a/tests/extension-testing/ext_test/Makefile
+++ b/tests/extension-testing/ext_test/Makefile
@@ -1,5 +1,12 @@
 # Configurable parts
 SQL_MODULE := sql
 
+### Boilerplate
+PYTHON := python3
+EDB := $(PYTHON) -m edb.tools $(EDBFLAGS)
+MKS := $(shell $(EDB) config --make-include)
+include $(MKS)
+### End Boilerplate
+
 MKS := $(shell edb config --make-include)
 include $(MKS)

--- a/tests/extension-testing/exts.mk
+++ b/tests/extension-testing/exts.mk
@@ -1,13 +1,13 @@
-EXT_NAME := $(shell python3 -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(f["name"])')
-EXT_VERSION := $(shell python3 -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(f["version"])')
-EDGEQL_SRCS := $(shell python3 -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(" ".join(f["files"]))')
-SQL_DIR := $(shell python3 -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(f["postgres_files"])')
+EXT_NAME := $(shell $(PYTHON) -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(f["name"])')
+EXT_VERSION := $(shell $(PYTHON) -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(f["version"])')
+EDGEQL_SRCS := $(shell $(PYTHON) -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(" ".join(f["files"]))')
+SQL_DIR := $(shell $(PYTHON) -c 'import tomllib; f = tomllib.load(open("MANIFEST.toml", "rb")); print(f["postgres_files"])')
 
 #
 
 EXT_FNAME := $(EXT_NAME)--$(EXT_VERSION)
 
-PG_CONFIG := $(shell edb config --pg-config)
+PG_CONFIG := $(shell $(EDB) config --pg-config)
 PG_DIR := $(shell dirname $(shell dirname $(PG_CONFIG)))
 
 rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))


### PR DESCRIPTION
Get the makefile to do it by making PYTHON configurable and invoking
`edb config` via `$(PYTHON) -m edb.tools`.

It doesn't actually work though, because the bundled postgres doesn't
include the development headers.