### PR TITLE
Fix inplace upgrade rollbacks

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -118,6 +118,7 @@ class PGConnectionProxy:
     def __init__(
         self,
         cluster: pgcluster.BaseCluster,
+        *,
         source_description: str,
         dbname: Optional[str] = None,
         log_listener: Optional[Callable[[str, str], None]] = None,

--- a/edb/server/inplace_upgrade.py
+++ b/edb/server/inplace_upgrade.py
@@ -487,7 +487,10 @@ async def _rollback_all(
 
     for database in databases:
         conn = bootstrap.PGConnectionProxy(
-            cluster, cluster.get_db_name(database))
+            cluster,
+            source_description='inplace upgrade: rollback all',
+            dbname=cluster.get_db_name(database),
+        )
         try:
             subctx = dataclasses.replace(ctx, conn=conn)
 


### PR DESCRIPTION
A new parameter got added to PGConnectionProxy, and it swalloed one
call site's dbname argument.  Fix that, and make the params
keyword-only.