### PR TITLE
Fix inplace upgrade tests after pg_addr changes

### DIFF
--- a/tests/inplace-testing/test.sh
+++ b/tests/inplace-testing/test.sh
@@ -77,22 +77,8 @@ EDGEDB_PORT=$PORT EDGEDB_CLIENT_TLS_SECURITY=insecure python3 tests/inplace-test
 patch -f -p1 < tests/inplace-testing/upgrade.patch
 make parsers
 
-# Get the DSN from the debug settings fields sent to the client on connection.
-DSN=$(python3 <<EOF
-import asyncio
-
-import edb.testbase.connection as edgedb
-
-async def run():
-    db = await edgedb.async_connect_test_client(
-        host='localhost', port=$PORT, tls_security='insecure'
-    )
-    print(db.get_settings()['pgdsn'].decode('utf-8'))
-    await db.aclose()
-
-asyncio.run(run())
-EOF
-)
+# Get the DSN from the debug endpoint
+DSN=$(curl -s http://localhost:$PORT/server-info | jq -r '.pg_addr.dsn')
 
 # Prepare the upgrade, operating against the postgres that the old
 # version server is managing


### PR DESCRIPTION
PR #7605 broke the inplace-upgrade tests, since it removed host and
port from the `pg_addr` field on the `server-info` endpoint and turned
the `server_settings` field into the toplevel.

Fix it by exposing the full DSN to server-info as well.

(An earlier iteration made the inplace upgrade tests use the testbase
python connection to read pgdsn from settings.)