### PR TITLE
Some mypy fixes/tweaks

### DIFF
--- a/edb/server/pgcon/connect.py
+++ b/edb/server/pgcon/connect.py
@@ -32,7 +32,7 @@ from . import rust_transport
 
 logger = logging.getLogger('edb.server')
 
-INIT_CON_SCRIPT = None
+INIT_CON_SCRIPT: bytes | None = None
 INIT_CON_SCRIPT_DATA = ''
 
 # The '_edgecon_state table' is used to store information about

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,9 +144,9 @@ warn_redundant_casts = true
 warn_unused_configs = true
 show_column_numbers = true
 show_error_codes = true
+local_partial_types = true
 # This being an error seems super confused to me.
 disable_error_code = "type-abstract"
-enable_incomplete_feature = ["Unpack"]
 
 [[tool.mypy.overrides]]
 module = [

--- a/tests/common/test_prometheus.py
+++ b/tests/common/test_prometheus.py
@@ -24,7 +24,7 @@ try:
     import prometheus_client as pmc_root
     import prometheus_client.registry as pmc_reg
 except ImportError:
-    PMC = None
+    PMC = None  # type: ignore
 else:
     class PMC:  # type: ignore
 


### PR DESCRIPTION
The daemon also uses local_partial_types = True, so set it for our
main config also and fix one error.
Also, remove the "enable_incomplete_features" that isn't needed anymore.