### PR TITLE
Wait until a finished ScheduleRequest.state

### DIFF
--- a/tests/test_http_std_net.py
+++ b/tests/test_http_std_net.py
@@ -94,7 +94,10 @@ class StdNetTestCase(server.QueryTestCase):
                         request := assert_exists((
                             select std::net::http::ScheduledRequest
                             filter .url = url
-                            and .state != std::net::RequestState.Pending
+                            and .state in {
+                                std::net::RequestState.Completed,
+                                std::net::RequestState.Failed,
+                            }
                             limit 1
                         ))
                     select request {*};


### PR DESCRIPTION
We set the in-flight requests to an `InProgress` state, so the old query was picking up requests that had not yet completed, but then our tests look at the completed requests. This update instead waits for one of the finished states (either completed or failed) before continuing on.