### PR TITLE
Include more information in HTTP protocol errors

### DIFF
--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -120,6 +120,18 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
                 f'EdgeDB message code is not set (type: {cls.__name__})')
         return cls._code
 
+    def to_json(self):
+        err_dct = {
+            'message': str(self),
+            'type': str(type(self).__name__),
+            'code': self.get_code(),
+        }
+        for name, field in _JSON_FIELDS.items():
+            if field in self._attrs:
+                err_dct[name] = self._attrs[field]
+
+        return err_dct
+
     def set_filename(self, filename):
         self._attrs[FIELD_FILENAME] = filename
 
@@ -232,3 +244,14 @@ FIELD_UTF16_COLUMN_END = 0x_FF_F8
 FIELD_CHARACTER_START = 0x_FF_F9
 FIELD_CHARACTER_END = 0x_FF_FA
 FIELD_FILENAME = 0x_FF_FB
+
+# Fields to include in the json dump of the type
+_JSON_FIELDS = {
+    'filename': FIELD_FILENAME,
+    'hint': FIELD_HINT,
+    'details': FIELD_DETAILS,
+    'start': FIELD_CHARACTER_START,
+    'end': FIELD_CHARACTER_END,
+    'line': FIELD_LINE_START,
+    'col': FIELD_COLUMN_START,
+}

--- a/edb/server/protocol/edgeql_ext.pyx
+++ b/edb/server/protocol/edgeql_ext.pyx
@@ -135,12 +135,6 @@ async def handle_request(
 
         ex = await execute.interpret_error(ex, db)
 
-        err_dct = {
-            'message': str(ex),
-            'type': str(type(ex).__name__),
-            'code': ex.get_code(),
-        }
-
-        response.body = json.dumps({'error': err_dct}).encode()
+        response.body = json.dumps({'error': ex.to_json()}).encode()
     else:
         response.body = b'{"data":' + result + b'}'


### PR DESCRIPTION
Define a to_json method on errors and use it there.  (I needed a
fully-featured to_json for something else, and it seemed natural to
split it off and use it here.)