### PR TITLE
Implement warnings in the server

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -367,6 +367,7 @@ def compile_ast_fragment_to_ir(
         type_rewrites={},
         singletons=[],
         triggers=(),
+        warnings=tuple(ctx.env.warnings),
     )
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -51,6 +51,8 @@ from edb.common import compiler
 from edb.common import ordered
 from edb.common import parsing
 
+from edb import errors
+
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
@@ -278,6 +280,9 @@ class Environment:
     dml_rewrites: Dict[irast.Set, irast.Rewrites]
     """Compiled rewrites that should be attached to InsertStmt or UpdateStmt"""
 
+    warnings: list[errors.EdgeDBError]
+    """List of warnings to emit"""
+
     def __init__(
         self,
         *,
@@ -325,6 +330,7 @@ class Environment:
         self.expr_view_cache = {}
         self.path_scope_map = {}
         self.dml_rewrites = {}
+        self.warnings = []
 
     def add_schema_ref(
         self, sobj: s_obj.Object, expr: Optional[qlast.Base]
@@ -792,6 +798,9 @@ class ContextLevel(compiler.ContextLevel):
         # since we clear cached rewrites when compiling them in the
         # *pgsql* compiler.
         return bool(self.suppress_rewrites)
+
+    def log_warning(self, warning: errors.EdgeDBError) -> None:
+        self.env.warnings.append(warning)
 
 
 class CompilerContext(compiler.CompilerContext[ContextLevel]):

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -1188,6 +1188,7 @@ def compile_ext_ai_search(
             df = df_expr.ensure_compiled(
                 schema,
                 as_fragment=True,
+                context=None,
             ).as_python_value()
         else:
             df = "Cosine"
@@ -1365,3 +1366,13 @@ def compile_fts_with_options(
             env=ctx.env,
         )
     )
+
+
+@_special_case('std::_warn_on_call')
+def compile_warn_on_call(
+    call: irast.FunctionCall, *, ctx: context.ContextLevel
+) -> irast.Expr:
+    ctx.log_warning(
+        errors.QueryError('Test warning please ignore', span=call.span)
+    )
+    return call

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -321,6 +321,7 @@ def fini_expression(
         dml_exprs=ctx.env.dml_exprs,
         singletons=ctx.env.singletons,
         triggers=ir_triggers,
+        warnings=tuple(ctx.env.warnings),
     )
     return result
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -72,6 +72,8 @@ import uuid
 
 from edb.common import ast, compiler, span, markup, enum as s_enum
 
+from edb import errors
+
 from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import objects as so
@@ -801,6 +803,7 @@ class Statement(Command):
     type_rewrites: typing.Dict[typing.Tuple[uuid.UUID, bool], Set]
     singletons: typing.List[PathId]
     triggers: tuple[tuple[Trigger, ...], ...]
+    warnings: tuple[errors.EdgeDBError, ...]
 
 
 class TypeIntrospection(ImmutableExpr):

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -142,7 +142,7 @@ def _get_schema(ls: EdgeDBLanguageServer) -> Optional[s_schema.Schema]:
 
     # apply SDL to std schema
     std_schema = _load_std_schema(ls.state)
-    schema = s_ddl.apply_sdl(
+    schema, _warnings = s_ddl.apply_sdl(
         sdl,
         base_schema=std_schema,
         current_schema=std_schema,

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -377,6 +377,10 @@ create function std::_set_config(sqlname: std::str, val: std::str) -> std::str {
     $$;
 };
 
+create function std::_warn_on_call() -> std::int64 {
+    using (0)
+};
+
 
 CREATE MODULE std::_test;
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1078,6 +1078,7 @@ class FunctionCommand(MetaCommand):
             comp = default.compiled(
                 schema=schema,
                 as_fragment=True,
+                context=None,
             )
 
             ir = comp.irast
@@ -3362,6 +3363,7 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
         index_expr = index_sexpr.ensure_compiled(
             schema=schema,
             options=options,
+            context=None,
         )
         ir = index_expr.irast
 
@@ -3370,6 +3372,7 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
             except_expr = except_expr.ensure_compiled(
                 schema=schema,
                 options=options,
+                context=None,
             )
             assert except_expr.irast
             except_res = compiler.compile_ir_to_sql_tree(

--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -256,6 +256,7 @@ def _compile_ai_embeddings_source_view_expr(
         except_expr = except_expr.ensure_compiled(
             schema=schema,
             options=options,
+            context=None,
         )
         assert except_expr.irast
         except_res = compiler.compile_ir_to_sql_tree(

--- a/edb/pgsql/deltafts.py
+++ b/edb/pgsql/deltafts.py
@@ -204,6 +204,7 @@ def update_fts_document(
     index_expr = index_sexpr.ensure_compiled(
         schema=schema,
         options=options,
+        context=None,
     )
     exprs = _compile_ir_index_exprs(index, index_expr.irast.expr, schema)
 
@@ -234,6 +235,7 @@ def _refresh_fts_document(
     index_expr = index_sexpr.ensure_compiled(
         schema=schema,
         options=options,
+        context=context,
     )
 
     exprs = _compile_ir_index_exprs(index, index_expr.irast.expr, schema)

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -159,7 +159,7 @@ def resolve_column_kind(
                 singletons=singletons,
                 make_globals_empty=False,
             )
-            compiled = expr.compiled(ctx.schema, options=options)
+            compiled = expr.compiled(ctx.schema, options=options, context=None)
 
             sql_tree = pgcompiler.compile_ir_to_sql_tree(
                 compiled.irast,

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -581,6 +581,7 @@ class ConstraintCommand(
                         apply_query_rewrites=False,
                         track_schema_ref_exprs=track_schema_ref_exprs,
                     ),
+                    context=context,
                 )
 
                 # compile the expression to sql to preempt errors downstream
@@ -613,6 +614,7 @@ class ConstraintCommand(
                     apply_query_rewrites=not context.stdmode,
                     track_schema_ref_exprs=track_schema_ref_exprs,
                 ),
+                context=context,
             )
 
             # compile the expression to sql to preempt errors downstream
@@ -846,6 +848,7 @@ class ConstraintCommand(
                 apply_query_rewrites=False,
                 schema_object_context=self.get_schema_metaclass(),
             ),
+            context=context,
         )
 
         bool_t = schema.get('std::bool', type=s_scalars.ScalarType)
@@ -872,7 +875,7 @@ class ConstraintCommand(
             )
 
             final_subjectexpr = subjectexpr.compiled(
-                schema=schema, options=options
+                schema=schema, options=options, context=context
             )
 
             refs = ir_utils.get_longest_paths(final_expr.irast)
@@ -880,7 +883,7 @@ class ConstraintCommand(
             final_except_expr: s_expr.CompiledExpression | None = None
             if except_expr:
                 final_except_expr = except_expr.compiled(
-                    schema=schema, options=options
+                    schema=schema, options=options, context=context
                 )
                 refs |= ir_utils.get_longest_paths(final_except_expr.irast)
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1621,6 +1621,7 @@ class DeltaRoot(CommandGroup, context_class=DeltaRootContext):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.new_types: Set[uuid.UUID] = set()
+        self.warnings: list[errors.EdgeDBError] = []
 
     @classmethod
     def from_commands(cls, *cmds: Command) -> DeltaRoot:
@@ -1724,7 +1725,8 @@ class Query(Command):
                 options=qlcompiler.CompilerOptions(
                     modaliases=context.modaliases,
                     apply_query_rewrites=False,
-                )
+                ),
+                context=context,
             )
         return schema
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -302,6 +302,7 @@ class AliasCommand(
                 in_ddl_context_name='alias definition',
                 track_schema_ref_exprs=track_schema_ref_exprs,
             ),
+            context=context,
         )
 
 

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -227,7 +227,7 @@ class GlobalCommand(
         default_expr = scls.get_default(schema)
 
         if default_expr is not None:
-            default_expr = default_expr.ensure_compiled(schema)
+            default_expr = default_expr.ensure_compiled(schema, context=context)
 
             default_schema = default_expr.irast.schema
             default_type = default_expr.irast.stype
@@ -301,6 +301,7 @@ class GlobalCommand(
                     track_schema_ref_exprs=track_schema_ref_exprs,
                     in_ddl_context_name=in_ddl_context_name,
                 ),
+                context=context,
             )
         else:
             return super().compile_expr_field(
@@ -456,7 +457,7 @@ class AlterGlobal(
             ):
                 self.set_attribute_value(
                     'expr',
-                    s_expr.Expression.not_compiled(old_expr)
+                    s_expr.Expression.not_compiled(old_expr),
                 )
 
             # Produce an error when setting a type on something with

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -463,6 +463,7 @@ class Index(
                 options=qlcompiler.CompilerOptions(
                     schema_object_context=s_func.Parameter,
                 ),
+                context=None,
             )
 
         return kwargs
@@ -825,6 +826,7 @@ class IndexCommand(
                     track_schema_ref_exprs=track_schema_ref_exprs,
                     detached=True,
                 ),
+                context=context,
             )
 
             # Check that the inferred cardinality is no more than 1
@@ -896,6 +898,7 @@ class IndexCommand(
                     in_ddl_context_name=idx_name,
                     detached=True,
                 ),
+                context=context,
             )
         else:
             return super().compile_expr_field(
@@ -1123,7 +1126,8 @@ class CreateIndex(
                 )
 
             param_type = param.get_type(schema)
-            comp_expr = s_expr.Expression.compiled(expr, schema=schema)
+            comp_expr = s_expr.Expression.compiled(
+                expr, schema=schema, context=None)
             expr_type = comp_expr.irast.stype
 
             if (
@@ -1312,7 +1316,7 @@ class CreateIndex(
                 schema_object_context=self.get_schema_metaclass(),
             )
             comp_expr = s_expr.Expression.compiled(
-                expr, schema=schema, options=options
+                expr, schema=schema, options=options, context=context
             )
             expr_type = comp_expr.irast.stype
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1515,7 +1515,10 @@ class PointerCommandOrFragment(
             )
 
             compiled = expr.compiled(
-                schema=schema, options=options, detached=detached
+                schema=schema,
+                options=options,
+                detached=detached,
+                context=context,
             )
 
             if singleton_result_expected and compiled.cardinality.is_multi():
@@ -2230,6 +2233,7 @@ class AlterPointer(
                 singletons=frozenset([source]),
                 apply_query_rewrites=not context.stdmode,
             ),
+            context=context,
         )
 
         target = expression.irast.stype

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -226,6 +226,7 @@ class AccessPolicyCommand(
                     in_ddl_context_name=in_ddl_context_name,
                     detached=True,
                 ),
+                context=context,
             )
         else:
             return super().compile_expr_field(

--- a/edb/schema/rewrites.py
+++ b/edb/schema/rewrites.py
@@ -271,6 +271,7 @@ class RewriteCommand(
                     detached=True,
                 ),
                 find_extra_refs=find_extra_refs,
+                context=context,
             )
         else:
             return super().compile_expr_field(

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -243,6 +243,7 @@ class TriggerCommand(
                         trigger_type=source,
                         trigger_kinds=kinds,
                     ),
+                    context=context,
                 )
             except errors.QueryError as e:
                 if not e.has_span():

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2972,6 +2972,7 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
                 in_ddl_context_name='type definition',
                 track_schema_ref_exprs=track_schema_ref_exprs,
             ),
+            context=context,
         )
 
     def get_dummy_expr_field_value(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1571,7 +1571,6 @@ def _compile_ql_query(
         script_info=script_info,
         options=options,
     )
-
     result_cardinality = enums.cardinality_from_ir_value(ir.cardinality)
 
     # This low-hanging-fruit is temporary; persistent cache should cover all
@@ -1703,6 +1702,7 @@ def _compile_ql_query(
         cacheable=cacheable,
         has_dml=bool(ir.dml_exprs),
         query_asts=query_asts,
+        warnings=ir.warnings,
     )
 
 
@@ -2415,6 +2415,7 @@ def _try_compile(
             output_format=stmt_ctx.output_format,
             cache_key=ctx.cache_key,
             user_schema_version=schema_version,
+            warnings=comp.warnings,
         )
 
         if not comp.is_transactional:
@@ -2625,6 +2626,10 @@ def _try_compile(
                 len(p.sub_params[0]) if p.sub_params else 1
                 for p in unit.in_type_args
             )
+
+        if unit.warnings:
+            for warning in unit.warnings:
+                warning.__traceback__ = None
 
         rv.append(unit)
 

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -313,7 +313,7 @@ class BaseSchemaTest(BaseDocTest):
                 if target_schema is None:
                     target_schema = _load_std_schema()
 
-                migration_target = s_ddl.apply_sdl(
+                migration_target, _ = s_ddl.apply_sdl(
                     stmt.target,
                     base_schema=target_schema,
                     current_schema=current_schema,
@@ -448,7 +448,7 @@ class BaseSchemaTest(BaseDocTest):
             sdl_schema,
             base_schema=schema,
             current_schema=schema,
-        )
+        )[0]
 
     @classmethod
     def get_schema_script(cls):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "EdgeDB Server"
 requires-python = '>=3.12.0'
 dynamic = ["version"]
 dependencies = [
-    'edgedb==2.0.1',
+    'edgedb @ git+https://github.com/edgedb/edgedb-python#egg=29370f2ba018eacb7b75ccf84f63f96e9f3c32ff',
 
     'httptools>=0.6.0',
     'immutables>=0.18',
@@ -99,7 +99,7 @@ requires = [
     "wheel",
 
     "parsing ~= 2.0",
-    'edgedb == 2.0.1',
+    'edgedb @ git+https://github.com/edgedb/edgedb-python#egg=29370f2ba018eacb7b75ccf84f63f96e9f3c32ff',
 ]
 # Custom backend needed to set up build-time sys.path because
 # setup.py needs to import `edb.buildmeta`.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9445,7 +9445,7 @@ class BaseDescribeTest(tb.BaseSchemaLoadTest):
         elif explicit_modules:
             sdl_schema = qlparser.parse_sdl(schema_text)
             schema = tb._load_std_schema()
-            schema = s_ddl.apply_sdl(
+            schema, _ = s_ddl.apply_sdl(
                 sdl_schema,
                 base_schema=schema,
                 current_schema=schema,
@@ -11121,7 +11121,7 @@ class TestSDLTextFromSchema(BaseDescribeTest):
         elif explicit_modules:
             sdl_schema = qlparser.parse_sdl(schema_text)
             schema = tb._load_std_schema()
-            schema = s_ddl.apply_sdl(
+            schema, _ = s_ddl.apply_sdl(
                 sdl_schema,
                 base_schema=schema,
                 current_schema=schema,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -177,3 +177,33 @@ class TestSession(tb.QueryTestCase):
             )
         finally:
             await tx.rollback()
+
+    async def test_session_warnings_01(self):
+        # N.B: The testbase warning system always raises
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Test warning please ignore"
+        ):
+            await self.con.query('''
+                select _warn_on_call()
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Test warning please ignore"
+        ):
+            await self.con.execute('''
+                create function asdf() -> int64 using (_warn_on_call())
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Test warning please ignore"
+        ):
+            await self.con.execute('''
+                start migration to {
+                module default {
+                    function asdf() -> int64 using (_warn_on_call())
+                }
+                }
+            ''')


### PR DESCRIPTION
Warnings are encoded in JSON as a header for
CommandDataDescription. Users of the clients should be able to provide
a callback that is invoked on the list of warnings; the default will
be to log them.

Adds a test function, `std::_warn_on_call()` that generates a warning
whenever we call it.

The most annoying part about all of this is collecting warnings
generated when compiling expressions in the schema and DDL.

Implements the server component of #7822.