### PR TITLE
Make CONFIGURE CURRENT DATABASE block until configuration is actually set

### DIFF
--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -92,8 +92,6 @@ cdef class Database:
         readonly object backend_ids
         readonly object extensions
 
-    cdef schedule_config_update(self)
-
     cdef _invalidate_caches(self)
     cdef _cache_compiled_query(self, key, compiled)
     cdef _new_view(self, query_cache, protocol_version)
@@ -131,9 +129,6 @@ cdef class DatabaseConnectionView:
         # Although, transient dbviews users should guarantee the transient use
         # of pgcons, because _pg_ensure_database_not_connected() may still time
         # out `DROP BRANCH` if the transient pgcon is not released soon enough.
-
-        object _db_config_temp
-        object _db_config_dbver
 
         # State properties
         object _config
@@ -223,7 +218,6 @@ cdef class DatabaseConnectionView:
     cdef get_state_serializer(self)
     cdef set_state_serializer(self, new_serializer)
 
-    cdef update_database_config(self)
     cpdef get_database_config(self)
     cdef set_database_config(self, new_conf)
 

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -377,7 +377,7 @@ async def execute(
         if state_serializer is not None:
             dbv.set_state_serializer(state_serializer)
         if side_effects:
-            signal_side_effects(dbv, side_effects)
+            await process_side_effects(dbv, side_effects)
         if not dbv.in_tx() and not query_unit.tx_rollback and query_unit.sql:
             state = dbv.serialize_state()
             if state is not orig_state:
@@ -540,6 +540,13 @@ async def execute_script(
                         "Side-effects in implicit transaction!"
                     )
 
+        # Need to sync before calling process_side_effects, which will
+        # look at the database. Also, want to sync before we record success,
+        # since sync could fail.
+        if sent and not sync:
+            sync = True
+            await conn.sync()
+
     except Exception as e:
         dbv.on_error()
 
@@ -570,7 +577,7 @@ async def execute_script(
                 cached_reflection,
             )
             if side_effects:
-                signal_side_effects(dbv, side_effects)
+                await process_side_effects(dbv, side_effects)
             state = dbv.serialize_state()
             if state is not orig_state:
                 conn.last_state = state
@@ -625,6 +632,14 @@ async def execute_system_config(
     # need to make sure it has been loaded.
     if query_unit.backend_config:
         await conn.sql_execute(b'SELECT pg_reload_conf()')
+
+
+async def process_side_effects(dbv, side_effects):
+    signal_side_effects(dbv, side_effects)
+
+    if side_effects & dbview.SideEffects.DatabaseConfigChanges:
+        tenant = dbv.tenant
+        await tenant.process_local_database_config_change(dbv.dbname)
 
 
 def signal_side_effects(dbv, side_effects):

--- a/tests/test_edgeql_extensions.py
+++ b/tests/test_edgeql_extensions.py
@@ -21,7 +21,6 @@ import textwrap
 
 import edgedb
 
-from edb.tools import test
 from edb.testbase import server as tb
 
 
@@ -879,7 +878,6 @@ class TestDDLExtensions(tb.DDLTestCase):
             finally:
                 await con2.aclose()
 
-    @test.skip('Too flaky')
     async def test_edgeql_extensions_05(self):
         # Test config extension
         await self.con.execute('''
@@ -999,7 +997,6 @@ class TestDDLExtensions(tb.DDLTestCase):
                 COMMIT MIGRATION;
             """)
 
-    @test.skip('Too flaky')
     async def test_edgeql_extensions_06(self):
         # Make an extension with dependencies
         await self.con.execute('''


### PR DESCRIPTION
... on the local instance, at least. Multi-frontend will still be racy.

Fixes #7330.