### PR TITLE
Add custom serialization for scalars.

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -185,6 +185,8 @@ class TypeRef(ImmutableBase):
     needs_custom_json_cast: bool = False
     # If this has a schema-configured backend type, what is it
     sql_type: typing.Optional[str] = None
+    # If this has a schema-configured custom sql serialization, what is it
+    custom_sql_serialization: typing.Optional[str] = None
 
     def __repr__(self) -> str:
         return f'<ir.TypeRef \'{self.name_hint}\' at 0x{id(self):x}>'

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -140,16 +140,15 @@ def compile_Parameter(
 
     if irtyputils.needs_custom_serialization(expr.typeref):
         if irtyputils.is_array(expr.typeref):
-            el_sql_type = irtyputils.get_custom_serialization(
-                expr.typeref.subtypes[0])
+            subt = expr.typeref.subtypes[0]
+            el_sql_type = subt.real_base_type.custom_sql_serialization
             # Arrays of text encoded types need to come in as the custom type
             result = pgast.TypeCast(
                 arg=result,
                 type_name=pgast.TypeName(name=(f'{el_sql_type}[]',)),
             )
         else:
-            el_sql_type = irtyputils.get_custom_serialization(
-                expr.typeref)
+            el_sql_type = expr.typeref.real_base_type.custom_sql_serialization
             assert el_sql_type is not None
             result = pgast.TypeCast(
                 arg=result,

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -640,7 +640,7 @@ def serialize_custom_array(
             ]
         )
     else:
-        el_sql_type = irtyputils.get_custom_serialization(el_type)
+        el_sql_type = el_type.real_base_type.custom_sql_serialization
         return pgast.TypeCast(
             arg=expr,
             type_name=pgast.TypeName(name=(f'{el_sql_type}[]',)),
@@ -715,7 +715,7 @@ def output_as_value(
         elif irtyputils.is_tuple(ser_typeref):
             return serialize_custom_tuple(expr, styperef=ser_typeref, env=env)
         else:
-            el_sql_type = irtyputils.get_custom_serialization(ser_typeref)
+            el_sql_type = ser_typeref.real_base_type.custom_sql_serialization
             assert el_sql_type is not None
             val = pgast.TypeCast(
                 arg=val,

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -88,6 +88,9 @@ class ScalarType(
         compcoef=0.0,
     )
 
+    custom_sql_serialization = so.SchemaField(
+        str, default=None, inheritable=False, compcoef=0.0)
+
     @classmethod
     def get_schema_class_displayname(cls) -> str:
         return 'scalar type'


### PR DESCRIPTION
Some scalar types need to be cast into some other SQL type during serialization. This can be defined as `custom_sql_serialization` on the scalar types in schema.