### PR TITLE
Fix ISE involving UNLESS CONFLICT and WITH interaction

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1945,8 +1945,14 @@ def _normalize_view_ptr_expr(
     if materialized and is_mutation and any(
         x.is_binding == irast.BindingKind.With
         and x.expr
+        # If it is a computed pointer, look just at the definition.
+        # TODO: It is a weird artifact of how our shapes are defined
+        # that if a shape element is defined to be some WITH-bound variable,
+        # that set can is both a is_binding and an irast.Pointer. It seems like
+        # the is_binding part should be nested inside it.
+        and (y := x.expr.expr if isinstance(x.expr, irast.Pointer) else x.expr)
         and inference.infer_volatility(
-            x.expr, ctx.env, exclude_dml=True).is_volatile()
+            y, ctx.env, exclude_dml=True).is_volatile()
 
         for reason in materialized
         if isinstance(reason, irast.MaterializeVisible)

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -35,6 +35,9 @@ type InsertTest {
     link sub -> Subordinate {
         property note -> str;
     }
+    link sub_ex -> Subordinate {
+        constraint exclusive;
+    }
 }
 
 type DerivedTest extending InsertTest;

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3861,6 +3861,22 @@ class TestInsert(tb.QueryTestCase):
             [{'name': {'foo', 'bar'}}],
         )
 
+    async def test_edgeql_insert_unless_conflict_29(self):
+        await self.con.execute('''
+            with
+                sub := <Subordinate>{},
+                upsert := (
+                    insert InsertTest {
+                        l2 := 0,
+                        sub_ex := sub
+                    }
+                    unless conflict
+                ),
+            insert Note {
+                name := '', subject := upsert,
+            };
+        ''')
+
     async def test_edgeql_insert_dependent_01(self):
         query = r'''
             SELECT (

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2849,7 +2849,7 @@ class TestUpdate(tb.QueryTestCase):
                 ) FILTER false;
             """)
 
-    async def test_edgeql_insert_multi_required_01(self):
+    async def test_edgeql_update_insert_multi_required_01(self):
         await self.con.execute("""
             insert MultiRequiredTest {
               name := "___",
@@ -2865,7 +2865,7 @@ class TestUpdate(tb.QueryTestCase):
             };
         """)
 
-    async def test_edgeql_insert_multi_required_02(self):
+    async def test_edgeql_update_insert_multi_required_02(self):
         await self.con.execute("""
             insert MultiRequiredTest {
               name := "___",


### PR DESCRIPTION
We are directly invoking `infer_volatility` on a Pointer in some
cases, and that isn't supported yet. Fix it in the simplest way by
making the logic behave like it did before the Pointer refactor.

It is actually also easy to fix the `infer_volatility` shortcoming
(and I will), but if we just do that, we run into a spurious
volatility error that I need to track down.

Fixes #7433.