### PR TITLE
Make WebhookConfig exclusive on url

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -377,6 +377,8 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property url: std::str {
             create annotation std::description :=
                 "The url to send webhooks to.";
+
+            create constraint exclusive;
         };
 
         create required multi property events: ext::auth::WebhookEvent {


### PR DESCRIPTION
Config objects need a an explicit unique property set, so instead of using a synthetic random value, make it unique on the URL. This means adding more events to the same URL is updating the event set rather than having a separate config for that event.