### PR TITLE
Handle multiple WebAuthn email factors

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -729,11 +729,20 @@ class Router:
         request_data = self._get_data_from_request(request)
 
         _check_keyset(request_data, {"provider"})
-        local_client = local.Client(db=self.db)
+        provider_name = request_data["provider"]
+        match provider_name:
+            case "builtin::local_emailpassword":
+                local_client = email_password.Client(db=self.db)
+            case "builtin::local_webauthn":
+                local_client = webauthn.Client(db=self.db)
+            case _:
+                raise errors.InvalidData(
+                    f"Unsupported provider: {request_data['provider']}"
+                )
+
         verify_url = request_data.get(
             "verify_url", f"{self.base_path}/ui/verify"
         )
-        identity_id: Optional[str] = None
         email_factor: Optional[EmailFactor] = None
         if "verification_token" in request_data:
             (
@@ -759,21 +768,32 @@ class Router:
                 raise errors.InvalidData(
                     "Redirect URL does not match any allowed URLs.",
                 )
-
-            email_factor = await local_client.get_email_factor_by_email(
-                request_data["email"]
-            )
-            identity_id = (
-                email_factor.identity.id if email_factor is not None else None
-            )
+            match local_client:
+                case webauthn.Client():
+                    maybe_credential_id = request_data.get("credential_id")
+                    if maybe_credential_id is None:
+                        raise errors.InvalidData(
+                            "Missing 'credential_id' in request to resend"
+                            " verification email for WebAuthn authentication"
+                            " factor."
+                        )
+                    email_factor = (
+                        await local_client.get_email_factor_by_credential_id(
+                            base64.b64decode(maybe_credential_id)
+                        )
+                    )
+                case email_password.Client():
+                    email_factor = await local_client.get_email_factor_by_email(
+                        request_data["email"]
+                    )
         else:
             raise errors.InvalidData("Missing 'verification_token' or 'email'")
 
-        if identity_id is None or email_factor is None:
+        if email_factor is None:
             await auth_emails.send_fake_email(self.tenant)
         else:
             verification_token = self._make_verification_token(
-                identity_id=identity_id,
+                identity_id=email_factor.identity.id,
                 verify_url=verify_url,
                 maybe_challenge=maybe_challenge,
                 maybe_redirect_to=maybe_redirect_to,
@@ -782,7 +802,7 @@ class Router:
                 webhook.EmailVerificationRequested(
                     event_id=str(uuid.uuid4()),
                     timestamp=datetime.datetime.now(datetime.timezone.utc),
-                    identity_id=identity_id,
+                    identity_id=email_factor.identity.id,
                     email_factor_id=email_factor.id,
                     verification_token=verification_token,
                 )

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -55,7 +55,6 @@ from . import (
     webauthn,
     magic_link,
     webhook,
-    local,
 )
 from .data import EmailFactor
 
@@ -730,6 +729,7 @@ class Router:
 
         _check_keyset(request_data, {"provider"})
         provider_name = request_data["provider"]
+        local_client: email_password.Client | webauthn.Client
         match provider_name:
             case "builtin::local_emailpassword":
                 local_client = email_password.Client(db=self.db)

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -523,7 +523,8 @@ select ext::auth::WebAuthnFactor {
         if len(result_json) == 0:
             return None
         elif len(result_json) > 1:
+            # This should never happen given the exclusive constraint
             raise errors.WebAuthnAuthenticationFailed(
-                "Multiple challenges found. Please retry authentication."
+                "Multiple WebAuthn factors found for the same credential ID."
             )
         return data.EmailFactor(**result_json[0])

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -497,3 +497,33 @@ filter .factors.email = email and .factors.credential_id = credential_id;""",
             )
 
         return factor.identity
+
+    async def get_email_factor_by_credential_id(
+        self,
+        credential_id: bytes,
+    ) -> Optional[data.EmailFactor]:
+        result = await execute.parse_execute_json(
+            self.db,
+            """
+with
+    credential_id := <bytes>$credential_id,
+select ext::auth::WebAuthnFactor {
+    id,
+    created_at,
+    modified_at,
+    email,
+    verified_at,
+    identity: {*},
+} filter .credential_id = credential_id;""",
+            variables={
+                "credential_id": credential_id,
+            },
+        )
+        result_json = json.loads(result.decode())
+        if len(result_json) == 0:
+            return None
+        elif len(result_json) > 1:
+            raise errors.WebAuthnAuthenticationFailed(
+                "Multiple challenges found. Please retry authentication."
+            )
+        return data.EmailFactor(**result_json[0])

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3348,10 +3348,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 public_key_two=uuid.uuid4().bytes,
             )
 
-            # Resend verification email with just the email
+            # Resend verification email with credential_id
             resend_data = {
                 "provider": provider_name,
-                "email": email,
                 "credential_id": base64.b64encode(credential_one).decode(),
             }
             resend_data_encoded = urllib.parse.urlencode(resend_data).encode()
@@ -3409,7 +3408,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             self.assertEqual(status, 200)
 
-            # Resend verification email but no credential_id
+            # Resend verification email with email
             resend_data = {
                 "provider": provider_name,
                 "email": email,


### PR DESCRIPTION
`email` is not exclusive for WebAuthn factors, so we need to detect the
case where you are trying to resend the verification email, require a
`credential_id` which is the exclusive identifier for each WebAuthn
credential stored in the browser for a given identity, and select on
that instead.