### PR TITLE
Inject type casts into DML value relations for all types over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -678,6 +678,7 @@ def _uncompile_insert_pointer_stmt(
     )
     value_columns: List[Tuple[str, bool]] = []
     for index, expected_col in enumerate(expected_columns):
+        ptr: Optional[s_pointers.Pointer] = None
         if expected_col.name == 'source':
             ptr_name = 'source'
             is_link = True
@@ -709,6 +710,7 @@ def _uncompile_insert_pointer_stmt(
                 value_relation, index, pgast.TypeName(name=('uuid',))
             )
         else:
+            assert ptr
             _try_inject_ptr_type_cast(value_relation, index, ptr, ctx)
 
         value_columns.append((ptr_name, is_link))

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -356,10 +356,7 @@ def _uncompile_insert_object_stmt(
         value_columns.append((ptr_name, is_link))
 
         # inject type annotation into value relation
-        if is_link or ptr_name == 'id':
-            _try_inject_type_cast(
-                value_relation, index, pgast.TypeName(name=('uuid',))
-            )
+        _try_inject_ptr_type_cast(value_relation, index, ptr, ctx)
 
         # prepare the outputs of the source CTE
         ptr_id = _get_ptr_id(value_id, ptr, ctx)
@@ -706,10 +703,7 @@ def _uncompile_insert_pointer_stmt(
         value_rel.path_outputs[(ptr_id, pgce.PathAspect.VALUE)] = var
 
         # inject type annotation into value relation
-        if is_link:
-            _try_inject_type_cast(
-                value_relation, index, pgast.TypeName(name=('uuid',))
-            )
+        _try_inject_ptr_type_cast(value_relation, index, ptr, ctx)
 
         value_columns.append((ptr_name, is_link))
 
@@ -1424,10 +1418,7 @@ def _uncompile_update_object_stmt(
             value_columns.append((ptr_name, is_link))
 
         # inject type annotation into value relation
-        if is_link:
-            _try_inject_type_cast(
-                value_relation, index + 1, pgast.TypeName(name=('uuid',))
-            )
+        _try_inject_ptr_type_cast(value_relation, index + 1, ptr, ctx)
 
         # prepare the outputs of the source CTE
         ptr_id = _get_ptr_id(value_id, ptr, ctx)
@@ -2014,6 +2005,21 @@ def _get_ptr_id(
     return source_id.extend(ptrref=ptrref)
 
 
+def _try_inject_ptr_type_cast(
+    rel: pgast.BaseRelation, index: int, ptr: s_pointers.Pointer, ctx: Context
+):
+    ptr_name = ptr.get_shortname(ctx.schema).name
+
+    tgt_pg: Tuple[str, ...]
+    if ptr_name == 'id' or isinstance(ptr, s_links.Link):
+        tgt_pg = ('uuid',)
+    else:
+        tgt = ptr.get_target(ctx.schema)
+        assert tgt
+        tgt_pg = pgtypes.pg_type_from_object(ctx.schema, tgt)
+    _try_inject_type_cast(rel, index, pgast.TypeName(name=tgt_pg))
+
+
 def _try_inject_type_cast(
     rel: pgast.BaseRelation,
     pos: int,
@@ -2022,7 +2028,16 @@ def _try_inject_type_cast(
     """
     If a relation is simple, injects type annotation for a column.
     This is needed for Postgres to correctly infer the type so it will be able
-    to bind to correct paramater types.
+    to bind to correct paramater types. For example:
+
+    INSERT x (a, b) VALUES ($1, $2)
+
+    is compiled into something like:
+
+    WITH cte AS (VALUES ($1, $2))
+    INSERT x (a, b) SELECT * FROM cte
+
+    This function adds type casts into `cte`.
     """
 
     if not isinstance(rel, pgast.SelectStmt):

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -685,6 +685,7 @@ def _uncompile_insert_pointer_stmt(
         elif expected_col.name == 'target':
             ptr_name = 'target'
             is_link = isinstance(sub, s_links.Link)
+            ptr = sub
             ptr_id = target_id
         else:
             # link pointer
@@ -703,7 +704,12 @@ def _uncompile_insert_pointer_stmt(
         value_rel.path_outputs[(ptr_id, pgce.PathAspect.VALUE)] = var
 
         # inject type annotation into value relation
-        _try_inject_ptr_type_cast(value_relation, index, ptr, ctx)
+        if is_link:
+            _try_inject_type_cast(
+                value_relation, index, pgast.TypeName(name=('uuid',))
+            )
+        else:
+            _try_inject_ptr_type_cast(value_relation, index, ptr, ctx)
 
         value_columns.append((ptr_name, is_link))
 
@@ -721,7 +727,8 @@ def _uncompile_insert_pointer_stmt(
     sub_name = sub.get_shortname(ctx.schema)
 
     target_ql: qlast.Expr = qlast.Path(
-        steps=[value_ql, qlast.Ptr(name='__target__')])
+        steps=[value_ql, qlast.Ptr(name='__target__')]
+    )
 
     if isinstance(sub_target, s_objtypes.ObjectType):
         assert isinstance(target_ql, qlast.Path)

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -735,6 +735,26 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         res = await self.squery_values("SELECT x'00abcdef00';")
         self.assertEqual(res, [[b'\x00\xab\xcd\xef\x00']])
 
+    async def test_sql_query_42(self):
+        # params out of order
+
+        res = await self.squery_values(
+            'SELECT $2::int, $3::bool, $1::text', 'hello', 42, True,
+        )
+        self.assertEqual(res, [[42, True, 'hello']])
+
+        tran = self.scon.transaction()
+        await tran.start()
+        res = await self.scon.execute(
+            '''
+            UPDATE "Book" SET pages = $1 WHERE (title = $2)
+            ''',
+            207,
+            'Chronicles of Narnia',
+        )
+        self.assertEqual(res, 'UPDATE 1')
+        await tran.rollback()
+
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname
         res = await self.squery_values(


### PR DESCRIPTION
```sql
INSERT x (a, b) VALUES ($1, $2)
```

... is compiled into something like:

```sql
WITH cte AS (VALUES ($1, $2))
INSERT x (a, b) SELECT * FROM cte
```

Clients expect PostgreSQL to infer types of $1 and $2. Which it is able to do in first case, but not in the second.

This PR injects type casts into `cte` relation which enabled PostgreSQL to correctly infer types.
