### PR TITLE
Add debug flag to disable net worker

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -180,6 +180,8 @@ class flags(metaclass=FlagsMeta):
 
     zombodb = Flag(doc="Enabled zombodb and disables postgres FTS")
 
+    disable_net_worker = Flag(doc="Disables net worker")
+
 
 @contextlib.contextmanager
 def timeit(title='block'):

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -56,6 +56,7 @@ from edb.common import devmode
 from edb.common import lru
 from edb.common import secretkey
 from edb.common import windowedsum
+from edb.common import debug
 from edb.common.log import current_tenant
 
 from edb.schema import reflection as s_refl
@@ -1046,7 +1047,10 @@ class BaseServer:
 
         await self._after_start_servers()
         self._auth_gc = self.__loop.create_task(pkce.gc(self))
-        if self._net_worker_mode is srvargs.NetWorkerMode.Default:
+        if (
+            self._net_worker_mode is srvargs.NetWorkerMode.Default
+            and not debug.flags.disable_net_worker
+        ):
             self._net_worker_http = self.__loop.create_task(
                 net_worker.http(self)
             )


### PR DESCRIPTION
Adds `EDGEDB_DEBUG_DISABLE_NET_WORKER` flag