### PR TITLE
Fix install paths in edgedb-load-ext

### DIFF
--- a/edb/load_ext/main.py
+++ b/edb/load_ext/main.py
@@ -40,8 +40,8 @@ import zipfile
 # Directories that we map to config values in pg_config.
 CONFIG_PATHS = {
     'share': 'sharedir',
-    'lib': 'libdir',
-    'include': 'includedir',
+    'lib': 'pkglibdir',
+    'include': 'pkgincludedir-server',
 }
 
 


### PR DESCRIPTION
We actually want to drop our .so files in `pkglibdir`, which is the
same as `libdir` in our dev/build environment but not in our
artifacts.