### PR TITLE
Support accessing link properties through FOR bindings

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1054,12 +1054,30 @@ def process_set_as_path_type_intersection(
                 aspect=aspect,
             )
 
-    return new_stmt_set_rvar(
+    rvars = new_stmt_set_rvar(
         ir_set,
         stmt,
         aspects=[pgce.PathAspect.VALUE, pgce.PathAspect.SOURCE],
         ctx=ctx,
     )
+    # If the inner set also exposes a pointer path source, we need to
+    # also expose a pointer path source. See tests like
+    # test_edgeql_for_lprop_02, where it is needed to to make FOR binding
+    # of backlinks work.
+    if pathctx.maybe_get_path_rvar(
+        stmt,
+        ir_source.path_id.ptr_path(),
+        aspect=pgce.PathAspect.SOURCE,
+    ):
+        rvars.new.append(
+            SetRVar(
+                rvars.main.rvar,
+                ir_set.path_id.ptr_path(),
+                aspects=(pgce.PathAspect.SOURCE,),
+            )
+        )
+
+    return rvars
 
 
 def _source_path_needs_semi_join(


### PR DESCRIPTION
So now you can write something like
```
SELECT User {
    cards := (
        (FOR d IN .deck[is SpecialCard] SELECT (d.name, d@count))
    ),

}
```
and have it work.

See [RFC 1027 - Simplifying path resolution](https://github.com/edgedb/rfcs/blob/master/text/1027-no-factoring.rst)
for some of the motivation here - this removes the necessity of using
path factoring in one of the main places it was hard to avoid.