### PR TITLE
Disable net_worker for conflicting tests

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -70,7 +70,7 @@ class BaseCluster:
         ] = None,
         net_worker_mode: Optional[
             edgedb_args.NetWorkerMode
-        ] = edgedb_args.NetWorkerMode.Disabled,
+        ] = None,
     ):
         self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
 

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -68,6 +68,9 @@ class BaseCluster:
         compiler_pool_mode: Optional[
             edgedb_args.CompilerPoolMode
         ] = None,
+        net_worker_mode: Optional[
+            edgedb_args.NetWorkerMode
+        ] = edgedb_args.NetWorkerMode.Disabled,
     ):
         self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
 
@@ -112,6 +115,12 @@ class BaseCluster:
             self._edgedb_cmd.extend((
                 '--compiler-pool-mode',
                 str(compiler_pool_mode),
+            ))
+
+        if net_worker_mode is not None:
+            self._edgedb_cmd.extend((
+                '--net-worker-mode',
+                str(net_worker_mode),
             ))
 
         self._log_level = log_level

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -251,6 +251,7 @@ async def _run_server(
                 srvargs.ReloadTrigger.Default,
                 srvargs.ReloadTrigger.FileSystemEvent,
             ],
+            net_worker_mode=args.net_worker_mode,
         )
         # This coroutine runs as long as the server,
         # and compiler_state is *heavy*, so make sure we don't

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -162,6 +162,7 @@ class BaseServer:
         disable_dynamic_system_config: bool = False,
         compiler_state: edbcompiler.CompilerState,
         use_monitor_fs: bool = False,
+        net_worker_mode: srvargs.NetWorkerMode = srvargs.NetWorkerMode.Default,
     ):
         self.__loop = asyncio.get_running_loop()
         self._use_monitor_fs = use_monitor_fs
@@ -228,6 +229,7 @@ class BaseServer:
         self._http_request_logger = None
         self._auth_gc = None
         self._net_worker_http = None
+        self._net_worker_mode = net_worker_mode
 
         self._stop_evt = asyncio.Event()
         self._tls_cert_file: str | Any = None
@@ -1044,7 +1046,10 @@ class BaseServer:
 
         await self._after_start_servers()
         self._auth_gc = self.__loop.create_task(pkce.gc(self))
-        self._net_worker_http = self.__loop.create_task(net_worker.http(self))
+        if self._net_worker_mode is srvargs.NetWorkerMode.Default:
+            self._net_worker_http = self.__loop.create_task(
+                net_worker.http(self)
+            )
 
         if self._echo_runtime_info:
             ri = {

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2234,7 +2234,7 @@ class _EdgeDBServer:
         default_branch: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
         extra_args: Optional[List[str]] = None,
-        net_worker_mode: Optional[str] = 'disabled',
+        net_worker_mode: Optional[str] = None,
     ) -> None:
         self.bind_addrs = bind_addrs
         self.auto_shutdown_after = auto_shutdown_after
@@ -2601,7 +2601,7 @@ def start_edgedb_server(
     env: Optional[Dict[str, str]] = None,
     extra_args: Optional[List[str]] = None,
     default_branch: Optional[str] = None,
-    net_worker_mode: Optional[str] = 'disabled',
+    net_worker_mode: Optional[str] = None,
 ):
     if (not devmode.is_in_dev_mode() or adjacent_to) and not runstate_dir:
         if backend_dsn or adjacent_to:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2234,6 +2234,7 @@ class _EdgeDBServer:
         default_branch: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
         extra_args: Optional[List[str]] = None,
+        net_worker_mode: Optional[str] = 'disabled',
     ) -> None:
         self.bind_addrs = bind_addrs
         self.auto_shutdown_after = auto_shutdown_after
@@ -2268,6 +2269,7 @@ class _EdgeDBServer:
         self.default_branch = default_branch
         self.env = env
         self.extra_args = extra_args
+        self.net_worker_mode = net_worker_mode
 
     async def wait_for_server_readiness(self, stream: asyncio.StreamReader):
         while True:
@@ -2438,6 +2440,9 @@ class _EdgeDBServer:
         if not self.multitenant_config:
             cmd += ['--instance-name=localtest']
 
+        if self.net_worker_mode:
+            cmd += ['--net-worker-mode', self.net_worker_mode]
+
         if self.extra_args:
             cmd.extend(self.extra_args)
 
@@ -2596,6 +2601,7 @@ def start_edgedb_server(
     env: Optional[Dict[str, str]] = None,
     extra_args: Optional[List[str]] = None,
     default_branch: Optional[str] = None,
+    net_worker_mode: Optional[str] = 'disabled',
 ):
     if (not devmode.is_in_dev_mode() or adjacent_to) and not runstate_dir:
         if backend_dsn or adjacent_to:
@@ -2665,6 +2671,7 @@ def start_edgedb_server(
         env=env,
         extra_args=extra_args,
         default_branch=default_branch,
+        net_worker_mode=net_worker_mode,
     )
 
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -764,7 +764,18 @@ def _extract_background_errors(metrics: str) -> str | None:
 
 
 async def drop_db(conn, dbname):
-    await conn.execute(f'DROP DATABASE {dbname}')
+    # net_worker (#7742) may issue a query while DROP DATABASE happens.
+    # This is a WIP bug that should be solved when adopting notification-
+    # driven net_worker, but hack around it with a retry loop for now.
+    # Without this, tests would flake a lot.
+    async for tr in TestCase.try_until_succeeds(
+        ignore=(edgedb.ExecutionError, edgedb.ClientConnectionError),
+        timeout=30
+    ):
+        async with tr:
+            await conn.execute(
+                f'DROP DATABASE {dbname};'
+            )
 
 
 class ClusterTestCase(BaseHTTPTestCase):

--- a/tests/test_http_std_net.py
+++ b/tests/test_http_std_net.py
@@ -59,53 +59,48 @@ class StdNetTestCase(server.QueryTestCase):
             )
         )
 
-        async with server.start_edgedb_server(net_worker_mode='default') as sd:
-            con = await sd.connect()
+        await self.con.query(
+            """
+            with
+                nh as module std::net::http,
+                net as module std::net,
+                url := <str>$url,
+                request := (
+                    insert nh::ScheduledRequest {
+                        created_at := datetime_of_statement(),
+                        state := std::net::RequestState.Pending,
 
-            await con.query(
-                """
-                with
-                    nh as module std::net::http,
-                    net as module std::net,
-                    url := <str>$url,
-                    request := (
-                        insert nh::ScheduledRequest {
-                            created_at := datetime_of_statement(),
-                            state := std::net::RequestState.Pending,
+                        url := url,
+                        method := nh::Method.`GET`,
+                        headers := [
+                            ("Accept", "text/plain"),
+                            ("x-test-header", "test-value"),
+                        ],
+                    }
+                )
+            select request {*};
+            """,
+            url=f"{self.base_url}/test",
+        )
 
-                            url := url,
-                            method := nh::Method.`GET`,
-                            headers := [
-                                ("Accept", "text/plain"),
-                                ("x-test-header", "test-value"),
-                            ],
-                        }
-                    )
-                select request {*};
-                """,
-                url=f"{self.base_url}/test",
-            )
-
-            async for tr in self.try_until_succeeds(
-                delay=2,
-                timeout=120,
-                ignore=(edgedb.CardinalityViolationError,),
-            ):
-                async with tr:
-                    await con.query(
-                        """
-                        with
-                            url := <str>$url,
-                            request := assert_exists((
-                                select std::net::http::ScheduledRequest
-                                filter .url = url
-                                and .state != std::net::RequestState.Pending
-                                limit 1
-                            ))
-                        select request {*};
-                        """,
-                        url=f"{self.base_url}/test",
-                    )
+        async for tr in self.try_until_succeeds(
+            delay=2, timeout=120, ignore=(edgedb.CardinalityViolationError,)
+        ):
+            async with tr:
+                await self.con.query(
+                    """
+                    with
+                        url := <str>$url,
+                        request := assert_exists((
+                            select std::net::http::ScheduledRequest
+                            filter .url = url
+                            and .state != std::net::RequestState.Pending
+                            limit 1
+                        ))
+                    select request {*};
+                    """,
+                    url=f"{self.base_url}/test",
+                )
 
         requests_for_example = self.mock_server.requests[example_request]
         self.assertEqual(len(requests_for_example), 1)

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -720,6 +720,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
             async with tb.start_edgedb_server(
                 data_dir=temp_dir,
                 default_auth_method=args.ServerAuthMethod.Trust,
+                net_worker_mode='disabled',
             ) as sd:
                 con = await sd.connect()
                 try:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -776,6 +776,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
             async with tb.start_edgedb_server(
                 data_dir=temp_dir,
                 default_auth_method=args.ServerAuthMethod.Trust,
+                net_worker_mode='disabled',
             ) as sd:
                 con = await sd.connect()
                 try:


### PR DESCRIPTION
This adds a hidden option/envvar `--net-worker-mode` that is turned off for tests that have conflict with the current net_worker.

Also takes back a retry around DROP DATABASE for tests as a workaround.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/10946518415)