### PR TITLE
Update the pgvector extension.

### DIFF
--- a/edb/common/assert_data_shape.py
+++ b/edb/common/assert_data_shape.py
@@ -61,7 +61,10 @@ def sort_results(results, sort):
             results.sort(key=sort)
 
 
-def assert_data_shape(data, shape, fail, message=None, from_sql=False):
+def assert_data_shape(
+    data, shape, fail,
+    message=None, from_sql=False, rel_tol=None, abs_tol=None,
+):
     try:
         import asyncpg
         from asyncpg import types as pgtypes
@@ -71,6 +74,8 @@ def assert_data_shape(data, shape, fail, message=None, from_sql=False):
                 'SQL tests skipped: asyncpg not installed')
 
     base_fail = fail
+    rel_tol = 1e-04 if rel_tol is None else rel_tol
+    abs_tol = 1e-15 if abs_tol is None else abs_tol
 
     def fail(msg):
         base_fail(f'{msg}\nshape: {shape!r}\ndata: {data!r}')
@@ -265,7 +270,7 @@ def assert_data_shape(data, shape, fail, message=None, from_sql=False):
                 return _assert_type_shape(path, data, shape)
             elif isinstance(shape, float):
                 if not math.isclose(data, shape,
-                                    rel_tol=1e-04, abs_tol=1e-15):
+                                    rel_tol=rel_tol, abs_tol=abs_tol):
                     fail(
                         f'{message}: not isclose({data}, {shape}) '
                         f'{_format_path(path)}')
@@ -337,7 +342,7 @@ def assert_data_shape(data, shape, fail, message=None, from_sql=False):
                 return _assert_type_shape(path, data, shape)
             elif isinstance(shape, float):
                 if not math.isclose(data, shape,
-                                    rel_tol=1e-04, abs_tol=1e-15):
+                                    rel_tol=rel_tol, abs_tol=abs_tol):
                     fail(
                         f'{message}: not isclose({data}, {shape}) '
                         f'{_format_path(path)}')

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -19,7 +19,7 @@
 
 CREATE EXTENSION PACKAGE ai VERSION '1.0' {
     set ext_module := "ext::ai";
-    set dependencies := ["pgvector==0.5"];
+    set dependencies := ["pgvector==0.7"];
 
     create module ext::ai;
 

--- a/edb/lib/ext/pgvector.edgeql
+++ b/edb/lib/ext/pgvector.edgeql
@@ -17,9 +17,135 @@
 #
 
 
-create extension package pgvector version '0.5.0' {
+create extension package pgvector version '0.7.4' {
     set ext_module := "ext::pgvector";
-    set sql_extensions := ["vector >=0.5.0,<0.7.0"];
+    set sql_extensions := ["vector >=0.7.4,<0.8.0"];
+
+    set sql_setup_script := $script$
+        -- Rename the vector_norm to be consistent with l2_norm
+        ALTER FUNCTION edgedb.vector_norm(edgedb.vector) RENAME TO l2_norm;
+
+        -- Add some helpers
+
+        -- about 5-6 times slower than the C cast, but retains 0-based index
+        CREATE FUNCTION sparsevec_to_text(val sparsevec) RETURNS text AS $$
+        DECLARE
+            vectxt text := val::text;
+            mid text[];
+            kv text[];
+            i int8;
+            res text := '{';
+        BEGIN
+            mid := string_to_array(substr(split_part(vectxt, '}', 1), 2), ',');
+            FOR i IN 1..cardinality(mid)
+            LOOP
+                kv := string_to_array(mid[i], ':');
+                kv[1] := (kv[1]::int8 - 1)::text;
+                res := res || kv[1] || ':' || kv[2] || ',';
+            END LOOP;
+
+            RETURN left(res, -1) || '}' || split_part(vectxt, '}', 2);
+        END;
+        $$ LANGUAGE plpgsql
+        IMMUTABLE STRICT;
+
+        -- about 10 times slower than a cast
+        CREATE FUNCTION text_to_sparsevec(val text) RETURNS sparsevec AS $$
+        DECLARE
+            mid text[];
+            kv text[];
+            i int8;
+            res text := '{';
+        BEGIN
+            IF val ~ '^\s*{\s*(\d+\s*:.+?,\s*)*\d+\s*:.+}\s*/\s*\d+\s*$'
+            THEN
+                mid := string_to_array(split_part(split_part(val, '}', 1), '{', 2), ',');
+                FOR i IN 1..cardinality(mid)
+                LOOP
+                    kv := string_to_array(mid[i], ':');
+                    kv[1] := (trim(kv[1])::int8 + 1)::text;
+                    res := res || kv[1] || ':' || kv[2] || ',';
+                END LOOP;
+                RETURN (left(res, -1) || '}' || split_part(val, '}', 2))::sparsevec;
+            ELSE
+                RETURN val::sparsevec;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql
+        IMMUTABLE STRICT;
+
+        CREATE FUNCTION sparsevec_to_jsonb(val sparsevec) RETURNS jsonb AS $$
+        DECLARE
+            vectxt text := val::text;
+            mid text[];
+            kv text[];
+            i int8;
+            dim text := split_part(vectxt, '/', 2);
+            res text := '{';
+        BEGIN
+            mid := string_to_array(substr(split_part(vectxt, '}', 1), 2), ',');
+            FOR i IN 1..cardinality(mid)
+            LOOP
+                kv := string_to_array(mid[i], ':');
+                kv[1] := (kv[1]::int8 - 1)::text;
+                res := res || '"' || kv[1] || '":' || kv[2] || ',';
+            END LOOP;
+
+            RETURN (res || '"dim":' || dim || '}')::jsonb;
+        END;
+        $$ LANGUAGE plpgsql
+        IMMUTABLE STRICT;
+
+        CREATE FUNCTION jsonb_to_sparsevec(val jsonb) RETURNS sparsevec AS $$
+        DECLARE
+            mid text[];
+            kv text[];
+            r record;
+            i int8;
+            dim text := NULL;
+            res text := '{';
+            msg text;
+        BEGIN
+            IF jsonb_typeof(val) = 'object'
+            THEN
+                msg := 'missing "dim"';
+                FOR r IN SELECT * FROM jsonb_each(val)
+                LOOP
+                    CASE
+                        WHEN r.key = 'dim' THEN
+                            dim := r.value::text;
+                        WHEN r.key ~ $r$\d+$r$ THEN
+                            res := res || (r.key::int8 + 1)::text || ':'
+                                       || r.value::text || ',';
+                        ELSE
+                            msg := 'unexpected key in JSON object: ' || r.key;
+                            EXIT;
+                    END CASE;
+                END LOOP;
+
+                IF dim IS NOT NULL
+                THEN
+                    RETURN (left(res, -1) || '}/' || dim)::sparsevec;
+                END IF;
+            ELSE
+                msg := 'JSON object expected, got ' || jsonb_typeof(val) || ' instead';
+            END IF;
+
+            RAISE EXCEPTION USING
+                ERRCODE = 22000,
+                MESSAGE = msg;
+        END;
+        $$ LANGUAGE plpgsql
+        IMMUTABLE STRICT;
+    $script$;
+    set sql_teardown_script := $$
+        ALTER FUNCTION edgedb.l2_norm(edgedb.vector) RENAME TO vector_norm;
+        -- remove helpers
+        DROP FUNCTION edgedb.sparsevec_to_jsonb;
+        DROP FUNCTION edgedb.jsonb_to_sparsevec;
+        DROP FUNCTION edgedb.sparsevec_to_text;
+        DROP FUNCTION edgedb.text_to_sparsevec;
+    $$;
 
     create module ext::pgvector;
 
@@ -55,6 +181,20 @@ create extension package pgvector version '0.5.0' {
         set num_params := 1;
     };
 
+    create scalar type ext::pgvector::halfvec extending std::anyscalar {
+        set id := <uuid>"4ba84534-188e-43b4-a7ce-cea2af0f405b";
+        set sql_type := "halfvec";
+        set sql_type_scheme := "halfvec({__arg_0__})";
+        set num_params := 1;
+    };
+
+    create scalar type ext::pgvector::sparsevec extending std::anyscalar {
+        set id := <uuid>"003e434d-cac2-430a-b238-fb39d73447d2";
+        set sql_type := "sparsevec";
+        set sql_type_scheme := "sparsevec({__arg_0__})";
+        set num_params := 1;
+    };
+
     create cast from ext::pgvector::vector to std::json {
         set volatility := 'Immutable';
         using sql 'SELECT val::text::jsonb';
@@ -69,6 +209,75 @@ create extension package pgvector version '0.5.0' {
         $$;
     };
 
+    create cast from ext::pgvector::vector to std::str {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create cast from std::str to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create cast from ext::pgvector::vector to std::bytes {
+        set volatility := 'Immutable';
+        using sql 'SELECT vector_send(val)';
+    };
+
+    create cast from ext::pgvector::halfvec to std::json {
+        set volatility := 'Immutable';
+        using sql 'SELECT val::text::jsonb';
+    };
+
+    create cast from std::json to ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql $$
+        SELECT (
+            nullif(val, 'null'::jsonb)::text::halfvec
+        )
+        $$;
+    };
+
+    create cast from ext::pgvector::halfvec to std::str {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create cast from std::str to ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create cast from ext::pgvector::halfvec to std::bytes {
+        set volatility := 'Immutable';
+        using sql 'SELECT halfvec_send(val)';
+    };
+
+    create cast from ext::pgvector::sparsevec to std::str {
+        set volatility := 'Immutable';
+        using sql 'SELECT sparsevec_to_text(val)';
+    };
+
+    create cast from std::str to ext::pgvector::sparsevec {
+        set volatility := 'Immutable';
+        using sql 'SELECT text_to_sparsevec(val)';
+    };
+
+    create cast from ext::pgvector::sparsevec to std::bytes {
+        set volatility := 'Immutable';
+        using sql 'SELECT sparsevec_send(val)';
+    };
+
+    create cast from ext::pgvector::sparsevec to std::json {
+        set volatility := 'Immutable';
+        using sql 'SELECT sparsevec_to_jsonb(val)';
+    };
+
+    create cast from std::json to ext::pgvector::sparsevec {
+        set volatility := 'Immutable';
+        using sql 'SELECT jsonb_to_sparsevec(val)';
+    };
+
     # All casts from numerical arrays should allow assignment casts.
     create cast from array<std::float32> to ext::pgvector::vector {
         set volatility := 'Immutable';
@@ -76,7 +285,19 @@ create extension package pgvector version '0.5.0' {
         allow assignment;
     };
 
+    create cast from array<std::float32> to ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
     create cast from array<std::float64> to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from array<std::float64> to ext::pgvector::halfvec {
         set volatility := 'Immutable';
         using sql cast;
         allow assignment;
@@ -90,7 +311,21 @@ create extension package pgvector version '0.5.0' {
         allow assignment;
     };
 
+    create cast from array<std::int16> to ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql $$
+        SELECT val::float4[]::halfvec
+        $$;
+        allow assignment;
+    };
+
     create cast from array<std::int32> to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from array<std::int32> to ext::pgvector::halfvec {
         set volatility := 'Immutable';
         using sql cast;
         allow assignment;
@@ -104,14 +339,83 @@ create extension package pgvector version '0.5.0' {
         allow assignment;
     };
 
+    create cast from array<std::int64> to ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql $$
+        SELECT val::float4[]::halfvec
+        $$;
+        allow assignment;
+    };
+
     create cast from ext::pgvector::vector to array<std::float32> {
         set volatility := 'Immutable';
         using sql cast;
     };
 
+    create cast from ext::pgvector::halfvec to array<std::float32> {
+        set volatility := 'Immutable';
+        using sql cast;
+    };
+
+    create cast from ext::pgvector::vector to ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from ext::pgvector::vector to ext::pgvector::sparsevec {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from ext::pgvector::halfvec to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow implicit;
+    };
+
+    create cast from ext::pgvector::halfvec to ext::pgvector::sparsevec {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from ext::pgvector::sparsevec to ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
+    create cast from ext::pgvector::sparsevec to ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql cast;
+        allow assignment;
+    };
+
     create function ext::pgvector::euclidean_distance(
         a: ext::pgvector::vector,
         b: ext::pgvector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <-> b';
+    };
+
+    create function ext::pgvector::euclidean_distance(
+        a: ext::pgvector::halfvec,
+        b: ext::pgvector::halfvec,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <-> b';
+    };
+
+    create function ext::pgvector::euclidean_distance(
+        a: ext::pgvector::sparsevec,
+        b: ext::pgvector::sparsevec,
     ) -> std::float64 {
         set volatility := 'Immutable';
         # Needed to pick up the indexes when used in ORDER BY.
@@ -129,6 +433,26 @@ create extension package pgvector version '0.5.0' {
         using sql 'SELECT (a <#> b)';
     };
 
+    create function ext::pgvector::neg_inner_product(
+        a: ext::pgvector::halfvec,
+        b: ext::pgvector::halfvec,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT (a <#> b)';
+    };
+
+    create function ext::pgvector::neg_inner_product(
+        a: ext::pgvector::sparsevec,
+        b: ext::pgvector::sparsevec,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT (a <#> b)';
+    };
+
     create function ext::pgvector::cosine_distance(
         a: ext::pgvector::vector,
         b: ext::pgvector::vector,
@@ -139,12 +463,120 @@ create extension package pgvector version '0.5.0' {
         using sql 'SELECT a <=> b';
     };
 
+    create function ext::pgvector::cosine_distance(
+        a: ext::pgvector::halfvec,
+        b: ext::pgvector::halfvec,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <=> b';
+    };
+
+    create function ext::pgvector::cosine_distance(
+        a: ext::pgvector::sparsevec,
+        b: ext::pgvector::sparsevec,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <=> b';
+    };
+
+    create function ext::pgvector::taxicab_distance(
+        a: ext::pgvector::vector,
+        b: ext::pgvector::vector,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <+> b';
+    };
+
+    create function ext::pgvector::taxicab_distance(
+        a: ext::pgvector::halfvec,
+        b: ext::pgvector::halfvec,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <+> b';
+    };
+
+    create function ext::pgvector::taxicab_distance(
+        a: ext::pgvector::sparsevec,
+        b: ext::pgvector::sparsevec,
+    ) -> std::float64 {
+        set volatility := 'Immutable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        using sql 'SELECT a <+> b';
+    };
+
     create function ext::pgvector::euclidean_norm(
         a: ext::pgvector::vector
     ) -> std::float64 {
-        using sql function 'vector_norm';
+        using sql function 'l2_norm';
         set volatility := 'Immutable';
         set force_return_cast := true;
+    };
+
+    create function ext::pgvector::euclidean_norm(
+        a: ext::pgvector::halfvec
+    ) -> std::float64 {
+        using sql function 'l2_norm';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function ext::pgvector::euclidean_norm(
+        a: ext::pgvector::sparsevec
+    ) -> std::float64 {
+        using sql function 'l2_norm';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function ext::pgvector::l2_normalize(
+        a: ext::pgvector::vector
+    ) -> ext::pgvector::vector {
+        using sql function 'l2_normalize';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function ext::pgvector::l2_normalize(
+        a: ext::pgvector::halfvec
+    ) -> ext::pgvector::halfvec {
+        using sql function 'l2_normalize';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function ext::pgvector::l2_normalize(
+        a: ext::pgvector::sparsevec
+    ) -> ext::pgvector::sparsevec {
+        using sql function 'l2_normalize';
+        set volatility := 'Immutable';
+        set force_return_cast := true;
+    };
+
+    create function ext::pgvector::subvector(
+        a: ext::pgvector::vector,
+        i: std::int64,
+        len: std::int64,
+    ) -> ext::pgvector::vector {
+        set volatility := 'Immutable';
+        using sql 'SELECT subvector(a, (i+1)::int, len::int)';
+    };
+
+    create function ext::pgvector::subvector(
+        a: ext::pgvector::halfvec,
+        i: std::int64,
+        len: std::int64,
+    ) -> ext::pgvector::halfvec {
+        set volatility := 'Immutable';
+        using sql 'SELECT subvector(a, (i+1)::int, len::int)';
     };
 
     create function ext::pgvector::set_probes(num: std::int64) -> std::int64 {
@@ -221,10 +653,159 @@ create extension package pgvector version '0.5.0' {
         $$;
     };
 
+    create abstract index ext::pgvector::hnsw_taxicab(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for taxicab (L1) distance.';
+        set code := $$
+            hnsw (__col__ vector_l1_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
     create index match for ext::pgvector::vector using ext::pgvector::ivfflat_euclidean;
     create index match for ext::pgvector::vector using ext::pgvector::ivfflat_ip;
     create index match for ext::pgvector::vector using ext::pgvector::ivfflat_cosine;
     create index match for ext::pgvector::vector using ext::pgvector::hnsw_euclidean;
     create index match for ext::pgvector::vector using ext::pgvector::hnsw_ip;
     create index match for ext::pgvector::vector using ext::pgvector::hnsw_cosine;
+    create index match for ext::pgvector::vector using ext::pgvector::hnsw_taxicab;
+
+    create abstract index ext::pgvector::ivfflat_hv_euclidean(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for euclidean distance.';
+        set code :=
+            'ivfflat (__col__ halfvec_l2_ops) WITH (lists = __kw_lists__)';
+    };
+
+    create abstract index ext::pgvector::ivfflat_hv_ip(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for inner product.';
+        set code :=
+            'ivfflat (__col__ halfvec_ip_ops) WITH (lists = __kw_lists__)';
+    };
+
+    create abstract index ext::pgvector::ivfflat_hv_cosine(
+        named only lists: int64
+    ) {
+        create annotation std::description :=
+            'IVFFlat index for cosine distance.';
+        set code :=
+            'ivfflat (__col__ halfvec_cosine_ops) WITH (lists = __kw_lists__)';
+    };
+
+    create abstract index ext::pgvector::hnsw_hv_euclidean(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for euclidean distance.';
+        set code := $$
+            hnsw (__col__ halfvec_l2_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create abstract index ext::pgvector::hnsw_hv_ip(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for inner product.';
+        set code := $$
+            hnsw (__col__ halfvec_ip_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create abstract index ext::pgvector::hnsw_hv_cosine(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for cosine distance.';
+        set code := $$
+            hnsw (__col__ halfvec_cosine_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create abstract index ext::pgvector::hnsw_hv_taxicab(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for taxicab (L1) distance.';
+        set code := $$
+            hnsw (__col__ halfvec_l1_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create index match for ext::pgvector::halfvec using ext::pgvector::ivfflat_hv_euclidean;
+    create index match for ext::pgvector::halfvec using ext::pgvector::ivfflat_hv_ip;
+    create index match for ext::pgvector::halfvec using ext::pgvector::ivfflat_hv_cosine;
+    create index match for ext::pgvector::halfvec using ext::pgvector::hnsw_hv_euclidean;
+    create index match for ext::pgvector::halfvec using ext::pgvector::hnsw_hv_ip;
+    create index match for ext::pgvector::halfvec using ext::pgvector::hnsw_hv_cosine;
+    create index match for ext::pgvector::halfvec using ext::pgvector::hnsw_hv_taxicab;
+
+    create abstract index ext::pgvector::hnsw_sv_euclidean(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for euclidean distance.';
+        set code := $$
+            hnsw (__col__ sparsevec_l2_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create abstract index ext::pgvector::hnsw_sv_ip(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for inner product.';
+        set code := $$
+            hnsw (__col__ sparsevec_ip_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create abstract index ext::pgvector::hnsw_sv_cosine(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for cosine distance.';
+        set code := $$
+            hnsw (__col__ sparsevec_cosine_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create abstract index ext::pgvector::hnsw_sv_taxicab(
+        named only m: int64 = 16,
+        named only ef_construction: int64 = 64,
+    ) {
+        create annotation std::description :=
+            'HNSW index for taxicab (L1) distance.';
+        set code := $$
+            hnsw (__col__ sparsevec_l1_ops)
+            WITH (m = __kw_m__, ef_construction = __kw_ef_construction__)
+        $$;
+    };
+
+    create index match for ext::pgvector::sparsevec using ext::pgvector::hnsw_sv_euclidean;
+    create index match for ext::pgvector::sparsevec using ext::pgvector::hnsw_sv_ip;
+    create index match for ext::pgvector::sparsevec using ext::pgvector::hnsw_sv_cosine;
+    create index match for ext::pgvector::sparsevec using ext::pgvector::hnsw_sv_taxicab;
 };

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1092,9 +1092,12 @@ class ConnectedTestCase(ClusterTestCase):
         async for tx in self.con.retrying_transaction():
             yield cm(tx)
 
-    def assert_data_shape(self, data, shape, message=None):
+    def assert_data_shape(self, data, shape,
+                          message=None, rel_tol=None, abs_tol=None):
         assert_data_shape.assert_data_shape(
-            data, shape, self.fail, message=message)
+            data, shape, self.fail,
+            message=message, rel_tol=rel_tol, abs_tol=abs_tol,
+        )
 
     async def assert_query_result(self, query,
                                   exp_result_json,
@@ -1102,7 +1105,8 @@ class ConnectedTestCase(ClusterTestCase):
                                   *,
                                   always_typenames=False,
                                   msg=None, sort=None, implicit_limit=0,
-                                  variables=None, json_only=False):
+                                  variables=None, json_only=False,
+                                  rel_tol=None, abs_tol=None):
         fetch_args = variables if isinstance(variables, tuple) else ()
         fetch_kw = variables if isinstance(variables, dict) else {}
         try:
@@ -1121,7 +1125,9 @@ class ConnectedTestCase(ClusterTestCase):
             if sort is not None:
                 assert_data_shape.sort_results(res, sort)
             assert_data_shape.assert_data_shape(
-                res, exp_result_json, self.fail, message=msg)
+                res, exp_result_json, self.fail,
+                message=msg, rel_tol=rel_tol, abs_tol=abs_tol,
+            )
         except Exception:
             self.add_fail_notes(serialization='json')
             if msg:
@@ -1151,7 +1157,9 @@ class ConnectedTestCase(ClusterTestCase):
             if sort is not None:
                 assert_data_shape.sort_results(res, sort)
             assert_data_shape.assert_data_shape(
-                res, exp_result_binary, self.fail, message=msg)
+                res, exp_result_binary, self.fail,
+                message=msg, rel_tol=rel_tol, abs_tol=abs_tol,
+            )
         except Exception:
             self.add_fail_notes(
                 serialization='binary',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EDGEDBGUI_COMMIT = 'main'
 
 PGVECTOR_REPO = 'https://github.com/pgvector/pgvector.git'
 # This can be a branch, tag, or commit
-PGVECTOR_COMMIT = 'v0.6.0'
+PGVECTOR_COMMIT = 'v0.7.4'
 
 SAFE_EXT_CFLAGS: list[str] = []
 if flag := os.environ.get('EDGEDB_OPT_CFLAG'):

--- a/tests/schemas/pgvector.esdl
+++ b/tests/schemas/pgvector.esdl
@@ -18,6 +18,8 @@
 
 
 scalar type v3 extending ext::pgvector::vector<3>;
+scalar type hv3 extending ext::pgvector::halfvec<3>;
+scalar type sv3 extending ext::pgvector::sparsevec<3>;
 
 scalar type myf64 extending float64 {
     constraint max_value(100);
@@ -30,34 +32,94 @@ type Basic {
     p_json: json {rewrite insert using (to_json(__subject__.p_str))};
 }
 
-type IVFFlat_L2 {
+type IVFFlat_vec_L2 {
     required vec: v3;
     index ext::pgvector::ivfflat_euclidean(lists := 100) on (.vec);
 }
 
-type IVFFlat_IP {
+type IVFFlat_vec_IP {
     required vec: v3;
     index ext::pgvector::ivfflat_ip(lists := 100) on (.vec);
 }
 
-type IVFFlat_Cosine {
+type IVFFlat_vec_Cosine {
     required vec: v3;
     index ext::pgvector::ivfflat_cosine(lists := 100) on (.vec);
 }
 
-type HNSW_L2 {
+type HNSW_vec_L2 {
     required vec: v3;
     index ext::pgvector::hnsw_euclidean() on (.vec);
 }
 
-type HNSW_IP {
+type HNSW_vec_IP {
     required vec: v3;
     index ext::pgvector::hnsw_ip(m := 4) on (.vec);
 }
 
-type HNSW_Cosine {
+type HNSW_vec_Cosine {
     required vec: v3;
     index ext::pgvector::hnsw_cosine(m := 2, ef_construction := 4) on (.vec);
+}
+
+type HNSW_vec_L1 {
+    required vec: v3;
+    index ext::pgvector::hnsw_taxicab() on (.vec);
+}
+
+type IVFFlat_hv_L2 {
+    required vec: hv3;
+    index ext::pgvector::ivfflat_hv_euclidean(lists := 100) on (.vec);
+}
+
+type IVFFlat_hv_IP {
+    required vec: hv3;
+    index ext::pgvector::ivfflat_hv_ip(lists := 100) on (.vec);
+}
+
+type IVFFlat_hv_Cosine {
+    required vec: hv3;
+    index ext::pgvector::ivfflat_hv_cosine(lists := 100) on (.vec);
+}
+
+type HNSW_hv_L2 {
+    required vec: hv3;
+    index ext::pgvector::hnsw_hv_euclidean() on (.vec);
+}
+
+type HNSW_hv_IP {
+    required vec: hv3;
+    index ext::pgvector::hnsw_hv_ip(m := 4) on (.vec);
+}
+
+type HNSW_hv_Cosine {
+    required vec: hv3;
+    index ext::pgvector::hnsw_hv_cosine(m := 2, ef_construction := 4) on (.vec);
+}
+
+type HNSW_hv_L1 {
+    required vec: hv3;
+    index ext::pgvector::hnsw_hv_taxicab() on (.vec);
+}
+
+type HNSW_sv_L2 {
+    required vec: sv3;
+    index ext::pgvector::hnsw_sv_euclidean() on (.vec);
+}
+
+type HNSW_sv_IP {
+    required vec: sv3;
+    index ext::pgvector::hnsw_sv_ip(m := 4) on (.vec);
+}
+
+type HNSW_sv_Cosine {
+    required vec: sv3;
+    index ext::pgvector::hnsw_sv_cosine(m := 2, ef_construction := 4) on (.vec);
+}
+
+type HNSW_sv_L1 {
+    required vec: sv3;
+    index ext::pgvector::hnsw_sv_taxicab() on (.vec);
 }
 
 type Con {

--- a/tests/schemas/pgvector_setup.edgeql
+++ b/tests/schemas/pgvector_setup.edgeql
@@ -26,10 +26,24 @@ union (
 for x in {[0, 1, 2.3], [1, 1, 10.11], [4.5, 6.7, 8.9]}
 union (
     (insert Basic {p_str := to_str(<json>x)}),
-    (insert IVFFlat_L2 {vec := <v3>x}),
-    (insert IVFFlat_IP {vec := <v3>x}),
-    (insert IVFFlat_Cosine {vec := <v3>x}),
-    (insert HNSW_L2 {vec := <v3>x}),
-    (insert HNSW_IP {vec := <v3>x}),
-    (insert HNSW_Cosine {vec := <v3>x}),
+    (insert IVFFlat_vec_L2 {vec := <v3>x}),
+    (insert IVFFlat_vec_IP {vec := <v3>x}),
+    (insert IVFFlat_vec_Cosine {vec := <v3>x}),
+    (insert HNSW_vec_L2 {vec := <v3>x}),
+    (insert HNSW_vec_IP {vec := <v3>x}),
+    (insert HNSW_vec_Cosine {vec := <v3>x}),
+    (insert HNSW_vec_L1 {vec := <v3>x}),
+
+    (insert IVFFlat_hv_L2 {vec := <hv3>x}),
+    (insert IVFFlat_hv_IP {vec := <hv3>x}),
+    (insert IVFFlat_hv_Cosine {vec := <hv3>x}),
+    (insert HNSW_hv_L2 {vec := <hv3>x}),
+    (insert HNSW_hv_IP {vec := <hv3>x}),
+    (insert HNSW_hv_Cosine {vec := <hv3>x}),
+    (insert HNSW_hv_L1 {vec := <hv3>x}),
+
+    (insert HNSW_sv_L2 {vec := <sv3><v3>x}),
+    (insert HNSW_sv_IP {vec := <sv3><v3>x}),
+    (insert HNSW_sv_Cosine {vec := <sv3><v3>x}),
+    (insert HNSW_sv_L1 {vec := <sv3><v3>x}),
 );

--- a/tests/test_edgeql_vector.py
+++ b/tests/test_edgeql_vector.py
@@ -341,6 +341,21 @@ class TestEdgeQLVector(tb.QueryTestCase):
             json_only=True,
         )
 
+    async def test_edgeql_vector_cast_12(self):
+        # Vectors <-> bytes casts.
+        await self.assert_query_result(
+            r'''
+                with module ext::pgvector
+                select
+                    <bytes><vector>[0, 1, 2]
+                    = (
+                        b'\x00\x03' ++
+                        b'\x00\x00\x00\x00\x00\x00?\x80\x00\x00@\x00\x00\x00'
+                    )
+            ''',
+            [True],
+        )
+
     async def test_edgeql_vector_op_01(self):
         # Comparison operators.
         await self.assert_query_result(
@@ -453,7 +468,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
         await self.assert_query_result(
             '''
                 with module ext::pgvector
-                select len(default::IVFFlat_L2.vec) limit 1;
+                select len(default::IVFFlat_vec_L2.vec) limit 1;
             ''',
             [3],
         )
@@ -474,7 +489,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
             '''
                 with module ext::pgvector
                 select euclidean_distance(
-                    default::IVFFlat_L2.vec,
+                    default::IVFFlat_vec_L2.vec,
                     <vector>[0, 1, 0],
                 );
             ''',
@@ -493,7 +508,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
         await self.assert_query_result(
             '''
                 with module ext::pgvector
-                select euclidean_norm(default::IVFFlat_L2.vec);
+                select euclidean_norm(default::IVFFlat_vec_L2.vec);
             ''',
             {2.5079872331917934, 10.208432276239787, 12.014573942925704},
         )
@@ -514,7 +529,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
             '''
                 with module ext::pgvector
                 select neg_inner_product(
-                    default::IVFFlat_IP.vec,
+                    default::IVFFlat_vec_IP.vec,
                     <vector>[3, 4, 1],
                 );
             ''',
@@ -537,7 +552,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
             '''
                 with module ext::pgvector
                 select cosine_distance(
-                    default::IVFFlat_Cosine.vec,
+                    default::IVFFlat_vec_Cosine.vec,
                     <vector>[3, 4, 1],
                 );
             ''',
@@ -562,17 +577,69 @@ class TestEdgeQLVector(tb.QueryTestCase):
             '''
                 with module ext::pgvector
                 select <array<float32>>
-                    mean(default::IVFFlat_L2.vec);
+                    mean(default::IVFFlat_vec_L2.vec);
             ''',
             [[1.8333334, 2.8999999, 7.103333]],
         )
+
+    async def test_edgeql_vector_func_07(self):
+        await self.assert_query_result(
+            '''
+                with
+                    module ext::pgvector,
+                    x := <vector>[1, 3, 0, 6, 7]
+                select (
+                    <array<float32>>subvector(x, 3, 1) = [6],
+                    <array<float32>>subvector(x, 3, 2) = [6, 7],
+                    <array<float32>>subvector(x, 3, 20) = [6, 7],
+                    <array<float32>>subvector(x, 0, 3) = [1, 3, 0],
+                    <array<float32>>subvector(x, 1, 3) = [3, 0, 6],
+                    <array<float32>>subvector(x, -2, 3) = [1],
+                )
+            ''',
+            [[True, True, True, True, True, True]],
+        )
+
+    async def test_edgeql_vector_func_08(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'must have at least 1 dimension',
+        ):
+            await self.con.execute(r"""
+                with
+                    module ext::pgvector,
+                    x := <vector>[1, 3, 0, 6, 7]
+                select <array<float32>>subvector(x, 3, 0)
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'must have at least 1 dimension',
+        ):
+            await self.con.execute(r"""
+                with
+                    module ext::pgvector,
+                    x := <vector>[1, 3, 0, 6, 7]
+                select <array<float32>>subvector(x, -2, 1)
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'must have at least 1 dimension',
+        ):
+            await self.con.execute(r"""
+                with
+                    module ext::pgvector,
+                    x := <vector>[1, 3, 0, 6, 7]
+                select <array<float32>>subvector(x, 20, 2)
+            """)
 
     async def test_edgeql_vector_insert_01(self):
         # Test assignment casts
         res = [0, 3, 4]
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                insert IVFFlat_L2 {
+                insert IVFFlat_vec_L2 {
                     vec := array_agg(
                         Raw.p_int16 order by Raw.p_int16
                     )[:3]
@@ -582,7 +649,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
                 '''
                     with res := <array<float32>>$res
                     select <array<float32>>(
-                        select IVFFlat_L2
+                        select IVFFlat_vec_L2
                         filter .vec = <ext::pgvector::vector>res
                     ).vec
                 ''',
@@ -592,7 +659,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
 
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                insert IVFFlat_L2 {
+                insert IVFFlat_vec_L2 {
                     vec := array_agg(
                         Raw.p_int32 order by Raw.p_int32
                     )[:3]
@@ -602,7 +669,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
                 '''
                     with res := <array<float32>>$res
                     select <array<float32>>(
-                        select IVFFlat_L2
+                        select IVFFlat_vec_L2
                         filter .vec = <ext::pgvector::vector>res
                     ).vec
                 ''',
@@ -612,7 +679,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
 
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                insert IVFFlat_L2 {
+                insert IVFFlat_vec_L2 {
                     vec := array_agg(
                         Raw.p_int64 order by Raw.p_int64
                     )[:3]
@@ -622,7 +689,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
                 '''
                     with res := <array<float32>>$res
                     select <array<float32>>(
-                        select IVFFlat_L2
+                        select IVFFlat_vec_L2
                         filter .vec = <ext::pgvector::vector>res
                     ).vec
                 ''',
@@ -635,7 +702,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
         res = [0, 3, 4.25]
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                insert IVFFlat_L2 {
+                insert IVFFlat_vec_L2 {
                     vec := array_agg(
                         Raw.p_float32 order by Raw.p_float32
                     )[:3]
@@ -645,7 +712,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
                 '''
                     with res := <array<float32>>$res
                     select <array<float32>>(
-                        select IVFFlat_L2
+                        select IVFFlat_vec_L2
                         filter .vec = <ext::pgvector::vector>res
                     ).vec
                 ''',
@@ -655,7 +722,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
 
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                insert IVFFlat_L2 {
+                insert IVFFlat_vec_L2 {
                     vec := array_agg(
                         Raw.val order by Raw.val
                     )[:3]
@@ -665,7 +732,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
                 '''
                     with res := <array<float32>>$res
                     select <array<float32>>(
-                        select IVFFlat_L2
+                        select IVFFlat_vec_L2
                         filter .vec = <ext::pgvector::vector>res
                     ).vec
                 ''',
@@ -714,7 +781,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
         if not look(json.loads(plan)):
             raise AssertionError(f'query did not use {index_type} index')
 
-    async def _check_index(self, obj, func, index_type, index_op):
+    async def _check_index(self, obj, func, index_type, index_op, vec_type):
         # Test that we actually hit the indexes by looking at the query plans.
 
         obj_id = (await self.con.query_single(f"""
@@ -747,7 +814,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
             f'''
             with vec as module ext::pgvector
             select {obj}
-            order by vec::{func}(.vec, <v3>to_json(<str>$0))
+            order by vec::{func}(.vec, <{vec_type}>to_json(<str>$0))
             empty last limit 5;
             ''',
             str(embedding),
@@ -759,7 +826,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
             f'''
             with vec as module ext::pgvector
             select {obj}
-            order by vec::{func}(.vec, <v3><json>$0)
+            order by vec::{func}(.vec, <{vec_type}><json>$0)
             empty last limit 5;
             ''',
             json.dumps(embedding),
@@ -771,7 +838,7 @@ class TestEdgeQLVector(tb.QueryTestCase):
             f'''
             with vec as module ext::pgvector
             select {obj}
-            order by vec::{func}(.vec, <v3><array<float32>>$0)
+            order by vec::{func}(.vec, <{vec_type}><array<float32>>$0)
             empty last limit 5;
             ''',
             embedding,
@@ -781,27 +848,33 @@ class TestEdgeQLVector(tb.QueryTestCase):
 
     async def test_edgeql_vector_index_01(self):
         await self._check_index(
-            'IVFFlat_L2', 'euclidean_distance', 'ivfflat', 'euclidean')
+            'IVFFlat_vec_L2', 'euclidean_distance', 'ivfflat', 'euclidean',
+            'v3')
 
     async def test_edgeql_vector_index_02(self):
         await self._check_index(
-            'IVFFlat_Cosine', 'cosine_distance', 'ivfflat', 'cosine')
+            'IVFFlat_vec_Cosine', 'cosine_distance', 'ivfflat', 'cosine',
+            'v3')
 
     async def test_edgeql_vector_index_03(self):
         await self._check_index(
-            'IVFFlat_IP', 'neg_inner_product', 'ivfflat', 'ip')
+            'IVFFlat_vec_IP', 'neg_inner_product', 'ivfflat', 'ip', 'v3')
 
     async def test_edgeql_vector_index_04(self):
         await self._check_index(
-            'HNSW_L2', 'euclidean_distance', 'hnsw', 'euclidean')
+            'HNSW_vec_L2', 'euclidean_distance', 'hnsw', 'euclidean', 'v3')
 
     async def test_edgeql_vector_index_05(self):
         await self._check_index(
-            'HNSW_Cosine', 'cosine_distance', 'hnsw', 'cosine')
+            'HNSW_vec_Cosine', 'cosine_distance', 'hnsw', 'cosine', 'v3')
 
     async def test_edgeql_vector_index_06(self):
         await self._check_index(
-            'HNSW_IP', 'neg_inner_product', 'hnsw', 'ip')
+            'HNSW_vec_IP', 'neg_inner_product', 'hnsw', 'ip', 'v3')
+
+    async def test_edgeql_vector_index_07(self):
+        await self._check_index(
+            'HNSW_vec_L1', 'taxicab_distance', 'hnsw', 'taxicab', 'v3')
 
     async def test_edgeql_vector_config(self):
         # We can't test the effects of config parameters easily, but we can
@@ -865,6 +938,684 @@ class TestEdgeQLVector(tb.QueryTestCase):
             'select <int64>_current_setting("hnsw.ef_search")',
             [40],
         )
+
+    async def test_edgeql_halfvec_cast_01(self):
+        # Basic casts to and from json. Also a cast into an
+        # array<float32>.
+        await self.assert_query_result(
+            '''
+                select <json><ext::pgvector::halfvec>[1, 2, 3.5];
+            ''',
+            [[1, 2, 3.5]],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>
+                  to_json('[1.5, 2, 3]');
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+    async def test_edgeql_halfvec_cast_02(self):
+        # Basic casts from json.
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>to_json((
+                    select _ := Basic.p_str order by _
+                ))
+            ''',
+            [[0, 1, 2.3], [1, 1, 10.11], [4.5, 6.7, 8.9]],
+            # halfvecs will lose a fair bit of precision in convertions
+            rel_tol=0.01,
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>(
+                    select _ := Basic.p_json order by _
+                )
+            ''',
+            [[0, 1, 2.3], [1, 1, 10.11], [4.5, 6.7, 8.9]],
+            # halfvecs will lose a fair bit of precision in convertions
+            rel_tol=0.01,
+        )
+
+    async def test_edgeql_halfvec_cast_03(self):
+        # Casts from numeric array expressions.
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec><array<int16>>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec><array<int32>>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec><array<int64>>[1.0, 2.0, 3.0];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec><array<float32>>[1.5, 2, 3];
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec><array<float64>>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+    async def test_edgeql_halfvec_cast_04(self):
+        # Casts from numeric array expressions.
+        res = [0, 3, 4, 7]
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(
+                        Raw.p_int16 order by Raw.p_int16
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(
+                        Raw.p_int32 order by Raw.p_int32
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(
+                        Raw.p_int64 order by Raw.p_int64
+                    );
+            ''',
+            [res],
+        )
+
+    async def test_edgeql_halfvec_cast_05(self):
+        # Casts from numeric array expressions.
+        res = [0, 3, 4.25, 6.75]
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(
+                        Raw.p_float32 order by Raw.p_float32
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(
+                        Raw.val order by Raw.val
+                    );
+            ''',
+            [res],
+        )
+
+    async def test_edgeql_halfvec_cast_06(self):
+        # Casts from literal numeric arrays.
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>[1, 2, 3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>
+                    [<int16>1, <int16>2, <int16>3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>
+                    [<int32>1, <int32>2, <int32>3];
+            ''',
+            [[1, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>[1.5, 2, 3];
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>><ext::pgvector::halfvec>
+                    [<float32>1.5, <float32>2, <float32>3];
+            ''',
+            [[1.5, 2, 3]],
+        )
+
+    async def test_edgeql_halfvec_cast_07(self):
+        await self.assert_query_result(
+            '''
+                select <array<float32>><v3>[11, 3, 4];
+            ''',
+            [[11, 3, 4]],
+        )
+
+    async def test_edgeql_halfvec_cast_08(self):
+        # Casts from arrays of derived types.
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec><array<myf64>>[1, 2.3, 4.5];
+            ''',
+            [[1, 2.3, 4.5]],
+            # halfvecs will lose a fair bit of precision in convertions
+            rel_tol=0.01,
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec><array<deepf64>>[1, 2.3, 4.5];
+            ''',
+            [[1, 2.3, 4.5]],
+            # halfvecs will lose a fair bit of precision in convertions
+            rel_tol=0.01,
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(<myf64>{1, 2.3, 4.5});
+            ''',
+            [[1, 2.3, 4.5]],
+            # halfvecs will lose a fair bit of precision in convertions
+            rel_tol=0.01,
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(<deepf64>{1, 2.3, 4.5});
+            ''',
+            [[1, 2.3, 4.5]],
+            # halfvecs will lose a fair bit of precision in convertions
+            rel_tol=0.01,
+        )
+
+    async def test_edgeql_halfvec_cast_09(self):
+        # Casts from arrays of derived types.
+        res = [0, 3, 4.25, 6.75]
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(
+                        Raw.p_myf64 order by Raw.p_myf64
+                    );
+            ''',
+            [res],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <array<float32>>
+                    <ext::pgvector::halfvec>array_agg(
+                        Raw.p_deepf64 order by Raw.p_deepf64
+                    );
+            ''',
+            [res],
+        )
+
+    async def test_edgeql_halfvec_cast_10(self):
+        # Arrays of vectors.
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select [
+                    <vector>[0, 1],
+                    <vector>[2, 3],
+                    <vector>[4, 5, 6],
+                ]
+            ''',
+            [[[0, 1], [2, 3], [4, 5, 6]]],
+            json_only=True,
+        )
+
+        # Arrays of vectors.
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <json>[
+                    <vector>[0, 1],
+                    <vector>[2, 3],
+                    <vector>[4, 5, 6],
+                ]
+            ''',
+            [[[0, 1], [2, 3], [4, 5, 6]]],
+            json_only=True,
+        )
+
+    async def test_edgeql_halfvec_cast_11(self):
+        # Vectors in tuples.
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select (
+                    <vector>[0, 1],
+                    <vector>[2, 3],
+                    <vector>[4, 5, 6],
+                )
+            ''',
+            [[[0, 1], [2, 3], [4, 5, 6]]],
+            json_only=True,
+        )
+
+    async def test_edgeql_halfvec_cast_12(self):
+        # Vectors <-> bytes casts.
+        await self.assert_query_result(
+            r'''
+                with module ext::pgvector
+                select
+                    <bytes><halfvec>[0, 1, 2]
+                    =
+                    b'\x00\x03\x00\x00\x00\x00<\x00@\x00'
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_halfvec_op_01(self):
+        # Comparison operators.
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2, 3] =
+                    <ext::pgvector::halfvec>[0, 1, 1];
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2, 3] !=
+                    <ext::pgvector::halfvec>[0, 1, 1];
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2, 3] ?=
+                    <ext::pgvector::halfvec>{};
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2, 3] ?!=
+                    <ext::pgvector::halfvec>{};
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>{} ?=
+                    <ext::pgvector::halfvec>{};
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2] <
+                    <ext::pgvector::halfvec>[2, 3];
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2] <=
+                    <ext::pgvector::halfvec>[2, 3];
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2] >
+                    <ext::pgvector::halfvec>[2, 3];
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                select <ext::pgvector::halfvec>[1, 2] >=
+                    <ext::pgvector::halfvec>[2, 3];
+            ''',
+            [False],
+        )
+
+    async def test_edgeql_halfvec_op_02(self):
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <halfvec>to_json('[3, 0]') in {
+                    <halfvec>to_json('[1, 2]'),
+                    <halfvec>to_json('[3, 4]'),
+                };
+            ''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <halfvec>to_json('[3, 0]') not in {
+                    <halfvec>to_json('[1, 2]'),
+                    <halfvec>to_json('[3, 4]'),
+                };
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_halfvec_func_01(self):
+        await self.assert_query_result(
+            '''
+                with
+                    module ext::pgvector,
+                    x := <halfvec>[1, 3, 0, 6, 7]
+                select (
+                    <array<float32>>subvector(x, 3, 1) = [6],
+                    <array<float32>>subvector(x, 3, 2) = [6, 7],
+                    <array<float32>>subvector(x, 3, 20) = [6, 7],
+                    <array<float32>>subvector(x, 0, 3) = [1, 3, 0],
+                    <array<float32>>subvector(x, 1, 3) = [3, 0, 6],
+                    <array<float32>>subvector(x, -2, 3) = [1],
+                )
+            ''',
+            [[True, True, True, True, True, True]],
+        )
+
+    async def test_edgeql_halfvec_func_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'must have at least 1 dimension',
+        ):
+            await self.con.execute(r"""
+                with
+                    module ext::pgvector,
+                    x := <halfvec>[1, 3, 0, 6, 7]
+                select <array<float32>>subvector(x, 3, 0)
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'must have at least 1 dimension',
+        ):
+            await self.con.execute(r"""
+                with
+                    module ext::pgvector,
+                    x := <halfvec>[1, 3, 0, 6, 7]
+                select <array<float32>>subvector(x, -2, 1)
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'must have at least 1 dimension',
+        ):
+            await self.con.execute(r"""
+                with
+                    module ext::pgvector,
+                    x := <halfvec>[1, 3, 0, 6, 7]
+                select <array<float32>>subvector(x, 20, 2)
+            """)
+
+    async def test_edgeql_halfvec_index_01(self):
+        await self._check_index(
+            'IVFFlat_hv_L2', 'euclidean_distance', 'ivfflat_hv', 'euclidean',
+            'hv3')
+
+    async def test_edgeql_halfvec_index_02(self):
+        await self._check_index(
+            'IVFFlat_hv_Cosine', 'cosine_distance', 'ivfflat_hv', 'cosine',
+            'hv3')
+
+    async def test_edgeql_halfvec_index_03(self):
+        await self._check_index(
+            'IVFFlat_hv_IP', 'neg_inner_product', 'ivfflat_hv', 'ip', 'hv3')
+
+    async def test_edgeql_halfvec_index_04(self):
+        await self._check_index(
+            'HNSW_hv_L2', 'euclidean_distance', 'hnsw_hv', 'euclidean', 'hv3')
+
+    async def test_edgeql_halfvec_index_05(self):
+        await self._check_index(
+            'HNSW_hv_Cosine', 'cosine_distance', 'hnsw_hv', 'cosine', 'hv3')
+
+    async def test_edgeql_halfvec_index_06(self):
+        await self._check_index(
+            'HNSW_hv_IP', 'neg_inner_product', 'hnsw_hv', 'ip', 'hv3')
+
+    async def test_edgeql_halfvec_index_07(self):
+        await self._check_index(
+            'HNSW_hv_L1', 'taxicab_distance', 'hnsw_hv', 'taxicab', 'hv3')
+
+    async def test_edgeql_sparsevec_cast_01(self):
+        # Basic casts to and from json.
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <json><sparsevec><vector>[0, 2, 3.5, 0];
+            ''',
+            [{"1": 2, "2": 3.5, "dim": 4}],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <array<float32>><vector><sparsevec>
+                  to_json('{"dim": 4, "1": 2, "2": 3.5}');
+            ''',
+            [[0, 2, 3.5, 0]],
+        )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'object expected',
+        ):
+            await self.con.execute(r"""
+                with module ext::pgvector
+                select <sparsevec>to_json('[4,2]');
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'object expected',
+        ):
+            await self.con.execute(r"""
+                with module ext::pgvector
+                select <sparsevec>to_json('null');
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'missing "dim"',
+        ):
+            await self.con.execute(r"""
+                with module ext::pgvector
+                select <sparsevec>to_json('{"0": 4, "1": 2, "2": 3.5}');
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'unexpected key',
+        ):
+            await self.con.execute(r"""
+                with module ext::pgvector
+                select <sparsevec>to_json('{"z": 4, "dim": 2, "2": 3.5}');
+            """)
+
+    async def test_edgeql_sparsevec_cast_02(self):
+        # str casts
+        await self.assert_query_result(
+            '''
+                select <json><sv3>'{1:3.5}/3';
+            ''',
+            [{"1": 3.5, "dim": 3}],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            '''
+                select <str><sv3><ext::pgvector::vector>[0, 3.5, 0];
+            ''',
+            ['{1:3.5}/3'],
+        )
+
+    async def test_edgeql_sparsevec_cast_03(self):
+        # str casts
+        await self.assert_query_result(
+            '''
+                with module ext::pgvector
+                select <json><sparsevec>
+                    ' {   4     :   3.5e-6          }   /    5  ';
+            ''',
+            [{"4": 3.5e-6, "dim": 5}],
+            json_only=True,
+        )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'invalid input syntax',
+        ):
+            await self.con.execute(r"""
+                with module ext::pgvector
+                select <sparsevec>'{4:2}';
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.errors.InvalidValueError,
+            'invalid input syntax',
+        ):
+            await self.con.execute(r"""
+                with module ext::pgvector
+                select <sparsevec>'[4:2]';
+            """)
+
+    async def test_edgeql_sparsevec_cast_04(self):
+        # Vectors <-> bytes casts.
+        await self.assert_query_result(
+            r'''
+                with module ext::pgvector
+                select
+                    <bytes><sparsevec>'{1:5}/4'
+                    = (
+                        b'\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00' ++
+                        b'\x00\x00\x00\x01@\xa0\x00\x00'
+                    )
+            ''',
+            [True],
+        )
+
+    async def _check_sv_index(self, obj, func, index_type, index_op):
+        # Sparse vectors have differernt casts from regular vectors, so they
+        # need different queries for this test
+
+        obj_id = (await self.con.query_single(f"""
+            insert {obj} {{
+                vec := <sv3><v3>[1, 1, 0]
+            }}
+        """)).id
+        await self.con.execute(f"""
+            insert {obj} {{
+                vec := <sv3><v3>[0, -1, 0]
+            }}
+        """)
+        embedding = '{1:-0.1}/3'
+
+        await self._assert_index_use(
+            f'''
+            with vec as module ext::pgvector,
+                 base := (select {obj} filter .id = <uuid>$0),
+            select {obj}
+            filter {obj}.id != base.id
+            order by vec::{func}(.vec, base.vec)
+            empty last limit 5;
+            ''',
+            obj_id,
+            index_type=index_type,
+            index_op=index_op,
+        )
+
+        await self._assert_index_use(
+            f'''
+            with vec as module ext::pgvector
+            select {obj}
+            order by vec::{func}(.vec, <sv3><str>$0)
+            empty last limit 5;
+            ''',
+            embedding,
+            index_type=index_type,
+            index_op=index_op,
+        )
+
+        await self._assert_index_use(
+            f'''
+            with vec as module ext::pgvector
+            select {obj}
+            order by vec::{func}(.vec, <sv3><json>$0)
+            empty last limit 5;
+            ''',
+            json.dumps({'1': -0.1, 'dim': 3}),
+            index_type=index_type,
+            index_op=index_op,
+        )
+
+    async def test_edgeql_sparsevec_index_01(self):
+        await self._check_sv_index(
+            'HNSW_sv_L2', 'euclidean_distance', 'hnsw_sv', 'euclidean')
+
+    async def test_edgeql_sparsevec_index_02(self):
+        await self._check_sv_index(
+            'HNSW_sv_Cosine', 'cosine_distance', 'hnsw_sv', 'cosine')
+
+    async def test_edgeql_sparsevec_index_03(self):
+        await self._check_sv_index(
+            'HNSW_sv_IP', 'neg_inner_product', 'hnsw_sv', 'ip')
+
+    async def test_edgeql_sparsevec_index_04(self):
+        await self._check_sv_index(
+            'HNSW_sv_L1', 'taxicab_distance', 'hnsw_sv', 'taxicab')
 
 
 class TestEdgeQLVectorExtension(tb.QueryTestCase):


### PR DESCRIPTION
Update the underlying pgvector version to 0.7.4.
Add `sparsevec` and `halfvec` types and update the valid indexes. Add one more distance operator (L1 distance).