### PR TITLE
[5.x] Pin actions/upload-artifact version to 4.3.6

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -108,7 +108,7 @@
         <%- endif %>
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -177,7 +177,7 @@
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>

--- a/.github/workflows.src/tests-managed-pg.tpl.yml
+++ b/.github/workflows.src/tests-managed-pg.tpl.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -112,7 +112,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -135,7 +135,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -221,7 +221,7 @@ jobs:
           TF_VAR_do_token: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -248,7 +248,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -298,7 +298,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -327,7 +327,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -379,7 +379,7 @@ jobs:
           TF_VAR_vpc_id: ${{ secrets.AWS_VPC_ID }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -403,7 +403,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate
@@ -469,7 +469,7 @@ jobs:
           HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate

--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -59,7 +59,7 @@
     << caller() >>
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: shared-artifacts
         path: .tmp

--- a/.github/workflows.src/tests.tpl.yml
+++ b/.github/workflows.src/tests.tpl.yml
@@ -98,7 +98,7 @@ jobs:
         edb test -j2 -v -s ${SHARD}/16 --running-times-log=.results/shard_${SHARD}.csv
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: python-test-results-${{ matrix.shard }}
         path: .results
@@ -119,7 +119,7 @@ jobs:
         edb test --list > .tmp/all_tests.txt
 
     - name: Upload list of tests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: test-list
         path: .tmp

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -380,7 +380,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -404,7 +404,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -428,7 +428,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -452,7 +452,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -476,7 +476,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -500,7 +500,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -524,7 +524,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -548,7 +548,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -572,7 +572,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -596,7 +596,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -620,7 +620,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -644,7 +644,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -668,7 +668,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -692,7 +692,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -716,7 +716,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -740,7 +740,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -765,7 +765,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -790,7 +790,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -816,7 +816,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -842,7 +842,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -900,7 +900,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -958,7 +958,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -385,7 +385,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -409,7 +409,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -433,7 +433,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -457,7 +457,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -481,7 +481,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -505,7 +505,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -529,7 +529,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -553,7 +553,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -577,7 +577,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -601,7 +601,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -625,7 +625,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -649,7 +649,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -673,7 +673,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -697,7 +697,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -721,7 +721,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -745,7 +745,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -770,7 +770,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -795,7 +795,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -821,7 +821,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -847,7 +847,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -905,7 +905,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -963,7 +963,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -61,7 +61,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -83,7 +83,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -105,7 +105,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -127,7 +127,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -149,7 +149,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -171,7 +171,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -193,7 +193,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -215,7 +215,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -237,7 +237,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -259,7 +259,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -281,7 +281,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -303,7 +303,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -325,7 +325,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -347,7 +347,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -369,7 +369,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -392,7 +392,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -415,7 +415,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -439,7 +439,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -463,7 +463,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -519,7 +519,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -575,7 +575,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster
@@ -63,7 +63,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster
@@ -86,7 +86,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye
@@ -109,7 +109,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye
@@ -132,7 +132,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm
@@ -155,7 +155,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm
@@ -178,7 +178,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic
@@ -201,7 +201,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic
@@ -224,7 +224,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal
@@ -247,7 +247,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal
@@ -270,7 +270,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy
@@ -293,7 +293,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy
@@ -316,7 +316,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8
@@ -339,7 +339,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8
@@ -362,7 +362,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9
@@ -385,7 +385,7 @@ jobs:
         BUILD_IS_RELEASE: "true"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9
@@ -409,7 +409,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-x86_64
         path: artifacts/linux-x86_64
@@ -433,7 +433,7 @@ jobs:
         BUILD_GENERIC: true
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linux-aarch64
         path: artifacts/linux-aarch64
@@ -458,7 +458,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-x86_64
         path: artifacts/linuxmusl-x86_64
@@ -483,7 +483,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-linuxmusl-aarch64
         path: artifacts/linuxmusl-aarch64
@@ -540,7 +540,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -597,7 +597,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -100,7 +100,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: shared-artifacts
         path: .tmp

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -85,7 +85,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: shared-artifacts
         path: .tmp
@@ -365,7 +365,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -566,7 +566,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-rds-tfstate
           path: .github/aws-rds/terraform.tfstate
@@ -598,7 +598,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -829,7 +829,7 @@ jobs:
           TF_VAR_do_token: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: do-database-tfstate
           path: .github/do-database/terraform.tfstate
@@ -869,7 +869,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -1068,7 +1068,7 @@ jobs:
           TF_VAR_password: ${{ secrets.AWS_RDS_PASSWORD }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: gcp-cloud-sql-tfstate
           path: .github/gcp-cloud-sql/terraform.tfstate
@@ -1111,7 +1111,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -1313,7 +1313,7 @@ jobs:
           TF_VAR_vpc_id: ${{ secrets.AWS_VPC_ID }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
@@ -1346,7 +1346,7 @@ jobs:
 
       - name: Store Terraform state
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate
@@ -1562,7 +1562,7 @@ jobs:
           HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
 
       - name: Overwrite Terraform state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
         with:
           name: heroku-postgres-tfstate
           path: .github/heroku-postgres/terraform.tfstate

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -87,7 +87,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: shared-artifacts
         path: .tmp

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -85,7 +85,7 @@ jobs:
         echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: shared-artifacts
         path: .tmp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
         | xargs curl > .tmp/time_stats.csv
 
     - name: Upload shared artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: shared-artifacts
         path: .tmp
@@ -581,7 +581,7 @@ jobs:
         edb test -j2 -v -s ${SHARD}/16 --running-times-log=.results/shard_${SHARD}.csv
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: python-test-results-${{ matrix.shard }}
         path: .results
@@ -738,7 +738,7 @@ jobs:
         edb test --list > .tmp/all_tests.txt
 
     - name: Upload list of tests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # 4.3.6
       with:
         name: test-list
         path: .tmp


### PR DESCRIPTION
See #7705. 4.4.0 broke our actions definitions. On master, we've fixed
the definitions so they work, but I didn't want to have to resolve the
conflicts when I tried cherry picking, so on 5.x let's just pin the
old version.