### PR TITLE
Send configured Webhooks

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -369,6 +369,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         IdentityAuthenticated,
         EmailFactorCreated,
         EmailVerified,
+        EmailVerificationRequested,
         PasswordResetRequested,
         MagicLinkRequested,
     >;

--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -25,6 +25,7 @@ import typing
 import asyncio
 import logging
 import httpx
+import base64
 
 from edb.ir import statypes
 from edb.server import defines
@@ -133,6 +134,10 @@ class ScheduledRequest:
     url: str
     body: typing.Optional[bytes]
     headers: typing.Optional[list[dict]]
+
+    def __post_init__(self):
+        if self.body is not None:
+            self.body = base64.b64decode(self.body).decode('utf-8').encode()
 
 
 async def handle_request(

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -87,6 +87,7 @@ class MagicLinkProviderConfig(ProviderConfig):
     name: Literal["builtin::local_magic_link"]
     token_time_to_live: statypes.Duration
 
+
 @dataclass
 class WebhookConfig:
     events: list[str]

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -86,3 +86,9 @@ class WebAuthnProvider:
 class MagicLinkProviderConfig(ProviderConfig):
     name: Literal["builtin::local_magic_link"]
     token_time_to_live: statypes.Duration
+
+@dataclass
+class WebhookConfig:
+    events: list[str]
+    url: str
+    signing_secret_key: Optional[str]

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -139,13 +139,38 @@ class OpenIDConnectAccessTokenResponse(OAuthAccessTokenResponse):
 
 
 @dataclasses.dataclass
-class WebAuthnFactor:
+class EmailFactor:
     id: str
     created_at: datetime.datetime
     modified_at: datetime.datetime
     identity: LocalIdentity
     email: str
     verified_at: Optional[datetime.datetime]
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        created_at: datetime.datetime,
+        modified_at: datetime.datetime,
+        identity: LocalIdentity,
+        email: str,
+        verified_at: Optional[datetime.datetime],
+    ):
+        self.id = id
+        self.created_at = created_at
+        self.modified_at = modified_at
+        self.identity = (
+            LocalIdentity(**identity)
+            if isinstance(identity, dict)
+            else identity
+        )
+        self.email = email
+        self.verified_at = verified_at
+
+
+@dataclasses.dataclass
+class WebAuthnFactor(EmailFactor):
     user_handle: bytes
     credential_id: bytes
     public_key: bytes
@@ -187,14 +212,14 @@ class WebAuthnAuthenticationChallenge:
     factors: list[WebAuthnFactor]
 
     def __init__(
-            self,
-            *,
-            id: str,
-            created_at: datetime.datetime,
-            modified_at: datetime.datetime,
-            challenge: bytes,
-            factors: list[WebAuthnFactor],
-        ):
+        self,
+        *,
+        id: str,
+        created_at: datetime.datetime,
+        modified_at: datetime.datetime,
+        challenge: bytes,
+        factors: list[WebAuthnFactor],
+    ):
         self.id = id
         self.created_at = created_at
         self.modified_at = modified_at

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -396,13 +396,6 @@ class Router:
             ),
             {"code": pkce_code, "provider": provider_name},
         )
-        await self._maybe_send_webhook(
-            webhook.IdentityAuthenticated(
-                event_id=str(uuid.uuid4()),
-                timestamp=datetime.datetime.now(datetime.timezone.utc),
-                identity_id=identity.id,
-            )
-        )
         response.status = http.HTTPStatus.FOUND
         response.custom_headers["Location"] = new_url
 
@@ -460,7 +453,7 @@ class Router:
                     "auth_token": session_token,
                     "identity_id": pkce_object.identity_id,
                     "provider_token": pkce_object.auth_token,
-                    "provider_refresh_token": (pkce_object.refresh_token),
+                    "provider_refresh_token": pkce_object.refresh_token,
                 }
             ).encode()
         else:
@@ -623,13 +616,6 @@ class Router:
 
             pkce_code = await pkce.link_identity_challenge(
                 self.db, local_identity.id, maybe_challenge
-            )
-            await self._maybe_send_webhook(
-                webhook.IdentityAuthenticated(
-                    event_id=str(uuid.uuid4()),
-                    timestamp=datetime.datetime.now(datetime.timezone.utc),
-                    identity_id=local_identity.id,
-                )
             )
             if maybe_redirect_to:
                 response.status = http.HTTPStatus.FOUND

--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -61,7 +61,7 @@ class Client(local.Client):
             provider_name, f"Provider is not configured"
         )
 
-    async def register(self, email: str) -> data.LocalIdentity:
+    async def register(self, email: str) -> data.EmailFactor:
         try:
             result = await execute.parse_execute_json(
                 self.db,
@@ -76,7 +76,7 @@ with
         email := email,
         identity := identity,
     })
-select identity { * };""",
+select email_factor { ** };""",
                 variables={
                     "email": email,
                 },
@@ -92,28 +92,35 @@ select identity { * };""",
 
         result_json = json.loads(result.decode())
         assert len(result_json) == 1
+        factor_dict = result_json[0]
+        return data.EmailFactor(**factor_dict)
 
-        return data.LocalIdentity(**result_json[0])
-
-    async def send_magic_link(
-        self,
-        email: str,
-        callback_url: str,
-        link_url: str,
-        challenge: str,
-        redirect_on_failure: str,
-    ) -> None:
-        initial_key_material = self._get_signing_key()
-        identity_id = await self.get_identity_id_by_email(
-            email, factor_type='MagicLinkFactor'
+    async def get_email_factor_by_email(self, email: str) -> data.EmailFactor:
+        result = await execute.parse_execute_json(
+            self.db,
+            """\
+with
+    email := <str>$email,
+select ext::auth::MagicLinkFactor {**}
+filter .email = email;
+""",
+            variables={"email": email},
         )
+        result_json = json.loads(result.decode())
+        assert len(result_json) == 1
+        factor_dict = result_json[0]
+        return data.EmailFactor(**factor_dict)
 
-        if identity_id is None:
-            await auth_emails.send_fake_email(self.tenant)
-            return
-
+    def make_magic_link_token(
+        self,
+        *,
+        identity_id: str,
+        callback_url: str,
+        challenge: str,
+    ) -> str:
+        initial_key_material = self._get_signing_key()
         signing_key = util.derive_key(initial_key_material, "magic_link")
-        token = util.make_token(
+        return util.make_token(
             signing_key=signing_key,
             issuer=self.issuer,
             subject=identity_id,
@@ -125,6 +132,14 @@ select identity { * };""",
             expires_in=self.provider.token_time_to_live.to_timedelta(),
         )
 
+    async def send_magic_link(
+        self,
+        *,
+        email: str,
+        link_url: str,
+        token: str,
+        redirect_on_failure: str,
+    ) -> None:
         link = util.join_url_params(
             link_url,
             {
@@ -132,7 +147,6 @@ select identity { * };""",
                 "redirect_on_failure": redirect_on_failure,
             },
         )
-
         try:
             await auth_emails.send_magic_link_email(
                 db=self.db,

--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -95,22 +95,6 @@ select email_factor { ** };""",
         factor_dict = result_json[0]
         return data.EmailFactor(**factor_dict)
 
-    async def get_email_factor_by_email(self, email: str) -> data.EmailFactor:
-        result = await execute.parse_execute_json(
-            self.db,
-            """\
-with
-    email := <str>$email,
-select ext::auth::MagicLinkFactor {**}
-filter .email = email;
-""",
-            variables={"email": email},
-        )
-        result_json = json.loads(result.decode())
-        assert len(result_json) == 1
-        factor_dict = result_json[0]
-        return data.EmailFactor(**factor_dict)
-
     def make_magic_link_token(
         self,
         *,

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -158,7 +158,7 @@ insert ext::auth::WebAuthnRegistrationChallenge {
         credentials: str,
         email: str,
         user_handle: bytes,
-    ) -> data.LocalIdentity:
+    ) -> data.EmailFactor:
         registration_challenge = await self._get_registration_challenge(
             email=email,
             user_handle=user_handle,
@@ -195,7 +195,7 @@ with
         public_key := public_key,
         identity := identity,
     }),
-select identity { * };""",
+select factor { ** };""",
                 variables={
                     "email": email,
                     "user_handle": user_handle,
@@ -216,7 +216,9 @@ select identity { * };""",
         result_json = json.loads(result.decode())
         assert len(result_json) == 1
 
-        return data.LocalIdentity(**result_json[0])
+        factor_dict = result_json[0]
+        local_identity = data.LocalIdentity(**factor_dict["identity"])
+        return data.WebAuthnFactor(**factor_dict, identity=local_identity)
 
     async def _get_registration_challenge(
         self,

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -151,15 +151,16 @@ with
     url := <str>$url,
     payload := <bytes>$payload,
     headers := <array<tuple<str, str>>>$headers,
-insert nh::ScheduledRequest {
-    created_at := datetime_of_statement(),
-    state := net::RequestState.Pending,
-
-    url := url,
-    method := nh::Method.POST,
-    headers := headers,
-    body := payload,
-}""",
+    REQUEST := (
+        nh::schedule_request(
+          url,
+          method := nh::Method.POST,
+          headers := headers,
+          body := payload,
+        )
+    ),
+select REQUEST;
+""",
         variables={
             "url": url,
             "payload": payload,

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -139,4 +139,11 @@ insert nh::ScheduledRequest {
     )
     result = json.loads(result_json)
 
-    return result[0]["id"]
+    match result[0]["id"]:
+        case str(id):
+            return id
+        case _:
+            raise ValueError(
+                "Expected single result with 'id' string property, got "
+                f"{result[0]!r}"
+            )

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -79,6 +79,7 @@ class EmailFactorCreated(Event, HasIdentity, HasEmailFactor):
         default="EmailFactorCreated",
         init=False,
     )
+    verification_token: str
 
 
 @dataclasses.dataclass

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -149,7 +149,7 @@ with
     net as module std::net,
 
     # n.b. workaround for bug in parse_execute_json
-    url := assert_exists(<str>$url),
+    url := <required str>$url,
     headers := <array<tuple<str, str>>>$headers,
     body := <bytes>$body,
 

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -1,0 +1,142 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2024-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+import dataclasses
+import typing
+import abc
+import datetime
+import json
+import hmac
+import hashlib
+
+from edb.server.protocol import execute
+
+if typing.TYPE_CHECKING:
+    from edb.server import tenant as edbtenant
+
+
+@dataclasses.dataclass
+class Event(abc.ABC):
+    event_type: str
+    event_id: str
+    timestamp: datetime.datetime
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"event_id={self.event_id!r}, "
+            f"timestamp={self.timestamp!r})"
+        )
+
+
+@dataclasses.dataclass
+class HasIdentity(abc.ABC):
+    identity_id: str
+
+
+@dataclasses.dataclass
+class HasEmailFactor(abc.ABC):
+    email_factor_id: str
+
+
+@dataclasses.dataclass
+class IdentityCreated(Event, HasIdentity):
+    event_type: typing.Literal["IdentityCreated"] = dataclasses.field(
+        default="IdentityCreated",
+        init=False,
+    )
+
+
+@dataclasses.dataclass
+class IdentityAuthenticated(Event, HasIdentity):
+    event_type: typing.Literal["IdentityAuthenticated"] = dataclasses.field(
+        default="IdentityAuthenticated",
+        init=False,
+    )
+
+
+@dataclasses.dataclass
+class EmailFactorCreated(Event, HasIdentity, HasEmailFactor):
+    event_type: typing.Literal["EmailFactorCreated"] = dataclasses.field(
+        default="EmailFactorCreated",
+        init=False,
+    )
+
+
+@dataclasses.dataclass
+class EmailVerified(Event, HasIdentity, HasEmailFactor):
+    event_type: typing.Literal["EmailVerified"] = dataclasses.field(
+        default="EmailVerified",
+        init=False,
+    )
+
+
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj: typing.Any) -> typing.Any:
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+async def send(
+    db: edbtenant.dbview.Database,
+    url: str,
+    secret: typing.Optional[str],
+    event: Event,
+) -> str:
+    payload = json.dumps(
+        dataclasses.asdict(event), cls=DateTimeEncoder
+    ).encode()
+    headers = [("Content-Type", "application/json")]
+    if secret:
+        signature = hmac.new(
+            secret.encode(), payload, hashlib.sha256
+        ).hexdigest()
+        headers.append(("x-ext-auth-signature-sha256", signature))
+
+    result_json = await execute.parse_execute_json(
+        db,
+        """
+with
+    nh as module std::net::http,
+    net as module std::net,
+
+    url := <str>$url,
+    payload := <bytes>$payload,
+    headers := <array<tuple<str, str>>>$headers,
+insert nh::ScheduledRequest {
+    created_at := datetime_of_statement(),
+    state := net::RequestState.Pending,
+
+    url := url,
+    method := nh::Method.POST,
+    headers := headers,
+    body := payload,
+}""",
+        variables={
+            "url": url,
+            "payload": payload,
+            "headers": headers,
+        },
+    )
+    result = json.loads(result_json)
+
+    return result[0]["id"]

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -79,6 +79,16 @@ class EmailFactorCreated(Event, HasIdentity, HasEmailFactor):
         default="EmailFactorCreated",
         init=False,
     )
+
+
+@dataclasses.dataclass
+class EmailVerificationRequested(Event, HasIdentity, HasEmailFactor):
+    event_type: typing.Literal["EmailVerificationRequested"] = (
+        dataclasses.field(
+            default="EmailVerificationRequested",
+            init=False,
+        )
+    )
     verification_token: str
 
 
@@ -88,6 +98,24 @@ class EmailVerified(Event, HasIdentity, HasEmailFactor):
         default="EmailVerified",
         init=False,
     )
+
+
+@dataclasses.dataclass
+class PasswordResetRequested(Event, HasIdentity, HasEmailFactor):
+    event_type: typing.Literal["PasswordResetRequested"] = dataclasses.field(
+        default="PasswordResetRequested",
+        init=False,
+    )
+    reset_token: str
+
+
+@dataclasses.dataclass
+class MagicLinkRequested(Event, HasIdentity, HasEmailFactor):
+    event_type: typing.Literal["MagicLinkRequested"] = dataclasses.field(
+        default="MagicLinkRequested",
+        init=False,
+    )
+    magic_link_token: str
 
 
 class DateTimeEncoder(json.JSONEncoder):

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -2460,6 +2460,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             base_url,
             "/webhook-01",
         )
+        await self._wait_for_db_config("ext::auth::AuthConfig::webhooks")
         try:
             with self.http_con() as http_con:
                 self.mock_net_server.register_route_handler(*webhook_request)(
@@ -2707,8 +2708,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             await self.con.query(
                 f"""
                 CONFIGURE CURRENT DATABASE
-                RESET ext::auth::WebhookConfig;
-                """
+                RESET ext::auth::WebhookConfig filter .url = <str>$url;
+                """,
+                url=url,
             )
 
     async def test_http_auth_ext_local_password_register_form_02(self):
@@ -2939,6 +2941,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             base_url,
             "/webhook-02",
         )
+        await self._wait_for_db_config("ext::auth::AuthConfig::webhooks")
 
         try:
             with self.http_con() as http_con:
@@ -3209,8 +3212,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             await self.con.query(
                 f"""
                 CONFIGURE CURRENT DATABASE
-                RESET ext::auth::WebhookConfig;
-                """
+                RESET ext::auth::WebhookConfig filter .url = <str>$url;
+                """,
+                url=url,
             )
 
     async def test_http_auth_ext_resend_verification_email(self):

--- a/tests/test_http_std_net.py
+++ b/tests/test_http_std_net.py
@@ -154,7 +154,4 @@ class StdNetTestCase(server.QueryTestCase):
         headers = list(requests_for_example[0]["headers"].items())
         self.assertIn(("accept", "text/plain"), headers)
         self.assertIn(("x-test-header", "test-value"), headers)
-        self.assertEqual(
-            requests_for_example[0]["body"],
-            base64.b64encode(b"Hello, world!").decode(),
-        )
+        self.assertEqual(requests_for_example[0]["body"], "Hello, world!")

--- a/tests/test_http_std_net.py
+++ b/tests/test_http_std_net.py
@@ -19,7 +19,6 @@
 
 import typing
 import json
-import base64
 
 from edb.testbase import http as tb
 import edb.testbase.server as server


### PR DESCRIPTION
In the auth `http.py` module, send webhooks via the `std::net` module for every configured url for a given event.