### PR TITLE
Access policies for selects over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -2058,7 +2058,7 @@ def merge_params(
                 i
                 for i, p in enumerate(ctx.query_params)
                 if isinstance(p, dbstate.SQLParamGlobal)
-                and p.global_name == glob.name
+                and p.global_name == glob.global_name
             ),
             None,
         )

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -1619,6 +1619,7 @@ def _compile_uncompiled_dml(
             singletons=singletons,
             anchors=anchors,
             allow_user_specified_id=ctx.options.allow_user_specified_id,
+            apply_user_access_policies=ctx.options.apply_access_policies
         )
         ir_stmt = qlcompiler.compile_ast_to_ir(
             ql_stmt,

--- a/edb/pgsql/resolver/context.py
+++ b/edb/pgsql/resolver/context.py
@@ -49,6 +49,9 @@ class Options:
     # allow setting id in inserts
     allow_user_specified_id: bool
 
+    # apply access policies to select & dml statements
+    apply_access_policies: bool
+
 
 @dataclass(kw_only=True)
 class Scope:

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -172,6 +172,7 @@ def resolve_column_kind(
                     ),
                 },
                 output_format=pgcompiler.OutputFormat.NATIVE_INTERNAL,
+                alias_generator=ctx.alias_generator,
             )
             command.merge_params(sql_tree, compiled.irast, ctx)
 

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -158,6 +158,7 @@ def resolve_column_kind(
                 path_prefix_anchor='__source__',
                 singletons=singletons,
                 make_globals_empty=False,
+                apply_user_access_policies=ctx.options.apply_access_policies,
             )
             compiled = expr.compiled(ctx.schema, options=options, context=None)
 

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -630,6 +630,7 @@ DEFAULT_SQL_SETTINGS: SQLSettings = immutables.Map()
 DEFAULT_SQL_FE_SETTINGS: SQLSettings = immutables.Map({
     "search_path": ("public",),
     "allow_user_specified_id": ("false",),
+    "apply_access_policies_sql": ("false",),
     "server_version": cast(SQLSetting, (defines.PGEXT_POSTGRES_VERSION,)),
     "server_version_num": cast(
         SQLSetting, (defines.PGEXT_POSTGRES_VERSION_NUM,)

--- a/edb/server/compiler/sql.py
+++ b/edb/server/compiler/sql.py
@@ -322,7 +322,7 @@ def lookup_bool_setting(
             truthy = {'on', 'true', 'yes', '1'}
             return setting[0].lower() in truthy
         elif isinstance(setting[0], int):
-            return bool(setting[0])    
+            return bool(setting[0])
     return None
 
 

--- a/edb/server/compiler/sql.py
+++ b/edb/server/compiler/sql.py
@@ -45,6 +45,7 @@ FE_SETTINGS_MUTABLE: immutables.Map[str, bool] = immutables.Map(
     {
         'search_path': True,
         'allow_user_specified_id': True,
+        'apply_access_policies_sql': True,
         'server_version': False,
         'server_version_num': False,
     }
@@ -278,24 +279,23 @@ def resolve_query(
     from edb.pgsql import resolver as pg_resolver
 
     search_path: Sequence[str] = ("public",)
-    allow_user_specified_id: bool = False
-
     try:
         setting = tx_state.get("search_path")
     except KeyError:
         setting = None
     search_path = parse_search_path(setting)
 
-    try:
-        setting = tx_state.get("allow_user_specified_id")
-    except KeyError:
-        setting = None
-    if setting:
-        if isinstance(setting[0], str):
-            truthy = {'on', 'true', 'yes', '1'}
-            allow_user_specified_id = setting[0].lower() in truthy
-        elif isinstance(setting[0], int):
-            allow_user_specified_id = bool(setting[0])
+    allow_user_specified_id = lookup_bool_setting(
+        tx_state, 'allow_user_specified_id'
+    )
+    if allow_user_specified_id is None:
+        allow_user_specified_id = False
+
+    apply_access_policies = lookup_bool_setting(
+        tx_state, 'apply_access_policies_sql'
+    )
+    if apply_access_policies is None:
+        apply_access_policies = False
 
     options = pg_resolver.Options(
         current_user=opts.current_user,
@@ -303,10 +303,27 @@ def resolve_query(
         current_query=opts.query_str,
         search_path=search_path,
         allow_user_specified_id=allow_user_specified_id,
+        apply_access_policies=apply_access_policies,
     )
     resolved = pg_resolver.resolve(stmt, schema, options)
     source = pg_codegen.generate(resolved.ast, with_translation_data=True)
     return resolved, source
+
+
+def lookup_bool_setting(
+    tx_state: dbstate.SQLTransactionState, name: str
+) -> Optional[bool]:
+    try:
+        setting = tx_state.get(name)
+    except KeyError:
+        setting = None
+    if setting:
+        if isinstance(setting[0], str):
+            truthy = {'on', 'true', 'yes', '1'}
+            return setting[0].lower() in truthy
+        elif isinstance(setting[0], int):
+            return bool(setting[0])    
+    return None
 
 
 def compute_stmt_name(text: str, tx_state: dbstate.SQLTransactionState) -> str:

--- a/tests/schemas/movies.esdl
+++ b/tests/schemas/movies.esdl
@@ -31,9 +31,16 @@ type Genre {
     required name: str;
 }
 
+global filter_title: str;
+
 type Content {
     required title: str;
     genre: Genre;
+
+    access policy filter_title
+        allow select
+        using (global filter_title ?= .title);
+    access policy dml allow insert, update, delete;
 }
 
 type Movie extending Content {
@@ -68,4 +75,12 @@ module nested {
             property rolling -> str;
         };
     };
+}
+
+type ContentSummary {
+    property x := std::count((select Content));
+
+    access policy select_always allow select;
+    access policy dml allow insert, update, delete
+        using (global filter_title ?= 'summary');
 }

--- a/tests/test_edgeql_rewrites.py
+++ b/tests/test_edgeql_rewrites.py
@@ -61,6 +61,11 @@ class TestRewrites(tb.QueryTestCase):
             ));
           };
         };
+
+        alter type Content {
+          drop access policy filter_title;
+          drop access policy dml;
+        };
     """
     ]
 

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -836,13 +836,13 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             GROUP BY tbl_name
             '''
         )
-        for [table_name, columns_from_information_schema] in tables:
-            if table_name.split('.')[0] in ('cfg', 'schema', 'sys'):
+        for [tbl_name, columns_from_information_schema] in tables:
+            if tbl_name.split('.')[0] in ('cfg', 'schema', 'sys', '"ext::ai"'):
                 continue
 
             try:
                 prepared = await self.scon.prepare(
-                    f'SELECT * FROM {table_name}'
+                    f'SELECT * FROM {tbl_name}'
                 )
 
                 attributes = prepared.get_attributes()
@@ -853,7 +853,7 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                     columns_from_information_schema,
                 )
             except Exception:
-                raise Exception(f'introspecting {table_name}')
+                raise Exception(f'introspecting {tbl_name}')
 
     async def test_sql_query_introspection_03(self):
         res = await self.squery_values(

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1774,7 +1774,7 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         # no access policies
         res = await self.squery_values('SELECT x FROM "ContentSummary"')
         self.assertEqual(res, [[5]])
-        
+
         await self.scon.execute('SET LOCAL apply_access_policies_sql TO true')
 
         # access policies applied
@@ -1832,9 +1832,9 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             'SELECT * FROM ONLY "Content"'
         )
         self.assertEqual(len(res), 1)
-        
+
         await self.scon.execute('SET LOCAL apply_access_policies_sql TO true')
-        
+
         await self.scon.execute(
             """SET LOCAL "global default::filter_title" TO 'Halo 3'"""
         )
@@ -1842,7 +1842,7 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             'SELECT * FROM ONLY "Content"'
         )
         self.assertEqual(len(res), 1)
-        
+
         await self.scon.execute(
             """SET LOCAL "global default::filter_title" TO 'Forrest Gump'"""
         )

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -610,6 +610,9 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         tran = self.scon.transaction()
         await tran.start()
         await self.scon.execute('SET LOCAL apply_access_policies_sql TO true')
+        await self.scon.execute(
+            """SET LOCAL "global default::filter_title" TO 'Halo 3'"""
+        )
 
         res = await self.squery_values(
             '''
@@ -781,6 +784,7 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                 ['public', 'Book'],
                 ['public', 'Book.chapters'],
                 ['public', 'Content'],
+                ['public', 'ContentSummary'],
                 ['public', 'Genre'],
                 ['public', 'Movie'],
                 ['public', 'Movie.actors'],
@@ -817,6 +821,9 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                 ['Content', '__type__', 'NO', 2],
                 ['Content', 'genre_id', 'YES', 3],
                 ['Content', 'title', 'NO', 4],
+                ['ContentSummary', 'id', 'NO', 1],
+                ['ContentSummary', '__type__', 'NO', 2],
+                ['ContentSummary', 'x', 'NO', 3],
                 ['Genre', 'id', 'NO', 1],
                 ['Genre', '__type__', 'NO', 2],
                 ['Genre', 'name', 'NO', 3],
@@ -1136,6 +1143,7 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                 ["Book", 8192],
                 ["Book.chapters", 8192],
                 ["Content", 8192],
+                ["ContentSummary", 8192],
                 ["Genre", 8192],
                 ["Movie", 8192],
                 ["Movie.actors", 8192],


### PR DESCRIPTION
- adds sql conn setting `apply_access_policies_sql`
- it is passed into qlcompiler as `apply_user_access_policies` when compiling DML or computeds,
- when compiling table references and `apply_access_policies_sql` is enabled, instead of composing inheritance view, we now compile edgeql `select ObjectType { id, __type__, ... all ptrs ... }`, which will include `select` access policies.

If `apply_access_policies_sql` is not set, we still use inheritance views (or base table directly if ONLY is used), which yields faster compilation times.

Two important details:
- When `apply_access_policies_sql` is set, system columns (tableoid, xmin, ...) are all NULL.

- Link and pointer tables currently do not have access policies applied. We should probably implement a behavior where access polices are applied to the source of the link/pointer table. 