### PR TITLE
Initial implementation of "RFC 1027 - Simplfying path resolution"

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -67,6 +67,7 @@
 0x_04_03_00_04   UnknownUserError
 0x_04_03_00_05   UnknownDatabaseError
 0x_04_03_00_06   UnknownParameterError
+0x_04_03_00_07   DeprecatedScopingError
 
 0x_04_04_00_00   SchemaError
 

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_10_10_00_00
+EDGEDB_CATALOG_VERSION = 2024_10_10_00_01
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -359,6 +359,7 @@ PathElement = typing.Union[Expr, Ptr, TypeIntersection, ObjectRef, Splat]
 class Path(Expr):
     steps: typing.List[PathElement]
     partial: bool = False
+    allow_factoring: bool = False
 
 
 class TypeCast(Expr):
@@ -487,6 +488,7 @@ class ShapeElement(Expr):
 class Shape(Expr):
     expr: typing.Optional[Expr]
     elements: typing.List[ShapeElement]
+    allow_factoring: bool = False
 
 
 class Query(Expr):

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -649,7 +649,9 @@ def _cast_json_to_tuple(
 ) -> irast.Set:
 
     with ctx.new() as subctx:
+        subctx.allow_factoring()
         pathctx.register_set_in_scope(ir_set, ctx=subctx)
+
         subctx.anchors = subctx.anchors.copy()
         source_path = subctx.create_anchor(ir_set, 'a')
 
@@ -868,6 +870,7 @@ def _cast_range(
             span=span)
 
     with ctx.new() as subctx:
+        subctx.allow_factoring()
         subctx.anchors = subctx.anchors.copy()
         source_path = subctx.create_anchor(ir_set, 'a')
 
@@ -948,6 +951,7 @@ def _cast_multirange(
         ctx.env.schema, [el_type])
     ql_range_type = typegen.type_to_ql_typeref(new_range_type, ctx=ctx)
     with ctx.new() as subctx:
+        subctx.allow_factoring()
         subctx.anchors = subctx.anchors.copy()
         source_path = subctx.create_anchor(ir_set, 'a')
 
@@ -1222,6 +1226,8 @@ def _cast_array(
             ir_set, el_cast, orig_stype, new_stype, ctx=ctx)
     else:
         with ctx.new() as subctx:
+            subctx.allow_factoring()
+
             subctx.anchors = subctx.anchors.copy()
             source_path = subctx.create_anchor(ir_set, 'a')
 

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -432,7 +432,6 @@ def _compile_conflict_select(
     # Union them all together
     select_ast = qlast.Set(elements=frags)
     with ctx.new() as ectx:
-        # XXX: Should we need this, and do we need it for other things?
         ectx.allow_factoring()
 
         ectx.implicit_limit = 0

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -26,6 +26,7 @@ from typing import Optional, Tuple, Iterable, Sequence, Dict, List, Set
 from edb import errors
 
 from edb.ir import ast as irast
+from edb.ir import utils as irutils
 from edb.ir import typeutils
 
 from edb.schema import constraints as s_constr
@@ -431,6 +432,9 @@ def _compile_conflict_select(
     # Union them all together
     select_ast = qlast.Set(elements=frags)
     with ctx.new() as ectx:
+        # XXX: Should we need this, and do we need it for other things?
+        ectx.allow_factoring()
+
         ectx.implicit_limit = 0
         ectx.allow_endpoint_linkprops = True
         select_ir = dispatch.compile(select_ast, ctx=ectx)
@@ -513,6 +517,8 @@ def compile_insert_unless_conflict_on(
         cspec_args = [elem.val for elem in cspec_res.expr.elements]
     else:
         cspec_args = [cspec_res]
+
+    cspec_args = [irutils.unwrap_set(arg) for arg in cspec_args]
 
     for cspec_arg in cspec_args:
         if not isinstance(cspec_arg.expr, irast.Pointer):

--- a/edb/edgeql/compiler/eta_expand.py
+++ b/edb/edgeql/compiler/eta_expand.py
@@ -228,6 +228,8 @@ def eta_expand_ir(
         return ir
 
     with ctx.new() as subctx:
+        subctx.allow_factoring()
+
         subctx.anchors = subctx.anchors.copy()
         source_ref = subctx.create_anchor(ir)
 

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -153,3 +153,9 @@ class CompilerOptions(GlobalCompilerOptions):
     #: schema_object_context is set to Trigger.
     trigger_type: Optional[s_types.Type] = None
     trigger_kinds: Optional[Collection[qltypes.TriggerKind]] = None
+
+    #: These represent the *configured* values of
+    #: simple_scoping/warn_old_scoping. If they are None, we check the
+    #: presence of the futures in the schema.
+    simple_scoping: Optional[bool] = None
+    warn_old_scoping: Optional[bool] = None

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -102,6 +102,7 @@ def register_set_in_scope(
         ir_set.path_id,
         optional=optional,
         span=ir_set.span,
+        ctx=ctx,
     )
 
 

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -147,6 +147,7 @@ def compile_pol(
 
     # Compile it with all of the
     with ctx.detached() as dctx:
+        dctx.schema_factoring()
         dctx.partial_path_prefix = ctx.partial_path_prefix
         dctx.expr_exposed = context.Exposure.UNEXPOSED
         dctx.suppress_rewrites = frozenset(descs)
@@ -470,3 +471,4 @@ def _prepare_dml_policy_context(
 
     ctx.anchors['__subject__'] = result
     ctx.partial_path_prefix = result
+    ctx.schema_factoring()

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1733,6 +1733,8 @@ def _get_schema_computed_ctx(
     @contextlib.contextmanager
     def newctx() -> Iterator[context.ContextLevel]:
         with ctx.detached() as subctx:
+            subctx.schema_factoring()
+
             source_scope = pathctx.get_set_scope(rptr.source, ctx=ctx)
             if source_scope and source_scope.namespaces:
                 subctx.path_id_namespace |= source_scope.namespaces

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -87,12 +87,25 @@ def try_desugar(
     return None
 
 
+def _protect_expr(
+    expr: Optional[qlast.Expr], *, ctx: context.ContextLevel
+) -> None:
+    if ctx.no_factoring or ctx.warn_factoring:
+        while isinstance(expr, qlast.Shape):
+            expr.allow_factoring = True
+            expr = expr.expr
+        if isinstance(expr, qlast.Path):
+            expr.allow_factoring = True
+
+
 @dispatch.compile.register(qlast.SelectQuery)
 def compile_SelectQuery(
     expr: qlast.SelectQuery, *, ctx: context.ContextLevel
 ) -> irast.Set:
     if rewritten := try_desugar(expr, ctx=ctx):
         return rewritten
+
+    _protect_expr(expr.result, ctx=ctx)
 
     with ctx.subquery() as sctx:
         stmt = irast.SelectStmt()
@@ -450,7 +463,7 @@ def compile_InsertQuery(
         with ictx.new() as ectx:
             ectx.expr_exposed = context.Exposure.UNEXPOSED
             subject = dispatch.compile(
-                qlast.Path(steps=[expr.subject]), ctx=ectx
+                qlast.Path(steps=[expr.subject], allow_factoring=True), ctx=ectx
             )
         assert isinstance(subject, irast.Set)
 
@@ -594,6 +607,8 @@ def compile_UpdateQuery(
             span=expr.span,
         )
 
+    _protect_expr(expr.subject, ctx=ctx)
+
     # Record this node in the list of DML statements.
     ctx.env.dml_exprs.append(expr)
 
@@ -701,6 +716,8 @@ def compile_DeleteQuery(
             ),
             span=expr.span,
         )
+
+    _protect_expr(expr.subject, ctx=ctx)
 
     # Record this node in the list of potential DML expressions.
     ctx.env.dml_exprs.append(expr)
@@ -1090,6 +1107,21 @@ def compile_DescribeStmt(
 def compile_Shape(
     shape: qlast.Shape, *, ctx: context.ContextLevel
 ) -> irast.Set:
+
+    if ctx.no_factoring and not shape.allow_factoring:
+        return dispatch.compile(
+            qlast.SelectQuery(result=shape, implicit=True),
+            ctx=ctx,
+        )
+
+    if ctx.warn_factoring and not shape.allow_factoring:
+        with ctx.newscope(fenced=False) as subctx:
+            subctx.path_scope.warn = True
+            _protect_expr(shape, ctx=ctx)
+            return dispatch.compile(
+                shape, ctx=subctx
+            )
+
     shape_expr = shape.expr or qlutils.FREE_SHAPE_EXPR
     with ctx.new() as subctx:
         subctx.qlstmt = astutils.ensure_ql_query(shape)
@@ -1146,7 +1178,8 @@ def init_stmt(
             and not (
                 # We allow DML in trivial *top-level* free objects
                 ctx.partial_path_prefix
-                and irutils.is_trivial_free_object(ctx.partial_path_prefix)
+                and irutils.is_trivial_free_object(
+                    irutils.unwrap_set(ctx.partial_path_prefix))
                 # Find the enclosing context at the point the free object
                 # was defined.
                 and (outer_ctx := next((
@@ -1175,6 +1208,8 @@ def init_stmt(
         parent_ctx.toplevel_stmt = ctx.toplevel_stmt = irstmt
 
     ctx.path_scope = parent_ctx.path_scope.attach_fence()
+    # XXX???
+    ctx.path_scope.warn = ctx.warn_factoring
 
     pending_own_ns = parent_ctx.pending_stmt_own_path_id_namespace
     if pending_own_ns:
@@ -1328,7 +1363,8 @@ def compile_result_clause(
             )
 
             result = qlast.Path(
-                steps=[qlast.ObjectRef(name=result_alias)]
+                steps=[qlast.ObjectRef(name=result_alias)],
+                allow_factoring=True,
             )
 
         result_expr: qlast.Expr

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -241,8 +241,11 @@ def compile_ForQuery(
                 node.factoring_allowlist.update(ctx.iterator_path_ids)
                 node = node.attach_branch()
 
-            node.attach_subtree(view_scope_info.path_scope,
-                                span=iterator.span)
+            node.attach_subtree(
+                view_scope_info.path_scope,
+                span=iterator.span,
+                ctx=ctx,
+            )
 
         # Compile the body
         with sctx.newscope(fenced=True) as bctx:

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1211,7 +1211,6 @@ def init_stmt(
         parent_ctx.toplevel_stmt = ctx.toplevel_stmt = irstmt
 
     ctx.path_scope = parent_ctx.path_scope.attach_fence()
-    # XXX???
     ctx.path_scope.warn = ctx.warn_factoring
 
     pending_own_ns = parent_ctx.pending_stmt_own_path_id_namespace

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -42,6 +42,7 @@ from edb.ir import utils as irutils
 from edb.ir import typeutils as irtyputils
 
 from edb.schema import constraints as s_constr
+from edb.schema import futures as s_futures
 from edb.schema import modules as s_mod
 from edb.schema import name as s_name
 from edb.schema import objects as s_obj
@@ -170,6 +171,23 @@ def init_context(
     ctx.implicit_tname_in_shapes = options.implicit_tname_in_shapes
     ctx.implicit_limit = options.implicit_limit
     ctx.expr_exposed = context.Exposure.EXPOSED
+
+    # Resolve simple_scoping/warn_old_scoping configs.
+    # options specifies the value in the configuration system;
+    # if that is None, we rely on the presence of the future.
+    simple_scoping = options.simple_scoping
+    if simple_scoping is None:
+        simple_scoping = s_futures.future_enabled(
+            ctx.env.schema, 'simple_scoping'
+        )
+    warn_old_scoping = options.warn_old_scoping
+    if warn_old_scoping is None:
+        warn_old_scoping = s_futures.future_enabled(
+            ctx.env.schema, 'warn_old_scoping'
+        )
+
+    ctx.no_factoring = simple_scoping
+    ctx.warn_factoring = warn_old_scoping
 
     return ctx
 
@@ -787,6 +805,7 @@ def _declare_view_from_schema(
     # subcontext to compile in, but it should avoid depending on the
     # context, because of the cache.
     with ctx.detached() as subctx:
+        subctx.schema_factoring()
         subctx.current_schema_views += (viewcls,)
         subctx.expr_exposed = context.Exposure.UNEXPOSED
         view_expr: s_expr.Expression | None = viewcls.get_expr(ctx.env.schema)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -125,7 +125,8 @@ def init_context(
             had_optional |= optional
             path_id = compile_anchor('__', singleton, ctx=ctx).path_id
             ctx.env.path_scope.attach_path(
-                path_id, optional=optional, span=None)
+                path_id, optional=optional, span=None, ctx=ctx
+            )
             if not optional:
                 ctx.env.singletons.append(path_id)
             ctx.iterator_path_ids |= {path_id}

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -65,7 +65,7 @@ def compile_trigger(
     kinds = set(trigger.get_kinds(schema))
     source = trigger.get_subject(schema)
 
-    with ctx.detached() as _, _.newscope(fenced=True) as sctx:
+    with ctx.detached() as tc, tc.newscope(fenced=True) as sctx:
         sctx.schema_factoring()
         sctx.anchors = sctx.anchors.copy()
 
@@ -97,7 +97,7 @@ def compile_trigger(
 
         for name, ir in anchors.items():
             if scope == qltypes.TriggerScope.Each:
-                sctx.path_scope.attach_path(ir.path_id, span=None)
+                sctx.path_scope.attach_path(ir.path_id, span=None, ctx=sctx)
                 sctx.iterator_path_ids |= {ir.path_id}
             sctx.anchors[name] = ir
 

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -66,6 +66,7 @@ def compile_trigger(
     source = trigger.get_subject(schema)
 
     with ctx.detached() as _, _.newscope(fenced=True) as sctx:
+        sctx.schema_factoring()
         sctx.anchors = sctx.anchors.copy()
 
         anchors = {}

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -152,7 +152,7 @@ def process_view(
     hackscope = ctx.path_scope.attach_branch()
     pathctx.register_set_in_scope(ir_set, path_scope=hackscope, ctx=ctx)
     hackscope.remove()
-    ctx.path_scope.attach_subtree(hackscope)
+    ctx.path_scope.attach_subtree(hackscope, ctx=ctx)
 
     # Make a snapshot of aliased_views that can't be mutated
     # in any parent scopes.
@@ -881,6 +881,7 @@ def _gen_pointers_from_defaults(
             scopectx.path_scope.attach_path(
                 source_set.path_id, span=None,
                 optional=False,
+                ctx=ctx,
             )
             scopectx.iterator_path_ids |= {source_set.path_id}
             scopectx.anchors['__source__'] = source_set
@@ -1213,6 +1214,7 @@ def _compile_rewrites_for_stype(
                     anchor.path_id,
                     optional=(anchor is anchors.subject_set),
                     span=None,
+                    ctx=ctx,
                 )
                 scopectx.iterator_path_ids |= {anchor.path_id}
                 scopectx.anchors[key] = anchor

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -872,6 +872,8 @@ def _gen_pointers_from_defaults(
         )
 
         with ctx.new() as scopectx:
+            scopectx.schema_factoring()
+
             scopectx.active_defaults |= {stype}
 
             # add __source__ to anchors
@@ -1195,6 +1197,7 @@ def _compile_rewrites_for_stype(
         assert rewrite_expr
 
         with ctx.newscope(fenced=True) as scopectx:
+            scopectx.schema_factoring()
             scopectx.active_rewrites |= {stype}
 
             # prepare context

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -34,6 +34,7 @@ from . import ast as qlast
 FREE_SHAPE_EXPR = qlast.DetachedExpr(
     expr=qlast.Path(
         steps=[qlast.ObjectRef(module='std', name='FreeObject')],
+        allow_factoring=True,
     ),
 )
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -39,6 +39,7 @@ __all__ = base.__all__ + (  # type: ignore
     'UnknownUserError',
     'UnknownDatabaseError',
     'UnknownParameterError',
+    'DeprecatedScopingError',
     'SchemaError',
     'SchemaDefinitionError',
     'InvalidDefinitionError',
@@ -217,6 +218,10 @@ class UnknownDatabaseError(InvalidReferenceError):
 
 class UnknownParameterError(InvalidReferenceError):
     _code = 0x_04_03_00_06
+
+
+class DeprecatedScopingError(InvalidReferenceError):
+    _code = 0x_04_03_00_07
 
 
 class SchemaError(QueryError):

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -626,8 +626,6 @@ class ScopeTreeNode:
                                 span=span,
                             )
                             ctx.log_warning(ex)
-                    # XXX: HMMMMMM??? including current_warn causes bad problems
-                    # if current_warn or existing_warn:
                     if existing_warn:
                         existing.warn = True
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -192,6 +192,19 @@ ALTER TYPE cfg::AbstractConfig {
             'Whether inserts are allowed to set the \'id\' property.';
     };
 
+    CREATE PROPERTY simple_scoping -> std::bool {
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION std::description :=
+            'Whether to use the new simple scoping behavior \
+            (disable path factoring)';
+    };
+
+    CREATE PROPERTY warn_old_scoping -> std::bool {
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION std::description :=
+            'Whether to warn when depending on old scoping behavior.';
+    };
+
     CREATE MULTI PROPERTY cors_allow_origins -> std::str {
         CREATE ANNOTATION std::description :=
             'List of origins that can be returned in the \

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -7319,6 +7319,11 @@ class DeleteFutureBehavior(
     pass
 
 
+class AlterFutureBehavior(
+        FutureBehaviorCommand, adapts=s_futures.AlterFutureBehavior):
+    pass
+
+
 class DeltaRoot(MetaCommand, adapts=sd.DeltaRoot):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -582,6 +582,11 @@ class ExpressionDict(checked.CheckedDict[str, Expression]):
         return basecoef + (1 - basecoef) * compcoef
 
 
+EXPRESSION_TYPES = (
+    Expression, ExpressionList, ExpressionDict
+)
+
+
 def imprint_expr_context(
     qltree: qlast_.Base,
     modaliases: Mapping[Optional[str], str],

--- a/edb/schema/futures.py
+++ b/edb/schema/futures.py
@@ -214,7 +214,6 @@ def _get_all_expr_fields() -> dict[type[so.Object], list[str]]:
         fields = [
             name
             for name, field in schemacls.get_schema_fields().items()
-            # XXX ExpressionList and ExpressionDict!!?
             if issubclass(field.type, s_expr.EXPRESSION_TYPES)
         ]
         if fields:

--- a/edb/schema/futures.py
+++ b/edb/schema/futures.py
@@ -138,5 +138,19 @@ class DeleteFutureBehavior(
     FutureBehaviorCommand,
     sd.DeleteObject[FutureBehavior],
 ):
-
     astnode = qlast.DropFuture
+
+
+# These are registered here because they aren't directly related to
+# any schema elements.
+@register_handler('simple_scoping')
+@register_handler('warn_old_scoping')
+def toggle_scoping_future(
+    cmd: FutureBehaviorCommand,
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+    on: bool,
+) -> tuple[s_schema.Schema, sd.Command]:
+    # TODO: Recompile every expression! Wow!
+    group = sd.CommandGroup()
+    return schema, group

--- a/edb/schema/futures.py
+++ b/edb/schema/futures.py
@@ -111,7 +111,7 @@ class FutureBehaviorCommand(
         context: sd.CommandContext,
     ) -> s_schema.Schema:
         schema = super().apply(schema, context)
-        if not context.canonical:
+        if not context.canonical and not isinstance(self, sd.AlterObject):
             key = str(self.classname)
             if key not in FUTURE_HANDLERS:
                 raise errors.QueryError(
@@ -141,6 +141,13 @@ class DeleteFutureBehavior(
     astnode = qlast.DropFuture
 
 
+class AlterFutureBehavior(
+    FutureBehaviorCommand,
+    sd.AlterObject[FutureBehavior],
+):
+    pass
+
+
 # These are registered here because they aren't directly related to
 # any schema elements.
 @register_handler('simple_scoping')
@@ -151,6 +158,66 @@ def toggle_scoping_future(
     context: sd.CommandContext,
     on: bool,
 ) -> tuple[s_schema.Schema, sd.Command]:
-    # TODO: Recompile every expression! Wow!
-    group = sd.CommandGroup()
-    return schema, group
+    from . import types as s_types
+    from . import pointers as s_pointers
+    from . import constraints as s_constraints
+    from . import indexes as s_indexes
+
+    # We need a subcommand to apply the _propagate_if_expr_refs on, so
+    # make an alter.
+    dummy_object = cmd.scls
+    alter_cmd = dummy_object.init_delta_command(
+        schema, cmdtype=sd.AlterObject)
+
+    all_expr_fields = _get_all_expr_fields()
+
+    # Indexes and constraints use simple expressions that cannot
+    # depend on path factoring!
+    del all_expr_fields[s_constraints.Constraint]
+    del all_expr_fields[s_indexes.Index]
+
+    types = tuple(all_expr_fields)
+
+    all_expr_objects: list[so.Object] = list(schema.get_objects(
+        exclude_stdlib=True,
+        extra_filters=[lambda _, x: isinstance(x, types)],
+    ))
+    extra_refs = {
+        obj: fields
+        for obj in all_expr_objects
+        if (fields := all_expr_fields[type(obj)])
+        and any(obj.get_field_value(schema, name) for name in fields)
+        and not (
+            isinstance(obj, (s_types.Type, s_pointers.Pointer))
+            and obj.get_from_alias(schema)
+        )
+    }
+
+    schema = alter_cmd._propagate_if_expr_refs(
+        schema,
+        context,
+        action=f'toggle value of scoping future behavior',
+        extra_refs=extra_refs,
+        metadata_only=False,
+    )
+
+    return schema, alter_cmd
+
+
+def _get_all_expr_fields() -> dict[type[so.Object], list[str]]:
+    r = {}
+    from . import expr as s_expr
+
+    for schemacls in so.ObjectMeta.get_schema_metaclasses():
+        if schemacls.is_abstract():
+            continue
+        fields = [
+            name
+            for name, field in schemacls.get_schema_fields().items()
+            # XXX ExpressionList and ExpressionDict!!?
+            if issubclass(field.type, s_expr.EXPRESSION_TYPES)
+        ]
+        if fields:
+            r[schemacls] = fields
+
+    return r

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -466,12 +466,13 @@ def _build_object_mutation_shape(
                     WITH
                         orig_json := json_array_unpack(<json>${var_n})
                     SELECT
-                        array_agg(
+                        array_agg((
+                            for orig_json in orig_json union
                             (
                                 name := <str>orig_json['name'],
                                 expr := <str>orig_json['expr']['text'],
                             )
-                        )
+                        ))
                 )
             '''
             if v is not None:
@@ -496,14 +497,15 @@ def _build_object_mutation_shape(
                     WITH
                         orig_json := json_array_unpack(<json>${var_n})
                     SELECT
-                        array_agg(
+                        array_agg((
+                            for orig_json in orig_json union
                             (
                                 name := <str>orig_json['name'],
                                 expr := sys::_expr_from_json(
                                     orig_json['expr']
                                 )
                             )
-                        )
+                        ))
                 )
             '''
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1407,7 +1407,15 @@ def _get_compile_options(
         schema_reflection_mode=(
             ctx.schema_reflection_mode
             or _get_config_val(ctx, '__internal_query_reflschema')
-        )
+        ),
+        simple_scoping=(
+            _get_config_val(ctx, 'simple_scoping')
+        ),
+        warn_old_scoping=(
+            ctx.schema_reflection_mode or
+            ctx.bootstrap_mode or
+            _get_config_val(ctx, 'warn_old_scoping')
+        ),
     )
 
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -949,6 +949,8 @@ class ClusterTestCase(BaseHTTPTestCase):
 class ConnectedTestCase(ClusterTestCase):
 
     BASE_TEST_CLASS = True
+    NO_FACTOR = False
+    WARN_FACTOR = False
 
     con: Any  # XXX: the real type?
 
@@ -988,6 +990,16 @@ class ConnectedTestCase(ClusterTestCase):
                     'CONFIGURE SESSION SET auto_rebuild_query_cache := false;'
                 )
             )
+
+        if self.NO_FACTOR:
+            self.loop.run_until_complete(
+                self.con.execute(
+                    'CONFIGURE SESSION SET simple_scoping := true;'))
+
+        if self.WARN_FACTOR:
+            self.loop.run_until_complete(
+                self.con.execute(
+                    'CONFIGURE SESSION SET warn_old_scoping := true;'))
 
         if self.TRANSACTION_ISOLATION:
             self.xact = self.con.transaction()

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -17,6 +17,7 @@
 #
 
 
+import contextlib
 import os.path
 import uuid
 
@@ -28,10 +29,20 @@ from edb.tools import test
 
 class TestInsert(tb.QueryTestCase):
     '''The scope of the tests is testing various modes of Object creation.'''
+    # NO_FACTOR = True
+    WARN_FACTOR = True
     INTERNAL_TESTMODE = False
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'insert.esdl')
+
+    def assertRaisesRegex(self, exc, r, **kwargs):
+        if (
+            (self.NO_FACTOR or self.WARN_FACTOR)
+            and "cannot reference correlated set" in r
+        ):
+            r = ""
+        return super().assertRaisesRegex(exc, r, **kwargs)
 
     async def test_edgeql_insert_fail_01(self):
         with self.assertRaisesRegex(
@@ -2074,6 +2085,7 @@ class TestInsert(tb.QueryTestCase):
             """
             )
 
+    @tb.needs_factoring_weakly  # XXX: maybe it shouldn't?
     async def test_edgeql_insert_dunder_default_01(self):
         await self.con.execute(r'''
             INSERT DunderDefaultTest01 { a := 1, c := __default__ };
@@ -5808,6 +5820,7 @@ class TestInsert(tb.QueryTestCase):
                 }
             ''')
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_insert_volatile_01(self):
         # Ideally we'll support these versions eventually
         async with self.assertRaisesRegexTx(
@@ -5851,6 +5864,7 @@ class TestInsert(tb.QueryTestCase):
             INSERT Person { name := "asdf", multi_prop := "a" };
         ''')
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_insert_enumerate_01(self):
         await self.assert_query_result(
             r"""
@@ -6473,6 +6487,7 @@ class TestInsert(tb.QueryTestCase):
             variables=([True, False],)
         )
 
+        # XXX: THIS IS FAILING BUT THAT IS BULLSHIT
         await self.assert_query_result(
             '''
             with go := <bool>$0
@@ -6498,10 +6513,14 @@ class TestInsert(tb.QueryTestCase):
         )
 
     async def test_edgeql_insert_conditional_02(self):
-        async with self.assertRaisesRegexTx(
-            edgedb.errors.QueryError,
-            "cannot reference correlated set",
-        ):
+        ctxmgr = (
+            contextlib.nullcontext() if self.NO_FACTOR
+            else self.assertRaisesRegexTx(
+                edgedb.errors.QueryError,
+                "cannot reference correlated set",
+            )
+        )
+        async with ctxmgr:
             await self.con.execute('''
                 select ((if ExceptTest.deleted then (
                     insert InsertTest { l2 := 2 }

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2085,7 +2085,7 @@ class TestInsert(tb.QueryTestCase):
             """
             )
 
-    @tb.needs_factoring_weakly  # XXX: maybe it shouldn't?
+    @tb.needs_factoring_weakly  # XXX(factor): maybe it shouldn't?
     async def test_edgeql_insert_dunder_default_01(self):
         await self.con.execute(r'''
             INSERT DunderDefaultTest01 { a := 1, c := __default__ };
@@ -6487,7 +6487,6 @@ class TestInsert(tb.QueryTestCase):
             variables=([True, False],)
         )
 
-        # XXX: THIS IS FAILING BUT THAT IS BULLSHIT
         await self.assert_query_result(
             '''
             with go := <bool>$0

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2527,9 +2527,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
-    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
+    @tb.needs_factoring_weakly  # XXX(factor): WE WOULD PREFER NOT
     async def test_edgeql_select_setops_04(self):
-        # XXX: need to follow multiple steps in warn analysis
+        # XXX(factor): need to follow multiple steps in warn analysis
         await self.assert_query_result(
             r"""
             # equivalent to ?=
@@ -4054,7 +4054,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
-    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
+    @tb.needs_factoring_weakly  # XXX(factor): WE WOULD PREFER NOT
     async def test_edgeql_select_or_01(self):
         issues_h = await self.con.query(r'''
             SELECT Issue{number}
@@ -4070,7 +4070,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ORDER BY Issue.number;
         ''')
 
-        # XXX: need to follow multiple steps in warn analysis
+        # XXX(factor): need to follow multiple steps in warn analysis
         await self.assert_query_result(
             r'''
             SELECT Issue{number}
@@ -4083,9 +4083,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': o.number} for o in [*issues_h, *issues_l]]
         )
 
-    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
+    @tb.needs_factoring_weakly  # XXX(factor): WE WOULD PREFER NOT
     async def test_edgeql_select_or_04(self):
-        # XXX: need to follow multiple steps in warn analysis
+        # XXX(factor): need to follow multiple steps in warn analysis
         await self.assert_query_result(
             r'''
             SELECT Issue{number}
@@ -4957,7 +4957,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [],
         )
 
-    # XXX: THIS KIND OF THING IS THE BIGGEST PROBLEM
     @tb.needs_factoring
     async def test_edgeql_select_subqueries_06(self):
         await self.assert_query_result(
@@ -6452,8 +6451,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [],
         )
 
-    # XXX
-    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
+    @tb.needs_factoring_weakly  # XXX(factor): WE WOULD PREFER NOT
     async def test_edgeql_select_if_else_07_b(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -681,6 +681,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 FILTER Issue.number = '1';
             """)
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_computable_30(self):
         await self.assert_query_result(
             r"""
@@ -703,6 +704,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_computable_32(self):
         await self.assert_query_result(
             r"""
@@ -1427,7 +1429,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
-    async def test_edgeql_select_polymorphic_04(self):
+    async def test_edgeql_select_polymorphic_04a(self):
         # Since using a polymorphic shape element means that sometimes
         # that element may be empty, it is prohibited to access
         # protected property such as `id` on it as that would be
@@ -1462,6 +1464,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             },
         )
 
+    @tb.needs_factoring
+    async def test_edgeql_select_polymorphic_04b(self):
         await self.assert_query_result(
             r'''
             SELECT Object[IS Status].name ?? Object[IS Priority].name;
@@ -2018,6 +2022,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 ''',
             )
 
+    @tb.needs_factoring
     async def test_edgeql_select_reverse_link_05(self):
         await self.assert_query_result(
             r'''
@@ -2262,6 +2267,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_tvariant_09(self):
         await self.assert_query_result(
             r"""
@@ -2521,7 +2527,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
+    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
     async def test_edgeql_select_setops_04(self):
+        # XXX: need to follow multiple steps in warn analysis
         await self.assert_query_result(
             r"""
             # equivalent to ?=
@@ -2740,6 +2748,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_setops_13a(self):
         await self.assert_query_result(
             r"""
@@ -2763,6 +2772,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_setops_13b(self):
         # This should be equivalent to the above test, but actually we
         # end up deduplicating.
@@ -2874,6 +2884,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             {'1', '2', '3', '4'},
         )
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_setops_20(self):
         res = await self.con.query(r'''
             SELECT (
@@ -2885,6 +2896,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         for row in res:
             self.assertNotEqual(row[1].id, None)
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_setops_21(self):
         res = await self.con.query(r'''
             SELECT (
@@ -2896,6 +2908,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         for row in res:
             self.assertNotEqual(row[1].id, None)
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_setops_22(self):
         res = await self.con.query(r'''
             SELECT (
@@ -3226,7 +3239,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
-    async def test_edgeql_select_func_01(self):
+    @tb.needs_factoring
+    async def test_edgeql_select_func_01a(self):
         await self.assert_query_result(
             r'''
             SELECT std::len(User.name) ORDER BY User.name;
@@ -3234,6 +3248,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [5, 4],
         )
 
+    async def test_edgeql_select_func_01b(self):
         await self.assert_query_result(
             r'''
             SELECT std::sum(<std::int64>Issue.number);
@@ -3747,7 +3762,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
-    async def test_edgeql_select_equivalence_02(self):
+    @tb.needs_factoring
+    async def test_edgeql_select_equivalence_02a(self):
         await self.assert_query_result(
             r'''
             # get Issues such that there's another Issue with
@@ -3759,6 +3775,26 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 I2 != Issue
                 AND
                 I2.priority.name ?= Issue.priority.name
+            ORDER BY Issue.number;
+            ''',
+            [{'number': '1'}, {'number': '4'}],
+        )
+
+    async def test_edgeql_select_equivalence_02b(self):
+        await self.assert_query_result(
+            r'''
+            # get Issues such that there's another Issue with
+            # equivalent priority
+            WITH
+                I2 := Issue
+            SELECT Issue {number}
+            FILTER (
+                FOR I2 IN I2
+                SELECT
+                I2 != Issue
+                AND
+                I2.priority.name ?= Issue.priority.name
+            )
             ORDER BY Issue.number;
             ''',
             [{'number': '1'}, {'number': '4'}],
@@ -4018,6 +4054,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         )
 
+    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
     async def test_edgeql_select_or_01(self):
         issues_h = await self.con.query(r'''
             SELECT Issue{number}
@@ -4033,6 +4070,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ORDER BY Issue.number;
         ''')
 
+        # XXX: need to follow multiple steps in warn analysis
         await self.assert_query_result(
             r'''
             SELECT Issue{number}
@@ -4045,7 +4083,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': o.number} for o in [*issues_h, *issues_l]]
         )
 
+    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
     async def test_edgeql_select_or_04(self):
+        # XXX: need to follow multiple steps in warn analysis
         await self.assert_query_result(
             r'''
             SELECT Issue{number}
@@ -4659,6 +4699,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [True],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_01(self):
         await self.assert_query_result(
             r"""
@@ -4669,6 +4710,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['ClosedHigh', 'ClosedLow', 'OpenHigh', 'OpenLow'],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_02(self):
         await self.assert_query_result(
             r"""
@@ -4679,6 +4721,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['OpenHigh', 'ClosedLow'],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_03(self):
         await self.assert_query_result(
             r"""
@@ -4690,6 +4733,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
              'Yury1', 'Yury2', 'Yury3', 'Yury4'],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_04(self):
         await self.assert_query_result(
             r"""
@@ -4700,6 +4744,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['Elvis1', 'Elvis4', 'Yury2', 'Yury3'],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross05(self):
         await self.assert_query_result(
             r"""
@@ -4710,6 +4755,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [['Elvis', 'Yury'], ['Yury', 'Elvis'], ['Yury', 'Elvis']],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross06(self):
         await self.assert_query_result(
             r"""
@@ -4720,6 +4766,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['ElvisYury', 'YuryElvis', 'YuryElvis'],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_07(self):
         await self.assert_query_result(
             r"""
@@ -4736,6 +4783,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [2],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross08(self):
         await self.assert_query_result(
             r"""
@@ -4745,6 +4793,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['Elvis0', 'Elvis1', 'Yury1', 'Yury1'],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_09(self):
         await self.assert_query_result(
             r"""
@@ -4754,6 +4803,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [4],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_10(self):
         await self.assert_query_result(
             r"""
@@ -4768,6 +4818,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [4],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_11(self):
         await self.assert_query_result(
             r"""
@@ -4780,6 +4831,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [4],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_cross_12(self):
         # Same as cross11, but without coalescing the time_estimate,
         # which should collapse the counted set to a single element.
@@ -4794,6 +4846,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [1],
         )
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_cross_13(self):
         await self.assert_query_result(
             r"""
@@ -4811,6 +4864,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [4],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_subqueries_01(self):
         await self.assert_query_result(
             r"""
@@ -4880,6 +4934,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '2'}, {'number': '3'}, {'number': '4'}],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_subqueries_05(self):
         await self.assert_query_result(
             r"""
@@ -4902,6 +4957,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [],
         )
 
+    # XXX: THIS KIND OF THING IS THE BIGGEST PROBLEM
+    @tb.needs_factoring
     async def test_edgeql_select_subqueries_06(self):
         await self.assert_query_result(
             r"""
@@ -4968,6 +5025,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '2'}, {'number': '3'}],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_subqueries_09(self):
         await self.assert_query_result(
             r"""
@@ -5150,6 +5208,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'body': 'EdgeDB needs to happen soon.'}],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_subqueries_18(self):
         await self.assert_query_result(
             r"""
@@ -5965,6 +6024,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             tb.bag(['red', 'black', 'red', 'green', 'red']),
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_tuple_01(self):
         await self.assert_query_result(
             r"""
@@ -5975,6 +6035,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [['Closed', 2], ['Open', 2]]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_tuple_02(self):
         await self.assert_query_result(
             r"""
@@ -6048,6 +6109,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'statuses': 2, 'issues': 4}],
         )
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_tuple_06(self):
         # Tuple in a common set expr.
         await self.assert_query_result(
@@ -6063,6 +6125,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [6],
         )
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_tuple_07(self):
         # Object in a tuple.
         await self.assert_query_result(
@@ -6140,6 +6203,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [False],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_linkproperty_01(self):
         await self.assert_query_result(
             r"""
@@ -6149,6 +6213,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [43, 44, 45, 46]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_linkproperty_02(self):
         await self.assert_query_result(
             r"""
@@ -6376,12 +6441,25 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '1'}, {'number': '3'}, {'number': '4'}],
         )
 
+    @tb.needs_factoring_weakly
     async def test_edgeql_select_if_else_07(self):
         await self.assert_query_result(
             r'''
             WITH a := (SELECT Issue FILTER .number = '2'),
                  b := (SELECT Issue FILTER .number = '1'),
             SELECT a.number IF a.time_estimate < b.time_estimate ELSE b.number;
+            ''',
+            [],
+        )
+
+    # XXX
+    @tb.needs_factoring_weakly  # XXX: WE WOULD PREFER NOT
+    async def test_edgeql_select_if_else_07_b(self):
+        await self.assert_query_result(
+            r'''
+            WITH a := (SELECT Issue FILTER .number = '2'),
+                 b := (SELECT Issue FILTER .number = '1'),
+            SELECT (a IF a.time_estimate < b.time_estimate ELSE b).number;
             ''',
             [],
         )
@@ -6647,7 +6725,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_json_01(self):
+    @tb.needs_factoring
+    async def test_edgeql_select_json_01a(self):
         await self.assert_query_result(
             r'''
             # cast a type variant into a set of json
@@ -6665,6 +6744,32 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
             SELECT (
                 SELECT <json>Issue {
+                    number,
+                    time_estimate
+                } FILTER Issue.number = '2'
+            ) = to_json('{"number": "2", "time_estimate": null}');
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_select_json_01b(self):
+        await self.assert_query_result(
+            r'''
+            # cast a type variant into a set of json
+            SELECT <json>(
+                SELECT Issue {
+                    number,
+                    time_estimate
+                } FILTER Issue.number = '1'
+            ) = to_json('{"number": "1", "time_estimate": 3000}');
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+            SELECT <json>(
+                SELECT Issue {
                     number,
                     time_estimate
                 } FILTER Issue.number = '2'
@@ -7313,7 +7418,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         "Known collation issue on Heroku Postgres",
         unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
     )
-    async def test_edgeql_select_expr_objects_04(self):
+    @tb.needs_factoring_weakly
+    async def test_edgeql_select_expr_objects_04a(self):
         await self.assert_query_result(
             r'''
                 WITH items := array_agg((SELECT Named ORDER BY .name))
@@ -7334,6 +7440,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
+    async def test_edgeql_select_expr_objects_04b(self):
         await self.assert_query_result(
             r'''
                 WITH items := (User.name, array_agg(User.todo ORDER BY .name))
@@ -7353,6 +7461,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_expr_objects_05(self):
         await self.assert_query_result(
             r"""
@@ -7366,6 +7475,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_expr_objects_06(self):
         await self.assert_query_result(
             r"""
@@ -7377,6 +7487,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_expr_objects_07(self):
         # get the User names and ids
         res = await self.con.query(r'''
@@ -7416,6 +7527,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_select_expr_objects_08(self):
         await self.assert_query_result(
             r'''
@@ -7878,6 +7990,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_collection_shape_07(self):
         await self.assert_query_result(
             r'''
@@ -8366,3 +8479,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ''',
             __typenames__=True
         )
+
+
+class TestEdgeQLSelectNoFactor(TestEdgeQLSelect):
+    NO_FACTOR = True
+
+
+class TestEdgeQLSelectWarnFactor(TestEdgeQLSelect):
+    WARN_FACTOR = True


### PR DESCRIPTION
See [RFC 1027 - Simplifying path resolution](https://github.com/edgedb/rfcs/blob/master/text/1027-no-factoring.rst) and  #7766.

There are still some improvements I would like to make to the `warn_old_scoping` mode, and we should update and triage more of the test suite to use `simple_scoping` and/or `warn_old_scoping`.
    
Note that while a lot of tests rely on path factoring, I expect this is very unrepresentative of actual EdgeQL in the wild. There are a lot of tests that use path factoring because path factoring needed a lot of tests to make sure it was right.