### PR TITLE
Pass in cardinality_mod of json_parameters

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -720,6 +720,7 @@ def compile_TypeCast(
                 pt,
                 span=expr.expr.span,
                 ctx=ctx,
+                cardinality_mod=expr.cardinality_mod,
             )
 
         else:

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -236,3 +236,8 @@ type NotEditable {
         readonly := true;
     }
 }
+
+function modifying_noop(x: str) -> str {
+    using (x);
+    volatility := 'Modifying';
+}

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -377,6 +377,33 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
                 use_http_post=use_http_post,
             )
 
+    def test_http_edgeql_query_func_02(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'parameter \$x is required'):
+            self.edgeql_query(
+                r'''select modifying_noop(<required str>$x)''',
+                variables=dict(x=None),
+            )
+
+    def test_http_edgeql_query_func_03(self):
+        self.assert_edgeql_query_result(
+            r'''select modifying_noop(<required str>$x)''',
+            ['foo'],
+            variables=dict(x='foo'),
+        )
+
+    def test_http_edgeql_query_func_04(self):
+        # JSON parameter can be null, so <str>$x is AT_MOST_ONE in this case
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'possibly an empty set passed as non-optional argument '
+                r'into modifying function'):
+            self.edgeql_query(
+                r'''select modifying_noop(<str>$x)''',
+                variables=dict(x='foo'),
+            )
+
     def test_http_edgeql_query_duration_01(self):
         Q = r"""select <duration>'15m' < <duration>'1h'"""
 


### PR DESCRIPTION
`<required ..>$xx` had been evaluated as AT_MOST_ONE with json_parameters on, even though it has a runtime check that guarantees non-empty values. This issue was captured with modifying function `std::net::schedule_request()` that errors if the required parameter value doesn't have cardinality ONE.

The issue seems to be a missing cardinality_mod, which is used to detect if a JSON typecasting should be widen to include empty values.