### PR TITLE
Move new std::net backend to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
  "pretty_assertions",
  "pyo3",
  "rand",
- "rstest",
+ "rstest 0.22.0",
  "scopeguard",
  "serde",
  "serde-pickle",
@@ -966,6 +966,7 @@ dependencies = [
  "futures",
  "pyo3",
  "reqwest",
+ "rstest 0.23.0",
  "scopeguard",
  "serde",
  "serde-pickle",
@@ -1525,7 +1526,7 @@ dependencies = [
  "pyo3",
  "rand",
  "roaring",
- "rstest",
+ "rstest 0.22.0",
  "scopeguard",
  "serde",
  "serde-pickle",
@@ -1917,7 +1918,19 @@ checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
 dependencies = [
  "futures",
  "futures-timer",
- "rstest_macros",
+ "rstest_macros 0.22.0",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros 0.23.0",
  "rustc_version",
 ]
 
@@ -1926,6 +1939,24 @@ name = "rstest_macros"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
 dependencies = [
  "cfg-if",
  "glob",
@@ -2305,9 +2336,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2606,9 +2637,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,8 +968,6 @@ dependencies = [
  "reqwest",
  "rstest 0.23.0",
  "scopeguard",
- "serde",
- "serde-pickle",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,7 +86,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -90,7 +96,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -127,6 +133,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "async-compression"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e614738943d3f68c628ae3dbce7c3daffb196665f82f8c8ea6b65de73c79429"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,7 +167,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -363,12 +388,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -566,6 +616,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,7 +670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -628,6 +687,22 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "flate2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.0",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -813,6 +888,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +959,134 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "futures",
+ "pyo3",
+ "reqwest",
+ "scopeguard",
+ "serde",
+ "serde-pickle",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "hyper"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http 1.1.0",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +1111,12 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "ipnet"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -925,6 +1153,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1006,12 +1243,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -1023,7 +1275,7 @@ dependencies = [
  "hermit-abi",
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1053,6 +1305,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1191,6 +1460,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -1565,6 +1840,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.12.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roaring"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,7 +1964,46 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1654,10 +2028,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1707,6 +2113,18 @@ dependencies = [
  "indexmap",
  "itoa",
  "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1810,8 +2228,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "statrs"
@@ -1891,6 +2315,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,7 +2360,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1989,7 +2443,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2004,6 +2458,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-openssl"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2475,30 @@ checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
 dependencies = [
  "openssl",
  "openssl-sys",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2030,6 +2518,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2091,6 +2585,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2159,6 +2659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,10 +2712,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wide"
@@ -2244,10 +2836,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -2360,3 +2991,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "edb/graphql-rewrite",
     "edb/server/conn_pool",
     "edb/server/pgrust",
+    "edb/server/http",
 ]
 resolver = "2"
 

--- a/edb/server/http/Cargo.toml
+++ b/edb/server/http/Cargo.toml
@@ -29,6 +29,7 @@ features = ["full"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+rstest = "0.23"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/edb/server/http/Cargo.toml
+++ b/edb/server/http/Cargo.toml
@@ -20,8 +20,6 @@ reqwest = { version = "0.12", features = ["gzip", "deflate"] }
 scopeguard = "1"
 
 futures = "0"
-serde = { version = "1", features = ["derive"] }
-serde-pickle = "1"
 
 [dependencies.derive_more]
 version = "1.0.0"

--- a/edb/server/http/Cargo.toml
+++ b/edb/server/http/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "http"
+version = "0.1.0"
+license = "MIT/Apache-2.0"
+authors = ["MagicStack Inc. <hello@magic.io>"]
+edition = "2021"
+
+[lints]
+workspace = true
+
+[features]
+python_extension = ["pyo3/extension-module"]
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+tokio.workspace = true
+tracing = "0"
+tracing-subscriber = "0"
+reqwest = { version = "0.12", features = ["gzip", "deflate"] }
+scopeguard = "1"
+
+futures = "0"
+serde = { version = "1", features = ["derive"] }
+serde-pickle = "1"
+
+[dependencies.derive_more]
+version = "1.0.0"
+features = ["full"]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "http"
+path = "src/lib.rs"

--- a/edb/server/http/src/lib.rs
+++ b/edb/server/http/src/lib.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "python_extension")]
+mod python;

--- a/edb/server/http/src/python.rs
+++ b/edb/server/http/src/python.rs
@@ -1,0 +1,400 @@
+use futures::future::poll_fn;
+use pyo3::{exceptions::PyException, prelude::*, types::PyByteArray};
+use reqwest::Method;
+use scopeguard::defer;
+use serde_pickle::SerOptions;
+use std::{
+    cell::RefCell, collections::HashMap, os::fd::IntoRawFd, pin::Pin, rc::Rc, sync::Mutex, thread,
+};
+use tokio::{
+    io::AsyncWrite,
+    sync::{AcquireError, Semaphore, SemaphorePermit},
+    task::LocalSet,
+};
+use tracing::{error, info, trace};
+
+pyo3::create_exception!(_http, InternalError, PyException);
+
+type PythonConnId = u64;
+
+#[derive(Debug)]
+enum RustToPythonMessage {
+    Response(PythonConnId, Vec<u8>),
+    Error(PythonConnId, String),
+}
+
+impl ToPyObject for RustToPythonMessage {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        use RustToPythonMessage::*;
+        match self {
+            Error(conn, error) => (0, *conn, error).to_object(py),
+            Response(conn, metrics) => {
+                (1, conn, PyByteArray::new_bound(py, &metrics)).to_object(py)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum PythonToRustMessage {
+    UpdateLimit(usize),
+    /// Acquire a connection.
+    Request(u64, String, String, Vec<u8>, Vec<(String, String)>),
+}
+
+type PipeSender = tokio::net::unix::pipe::Sender;
+
+struct RpcPipe {
+    rust_to_python_notify: RefCell<PipeSender>,
+    rust_to_python: std::sync::mpsc::Sender<RustToPythonMessage>,
+    python_to_rust: RefCell<tokio::sync::mpsc::UnboundedReceiver<PythonToRustMessage>>,
+}
+
+impl std::fmt::Debug for RpcPipe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RpcPipe")
+    }
+}
+
+impl RpcPipe {
+    async fn write(&self, msg: RustToPythonMessage) -> Result<(), String> {
+        self.rust_to_python.send(msg).map_err(|_| "Shutdown")?;
+        // If we're shutting down, this may fail (but that's OK)
+        poll_fn(|cx| {
+            let pipe = &mut *self.rust_to_python_notify.borrow_mut();
+            let this = Pin::new(pipe);
+            this.poll_write(cx, &[0])
+        })
+        .await
+        .map_err(|_| "Shutdown")?;
+        Ok(())
+    }
+}
+
+#[pyclass]
+struct Http {
+    python_to_rust: tokio::sync::mpsc::UnboundedSender<PythonToRustMessage>,
+    rust_to_python: std::sync::mpsc::Receiver<RustToPythonMessage>,
+    notify_fd: u64,
+}
+
+impl Drop for Http {
+    fn drop(&mut self) {
+        info!("Http dropped");
+    }
+}
+
+fn internal_error(message: &str) -> PyErr {
+    error!("{message}");
+    InternalError::new_err(())
+}
+
+async fn request(
+    client: reqwest::Client,
+    url: String,
+    method: String,
+    body: Vec<u8>,
+    headers: Vec<(String, String)>,
+) -> Result<(reqwest::StatusCode, Vec<u8>, HashMap<String, String>), String> {
+    let method =
+        Method::from_bytes(method.as_bytes()).map_err(|e| format!("Invalid HTTP method: {}", e))?;
+
+    let mut req = client.request(method, url);
+
+    for (key, value) in headers {
+        req = req.header(key, value);
+    }
+
+    if !body.is_empty() {
+        req = req.body(body);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
+
+    let status = resp.status();
+
+    let headers = resp
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+
+    let body = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read response body: {}", e))?
+        .to_vec();
+
+    Ok((status, body, headers))
+}
+
+struct PermitCount {
+    active: usize,
+    capacity: usize,
+}
+
+/// By default, the [`Semaphore`] does not allow for releasing permits that are currently
+/// outstanding. This allows us to keep a count of what the limit _should_ be, which we'll
+/// target if we've taken too many permits out by forgetting outstanding permits.
+struct PermitManager {
+    counts: Mutex<PermitCount>,
+    semaphore: Semaphore,
+}
+
+impl PermitManager {
+    fn new(capacity: usize) -> Self {
+        Self {
+            counts: Mutex::new(PermitCount {
+                active: 0,
+                capacity,
+            }),
+            semaphore: Semaphore::new(capacity),
+        }
+    }
+
+    async fn acquire(&self) -> Result<SemaphorePermit<'_>, AcquireError> {
+        let permit = self.semaphore.acquire().await?;
+        let mut counts = self.counts.lock().unwrap();
+        counts.active += 1;
+        Ok(permit)
+    }
+
+    fn release(&self, permit: SemaphorePermit<'_>) {
+        let mut counts = self.counts.lock().unwrap();
+        if counts.active > counts.capacity {
+            // We have too many permits, so forget this one instead of releasing
+            permit.forget();
+        } else {
+            // Normal release
+            drop(permit);
+        }
+        counts.active -= 1;
+    }
+
+    fn update_limit(&self, new_limit: usize) {
+        let mut counts = self.counts.lock().unwrap();
+        let old_capacity = counts.capacity;
+        counts.capacity = new_limit;
+
+        if new_limit > old_capacity {
+            let added = new_limit - old_capacity;
+            self.semaphore.add_permits(added);
+        } else if new_limit < old_capacity {
+            let removed = old_capacity - new_limit;
+            self.semaphore.forget_permits(removed);
+        }
+    }
+
+    #[cfg(test)]
+    fn active(&self) -> usize {
+        let counts = self.counts.lock().unwrap();
+        counts.active
+    }
+
+    #[cfg(test)]
+    fn capacity(&self) -> usize {
+        let counts = self.counts.lock().unwrap();
+        counts.capacity
+    }
+}
+
+async fn run_and_block(capacity: usize, rpc_pipe: RpcPipe) {
+    let rpc_pipe = Rc::new(rpc_pipe);
+
+    let client = reqwest::Client::new();
+    let permit_manager = Rc::new(PermitManager::new(capacity));
+
+    loop {
+        let Some(rpc) = poll_fn(|cx| rpc_pipe.python_to_rust.borrow_mut().poll_recv(cx)).await
+        else {
+            info!("Http shutting down");
+            break;
+        };
+        let client = client.clone();
+        trace!("Received RPC: {rpc:?}");
+        let rpc_pipe = rpc_pipe.clone();
+        let permit_manager = permit_manager.clone();
+        tokio::task::spawn_local(async move {
+            use PythonToRustMessage::*;
+            match rpc {
+                UpdateLimit(limit) => {
+                    permit_manager.update_limit(limit);
+                }
+                Request(id, url, method, body, headers) => {
+                    eprintln!("Getting permit");
+                    let Ok(permit) = permit_manager.acquire().await else {
+                        return;
+                    };
+                    eprintln!("Got permit");
+                    defer!(permit_manager.release(permit));
+                    match request(client, url, method, body, headers).await {
+                        Ok((status, body, headers)) => {
+                            _ = rpc_pipe
+                                .write(RustToPythonMessage::Response(
+                                    id,
+                                    serde_pickle::to_vec(
+                                        &(status.as_u16(), body, headers),
+                                        SerOptions::default(),
+                                    )
+                                    .unwrap(),
+                                ))
+                                .await;
+                        }
+                        Err(err) => {
+                            _ = rpc_pipe.write(RustToPythonMessage::Error(id, err)).await;
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+#[pymethods]
+impl Http {
+    /// Create the connection pool and automatically boot a tokio runtime on a
+    /// new thread. When this class is GC'd, the thread will be torn down.
+    #[new]
+    fn new(max_capacity: usize) -> Self {
+        info!("Http::new(max_capacity={max_capacity})");
+        let (txrp, rxrp) = std::sync::mpsc::channel();
+        let (txpr, rxpr) = tokio::sync::mpsc::unbounded_channel();
+        let (txfd, rxfd) = std::sync::mpsc::channel();
+
+        thread::spawn(move || {
+            info!("Rust-side Http thread booted");
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .enable_io()
+                .build()
+                .unwrap();
+            let _guard = rt.enter();
+            let (txn, rxn) = tokio::net::unix::pipe::pipe().unwrap();
+            let fd = rxn.into_nonblocking_fd().unwrap().into_raw_fd() as u64;
+            txfd.send(fd).unwrap();
+            let local = LocalSet::new();
+
+            let rpc_pipe = RpcPipe {
+                python_to_rust: rxpr.into(),
+                rust_to_python: txrp,
+                rust_to_python_notify: txn.into(),
+            };
+
+            local.block_on(&rt, run_and_block(max_capacity, rpc_pipe));
+        });
+
+        let notify_fd = rxfd.recv().unwrap();
+        Http {
+            python_to_rust: txpr,
+            rust_to_python: rxrp,
+            notify_fd,
+        }
+    }
+
+    #[getter]
+    fn _fd(&self) -> u64 {
+        self.notify_fd
+    }
+
+    fn _request(
+        &self,
+        id: u64,
+        url: String,
+        method: String,
+        body: Vec<u8>,
+        headers: Vec<(String, String)>,
+    ) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::Request(id, url, method, body, headers))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _update_limit(&self, limit: usize) -> PyResult<()> {
+        self.python_to_rust
+            .send(PythonToRustMessage::UpdateLimit(limit))
+            .map_err(|_| internal_error("In shutdown"))
+    }
+
+    fn _read(&self, py: Python<'_>) -> Py<PyAny> {
+        let Ok(msg) = self.rust_to_python.recv() else {
+            return py.None();
+        };
+        msg.to_object(py)
+    }
+
+    fn _try_read(&self, py: Python<'_>) -> Py<PyAny> {
+        let Ok(msg) = self.rust_to_python.try_recv() else {
+            return py.None();
+        };
+        msg.to_object(py)
+    }
+}
+
+#[pymodule]
+fn _http(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_class::<Http>()?;
+    m.add("InternalError", py.get_type_bound::<InternalError>())?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_permit_manager() {
+        let manager = Arc::new(PermitManager::new(5));
+
+        // Shared done flag
+        let done = Arc::new(AtomicBool::new(false));
+
+        // Create 100 tasks
+        let tasks = (0..100)
+            .map(|_| {
+                let manager = manager.clone();
+                let done = done.clone();
+                tokio::spawn(async move {
+                    loop {
+                        if done.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let permit = manager.acquire().await.unwrap();
+                        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+                        manager.release(permit);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // Create a task that changes the limit between 1..10 every 1ms
+        {
+            let manager = manager.clone();
+            tokio::spawn(async move {
+                for i in 1..100 {
+                    manager.update_limit(i % 10 + 1);
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                }
+            })
+            .await
+            .unwrap();
+        }
+
+        done.store(true, Ordering::Relaxed);
+
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        assert_eq!(manager.active(), 0);
+        assert_eq!(manager.capacity(), 10);
+    }
+}

--- a/edb/server/http/src/python.rs
+++ b/edb/server/http/src/python.rs
@@ -37,9 +37,10 @@ impl ToPyObject for RustToPythonMessage {
 
 #[derive(Debug)]
 enum PythonToRustMessage {
+    /// Update the inflight limit
     UpdateLimit(usize),
-    /// Acquire a connection.
-    Request(u64, String, String, Vec<u8>, Vec<(String, String)>),
+    /// Perform a request
+    Request(PythonConnId, String, String, Vec<u8>, Vec<(String, String)>),
 }
 
 type PipeSender = tokio::net::unix::pipe::Sender;
@@ -253,7 +254,7 @@ async fn run_and_block(capacity: usize, rpc_pipe: RpcPipe) {
 
 #[pymethods]
 impl Http {
-    /// Create the connection pool and automatically boot a tokio runtime on a
+    /// Create the HTTP pool and automatically boot a tokio runtime on a
     /// new thread. When this class is GC'd, the thread will be torn down.
     #[new]
     fn new(max_capacity: usize) -> Self {
@@ -299,7 +300,7 @@ impl Http {
 
     fn _request(
         &self,
-        id: u64,
+        id: PythonConnId,
         url: String,
         method: String,
         body: Vec<u8>,

--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -40,7 +40,7 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger("edb.server")
 
-POLLING_INTERVAL = statypes.Duration(microseconds=1 * 1_000_000)  # 10 seconds
+POLLING_INTERVAL = statypes.Duration(microseconds=10 * 1_000_000)  # 10 seconds
 
 
 async def _http_task(tenant: edbtenant.Tenant, http_client) -> None:

--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -30,7 +30,7 @@ import pickle
 from edb.ir import statypes
 from edb.server import defines
 from edb.server.protocol import execute
-from edb.server import _http
+from edb.server._http import Http
 from edb.common import retryloop
 from . import dbview
 
@@ -96,7 +96,7 @@ async def _http_task(tenant: edbtenant.Tenant, http_client) -> None:
 
 class HttpClient:
     def __init__(self, limit: int):
-        self._client = _http.Http(limit)
+        self._client = Http(limit)
         self._fd = self._client._fd
         self._task = None
         self._skip_reads = 0
@@ -292,8 +292,7 @@ async def handle_request(
                             )
                             else (<nh::Response>{})
                         ),
-                        FOUND := <nh::ScheduledRequest><uuid>$id,
-                    update FOUND
+                    update nh::ScheduledRequest filter .id = <uuid>$id
                     set {
                         state := state,
                         response := response,

--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -25,7 +25,6 @@ import asyncio
 import logging
 import base64
 import os
-import pickle
 
 from edb.ir import statypes
 from edb.server import defines
@@ -231,13 +230,12 @@ async def handle_request(
             if request.headers
             else None
         )
-        response_encoded = await client.request(
+        response = await client.request(
             method=request.method,
             url=request.url,
             content=request.body,
             headers=headers,
         )
-        response = pickle.loads(response_encoded)
         response_status, response_bytes, response_hdict = response
         response_body = bytes(response_bytes)
         response_headers = list(response_hdict.items())

--- a/setup.py
+++ b/setup.py
@@ -1140,5 +1140,11 @@ setuptools.setup(
             features=["python_extension"],
             binding=setuptools_rust.Binding.PyO3,
         ),
+        setuptools_rust.RustExtension(
+            "edb.server._http",
+            path="edb/server/http/Cargo.toml",
+            features=["python_extension"],
+            binding=setuptools_rust.Binding.PyO3,
+        ),
     ],
 )

--- a/tests/test_http_std_net.py
+++ b/tests/test_http_std_net.py
@@ -133,6 +133,7 @@ class StdNetTestCase(server.QueryTestCase):
             url=url,
         )
 
+        requests_for_example = None
         async for tr in self.try_until_succeeds(
             delay=2, timeout=120, ignore=(KeyError,)
         ):
@@ -141,6 +142,7 @@ class StdNetTestCase(server.QueryTestCase):
                     example_request
                 ]
 
+        assert requests_for_example is not None
         self.assertEqual(len(requests_for_example), 1)
         headers = list(requests_for_example[0]["headers"].items())
         self.assertIn(("accept", "application/json"), headers)
@@ -154,8 +156,12 @@ class StdNetTestCase(server.QueryTestCase):
         self.assertEqual(str(table_result.state), 'Completed')
         self.assertIsNone(table_result.failure)
         self.assertEqual(table_result.response.status, 200)
-        self.assertEqual(json.loads(table_result.response.body), {"message": "Hello, world!"})
-        self.assertIn(("content-type", "application/json"), table_result.response.headers)
+        self.assertEqual(
+            json.loads(table_result.response.body), {"message": "Hello, world!"}
+        )
+        self.assertIn(
+            ("content-type", "application/json"), table_result.response.headers
+        )
 
     async def test_http_std_net_con_schedule_request_post_01(self):
         assert self.mock_server is not None
@@ -202,6 +208,7 @@ class StdNetTestCase(server.QueryTestCase):
             body=b"Hello, world!",
         )
 
+        requests_for_example = None
         async for tr in self.try_until_succeeds(
             delay=2, timeout=120, ignore=(KeyError,)
         ):
@@ -210,6 +217,7 @@ class StdNetTestCase(server.QueryTestCase):
                     example_request
                 ]
 
+        assert requests_for_example is not None
         self.assertEqual(len(requests_for_example), 1)
         headers = list(requests_for_example[0]["headers"].items())
         self.assertIn(("accept", "application/json"), headers)
@@ -224,8 +232,12 @@ class StdNetTestCase(server.QueryTestCase):
         self.assertEqual(str(table_result.state), 'Completed')
         self.assertIsNone(table_result.failure)
         self.assertEqual(table_result.response.status, 200)
-        self.assertEqual(json.loads(table_result.response.body), {"message": "Hello, world!"})
-        self.assertIn(("content-type", "application/json"), table_result.response.headers)
+        self.assertEqual(
+            json.loads(table_result.response.body), {"message": "Hello, world!"}
+        )
+        self.assertIn(
+            ("content-type", "application/json"), table_result.response.headers
+        )
 
     async def test_http_std_net_con_schedule_request_bad_address(self):
         # Test a request to a known-bad address

--- a/tests/test_http_std_net.py
+++ b/tests/test_http_std_net.py
@@ -38,6 +38,56 @@ class StdNetTestCase(server.QueryTestCase):
             self.mock_server.stop()
         self.mock_server = None
 
+    async def _wait_for_request_completion(self, request_id: str):
+        async for tr in self.try_until_succeeds(
+            delay=2, timeout=120, ignore=(AssertionError,)
+        ):
+            async with tr:
+                updated_result = await self.con.query_single(
+                    """
+                    with
+                        nh as module std::net::http,
+                        net as module std::net,
+                        request := (
+                            select nh::ScheduledRequest
+                            filter .id = <uuid>$id
+                        )
+                    select request {
+                        id,
+                        state,
+                        failure,
+                    };
+                    """,
+                    id=request_id,
+                )
+                state = str(updated_result.state)
+                self.assertNotEqual(state, 'Pending')
+                self.assertNotEqual(state, 'InProgress')
+
+    async def _get_final_request_result(self, request_id: str):
+        return await self.con.query_single(
+            """
+            with
+                nh as module std::net::http,
+                net as module std::net,
+                request := (
+                    select nh::ScheduledRequest
+                    filter .id = <uuid>$id
+                )
+            select request {
+                id,
+                state,
+                failure,
+                response: {
+                    status,
+                    body,
+                    headers
+                }
+            };
+            """,
+            id=request_id,
+        )
+
     async def test_http_std_net_con_schedule_request_get_01(self):
         assert self.mock_server is not None
 
@@ -59,7 +109,7 @@ class StdNetTestCase(server.QueryTestCase):
             )
         )
 
-        await self.con.query(
+        result = await self.con.query_single(
             """
             with
                 nh as module std::net::http,
@@ -73,7 +123,7 @@ class StdNetTestCase(server.QueryTestCase):
                         url := url,
                         method := nh::Method.`GET`,
                         headers := [
-                            ("Accept", "text/plain"),
+                            ("Accept", "application/json"),
                             ("x-test-header", "test-value"),
                         ],
                     }
@@ -93,8 +143,19 @@ class StdNetTestCase(server.QueryTestCase):
 
         self.assertEqual(len(requests_for_example), 1)
         headers = list(requests_for_example[0]["headers"].items())
-        self.assertIn(("accept", "text/plain"), headers)
+        self.assertIn(("accept", "application/json"), headers)
         self.assertIn(("x-test-header", "test-value"), headers)
+
+        # Wait for the request to complete
+        await self._wait_for_request_completion(result.id)
+
+        # Check the table as well
+        table_result = await self._get_final_request_result(result.id)
+        self.assertEqual(str(table_result.state), 'Completed')
+        self.assertIsNone(table_result.failure)
+        self.assertEqual(table_result.response.status, 200)
+        self.assertEqual(json.loads(table_result.response.body), {"message": "Hello, world!"})
+        self.assertIn(("content-type", "application/json"), table_result.response.headers)
 
     async def test_http_std_net_con_schedule_request_post_01(self):
         assert self.mock_server is not None
@@ -117,7 +178,7 @@ class StdNetTestCase(server.QueryTestCase):
             )
         )
 
-        await self.con.query(
+        result = await self.con.query_single(
             """
             with
                 nh as module std::net::http,
@@ -129,7 +190,7 @@ class StdNetTestCase(server.QueryTestCase):
                         url,
                         method := nh::Method.POST,
                         headers := [
-                            ("Accept", "text/plain"),
+                            ("Accept", "application/json"),
                             ("x-test-header", "test-value"),
                         ],
                         body := body,
@@ -151,6 +212,49 @@ class StdNetTestCase(server.QueryTestCase):
 
         self.assertEqual(len(requests_for_example), 1)
         headers = list(requests_for_example[0]["headers"].items())
-        self.assertIn(("accept", "text/plain"), headers)
+        self.assertIn(("accept", "application/json"), headers)
         self.assertIn(("x-test-header", "test-value"), headers)
         self.assertEqual(requests_for_example[0]["body"], "Hello, world!")
+
+        # Wait for the request to complete
+        await self._wait_for_request_completion(result.id)
+
+        # Check the final result
+        table_result = await self._get_final_request_result(result.id)
+        self.assertEqual(str(table_result.state), 'Completed')
+        self.assertIsNone(table_result.failure)
+        self.assertEqual(table_result.response.status, 200)
+        self.assertEqual(json.loads(table_result.response.body), {"message": "Hello, world!"})
+        self.assertIn(("content-type", "application/json"), table_result.response.headers)
+
+    async def test_http_std_net_con_schedule_request_bad_address(self):
+        # Test a request to a known-bad address
+        bad_url = "http://256.256.256.256"
+
+        result = await self.con.query_single(
+            """
+            with
+                nh as module std::net::http,
+                net as module std::net,
+                url := <str>$url,
+                request := (
+                    nh::schedule_request(
+                        url,
+                        method := nh::Method.`GET`
+                    )
+                )
+            select request {
+                id,
+                state,
+                failure,
+            };
+            """,
+            url=bad_url,
+        )
+
+        await self._wait_for_request_completion(result.id)
+        table_result = await self._get_final_request_result(result.id)
+        self.assertEqual(str(table_result.state), 'Failed')
+        self.assertIsNotNone(table_result.failure)
+        self.assertEqual(str(table_result.failure.kind), 'NetworkError')
+        self.assertIsNone(table_result.response)


### PR DESCRIPTION
Migrate std::net to a new Rust library that provides access to `reqwest` to Python code.

Enhances the std::net tests to fully test the output of the network request, as well as adding an error-case test.
