### PR TITLE
Fix shape not being copied when inlining parameters.

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -498,7 +498,7 @@ class ArgumentInliner(ast.NodeTransformer):
                 # Inline param as an expr ref. The pg compiler will find the
                 # appropriate rvar.
                 self.mapped_args[node.path_id] = arg.expr.path_id
-                return setgen.ensure_set(
+                inlined_param_expr = setgen.ensure_set(
                     irast.InlinedParameterExpr(
                         typeref=arg.expr.typeref,
                         required=node.expr.required,
@@ -507,6 +507,8 @@ class ArgumentInliner(ast.NodeTransformer):
                     path_id=arg.expr.path_id,
                     ctx=self.ctx,
                 )
+                inlined_param_expr.shape = node.shape
+                return inlined_param_expr
             else:
                 # Directly inline the set.
                 # Used for default values, which are constants.

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -11877,8 +11877,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             ],
         )
 
-    @unittest.skip('TODO: Inlining parameters with link properties')
-    async def test_edgeql_functions_inline_insert_link_04(self):
+    async def test_edgeql_functions_inline_insert_linkprop_01(self):
         await self.con.execute('''
             create type Bar {
                 create required property a -> int64;
@@ -11899,7 +11898,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             'select foo('
-            '    (select Bar filter .a = 1 limit 1)'
+            '    assert_exists((select Bar filter .a = 1 limit 1))'
             '){a := .bar.a, b := .bar@b}',
             [{'a': 1, 'b': 10}],
         )
@@ -11908,8 +11907,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [{'a': 1, 'b': 10}],
         )
 
-    @unittest.skip('TODO: Inlining parameters with link properties')
-    async def test_edgeql_functions_inline_insert_link_05(self):
+    async def test_edgeql_functions_inline_insert_linkprop_02(self):
         await self.con.execute('''
             create type Bar {
                 create required property a -> int64;
@@ -11931,7 +11929,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             'select foo('
             '    4,'
-            '    (select Bar filter .a = 1 limit 1)'
+            '    assert_exists((select Bar filter .a = 1 limit 1))'
             '){a := .bar.a, b := .bar@b}',
             [{'a': 1, 'b': 4}],
         )


### PR DESCRIPTION
This fixes linkprops not working in dml functions.

related #7692 