### PR TITLE
Clear additional server parameters when providing pgdsn

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -326,6 +326,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             params.update(database=self.tenant.get_pg_dbname(
                 self.get_dbview().dbname
             ))
+            params.clear_server_settings()
             self.write_status(b'pgdsn', params.to_dsn().encode())
 
         self.write_status(


### PR DESCRIPTION
These server parameters are an EdgeDB extension, and psql does not support them. Clear them out so the DSN can be passed directly to psql.