### PR TITLE
workflow: Always use `github.sha` when building

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -2,7 +2,6 @@
   prep:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.whichver.outputs.branch }}
 <% if subdist == "nightly" %>
 <% for tgt in targets.linux + targets.macos %>
       if_<< tgt.name.replace('-', '_') >>: ${{ steps.scm.outputs.if_<< tgt.name.replace('-', '_') >> }}
@@ -10,13 +9,6 @@
 <% endif %>
     steps:
     - uses: actions/checkout@v4
-
-    - name: Determine package version
-      shell: bash
-      run: |
-        branch=${GITHUB_REF#refs/heads/}
-        echo branch="${branch}" >> $GITHUB_OUTPUT
-      id: whichver
 
 <% if subdist == "nightly" %>
     - name: Determine SCM revision
@@ -93,7 +85,7 @@
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/<< plat_id >>@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         <%- if subdist != "" %>
         PKG_SUBDIST: "<< subdist >>"
@@ -175,7 +167,7 @@
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         <%- if subdist != "nightly" %>
         BUILD_IS_RELEASE: "true"
         <%- endif %>

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -8,7 +8,6 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.whichver.outputs.branch }}
 
 
       if_debian_buster_x86_64: ${{ steps.scm.outputs.if_debian_buster_x86_64 }}
@@ -62,13 +61,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Determine package version
-      shell: bash
-      run: |
-        branch=${GITHUB_REF#refs/heads/}
-        echo branch="${branch}" >> $GITHUB_OUTPUT
-      id: whichver
 
 
     - name: Determine SCM revision
@@ -440,7 +432,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -464,7 +456,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -488,7 +480,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -512,7 +504,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -536,7 +528,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -560,7 +552,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -584,7 +576,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -608,7 +600,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -632,7 +624,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -656,7 +648,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -680,7 +672,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -704,7 +696,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -728,7 +720,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -752,7 +744,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -776,7 +768,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "centos"
@@ -800,7 +792,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "centos"
@@ -824,7 +816,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "rockylinux"
@@ -848,7 +840,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "rockylinux"
@@ -872,7 +864,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -897,7 +889,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -922,7 +914,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -948,7 +940,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -1017,7 +1009,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "macos"
@@ -1088,7 +1080,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "macos"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,6 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.whichver.outputs.branch }}
 
 
       if_debian_buster_x86_64: ${{ steps.scm.outputs.if_debian_buster_x86_64 }}
@@ -67,13 +66,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Determine package version
-      shell: bash
-      run: |
-        branch=${GITHUB_REF#refs/heads/}
-        echo branch="${branch}" >> $GITHUB_OUTPUT
-      id: whichver
 
 
     - name: Determine SCM revision
@@ -445,7 +437,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -469,7 +461,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -493,7 +485,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -517,7 +509,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -541,7 +533,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -565,7 +557,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -589,7 +581,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -613,7 +605,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -637,7 +629,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -661,7 +653,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -685,7 +677,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -709,7 +701,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -733,7 +725,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -757,7 +749,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -781,7 +773,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "centos"
@@ -805,7 +797,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "centos"
@@ -829,7 +821,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "rockylinux"
@@ -853,7 +845,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "rockylinux"
@@ -877,7 +869,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -902,7 +894,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -927,7 +919,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -953,7 +945,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
@@ -1022,7 +1014,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "macos"
@@ -1093,7 +1085,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "macos"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,9 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.whichver.outputs.branch }}
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Determine package version
-      shell: bash
-      run: |
-        branch=${GITHUB_REF#refs/heads/}
-        echo branch="${branch}" >> $GITHUB_OUTPUT
-      id: whichver
 
 
 
@@ -31,7 +23,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "buster"
@@ -53,7 +45,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "buster"
@@ -75,7 +67,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
@@ -97,7 +89,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
@@ -119,7 +111,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
@@ -141,7 +133,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
@@ -163,7 +155,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "bionic"
@@ -185,7 +177,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "bionic"
@@ -207,7 +199,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "focal"
@@ -229,7 +221,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "focal"
@@ -251,7 +243,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "jammy"
@@ -273,7 +265,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "jammy"
@@ -295,7 +287,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "noble"
@@ -317,7 +309,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "noble"
@@ -339,7 +331,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "8"
@@ -361,7 +353,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "8"
@@ -383,7 +375,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
@@ -405,7 +397,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
@@ -427,7 +419,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "x86_64"
@@ -450,7 +442,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
@@ -473,7 +465,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "x86_64"
@@ -497,7 +489,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
@@ -564,7 +556,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "macos"
@@ -633,7 +625,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "macos"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,17 +8,9 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.whichver.outputs.branch }}
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Determine package version
-      shell: bash
-      run: |
-        branch=${GITHUB_REF#refs/heads/}
-        echo branch="${branch}" >> $GITHUB_OUTPUT
-      id: whichver
 
 
 
@@ -31,7 +23,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
@@ -54,7 +46,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
@@ -77,7 +69,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
@@ -100,7 +92,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
@@ -123,7 +115,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
@@ -146,7 +138,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
@@ -169,7 +161,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -192,7 +184,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -215,7 +207,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -238,7 +230,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -261,7 +253,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -284,7 +276,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -307,7 +299,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -330,7 +322,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "ubuntu"
@@ -353,7 +345,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "centos"
@@ -376,7 +368,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "centos"
@@ -399,7 +391,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "rockylinux"
@@ -422,7 +414,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "rockylinux"
@@ -445,7 +437,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "linux"
@@ -469,7 +461,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "linux"
@@ -493,7 +485,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "linux"
@@ -518,7 +510,7 @@ jobs:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "linux"
@@ -586,7 +578,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"
@@ -656,7 +648,7 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        SRC_REF: "${{ github.sha }}"
         BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "testing"


### PR DESCRIPTION
Building from a branch results in builds being inconsistent across the
build matrix as they'll potentially be building different revisions.
`metapkg` does not require `SRC_REF` to be a name, it can figure out the
version from a hash just as well.
