### PR TITLE
Trampoline instdata to fix error messages on catalog mismatch

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_10_10_00_01
+EDGEDB_CATALOG_VERSION = 2024_10_11_00_01
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4985,7 +4985,6 @@ async def generate_instdata_table(
     return trampolines
 
 
-
 def get_bootstrap_commands(
     config_spec: edbconfig.Spec,
 ) -> tuple[dbops.CommandGroup, list[trampoline.Trampoline]]:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -38,6 +38,7 @@ import edb._edgeql_parser as ql_parser
 
 from edb.common import debug
 from edb.common import exceptions
+from edb.common import ordered
 from edb.common import uuidgen
 from edb.common import xdedent
 from edb.common.typeutils import not_none
@@ -147,6 +148,38 @@ class DBConfigTable(dbops.Table):
                 table_name=('edgedb', '_db_config'),
                 columns=['name'],
             ),
+        )
+
+
+class InstDataTable(dbops.Table):
+    def __init__(self) -> None:
+        sname = V('edgedbinstdata')
+        super().__init__(
+            name=(sname, 'instdata'),
+            columns=[
+                dbops.Column(
+                    name='key',
+                    type='text',
+                ),
+                dbops.Column(
+                    name='bin',
+                    type='bytea',
+                ),
+                dbops.Column(
+                    name='text',
+                    type='text',
+                ),
+                dbops.Column(
+                    name='json',
+                    type='jsonb',
+                ),
+            ],
+            constraints=ordered.OrderedSet([
+                dbops.PrimaryKey(
+                    table_name=(sname, 'instdata'),
+                    columns=['key'],
+                ),
+            ]),
         )
 
 
@@ -4852,6 +4885,12 @@ def _maybe_trampoline(
         and cmd.view.name[0].endswith(namespace)
     ):
         out.append(trampoline.make_view_trampoline(cmd.view))
+    elif (
+        isinstance(cmd, dbops.CreateTable)
+        and cmd.table.name[0].endswith(namespace)
+    ):
+        f, n = cmd.table.name
+        out.append(trampoline.make_table_trampoline((f, n)))
 
 
 def trampoline_functions(
@@ -4886,6 +4925,7 @@ def get_fixed_bootstrap_commands() -> dbops.CommandGroup:
         dbops.CreateSchema(name='edgedbt'),
         dbops.CreateSchema(name='edgedbpub'),
         dbops.CreateSchema(name='edgedbstd'),
+        dbops.CreateSchema(name='edgedbinstdata'),
 
         dbops.CreateTable(
             DBConfigTable(),
@@ -4930,7 +4970,9 @@ def get_bootstrap_commands(
         dbops.CreateSchema(name=V('edgedbpub')),
         dbops.CreateSchema(name=V('edgedbstd')),
         dbops.CreateSchema(name=V('edgedbsql')),
+        dbops.CreateSchema(name=V('edgedbinstdata')),
 
+        dbops.CreateTable(InstDataTable()),
         dbops.CreateView(NormalizedPgSettingsView()),
         dbops.CreateFunction(EvictQueryCacheFunction()),
         dbops.CreateFunction(ClearQueryCacheFunction()),


### PR DESCRIPTION
Putting catalog version in the schema names broke the nice error
message on catalog mismatch, and the original schema version broke it
on major version mismatches.

Trampoline the instdata table so we can read the data even if our
version is wrong.