### PR TITLE
Search std for module name when using with x as module.

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -381,16 +381,30 @@ def resolve_name(
     """Resolve a name into a fully-qualified one.
 
     This takes into account the current module and modaliases.
+
+    This function mostly mirrors schema.FlatSchema._search_with_getter
+    except:
+    - If no module and no default module was set, try the current module
+    - When searching in std, ensure module is not a local module
+    - If no result found, return a name with the best modname available
     """
+
+    def exists(name: sn.QualName) -> bool:
+        return (
+            objects.get(name) is not None
+            or schema.get(name, default=None, type=so.Object) is not None
+        )
+
     module = ref.module
+    orig_module = module
 
     no_std = declaration
     if module and module.startswith('__current__::'):
+        # Replace __current__ with default module
         no_std = True
         module = f'{current_module}::{module.removeprefix("__current__::")}'
-    elif not module:
-        module = current_module
     elif modaliases:
+        # Apply modalias
         if module:
             first, sep, rest = module.partition('::')
         else:
@@ -398,25 +412,42 @@ def resolve_name(
 
         fq_module = modaliases.get(first)
         if fq_module is not None:
-            no_std = True
             module = fq_module + sep + rest
 
-    qname = sn.QualName(module=module, name=ref.name)
+    # Check if something matches the name
+    if module is not None:
+        fqname = sn.QualName(module=module, name=ref.name)
+        if exists(fqname):
+            return fqname
 
-    # check if there's a name in default module
-    # that matches
-    if not no_std and not (
-        ref.module and ref.module in local_modules
-    ) and not (
-        objects.get(qname)
-        or schema.get(
-            qname, default=None, type=so.Object) is not None
-    ):
-        std_name = sn.QualName(
-            f'std::{ref.module}' if ref.module else 'std', ref.name)
-        if schema.get(std_name, default=None) is not None:
-            return std_name
-    return qname
+    elif orig_module is None:
+        # Look for name in current module
+        fqname = sn.QualName(module=current_module, name=ref.name)
+        if exists(fqname):
+            return fqname
+
+    # Try something in std if __current__ was not specified
+    if not no_std:
+        # If module == None, look in std
+        if orig_module is None:
+            mod_name = 'std'
+            fqname = sn.QualName(mod_name, ref.name)
+            if exists(fqname):
+                return fqname
+
+        # Ensure module is not a local module.
+        # Then try the module as part of std.
+        if module and module not in local_modules:
+            mod_name = f'std::{module}'
+            fqname = sn.QualName(mod_name, ref.name)
+            if exists(fqname):
+                return fqname
+
+    # Just pick the best module name available
+    return sn.QualName(
+        module=module or orig_module or current_module,
+        name=ref.name,
+    )
 
 
 class TracerContext:

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -398,21 +398,11 @@ def resolve_name(
     module = ref.module
     orig_module = module
 
-    no_std = declaration
-    if module and module.startswith('__current__::'):
-        # Replace __current__ with default module
-        no_std = True
-        module = f'{current_module}::{module.removeprefix("__current__::")}'
-    elif modaliases:
-        # Apply modalias
-        if module:
-            first, sep, rest = module.partition('::')
-        else:
-            first, sep, rest = module, '', ''
-
-        fq_module = modaliases.get(first)
-        if fq_module is not None:
-            module = fq_module + sep + rest
+    # Apply module aliases
+    is_current, module = s_schema.apply_module_aliases(
+        module, modaliases, current_module,
+    )
+    no_std = declaration or is_current
 
     # Check if something matches the name
     if module is not None:

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1102,7 +1102,7 @@ class FlatSchema(Schema):
             else:
                 return default
 
-        alias_hit = local = False
+        local = False
         if module and module.startswith('__current__::'):
             local = True
             if not module_aliases or None not in module_aliases:
@@ -1118,7 +1118,6 @@ class FlatSchema(Schema):
 
             fq_module = module_aliases.get(first)
             if fq_module is not None:
-                alias_hit = True
                 module = fq_module + sep + rest
 
         if module is not None:
@@ -1128,12 +1127,7 @@ class FlatSchema(Schema):
                 return result
 
         # Try something in std, but only if there isn't a module clash
-        if not local and (
-            orig_module is None
-            or (
-                not alias_hit and module
-            )
-        ):
+        if not local:
             # If no module was specified, look in std
             if orig_module is None:
                 mod_name = 'std'
@@ -1151,11 +1145,7 @@ class FlatSchema(Schema):
                 self.has_module(fmod := module.split('::')[0])
                 or (disallow_module and disallow_module(fmod))
             ):
-                mod_name = (
-                    f'std::{module}'
-                    if orig_module is None
-                    else f'std::{orig_module}'
-                )
+                mod_name = f'std::{module}'
                 fqname = sn.QualName(mod_name, shortname)
                 result = getter(self, fqname)
                 if result is not None:

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -9911,17 +9911,67 @@ aa \
             create module dummy;
         """)
 
-        valid_queries = [
-            'SELECT <int64>{} = 1',
-            'SELECT <std::int64>{} = 1',
-            'WITH MODULE dummy SELECT <int64>{} = 1',
-            'WITH MODULE dummy SELECT <std::int64>{} = 1',
-            'WITH MODULE std SELECT <int64>{} = 1',
-            'WITH MODULE std SELECT <std::int64>{} = 1',
+        NO_ERR = 1
+        REF_ERR = 2
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
+        with_mod = 'WITH MODULE dummy '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
+        with_mod = 'WITH MODULE std '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
+        with_mod = 'WITH dum as MODULE dummy '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dum::int64>{} = 1'),
+        ]
+        with_mod = 'WITH def as MODULE default '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <def::int64>{} = 1'),
+        ]
+        with_mod = 'WITH s as MODULE std '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <s::int64>{} = 1'),
         ]
 
-        for query in valid_queries:
-            await self.con.execute(query)
+        for error, query in queries:
+            if error == NO_ERR:
+                await self.con.execute(query)
+
+            elif error == REF_ERR:
+                async with self.assertRaisesRegexTx(
+                    edgedb.errors.InvalidReferenceError,
+                    "int64' does not exist",
+                ):
+                    await self.con.execute(query)
 
     async def test_edgeql_expr_with_module_02(self):
         await self.con.execute(f"""
@@ -9929,64 +9979,148 @@ aa \
             create type default::int64;
         """)
 
-        valid_queries = [
-            'SELECT <std::int64>{} = 1',
-            'WITH MODULE dummy SELECT <int64>{} = 1',
-            'WITH MODULE dummy SELECT <std::int64>{} = 1',
-            'WITH MODULE std SELECT <int64>{} = 1',
-            'WITH MODULE std SELECT <std::int64>{} = 1',
+        NO_ERR = 1
+        REF_ERR = 2
+        TYPE_ERR = 3
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (TYPE_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
         ]
-        invalid_queries = [
-            'SELECT <int64>{} = 1',
-            'SELECT <default::int64>{} = 1',
-            'WITH MODULE dummy SELECT <default::int64>{} = 1',
-            'WITH MODULE std SELECT <default::int64>{} = 1',
+        with_mod = 'WITH MODULE dummy '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
+        with_mod = 'WITH MODULE std '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
+        with_mod = 'WITH dum as MODULE dummy '
+        queries += [
+            (TYPE_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dum::int64>{} = 1'),
+        ]
+        with_mod = 'WITH def as MODULE default '
+        queries += [
+            (TYPE_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <def::int64>{} = 1'),
+        ]
+        with_mod = 'WITH s as MODULE std '
+        queries += [
+            (TYPE_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+            (NO_ERR, with_mod + 'SELECT <s::int64>{} = 1'),
         ]
 
-        for query in valid_queries:
-            await self.con.execute(query)
-
-        for query in invalid_queries:
-            async with self.assertRaisesRegexTx(
-                edgedb.errors.InvalidTypeError,
-                "operator '=' cannot be applied",
-            ):
+        for error, query in queries:
+            if error == NO_ERR:
                 await self.con.execute(query)
+
+            elif error == REF_ERR:
+                async with self.assertRaisesRegexTx(
+                    edgedb.errors.InvalidReferenceError,
+                    "int64' does not exist",
+                ):
+                    await self.con.execute(query)
+
+            elif error == TYPE_ERR:
+                async with self.assertRaisesRegexTx(
+                    edgedb.errors.InvalidTypeError,
+                    "operator '=' cannot be applied",
+                ):
+                    await self.con.execute(query)
 
     async def test_edgeql_expr_with_module_03(self):
         await self.con.execute(f"""
             create module dummy;
         """)
 
-        valid_queries = [
-            'select _test::abs(1)',
-            'select std::_test::abs(1)',
-            'with module dummy select _test::abs(1)',
-            'with module dummy select std::_test::abs(1)',
-            'with module _test select abs(1)',
-            'with module _test select _test::abs(1)',
-            'with module _test select std::_test::abs(1)',
-            'with module std select _test::abs(1)',
-            'with module std select std::_test::abs(1)',
-            'with module std::_test select abs(1)',
-            'with module std::_test select _test::abs(1)',
-            'with module std::_test select std::_test::abs(1)',
+        NO_ERR = 1
+        REF_ERR = 2
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
         ]
-        invalid_queries = [
-            'select abs(1)',
-            'with module dummy select abs(1)',
-            'with module std select abs(1)',
+        with_mod = 'with module dummy '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with module _test '
+        queries += [
+            (NO_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with module std '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with module std::_test '
+        queries += [
+            (NO_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with t as module _test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+            (REF_ERR, with_mod + 'select t::abs(1)'),
+        ]
+        with_mod = 'with s as module std '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+            (REF_ERR, with_mod + 'select s::abs(1)'),
+        ]
+        with_mod = 'with st as module std::_test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+            (NO_ERR, with_mod + 'select st::abs(1)'),
         ]
 
-        for query in valid_queries:
-            await self.con.execute(query)
-
-        for query in invalid_queries:
-            async with self.assertRaisesRegexTx(
-                edgedb.errors.InvalidReferenceError,
-                "abs' does not exist",
-            ):
+        for error, query in queries:
+            if error == NO_ERR:
                 await self.con.execute(query)
+
+            elif error == REF_ERR:
+                async with self.assertRaisesRegexTx(
+                    edgedb.errors.InvalidReferenceError,
+                    "abs' does not exist",
+                ):
+                    await self.con.execute(query)
 
     async def test_edgeql_expr_with_module_04(self):
         await self.con.execute(f"""
@@ -9994,35 +10128,73 @@ aa \
             create module _test;
         """)
 
-        valid_queries = [
-            'select std::_test::abs(1)',
-            'with module dummy select std::_test::abs(1)',
-            'with module _test select std::_test::abs(1)',
-            'with module std select std::_test::abs(1)',
-            'with module std::_test select abs(1)',
-            'with module std::_test select std::_test::abs(1)',
+        NO_ERR = 1
+        REF_ERR = 2
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
         ]
-        invalid_queries = [
-            'select abs(1)',
-            'select _test::abs(1)',
-            'with module dummy select abs(1)',
-            'with module dummy select _test::abs(1)',
-            'with module _test select abs(1)',
-            'with module _test select _test::abs(1)',
-            'with module std select abs(1)',
-            'with module std select _test::abs(1)',
-            'with module std::_test select _test::abs(1)',
+        with_mod = 'with module dummy '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with module _test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with module std '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with module std::_test '
+        queries += [
+            (NO_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+        ]
+        with_mod = 'with t as module _test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+            (REF_ERR, with_mod + 'select t::abs(1)'),
+        ]
+        with_mod = 'with s as module std '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+            (REF_ERR, with_mod + 'select s::abs(1)'),
+        ]
+        with_mod = 'with st as module std::_test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::_test::abs(1)'),
+            (NO_ERR, with_mod + 'select st::abs(1)'),
         ]
 
-        for query in valid_queries:
-            await self.con.execute(query)
-
-        for query in invalid_queries:
-            async with self.assertRaisesRegexTx(
-                edgedb.errors.InvalidReferenceError,
-                "abs' does not exist",
-            ):
+        for error, query in queries:
+            if error == NO_ERR:
                 await self.con.execute(query)
+
+            elif error == REF_ERR:
+                async with self.assertRaisesRegexTx(
+                    edgedb.errors.InvalidReferenceError,
+                    "abs' does not exist",
+                ):
+                    await self.con.execute(query)
 
     async def test_edgeql_expr_with_module_05(self):
         await self.con.execute(f"""
@@ -10031,35 +10203,73 @@ aa \
             create scalar type std::test::Foo extending int64;
         """)
 
-        valid_queries = [
-            'select <test::Foo>1',
-            'select <std::test::Foo>1',
-            'with module dummy select <test::Foo>1',
-            'with module dummy select <std::test::Foo>1',
-            'with module test select <Foo>1',
-            'with module test select <test::Foo>1',
-            'with module test select <std::test::Foo>1',
-            'with module std select <test::Foo>1',
-            'with module std select <std::test::Foo>1',
-            'with module std::test select <Foo>1',
-            'with module std::test select <test::Foo>1',
-            'with module std::test select <std::test::Foo>1',
+        NO_ERR = 1
+        REF_ERR = 2
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
         ]
-        invalid_queries = [
-            'select <Foo>1',
-            'with module dummy select <Foo>1',
-            'with module std select <Foo>1',
+        with_mod = 'with module dummy '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with module test '
+        queries += [
+            (NO_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with module std '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with module std::test '
+        queries += [
+            (NO_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with t as module test '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+            (REF_ERR, with_mod + 'select <t::Foo>1'),
+        ]
+        with_mod = 'with s as module std '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+            (REF_ERR, with_mod + 'select <s::Foo>1'),
+        ]
+        with_mod = 'with st as module std::test '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (NO_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+            (NO_ERR, with_mod + 'select <st::Foo>1'),
         ]
 
-        for query in valid_queries:
-            await self.con.execute(query)
-
-        for query in invalid_queries:
-            async with self.assertRaisesRegexTx(
-                edgedb.errors.InvalidReferenceError,
-                "Foo' does not exist",
-            ):
+        for error, query in queries:
+            if error == NO_ERR:
                 await self.con.execute(query)
+
+            elif error == REF_ERR:
+                async with self.assertRaisesRegexTx(
+                    edgedb.errors.InvalidReferenceError,
+                    "Foo' does not exist",
+                ):
+                    await self.con.execute(query)
 
     async def test_edgeql_expr_with_module_06(self):
         await self.con.execute(f"""
@@ -10069,32 +10279,70 @@ aa \
             create module test;
         """)
 
-        valid_queries = [
-            'select <std::test::Foo>1',
-            'with module dummy select <std::test::Foo>1',
-            'with module test select <std::test::Foo>1',
-            'with module std select <std::test::Foo>1',
-            'with module std::test select <Foo>1',
-            'with module std::test select <std::test::Foo>1',
+        NO_ERR = 1
+        REF_ERR = 2
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
         ]
-        invalid_queries = [
-            'select <Foo>1',
-            'select <test::Foo>1',
-            'with module dummy select <Foo>1',
-            'with module dummy select <test::Foo>1',
-            'with module test select <Foo>1',
-            'with module test select <test::Foo>1',
-            'with module std select <Foo>1',
-            'with module std select <test::Foo>1',
-            'with module std::test select <test::Foo>1',
+        with_mod = 'with module dummy '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with module test '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with module std '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with module std::test '
+        queries += [
+            (NO_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+        ]
+        with_mod = 'with t as module test '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+            (REF_ERR, with_mod + 'select <t::Foo>1'),
+        ]
+        with_mod = 'with s as module std '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+            (REF_ERR, with_mod + 'select <s::Foo>1'),
+        ]
+        with_mod = 'with st as module std::test '
+        queries += [
+            (REF_ERR, with_mod + 'select <Foo>1'),
+            (REF_ERR, with_mod + 'select <test::Foo>1'),
+            (NO_ERR, with_mod + 'select <std::test::Foo>1'),
+            (NO_ERR, with_mod + 'select <st::Foo>1'),
         ]
 
-        for query in valid_queries:
-            await self.con.execute(query)
-
-        for query in invalid_queries:
-            async with self.assertRaisesRegexTx(
-                edgedb.errors.InvalidReferenceError,
-                "Foo' does not exist",
-            ):
+        for error, query in queries:
+            if error == NO_ERR:
                 await self.con.execute(query)
+
+            elif error == REF_ERR:
+                async with self.assertRaisesRegexTx(
+                    edgedb.errors.InvalidReferenceError,
+                    "Foo' does not exist",
+                ):
+                    await self.con.execute(query)

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -10094,7 +10094,7 @@ aa \
             (REF_ERR, with_mod + 'select abs(1)'),
             (NO_ERR, with_mod + 'select _test::abs(1)'),
             (NO_ERR, with_mod + 'select std::_test::abs(1)'),
-            (REF_ERR, with_mod + 'select t::abs(1)'),
+            (NO_ERR, with_mod + 'select t::abs(1)'),
         ]
         with_mod = 'with s as module std '
         queries += [
@@ -10243,7 +10243,7 @@ aa \
             (REF_ERR, with_mod + 'select <Foo>1'),
             (NO_ERR, with_mod + 'select <test::Foo>1'),
             (NO_ERR, with_mod + 'select <std::test::Foo>1'),
-            (REF_ERR, with_mod + 'select <t::Foo>1'),
+            (NO_ERR, with_mod + 'select <t::Foo>1'),
         ]
         with_mod = 'with s as module std '
         queries += [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3306,7 +3306,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
             (REF_ERR, with_mod + 'select abs(1)'),
             (NO_ERR, with_mod + 'select _test::abs(1)'),
             (NO_ERR, with_mod + 'select std::_test::abs(1)'),
-            (REF_ERR, with_mod + 'select t::abs(1)'),
+            (NO_ERR, with_mod + 'select t::abs(1)'),
         ]
         with_mod = 'with s as module std '
         queries += [
@@ -11624,6 +11624,7 @@ class TestDescribe(BaseDescribeTest):
         queries += [
             with_mod + 'select _test::abs(1)',
             with_mod + 'select std::_test::abs(1)',
+            with_mod + 'select t::abs(1)',
         ]
         with_mod = 'with s as module std '
         queries += [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3123,6 +3123,186 @@ class TestSchema(tb.BaseSchemaLoadTest):
     def test_schema_with_module_01(self):
         schema_text = f'''
             module dummy {{}}
+            module A {{
+                type Foo;
+            }}
+        '''
+        NO_ERR = 1
+        REF_ERR = 2
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+        ]
+        with_mod = 'WITH MODULE dummy '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+        ]
+        with_mod = 'WITH MODULE std '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+        ]
+        with_mod = 'WITH MODULE A '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+        ]
+        with_mod = 'WITH dum as MODULE dummy '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dum::Foo>{}'),
+        ]
+        with_mod = 'WITH AAA as MODULE A '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <AAA::Foo>{}'),
+        ]
+        with_mod = 'WITH s as MODULE std '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <s::Foo>{}'),
+        ]
+        with_mod = 'WITH std as MODULE A '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (NO_ERR, with_mod + 'SELECT <A::Foo>{}'),
+        ]
+        with_mod = 'WITH A as MODULE std '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT <Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <std::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <dummy::Foo>{}'),
+            (REF_ERR, with_mod + 'SELECT <A::Foo>{}'),
+        ]
+
+        self._check_valid_queries(
+            schema_text,
+            [query for error, query in queries if error == NO_ERR],
+        )
+        self._check_invalid_queries(
+            schema_text,
+            [query for error, query in queries if error == REF_ERR],
+            errors.InvalidReferenceError,
+            "Foo' does not exist",
+        )
+
+    def test_schema_with_module_02(self):
+        schema_text = f'''
+            module dummy {{}}
+            module A {{
+                function abs(x: int64) -> int64 using (x);
+            }}
+        '''
+        NO_ERR = 1
+        REF_ERR = 2
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+        ]
+        with_mod = 'WITH MODULE dummy '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+        ]
+        with_mod = 'WITH MODULE std '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+        ]
+        with_mod = 'WITH MODULE A '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+        ]
+        with_mod = 'WITH dum as MODULE dummy '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dum::abs(1)'),
+        ]
+        with_mod = 'WITH AAA as MODULE A '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT AAA::abs(1)'),
+        ]
+        with_mod = 'WITH s as MODULE std '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT s::abs(1)'),
+        ]
+        with_mod = 'WITH std as MODULE A '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (NO_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (NO_ERR, with_mod + 'SELECT A::abs(1)'),
+        ]
+        with_mod = 'WITH A as MODULE std '
+        queries += [
+            (REF_ERR, with_mod + 'SELECT abs(1)'),
+            (REF_ERR, with_mod + 'SELECT std::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT dummy::abs(1)'),
+            (REF_ERR, with_mod + 'SELECT A::abs(1)'),
+        ]
+
+        self._check_valid_queries(
+            schema_text,
+            [query for error, query in queries if error == NO_ERR],
+        )
+        self._check_invalid_queries(
+            schema_text,
+            [query for error, query in queries if error == REF_ERR],
+            errors.InvalidReferenceError,
+            "abs' does not exist",
+        )
+
+    def test_schema_with_module_03(self):
+        schema_text = f'''
+            module dummy {{}}
         '''
         NO_ERR = 1
         REF_ERR = 2
@@ -3174,6 +3354,13 @@ class TestSchema(tb.BaseSchemaLoadTest):
             (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
             (NO_ERR, with_mod + 'SELECT <s::int64>{} = 1'),
         ]
+        with_mod = 'WITH std as MODULE dummy '
+        queries += [
+            (NO_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
 
         self._check_valid_queries(
             schema_text,
@@ -3186,7 +3373,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
             "int64' does not exist",
         )
 
-    def test_schema_with_module_02(self):
+    def test_schema_with_module_04(self):
         schema_text = f'''
             module dummy {{}}
             module default {{ type int64; }}
@@ -3243,6 +3430,20 @@ class TestSchema(tb.BaseSchemaLoadTest):
             (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
             (NO_ERR, with_mod + 'SELECT <s::int64>{} = 1'),
         ]
+        with_mod = 'WITH std as MODULE dummy '
+        queries += [
+            (TYPE_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
+        with_mod = 'WITH std as MODULE default '
+        queries += [
+            (TYPE_ERR, with_mod + 'SELECT <int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <std::int64>{} = 1'),
+            (TYPE_ERR, with_mod + 'SELECT <default::int64>{} = 1'),
+            (REF_ERR, with_mod + 'SELECT <dummy::int64>{} = 1'),
+        ]
 
         self._check_valid_queries(
             schema_text,
@@ -3261,7 +3462,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
             "operator '=' cannot be applied",
         )
 
-    def test_schema_with_module_03(self):
+    def test_schema_with_module_05(self):
         schema_text = f'''
             module dummy {{}}
         '''
@@ -3322,6 +3523,13 @@ class TestSchema(tb.BaseSchemaLoadTest):
             (NO_ERR, with_mod + 'select std::_test::abs(1)'),
             (NO_ERR, with_mod + 'select st::abs(1)'),
         ]
+        with_mod = 'with std as module _test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (NO_ERR, with_mod + 'select _test::abs(1)'),
+            (REF_ERR, with_mod + 'select std::_test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::abs(1)'),
+        ]
 
         self._check_valid_queries(
             schema_text,
@@ -3334,7 +3542,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
             "abs' does not exist",
         )
 
-    def test_schema_with_module_04(self):
+    def test_schema_with_module_06(self):
         schema_text = f'''
             module dummy {{}}
             module _test {{}}
@@ -3395,6 +3603,20 @@ class TestSchema(tb.BaseSchemaLoadTest):
             (REF_ERR, with_mod + 'select _test::abs(1)'),
             (NO_ERR, with_mod + 'select std::_test::abs(1)'),
             (NO_ERR, with_mod + 'select st::abs(1)'),
+        ]
+        with_mod = 'with std as module _test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (REF_ERR, with_mod + 'select std::_test::abs(1)'),
+            (REF_ERR, with_mod + 'select std::abs(1)'),
+        ]
+        with_mod = 'with std as module std::_test '
+        queries += [
+            (REF_ERR, with_mod + 'select abs(1)'),
+            (REF_ERR, with_mod + 'select _test::abs(1)'),
+            (REF_ERR, with_mod + 'select std::_test::abs(1)'),
+            (NO_ERR, with_mod + 'select std::abs(1)'),
         ]
 
         self._check_valid_queries(
@@ -11432,6 +11654,132 @@ class TestDescribe(BaseDescribeTest):
     def test_schema_describe_with_module_01(self):
         schema_text = f'''
             module dummy {{}}
+            module A {{
+                type Foo;
+            }}
+        '''
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            with_mod + 'SELECT <A::Foo>{}',
+        ]
+        with_mod = 'WITH MODULE dummy '
+        queries += [
+            with_mod + 'SELECT <A::Foo>{}',
+        ]
+        with_mod = 'WITH MODULE std '
+        queries += [
+            with_mod + 'SELECT <A::Foo>{}',
+        ]
+        with_mod = 'WITH MODULE A '
+        queries += [
+            with_mod + 'SELECT <Foo>{}',
+            with_mod + 'SELECT <A::Foo>{}',
+        ]
+        with_mod = 'WITH dum as MODULE dummy '
+        queries += [
+            with_mod + 'SELECT <A::Foo>{}',
+        ]
+        with_mod = 'WITH AAA as MODULE A '
+        queries += [
+            with_mod + 'SELECT <A::Foo>{}',
+            with_mod + 'SELECT <AAA::Foo>{}',
+        ]
+        with_mod = 'WITH s as MODULE std '
+        queries += [
+            with_mod + 'SELECT <A::Foo>{}',
+        ]
+        with_mod = 'WITH std as MODULE A '
+        queries += [
+            with_mod + 'SELECT <std::Foo>{}',
+            with_mod + 'SELECT <A::Foo>{}',
+        ]
+        with_mod = 'WITH A as MODULE std '
+        queries += []
+
+        normalized = 'SELECT <A::Foo>{}'
+        for query in queries:
+            self._assert_describe(
+                schema_text + f'''
+                    module default {{ alias query := ({query}); }}
+                ''',
+
+                'describe module default as sdl',
+
+                f'''
+                    alias default::query := ({normalized});
+                ''',
+                explicit_modules=True,
+            )
+
+    def test_schema_describe_with_module_02(self):
+        schema_text = f'''
+            module dummy {{}}
+            module A {{
+                function abs(x: int64) -> int64 using (x);
+            }}
+        '''
+
+        queries = []
+
+        with_mod = ''
+        queries += [
+            with_mod + 'SELECT A::abs(1)',
+        ]
+        with_mod = 'WITH MODULE dummy '
+        queries += [
+            with_mod + 'SELECT A::abs(1)',
+        ]
+        with_mod = 'WITH MODULE std '
+        queries += [
+            with_mod + 'SELECT A::abs(1)',
+        ]
+        with_mod = 'WITH MODULE A '
+        queries += [
+            with_mod + 'SELECT abs(1)',
+            with_mod + 'SELECT A::abs(1)',
+        ]
+        with_mod = 'WITH dum as MODULE dummy '
+        queries += [
+            with_mod + 'SELECT A::abs(1)',
+        ]
+        with_mod = 'WITH AAA as MODULE A '
+        queries += [
+            with_mod + 'SELECT A::abs(1)',
+            with_mod + 'SELECT AAA::abs(1)',
+        ]
+        with_mod = 'WITH s as MODULE std '
+        queries += [
+            with_mod + 'SELECT A::abs(1)',
+        ]
+        with_mod = 'WITH std as MODULE A '
+        queries += [
+            with_mod + 'SELECT std::abs(1)',
+            with_mod + 'SELECT A::abs(1)',
+        ]
+        with_mod = 'WITH A as MODULE std '
+        queries += []
+
+        normalized = 'SELECT A::abs(1)'
+        for query in queries:
+            self._assert_describe(
+                schema_text + f'''
+                    module default {{ alias query := ({query}); }}
+                ''',
+
+                'describe module default as sdl',
+
+                f'''
+                    alias default::query := ({normalized});
+                ''',
+                explicit_modules=True,
+            )
+
+    def test_schema_describe_with_module_03(self):
+        schema_text = f'''
+            module dummy {{}}
         '''
 
         queries = []
@@ -11467,6 +11815,10 @@ class TestDescribe(BaseDescribeTest):
             with_mod + 'SELECT <std::int64>{} = 1',
             with_mod + 'SELECT <s::int64>{} = 1',
         ]
+        with_mod = 'WITH std as MODULE dummy '
+        queries += [
+            with_mod + 'SELECT <int64>{} = 1',
+        ]
 
         normalized = 'SELECT (<std::int64>{} = 1)'
         for query in queries:
@@ -11483,7 +11835,7 @@ class TestDescribe(BaseDescribeTest):
                 explicit_modules=True,
             )
 
-    def test_schema_describe_with_module_02a(self):
+    def test_schema_describe_with_module_04a(self):
         schema_text = f'''
             module dummy {{}}
             module default {{ type int64; }}
@@ -11518,6 +11870,10 @@ class TestDescribe(BaseDescribeTest):
             with_mod + 'SELECT <std::int64>{} = 1',
             with_mod + 'SELECT <s::int64>{} = 1',
         ]
+        with_mod = 'WITH std as MODULE dummy '
+        queries += []
+        with_mod = 'WITH std as MODULE default '
+        queries += []
 
         normalized = 'SELECT (<std::int64>{} = 1)'
         for query in queries:
@@ -11535,7 +11891,7 @@ class TestDescribe(BaseDescribeTest):
                 explicit_modules=True,
             )
 
-    def test_schema_describe_with_module_02b(self):
+    def test_schema_describe_with_module_04b(self):
         schema_text = f'''
             module dummy {{}}
             module default {{ type int64; }}
@@ -11569,6 +11925,10 @@ class TestDescribe(BaseDescribeTest):
         queries += [
             with_mod + 'SELECT <default::int64>{}',
         ]
+        with_mod = 'WITH std as MODULE dummy '
+        queries += []
+        with_mod = 'WITH std as MODULE default '
+        queries += []
 
         normalized = 'SELECT <default::int64>{}'
         for query in queries:
@@ -11586,7 +11946,7 @@ class TestDescribe(BaseDescribeTest):
                 explicit_modules=True,
             )
 
-    def test_schema_describe_with_module_03(self):
+    def test_schema_describe_with_module_05(self):
         schema_text = f'''
             module dummy {{}}
         '''
@@ -11637,6 +11997,11 @@ class TestDescribe(BaseDescribeTest):
             with_mod + 'select std::_test::abs(1)',
             with_mod + 'select st::abs(1)',
         ]
+        with_mod = 'with std as module _test '
+        queries += [
+            with_mod + 'select _test::abs(1)',
+            with_mod + 'select std::abs(1)',
+        ]
 
         normalized = 'SELECT std::_test::abs(1)'
         for query in queries:
@@ -11653,7 +12018,7 @@ class TestDescribe(BaseDescribeTest):
                 explicit_modules=True,
             )
 
-    def test_schema_describe_with_module_04(self):
+    def test_schema_describe_with_module_06(self):
         schema_text = f'''
             module dummy {{}}
             module _test {{}}
@@ -11694,6 +12059,12 @@ class TestDescribe(BaseDescribeTest):
         queries += [
             with_mod + 'select std::_test::abs(1)',
             with_mod + 'select st::abs(1)',
+        ]
+        with_mod = 'with std as module _test '
+        queries += []
+        with_mod = 'with std as module std::_test '
+        queries += [
+            with_mod + 'select std::abs(1)',
         ]
 
         normalized = 'SELECT std::_test::abs(1)'


### PR DESCRIPTION
- Allows queries such as `with http as net::http select http::Response`. The aliased module `net::http` will resolve to `std::net::http`.
- Apply module aliases to function names during normalization, even if no function was found.
    - This fixes an issue where given the following modules:
        - `module A { function foo() -> int64 using (1) }`
        - `module B {}`
        - `module C { alias query := (with A as B select A::foo()}`
    - `C::query` would normalize to `select A::foo()` with the expectation that `A::Foo` does not exist.

related #7737