### PR TITLE
Fix a regression involving optional arguments and assert_exists

### DIFF
--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -573,7 +573,9 @@ class ScopeTreeNode:
                         unnest_fence, existing_finfo, span,
                     )
 
-                    existing_fenced = existing.parent_fence is not factor_point
+                    existing_fenced = existing.parent_fence is not None and (
+                        factor_point in existing.parent_fence.strict_ancestors
+                    )
                     if existing.is_optional_upto(factor_point):
                         existing.mark_as_optional()
 

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -1960,3 +1960,12 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ''',
             [[]],
         )
+
+    async def test_edgeql_coalesce_policy_link_01(self):
+        await self.con.query('''
+            with module schema
+            select Type {
+              range_element_type_id := [is Range].element_type.id
+                  ?? [is MultiRange].element_type.id,
+            };
+        ''')


### PR DESCRIPTION
A regression was introduced in #7763 having to do with determining
whether paths are optional in the scopetree. Most of the time, having
spuriously optional paths is just a performance issue, but in some
cases (like the assert_exists calls injecting into `required link`s
when there is an access policy on the target), having a path be
optional can result in an assert_exists error firing when really the
assert_exists shouldn't have been evaluated at all.

The cause of the regression was that the computation of whether an
existing node that is being factored is underneath a fence was wrong,
and that wrong computation was being used in more cases now.