### PR TITLE
Generalize matching types to indexes.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_09_19_00_00
+EDGEDB_CATALOG_VERSION = 2024_09_20_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql-parser/src/ast.rs
+++ b/edb/edgeql-parser/src/ast.rs
@@ -1019,6 +1019,7 @@ pub enum CreateObjectKind {
     CreateFunction(CreateFunction),
     CreateOperator(CreateOperator),
     CreateCast(CreateCast),
+    CreateIndexMatch(CreateIndexMatch),
 }
 
 #[derive(Debug, Clone)]
@@ -1096,6 +1097,7 @@ pub enum DropObjectKind {
     DropFunction(DropFunction),
     DropOperator(DropOperator),
     DropCast(DropCast),
+    DropIndexMatch(DropIndexMatch),
 }
 
 #[derive(Debug, Clone)]
@@ -1521,6 +1523,14 @@ pub struct AlterConcreteIndex {}
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "python", derive(IntoPython))]
 pub struct DropConcreteIndex {}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", derive(IntoPython))]
+pub struct CreateIndexMatch {}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", derive(IntoPython))]
+pub struct DropIndexMatch {}
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "python", derive(IntoPython))]

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1268,6 +1268,26 @@ class DropIndex(DropObject, IndexCommand):
     pass
 
 
+class IndexMatchCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    __rust_ignore__ = True
+    object_class: qltypes.SchemaObjectClass = \
+        qltypes.SchemaObjectClass.INDEX_MATCH
+    valid_type: TypeName
+
+
+class CreateIndexMatch(CreateObject, IndexMatchCommand):
+    pass
+    # XXX: we might want to have a code field to potentially customize the
+    # default index code (to account for operator classes and similar custom
+    # type-based syntax)
+
+
+class DropIndexMatch(DropObject, IndexMatchCommand):
+    pass
+
+
 class ConcreteIndexCommand(IndexCommand):
 
     __abstract_node__ = True

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -2078,6 +2078,27 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             node, 'INDEX', named=node.name.name != 'idx',
             after_name=lambda: self._after_index(node))
 
+    def visit_CreateIndexMatch(self, node: qlast.CreateIndexMatch) -> None:
+        def after_name() -> None:
+            self.visit(node.valid_type)
+            self._write_keywords(' using ')
+            self.visit(node.name)
+
+        self._visit_CreateObject(
+            node, 'index match', 'for',
+            named=False, after_name=after_name,
+        )
+
+    def visit_DropIndexMatch(self, node: qlast.DropIndexMatch) -> None:
+        def after_name() -> None:
+            self.visit(node.valid_type)
+            self._write_keywords(' using ')
+            self.visit(node.name)
+        self._visit_DropObject(
+            node, 'index match', 'for',
+            named=False, after_name=after_name,
+        )
+
     def visit_CreateOperator(self, node: qlast.CreateOperator) -> None:
         def after_name() -> None:
             self.write('(')

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -270,6 +270,14 @@ class InnerDDLStmt(Nonterm):
     def reduce_DropIndexStmt(self, *_):
         pass
 
+    @parsing.inline(0)
+    def reduce_CreateIndexMatchStmt(self, *_):
+        pass
+
+    @parsing.inline(0)
+    def reduce_DropIndexMatchStmt(self, *_):
+        pass
+
 
 class PointerName(Nonterm):
     @parsing.inline(0)
@@ -1679,6 +1687,38 @@ class DropConcreteIndexStmt(Nonterm, commondl.ProcessIndexMixin):
             expr=kids[4].val,
             except_expr=kids[5].val,
             commands=kids[6].val,
+        )
+
+
+#
+# CREATE INDEX MATCH
+#
+commands_block(
+    'CreateIndexMatch',
+    CreateAnnotationValueStmt,
+)
+
+
+class CreateIndexMatchStmt(Nonterm):
+    def reduce_CreateIndexMatch(self, *kids):
+        r"""%reduce CREATE INDEX MATCH FOR TypeName USING NodeName \
+                    OptCreateIndexMatchCommandsBlock"""
+        self.val = qlast.CreateIndexMatch(
+            valid_type=kids[4].val,
+            name=kids[6].val,
+            commands=kids[7].val,
+        )
+
+
+#
+# DROP INDEX MATCH
+#
+class DropIndexMatchStmt(Nonterm):
+    def reduce_DropIndexMatch(self, *kids):
+        r"""%reduce DROP INDEX MATCH FOR TypeName USING NodeName"""
+        self.val = qlast.DropIndexMatch(
+            valid_type=kids[4].val,
+            name=kids[6].val,
         )
 
 

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -262,6 +262,7 @@ class SchemaObjectClass(s_enum.StrEnum):
     FUNCTION = 'FUNCTION'
     GLOBAL = 'GLOBAL'
     INDEX = 'INDEX'
+    INDEX_MATCH = 'INDEX MATCH'
     LINK = 'LINK'
     MIGRATION = 'MIGRATION'
     MODULE = 'MODULE'

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -474,4 +474,6 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             })
         }
     };
+
+    create index match for std::str using ext::ai::index;
 };

--- a/edb/lib/ext/pg_trgm.edgeql
+++ b/edb/lib/ext/pg_trgm.edgeql
@@ -154,4 +154,7 @@ create extension package pg_trgm version '1.6' {
         set code :=
             'GIST (__col__ gist_trgm_ops(siglen = __kw_siglen__))';
     };
+
+    create index match for std::str using ext::pg_trgm::gin;
+    create index match for std::str using ext::pg_trgm::gist;
 };

--- a/edb/lib/ext/pgvector.edgeql
+++ b/edb/lib/ext/pgvector.edgeql
@@ -220,4 +220,11 @@ create extension package pgvector version '0.5.0' {
             WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
         $$;
     };
+
+    create index match for ext::pgvector::vector using ext::pgvector::ivfflat_euclidean;
+    create index match for ext::pgvector::vector using ext::pgvector::ivfflat_ip;
+    create index match for ext::pgvector::vector using ext::pgvector::ivfflat_cosine;
+    create index match for ext::pgvector::vector using ext::pgvector::hnsw_euclidean;
+    create index match for ext::pgvector::vector using ext::pgvector::hnsw_ip;
+    create index match for ext::pgvector::vector using ext::pgvector::hnsw_cosine;
 };

--- a/edb/lib/fts.edgeql
+++ b/edb/lib/fts.edgeql
@@ -68,6 +68,8 @@ CREATE SCALAR TYPE fts::document {
     SET transient := true;
 };
 
+create index match for fts::document using fts::index;
+
 CREATE FUNCTION fts::with_options(
     text: std::str,
     NAMED ONLY language: anyenum,

--- a/edb/lib/pg.edgeql
+++ b/edb/lib/pg.edgeql
@@ -25,11 +25,15 @@ CREATE ABSTRACT INDEX pg::hash {
     SET code := 'hash ((__col__))';
 };
 
+create index match for anytype using pg::hash;
+
 CREATE ABSTRACT INDEX pg::btree {
     CREATE ANNOTATION std::description :=
         'B-tree index can be used to retrieve data in sorted order.';
     SET code := 'btree ((__col__) NULLS FIRST)';
 };
+
+create index match for anytype using pg::btree;
 
 CREATE ABSTRACT INDEX pg::gin {
     CREATE ANNOTATION std::description :=
@@ -38,11 +42,18 @@ CREATE ABSTRACT INDEX pg::gin {
     SET code := 'gin ((__col__))';
 };
 
+create index match for array<anytype> using pg::gin;
+create index match for std::json using pg::gin;
+
 CREATE ABSTRACT INDEX pg::gist {
     CREATE ANNOTATION std::description :=
         'GIST index can be used to optimize searches involving ranges.';
     SET code := 'gist ((__col__))';
 };
+
+create index match for array<anytype> using pg::gist;
+create index match for range<std::anypoint> using pg::gist;
+create index match for multirange<std::anypoint> using pg::gist;
 
 CREATE ABSTRACT INDEX pg::spgist {
     CREATE ANNOTATION std::description :=
@@ -51,9 +62,25 @@ CREATE ABSTRACT INDEX pg::spgist {
     SET code := 'spgist ((__col__))';
 };
 
+create index match for range<std::anypoint> using pg::spgist;
+create index match for std::str using pg::spgist;
+
 CREATE ABSTRACT INDEX pg::brin {
     CREATE ANNOTATION std::description :=
         'BRIN (Block Range INdex) index works with summaries about the values \
         stored in consecutive physical block ranges in the database.';
     SET code := 'brin ((__col__))';
 };
+
+create index match for range<std::anypoint> using pg::brin;
+create index match for std::anyreal using pg::brin;
+create index match for std::bytes using pg::brin;
+create index match for std::str using pg::brin;
+create index match for std::uuid using pg::brin;
+create index match for std::datetime using pg::brin;
+create index match for std::duration using pg::brin;
+create index match for cal::local_datetime using pg::brin;
+create index match for cal::local_date using pg::brin;
+create index match for cal::local_time using pg::brin;
+create index match for cal::relative_duration using pg::brin;
+create index match for cal::date_duration using pg::brin;

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -279,14 +279,6 @@ CREATE TYPE schema::Index
 };
 
 
-CREATE TYPE schema::IndexMatch
-    EXTENDING schema::AnnotationSubject
-{
-    CREATE LINK valid_type -> schema::Type;
-    CREATE LINK index -> schema::Index;
-};
-
-
 CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
     CREATE MULTI LINK indexes EXTENDING schema::reference -> schema::Index {
         CREATE CONSTRAINT std::exclusive;

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -279,6 +279,14 @@ CREATE TYPE schema::Index
 };
 
 
+CREATE TYPE schema::IndexMatch
+    EXTENDING schema::AnnotationSubject
+{
+    CREATE LINK valid_type -> schema::Type;
+    CREATE LINK index -> schema::Index;
+};
+
+
 CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
     CREATE MULTI LINK indexes EXTENDING schema::reference -> schema::Index {
         CREATE CONSTRAINT std::exclusive;

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3587,6 +3587,20 @@ class RebaseIndex(IndexCommand, adapts=s_indexes.RebaseIndex):
     pass
 
 
+class IndexMatchCommand(MetaCommand):
+    pass
+
+
+class CreateIndexMatch(IndexMatchCommand, adapts=s_indexes.CreateIndexMatch):
+    # Index match is handled by the compiler and does not need explicit
+    # representation in the backend.
+    pass
+
+
+class DeleteIndexMatch(IndexMatchCommand, adapts=s_indexes.DeleteIndexMatch):
+    pass
+
+
 class CreateUnionType(
     MetaCommand,
     adapts=s_types.CreateUnionType,

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -236,6 +236,7 @@ def delta_schemas(
         excluded_modules.add(sn.UnqualName('__derived__'))
 
     excluded_modules.add(sn.UnqualName('__ext_casts__'))
+    excluded_modules.add(sn.UnqualName('__ext_index_matches__'))
 
     # Don't analyze the objects from extensions.
     if not include_extensions and isinstance(schema_b, s_schema.ChainedSchema):

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -53,12 +53,12 @@ from . import objects as so
 from . import referencing
 from . import scalars as s_scalars
 from . import types as s_types
+from . import schema as s_schema
 from . import utils
 
 
 if TYPE_CHECKING:
     from . import objtypes as s_objtypes
-    from . import schema as s_schema
 
 
 # The name used for default concrete indexes
@@ -71,134 +71,19 @@ def is_index_valid_for_type(
     schema: s_schema.Schema,
     context: sd.CommandContext,
 ) -> bool:
-    # HACK: currently this helper just hardcodes the permitted index & type
-    # combinations, but this should be inferred based on index definition.
-
-    # TODO: remove the explicit hardcode of types compatible with indexes and
-    # make them configurable in the schema instead. This is especially
-    # important for extension types.
-    #
-    # Also, once the hardcoded `issubclass` checks are removed, we no longer
-    # need the `issubclass` allow None as parent argument (fix objects.py and
-    # types.py).
     index_name = str(index.get_name(schema))
-    match index_name:
-        case 'pg::hash':
+
+    for index_match in schema.get_referrers(
+        index, scls_type=IndexMatch, field_name='index',
+    ):
+        valid_type = index_match.get_valid_type(schema)
+        if index_name == 'fts::index':
+            # FTS index works not only on its valid type (document), but also
+            # on tuples comtaining document as an element.
+            if is_subclass_or_tuple(expr_type, valid_type, schema):
+                return True
+        elif expr_type.issubclass(schema, valid_type):
             return True
-        case 'pg::btree':
-            return True
-        case 'pg::gin':
-            return (
-                expr_type.is_array()
-                or
-                expr_type.issubclass(
-                    schema,
-                    schema.get('std::json', type=s_scalars.ScalarType),
-                )
-            )
-        case 'fts::index':
-            return is_subclass_or_tuple(expr_type, 'fts::document', schema)
-        case 'pg::gist':
-            return (
-                expr_type.is_range()
-                or
-                expr_type.is_multirange()
-                or
-                expr_type.issubclass(
-                    schema,
-                    (
-                        schema.get('ext::postgis::geometry',
-                                   type=s_scalars.ScalarType,
-                                   default=None),
-                        schema.get('ext::postgis::geography',
-                                   type=s_scalars.ScalarType,
-                                   default=None),
-                    )
-                )
-            )
-        case 'pg::spgist':
-            return (
-                expr_type.is_range()
-                or
-                expr_type.issubclass(
-                    schema,
-                    (
-                        schema.get('std::str',
-                                   type=s_scalars.ScalarType),
-                        schema.get('ext::postgis::geometry',
-                                   type=s_scalars.ScalarType,
-                                   default=None),
-                        schema.get('ext::postgis::geography',
-                                   type=s_scalars.ScalarType,
-                                   default=None),
-                    )
-                )
-            )
-        case 'pg::brin':
-            return (
-                expr_type.is_range()
-                or
-                expr_type.issubclass(
-                    schema,
-                    (
-                        schema.get('std::anyreal',
-                                   type=s_scalars.ScalarType),
-                        schema.get('std::bytes',
-                                   type=s_scalars.ScalarType),
-                        schema.get('std::str',
-                                   type=s_scalars.ScalarType),
-                        schema.get('std::uuid',
-                                   type=s_scalars.ScalarType),
-                        schema.get('std::datetime',
-                                   type=s_scalars.ScalarType),
-                        schema.get('std::duration',
-                                   type=s_scalars.ScalarType),
-                        schema.get('cal::local_datetime',
-                                   type=s_scalars.ScalarType),
-                        schema.get('cal::local_date',
-                                   type=s_scalars.ScalarType),
-                        schema.get('cal::local_time',
-                                   type=s_scalars.ScalarType),
-                        schema.get('cal::relative_duration',
-                                   type=s_scalars.ScalarType),
-                        schema.get('cal::date_duration',
-                                   type=s_scalars.ScalarType),
-                        schema.get('ext::postgis::geometry',
-                                   type=s_scalars.ScalarType,
-                                   default=None),
-                        schema.get('ext::postgis::geography',
-                                   type=s_scalars.ScalarType,
-                                   default=None),
-                    )
-                )
-            )
-        case (
-            'ext::pgvector::ivfflat_euclidean'
-            | 'ext::pgvector::ivfflat_ip'
-            | 'ext::pgvector::ivfflat_cosine'
-            | 'ext::pgvector::hnsw_euclidean'
-            | 'ext::pgvector::hnsw_ip'
-            | 'ext::pgvector::hnsw_cosine'
-        ):
-            return expr_type.issubclass(
-                schema,
-                schema.get('ext::pgvector::vector', type=s_scalars.ScalarType),
-            )
-        case (
-            'ext::pg_trgm::gin'
-            | 'ext::pg_trgm::gist'
-        ):
-            return expr_type.issubclass(
-                schema,
-                schema.get('std::str', type=s_scalars.ScalarType),
-            )
-        case (
-            'ext::ai::index'
-        ):
-            return expr_type.issubclass(
-                schema,
-                schema.get('std::str', type=s_scalars.ScalarType),
-            )
 
     if context.testmode and index_name == 'default::test':
         # For functional tests of abstract indexes.
@@ -211,10 +96,8 @@ def is_index_valid_for_type(
 
 
 def is_subclass_or_tuple(
-    ty: s_types.Type, parent_name: str | sn.Name, schema: s_schema.Schema
+    ty: s_types.Type, parent: s_types.Type, schema: s_schema.Schema
 ) -> bool:
-    parent = schema.get(parent_name, type=s_types.Type)
-
     if isinstance(ty, s_types.Tuple):
         for (_, st) in ty.iter_subtypes(schema):
             if not st.issubclass(schema, parent):
@@ -314,6 +197,40 @@ def merge_deferred(
             )
 
         return local_deferred  # type: ignore
+
+
+def get_index_match_fullname_from_names(
+    valid_type: sn.Name,
+    index: sn.Name,
+) -> sn.QualName:
+    std = not (
+        (
+            isinstance(valid_type, sn.QualName)
+            and sn.UnqualName(valid_type.module) not in s_schema.STD_MODULES
+        ) or (
+            isinstance(index, sn.QualName)
+            and sn.UnqualName(index.module) not in s_schema.STD_MODULES
+        )
+    )
+    module = 'std' if std else '__ext_index_matches__'
+
+    quals = [str(valid_type), str(index)]
+    shortname = sn.QualName(module, 'index_match')
+    return sn.QualName(
+        module=shortname.module,
+        name=sn.get_specialized_name(shortname, *quals),
+    )
+
+
+def get_index_match_fullname(
+    schema: s_schema.Schema,
+    valid_type: s_types.TypeShell[s_types.Type],
+    index: so.ObjectShell[Index],
+) -> sn.QualName:
+    return get_index_match_fullname_from_names(
+        valid_type.get_name(schema),
+        index.get_name(schema),
+    )
 
 
 class Index(
@@ -595,6 +512,20 @@ class IndexableSubject(so.InheritingObject):
         return self.add_classref(schema, 'indexes', index)
 
 
+class IndexMatch(
+    so.QualifiedObject,
+    s_anno.AnnotationSubject,
+    qlkind=qltypes.SchemaObjectClass.INDEX_MATCH,
+    data_safe=True,
+):
+
+    valid_type = so.SchemaField(
+        s_types.Type, compcoef=0.5)
+
+    index = so.SchemaField(
+        Index, compcoef=0.5)
+
+
 class IndexSourceCommandContext:
     pass
 
@@ -607,6 +538,11 @@ class IndexSourceCommand(
 
 class IndexCommandContext(sd.ObjectCommandContext[Index],
                           s_anno.AnnotationSubjectCommandContext):
+    pass
+
+
+class IndexMatchCommandContext(sd.ObjectCommandContext[IndexMatch],
+                               s_anno.AnnotationSubjectCommandContext):
     pass
 
 
@@ -1816,6 +1752,152 @@ def get_effective_object_index(
         overridden = []
 
     return (effective, overridden)
+
+
+class IndexMatchCommand(sd.QualifiedObjectCommand[IndexMatch],
+                        context_class=IndexMatchCommandContext):
+
+    @classmethod
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
+        if not context.stdmode and not context.testmode:
+            raise errors.UnsupportedFeatureError(
+                'user-defined index matches are not supported',
+                span=astnode.span
+            )
+
+        return super()._cmd_tree_from_ast(schema, astnode, context)
+
+    @classmethod
+    def _classname_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.NamedDDL,
+        context: sd.CommandContext,
+    ) -> sn.QualName:
+        assert isinstance(astnode, qlast.IndexMatchCommand)
+        modaliases = context.modaliases
+
+        valid_type = utils.ast_to_type_shell(
+            astnode.valid_type,
+            metaclass=s_types.Type,
+            modaliases=modaliases,
+            schema=schema,
+        )
+
+        index = utils.ast_objref_to_object_shell(
+            astnode.name,
+            metaclass=Index,
+            modaliases=context.modaliases,
+            schema=schema,
+        )
+
+        return get_index_match_fullname(schema, valid_type, index)
+
+    def canonicalize_attributes(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super().canonicalize_attributes(schema, context)
+        schema = s_types.materialize_type_in_attribute(
+            schema, context, self, 'valid_type')
+        return schema
+
+
+class CreateIndexMatch(IndexMatchCommand, sd.CreateObject[IndexMatch]):
+    astnode = qlast.CreateIndexMatch
+
+    def _create_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        fullname = self.classname
+        index_match = schema.get(fullname, None)
+        if index_match:
+            valid_type = self.get_attribute_value('valid_type')
+            index = self.get_attribute_value('index')
+
+            raise errors.DuplicateDefinitionError(
+                f'an index match for {valid_type.get_displayname(schema)!r} '
+                f'using {index.get_displayname(schema)!r} is already defined',
+                span=self.span)
+
+        return super()._create_begin(schema, context)
+
+    @classmethod
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
+        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+
+        assert isinstance(astnode, qlast.CreateIndexMatch)
+
+        modaliases = context.modaliases
+
+        valid_type = utils.ast_to_type_shell(
+            astnode.valid_type,
+            metaclass=s_types.Type,
+            modaliases=modaliases,
+            schema=schema,
+        )
+        cmd.set_attribute_value('valid_type', valid_type)
+
+        index = utils.ast_objref_to_object_shell(
+            qlast.ObjectRef(
+                module=astnode.name.module,
+                name=astnode.name.name,
+            ),
+            metaclass=Index,
+            modaliases=context.modaliases,
+            schema=schema,
+        )
+        cmd.set_attribute_value('index', index)
+
+        return cmd
+
+    def _apply_field_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        node: qlast.DDLOperation,
+        op: sd.AlterObjectProperty,
+    ) -> None:
+        assert isinstance(node, qlast.CreateIndexMatch)
+        new_value: Any = op.new_value
+
+        if op.property == 'valid_type':
+            # In an index match we can only have pure types, so this is going
+            # to be a TypeName.
+            node.valid_type = cast(qlast.TypeName,
+                                   utils.typeref_to_ast(schema, new_value))
+
+        else:
+            super()._apply_field_ast(schema, context, node, op)
+
+
+class DeleteIndexMatch(IndexMatchCommand, sd.DeleteObject[IndexMatch]):
+    astnode = qlast.DropIndexMatch
+
+    def _delete_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._delete_begin(schema, context)
+        if not context.canonical:
+            valid_type = self.scls.get_valid_type(schema)
+            if op := valid_type.as_type_delete_if_unused(schema):
+                self.add_caused(op)
+        return schema
 
 
 # XXX: the below hardcode should be replaced by an index scope

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -517,6 +517,7 @@ class IndexMatch(
     s_anno.AnnotationSubject,
     qlkind=qltypes.SchemaObjectClass.INDEX_MATCH,
     data_safe=True,
+    abstract=False,
 ):
 
     valid_type = so.SchemaField(

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -3032,18 +3032,12 @@ class SubclassableObject(Object):
     def issubclass(
         self,
         schema: s_schema.Schema,
-        # TODO: once the hardcoded `issubclass` checks are removed, we no
-        # longer need the `issubclass` allow None as parent argument.
-        parent: Union[Optional[SubclassableObject],
-                      Tuple[Optional[SubclassableObject], ...]],
+        parent: Union[SubclassableObject,
+                      Tuple[SubclassableObject, ...]],
     ) -> bool:
         from . import types as s_types
         if isinstance(parent, tuple):
             return any(self.issubclass(schema, p) for p in parent)
-        # TODO: once the hardcoded `issubclass` checks are removed, we no
-        # longer need the `issubclass` allow None as parent argument.
-        elif parent is None:
-            return False
         if (
             isinstance(parent, s_types.Type)
             and parent.is_anyobject(schema)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -628,6 +628,10 @@ class ObjectMeta(type):
     #: object are fully reversible without possible data loss.
     _data_safe: bool
 
+    #: Whether the type should be abstract in EdgeDB schema.
+    #: This only applies if the type wasn't specified in schema.edgeql.
+    _abstract: Optional[bool]
+
     def __new__(
         mcls,
         name: str,
@@ -638,6 +642,7 @@ class ObjectMeta(type):
         reflection: ReflectionMethod = ReflectionMethod.REGULAR,
         reflection_link: Optional[str] = None,
         data_safe: bool = False,
+        abstract: Optional[bool] = None,
         **kwargs: Any,
     ) -> ObjectMeta:
         refdicts: collections.OrderedDict[str, RefDict]
@@ -691,6 +696,7 @@ class ObjectMeta(type):
                 })
 
         cls._data_safe = data_safe
+        cls._abstract = abstract
         cls._fields = fields
         cls._schema_fields = {
             fn: f

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -373,6 +373,7 @@ def generate_structure(
                     py_cls is s_obj.InternalObject
                     or not issubclass(py_cls, s_obj.InternalObject)
                 )
+                and py_cls._abstract is not False
             )
 
             schema = _run_ddl(

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -95,6 +95,7 @@ STD_MODULES = (
 SPECIAL_MODULES = (
     sn.UnqualName('__derived__'),
     sn.UnqualName('__ext_casts__'),
+    sn.UnqualName('__ext_index_matches__'),
 )
 
 # Specifies the order of processing of files and directories in lib/

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1088,19 +1088,13 @@ class Collection(Type, s_abc.Collection):
     def issubclass(
         self,
         schema: s_schema.Schema,
-        # TODO: once the hardcoded `issubclass` checks are removed, we no
-        # longer need the `issubclass` allow None as parent argument.
         parent: Union[
-            Optional[so.SubclassableObject],
-            typing.Tuple[Optional[so.SubclassableObject], ...],
+            so.SubclassableObject,
+            typing.Tuple[so.SubclassableObject, ...],
         ],
     ) -> bool:
         if isinstance(parent, tuple):
             return any(self.issubclass(schema, p) for p in parent)
-        # TODO: once the hardcoded `issubclass` checks are removed, we no
-        # longer need the `issubclass` allow None as parent argument.
-        elif parent is None:
-            return False
 
         if isinstance(parent, Type) and parent.is_any(schema):
             return True

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -6246,6 +6246,23 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_index_match_01(self):
+        """
+        create index match for std::str using pg::brin;
+        """
+
+    def test_edgeql_syntax_ddl_index_match_02(self):
+        """
+        create index match for std::str using pg::brin {
+            create annotation description := 'foo';
+        };
+        """
+
+    def test_edgeql_syntax_ddl_index_match_03(self):
+        """
+        drop index match for std::str using pg::brin;
+        """
+
     def test_edgeql_syntax_sdl_empty_01(self):
         """
         START MIGRATION to {


### PR DESCRIPTION
Make it possible to declare in the schema which types are valid for which indexes.

`create index match for <type_expr> using <index_name>;`

This enables defining new types of indexes in extensions and declare how they relate to each other without needing to update the server code.