### PR TITLE
Persist SQL param indexes over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/__init__.py
+++ b/edb/pgsql/resolver/__init__.py
@@ -67,6 +67,7 @@ def resolve(
 
     _ = context.ResolverContext(initial=ctx)
 
+    command.init_external_params(query, ctx)
     top_level_ctes = command.compile_dml(query, ctx=ctx)
 
     resolved = dispatch.resolve(query, ctx=ctx)

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -29,7 +29,6 @@ from edb.pgsql import ast as pgast
 from edb.pgsql import common
 from edb.pgsql import compiler as pgcompiler
 from edb.pgsql.compiler import enums as pgce
-from edb.server.compiler import dbstate
 
 from edb.schema import types as s_types
 
@@ -513,20 +512,8 @@ def resolve_ParamRef(
     *,
     ctx: Context,
 ) -> pgast.ParamRef:
-    internal_index: Optional[int] = None
-    param: Optional[dbstate.SQLParam] = None
-    for i, p in enumerate(ctx.query_params):
-        if isinstance(p, dbstate.SQLParamExternal) and p.index == expr.number:
-            param = p
-            internal_index = i + 1
-            break
-    if not param:
-        param = dbstate.SQLParamExternal(index=expr.number)
-        internal_index = len(ctx.query_params) + 1
-        ctx.query_params.append(param)
-    assert internal_index
-
-    return pgast.ParamRef(number=internal_index)
+    # external params map one-to-one to internal params
+    return expr
 
 
 @dispatch._resolve.register

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -600,8 +600,8 @@ class SQLParamExternal(SQLParam):
     # An internal query param whose value is provided by an external param.
     # So a user-visible param.
 
-    # External index
-    index: int
+    # External params share the index with internal params
+    pass
 
 
 @dataclasses.dataclass(kw_only=True, eq=False, slots=True, repr=False)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1789,9 +1789,9 @@ cdef class PGConnection:
                     external_params: int64_t = 0
                     if action.query_unit.params:
                         for index, param in enumerate(action.query_unit.params):
-                            external_params = index + 1
                             if not isinstance(param, dbstate.SQLParamExternal):
                                 break
+                            external_params = index + 1
 
                     msg_buf.write_int16(external_params)
                     msg_buf.write_bytes(data_internal[0:external_params * 4])

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -1638,9 +1638,9 @@ cdef WriteBuffer remap_arguments(
 
         param_count_external = 0
         for i, param in enumerate(params):
-            param_count_external = i + 1
             if not isinstance(param, dbstate.SQLParamExternal):
                 break
+            param_count_external = i + 1
         if param_count_external != arg_count_external:
             raise pgerror.new(
                 pgerror.ERROR_PROTOCOL_VIOLATION,

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -1585,7 +1585,8 @@ cdef WriteBuffer remap_arguments(
     cdef:
         int16_t param_format_count
         int32_t offset
-        int16_t max_external_used
+        int32_t arg_offset_external
+        int16_t param_count_external
         int32_t size
 
     # The "external" parameters (that are visible to the user)
@@ -1621,30 +1622,40 @@ cdef WriteBuffer remap_arguments(
     offset += param_format_count * 2
 
     # find positions of external args
-    param_count_external = read_int16(data[offset:offset+2])
+    arg_count_external = read_int16(data[offset:offset+2])
     offset += 2
-    param_pos_external = []
-    for p in range(param_count_external):
+    arg_offset_external = offset
+    for p in range(arg_count_external):
         size = read_int32(data[offset:offset+4])
         if size == -1:  # special case: NULL
             size = 0
         size += 4 # for size which is int32
-        param_pos_external.append((offset, size))
         offset += size
 
     # write remapped args
-    max_external_used = 0
     if params:
         buf.write_int16(len(params))
-        for param in params:
-            if isinstance(param, dbstate.SQLParamExternal):
-                # map external arg to internal
-                o, s = param_pos_external[param.index - 1]
-                buf.write_bytes(data[o:o+s])
 
-                if max_external_used < param.index:
-                    max_external_used = param.index
-            elif isinstance(param, dbstate.SQLParamGlobal):
+        param_count_external = 0
+        for i, param in enumerate(params):
+            param_count_external = i + 1
+            if not isinstance(param, dbstate.SQLParamExternal):
+                break
+        if param_count_external != arg_count_external:
+            raise pgerror.new(
+                pgerror.ERROR_PROTOCOL_VIOLATION,
+                f'bind message supplies {arg_count_external} '
+                f'parameters, but prepared statement "" requires '
+                f'{param_count_external}',
+            )
+
+        # write external args
+        if arg_offset_external < offset:
+            buf.write_bytes(data[arg_offset_external:offset])
+
+        # write global's args
+        for param in params[param_count_external:]:
+            if isinstance(param, dbstate.SQLParamGlobal):
                 name = param.global_name
                 setting_name = f'global {name.module}::{name.name}'
                 values = fe_settings.get(setting_name, None)
@@ -1656,14 +1667,7 @@ cdef WriteBuffer remap_arguments(
     else:
         buf.write_int16(0)
 
-    if max_external_used != param_count_external:
-        raise pgerror.new(
-            pgerror.ERROR_PROTOCOL_VIOLATION,
-            f'bind message supplies {param_count_external} '
-            f'parameters, but prepared statement "" requires '
-            f'{max_external_used}',
-        )
-
+    # result format codes
     buf.write_bytes(data[offset:])
     return buf
 


### PR DESCRIPTION
Followup for #7748

Changes how we resolve SQL params. Previous behavior was determine order of internal SQL params by the order of resolver AST pass. This meant that we sometimes had to reorder params and args in pg protocol. The benefit of this was that we did not need to know how many params there are in the query in advance.

But there was a bug somewhere, because Java PostgreSQL driver was throwing errors which I was not able to repro using asyncpg.

Now I've added a pre-resolving AST pass that counts number of params, which allows internal and external SQL params to use same indexes. Which allows for simpler and faster pg protocol arg handling. But means a bit slower resolver.
