### PR TITLE
Fix RETURNING clause rel var name resolution over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -1888,7 +1888,7 @@ def _fini_resolve_dml(
     if stmt.returning_list:
         assert isinstance(stmt.relation.relation, pgast.Relation)
         assert stmt.relation.relation.name
-        
+
         res_query, res_table = _resolve_returning_rows(
             stmt.returning_list,
             compiled_dml.output_relation_name,

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -1886,10 +1886,14 @@ def _fini_resolve_dml(
     stmt: pgast.DMLQuery, compiled_dml: context.CompiledDML, *, ctx: Context
 ) -> Tuple[pgast.Query, context.Table]:
     if stmt.returning_list:
+        assert isinstance(stmt.relation.relation, pgast.Relation)
+        assert stmt.relation.relation.name
+        
         res_query, res_table = _resolve_returning_rows(
             stmt.returning_list,
             compiled_dml.output_relation_name,
             compiled_dml.output_namespace,
+            stmt.relation.relation.name,
             stmt.relation.alias.aliasname,
             ctx,
         )
@@ -1930,6 +1934,7 @@ def _resolve_returning_rows(
     returning_list: List[pgast.ResTarget],
     output_relation_name: str,
     output_namespace: Mapping[str, pgast.BaseExpr],
+    subject_name: str,
     subject_alias: Optional[str],
     ctx: context.ResolverContextLevel,
 ) -> Tuple[pgast.Query, context.Table]:
@@ -1943,6 +1948,7 @@ def _resolve_returning_rows(
         ]
     )
     inserted_table = context.Table(
+        name=subject_name,
         alias=subject_alias,
         reference_as=inserted_rvar_name,
     )

--- a/tests/test_sql_dml.py
+++ b/tests/test_sql_dml.py
@@ -967,6 +967,23 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
         )
         self.assertEqual(res, [[doc_id, user_id]])
 
+    @test.xfail('''
+        RETURNING clause doesn't support table names
+
+        ERROR:  cannot find table `Document`
+    ''')
+    async def test_sql_dml_insert_44(self):
+        # Test that RETURNING supports "Table".col format
+        res = await self.squery_values(
+            '''
+            INSERT INTO "Document" (title) VALUES ('Test returning')
+            RETURNING "Document".id
+            '''
+        )
+        docid = res[0][0]
+        res = await self.squery_values('SELECT id, title FROM "Document"')
+        self.assertEqual(res, [[docid, 'Test returning (new)']])
+
     async def test_sql_dml_delete_01(self):
         # delete, inspect CommandComplete tag
 
@@ -1341,6 +1358,29 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             user_id,
         )
         self.assertEqual(res, 'DELETE 1')
+
+    @test.xfail('''
+        RETURNING clause doesn't support table names
+
+        ERROR:  cannot find table `Document`
+    ''')
+    async def test_sql_dml_delete_14(self):
+        # Test that RETURNING supports "Table".col format
+
+        await self.scon.execute(
+            '''
+            INSERT INTO "Document" (title)
+            VALUES ('Test returning')
+            '''
+        )
+        res = await self.squery_values(
+            '''
+            DELETE FROM "Document"
+            WHERE title LIKE 'Test returning%'
+            RETURNING "Document".title
+            ''',
+        )
+        self.assertEqual(res, [['Test returning (new)']])
 
     async def test_sql_dml_update_01(self):
         # update, inspect CommandComplete tag
@@ -1765,6 +1805,30 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
                 [doc_id, user_id],
             ],
         )
+
+    @test.xfail('''
+        RETURNING clause doesn't support table names
+
+        ERROR:  cannot find table `Document`
+    ''')
+    async def test_sql_dml_update_17(self):
+        # Test that RETURNING supports "Table".col format
+
+        await self.scon.execute(
+            '''
+            INSERT INTO "Document" (title)
+            VALUES ('Report')
+            '''
+        )
+        res = await self.squery_values(
+            '''
+            UPDATE "Document"
+            SET title = 'Test returning'
+            WHERE title LIKE 'Report%'
+            RETURNING "Document".title
+            ''',
+        )
+        self.assertEqual(res, [['Test returning (updated)']])
 
     async def test_sql_dml_01(self):
         # update/delete only

--- a/tests/test_sql_dml.py
+++ b/tests/test_sql_dml.py
@@ -967,11 +967,6 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
         )
         self.assertEqual(res, [[doc_id, user_id]])
 
-    @test.xfail('''
-        RETURNING clause doesn't support table names
-
-        ERROR:  cannot find table `Document`
-    ''')
     async def test_sql_dml_insert_44(self):
         # Test that RETURNING supports "Table".col format
         res = await self.squery_values(
@@ -1359,11 +1354,6 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
         )
         self.assertEqual(res, 'DELETE 1')
 
-    @test.xfail('''
-        RETURNING clause doesn't support table names
-
-        ERROR:  cannot find table `Document`
-    ''')
     async def test_sql_dml_delete_14(self):
         # Test that RETURNING supports "Table".col format
 
@@ -1806,11 +1796,6 @@ class TestSQLDataModificationLanguage(tb.SQLQueryTestCase):
             ],
         )
 
-    @test.xfail('''
-        RETURNING clause doesn't support table names
-
-        ERROR:  cannot find table `Document`
-    ''')
     async def test_sql_dml_update_17(self):
         # Test that RETURNING supports "Table".col format
 


### PR DESCRIPTION
Closes #7890

RETURNING clauses don't resolve table names.