### PR TITLE
Initialize `CompilationRequest` in one step

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -577,10 +577,11 @@ class Compiler:
     ) -> Tuple[
         dbstate.QueryUnitGroup, Optional[dbstate.CompilerConnectionState]
     ]:
-        request = rpc.CompilationRequest(
-            self.state.compilation_config_serializer
+        request = rpc.CompilationRequest.deserialize(
+            serialized_request,
+            original_query,
+            self.state.compilation_config_serializer,
         )
-        request.deserialize(serialized_request, original_query)
 
         units, cstate = self.compile(
             user_schema,
@@ -598,7 +599,7 @@ class Compiler:
             request.inline_typenames,
             request.protocol_version,
             request.inline_objectids,
-            request.json_parameters,
+            request.input_format is enums.InputFormat.JSON,
             cache_key=request.get_cache_key(),
         )
         return units, cstate
@@ -684,10 +685,11 @@ class Compiler:
     ) -> Tuple[
         dbstate.QueryUnitGroup, Optional[dbstate.CompilerConnectionState]
     ]:
-        request = rpc.CompilationRequest(
-            self.state.compilation_config_serializer
+        request = rpc.CompilationRequest.deserialize(
+            serialized_request,
+            original_query,
+            self.state.compilation_config_serializer,
         )
-        request.deserialize(serialized_request, original_query)
 
         # Apply session differences if any
         if (
@@ -712,7 +714,7 @@ class Compiler:
             request.inline_typenames,
             request.protocol_version,
             request.inline_objectids,
-            request.json_parameters,
+            request.input_format is enums.InputFormat.JSON,
             expect_rollback=expect_rollback,
             cache_key=request.get_cache_key(),
         )

--- a/edb/server/compiler/rpc.pxd
+++ b/edb/server/compiler/rpc.pxd
@@ -29,7 +29,7 @@ cdef class CompilationRequest:
         readonly object source
         readonly object protocol_version
         readonly object output_format
-        readonly bint json_parameters
+        readonly object input_format
         readonly bint expect_one
         readonly int implicit_limit
         readonly bint inline_typeids
@@ -46,4 +46,3 @@ cdef class CompilationRequest:
         object cache_key
 
     cdef _serialize(self)
-    cdef _deserialize_v0(self, bytes data, str query_text)

--- a/edb/server/compiler/rpc.pyi
+++ b/edb/server/compiler/rpc.pyi
@@ -29,7 +29,7 @@ class CompilationRequest:
     source: edgeql.Source
     protocol_version: defines.ProtocolVersion
     output_format: enums.OutputFormat
-    json_parameters: bool
+    input_format: enums.InputFormat
     expect_one: bool
     implicit_limit: int
     inline_typeids: bool
@@ -41,6 +41,21 @@ class CompilationRequest:
 
     def __init__(
         self,
+        *,
+        source: edgeql.Source,
+        protocol_version: defines.ProtocolVersion,
+        output_format: enums.OutputFormat = enums.OutputFormat.BINARY,
+        input_format: enums.InputFormat = enums.InputFormat.BINARY,
+        expect_one: bool = False,
+        implicit_limit: int = 0,
+        inline_typeids: bool = False,
+        inline_typenames: bool = False,
+        inline_objectids: bool = True,
+        schema_version: uuid.UUID | None = None,
+        modaliases: typing.Mapping[str | None, str] | None = None,
+        session_config: typing.Mapping[str, config.SettingValue] | None = None,
+        database_config: typing.Mapping[str, config.SettingValue] | None = None,
+        system_config: typing.Mapping[str, config.SettingValue] | None = None,
         compilation_config_serializer: sertypes.CompilationConfigSerializer,
     ):
         ...
@@ -86,7 +101,13 @@ class CompilationRequest:
     def serialize(self) -> bytes:
         ...
 
-    def deserialize(self, data: bytes, query_text: str) -> CompilationRequest:
+    @classmethod
+    def deserialize(
+        cls,
+        data: bytes,
+        query_text: str,
+        compilation_config_serializer: sertypes.CompilationConfigSerializer,
+    ) -> CompilationRequest:
         ...
 
     def get_cache_key(self) -> uuid.UUID:

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -16,6 +16,10 @@
 # limitations under the License.
 #
 
+from typing import (
+    Mapping,
+)
+
 import hashlib
 import uuid
 
@@ -77,35 +81,11 @@ cdef deserialize_output_format(char mode):
 cdef class CompilationRequest:
     def __cinit__(
         self,
-        compilation_config_serializer: sertypes.CompilationConfigSerializer,
-    ):
-        self._serializer = compilation_config_serializer
-
-    def __copy__(self):
-        cdef CompilationRequest rv = CompilationRequest(self._serializer)
-        rv.source = self.source
-        rv.protocol_version = self.protocol_version
-        rv.output_format = self.output_format
-        rv.json_parameters = self.json_parameters
-        rv.expect_one = self.expect_one
-        rv.implicit_limit = self.implicit_limit
-        rv.inline_typeids = self.inline_typeids
-        rv.inline_typenames = self.inline_typenames
-        rv.inline_objectids = self.inline_objectids
-        rv.modaliases = self.modaliases
-        rv.session_config = self.session_config
-        rv.database_config = self.database_config
-        rv.system_config = self.system_config
-        rv.schema_version = self.schema_version
-        rv.serialized_cache = self.serialized_cache
-        rv.cache_key = self.cache_key
-        return rv
-
-    def update(
-        self,
+        *,
         source: edgeql.Source,
         protocol_version: defines.ProtocolVersion,
-        *,
+        schema_version: uuid.UUID,
+        compilation_config_serializer: sertypes.CompilationConfigSerializer,
         output_format: enums.OutputFormat = OUT_FMT_BINARY,
         input_format: enums.InputFormat = IN_FMT_BINARY,
         expect_one: bint = False,
@@ -113,20 +93,53 @@ cdef class CompilationRequest:
         inline_typeids: bint = False,
         inline_typenames: bint = False,
         inline_objectids: bint = True,
-    ) -> CompilationRequest:
+        modaliases: Mapping[str | None, str] | None = None,
+        session_config: Mapping[str, config.SettingValue] | None = None,
+        database_config: Mapping[str, config.SettingValue] | None = None,
+        system_config: Mapping[str, config.SettingValue] | None = None,
+    ):
+        self._serializer = compilation_config_serializer
         self.source = source
         self.protocol_version = protocol_version
         self.output_format = output_format
-        self.json_parameters = input_format is IN_FMT_JSON
+        self.input_format = input_format
         self.expect_one = expect_one
         self.implicit_limit = implicit_limit
         self.inline_typeids = inline_typeids
         self.inline_typenames = inline_typenames
         self.inline_objectids = inline_objectids
+        self.schema_version = schema_version
+        self.modaliases = modaliases
+        self.session_config = session_config
+        self.database_config = database_config
+        self.system_config = system_config
 
         self.serialized_cache = None
         self.cache_key = None
-        return self
+
+    def __copy__(self):
+        cdef CompilationRequest rv
+
+        rv = CompilationRequest(
+            source=self.source,
+            protocol_version=self.protocol_version,
+            schema_version=self.schema_version,
+            compilation_config_serializer=self._serializer,
+            output_format=self.output_format,
+            input_format=self.input_format,
+            expect_one=self.expect_one,
+            implicit_limit=self.implicit_limit,
+            inline_typeids=self.inline_typeids,
+            inline_typenames=self.inline_typenames,
+            inline_objectids=self.inline_objectids,
+            modaliases=self.modaliases,
+            session_config=self.session_config,
+            database_config=self.database_config,
+            system_config=self.system_config,
+        )
+        rv.serialized_cache = self.serialized_cache
+        rv.cache_key = self.cache_key
+        return rv
 
     def set_modaliases(self, value) -> CompilationRequest:
         self.modaliases = value
@@ -158,14 +171,20 @@ cdef class CompilationRequest:
         self.cache_key = None
         return self
 
-    def deserialize(self, bytes data, str query_text) -> CompilationRequest:
+    @classmethod
+    def deserialize(
+        cls,
+        data: bytes,
+        query_text: str,
+        compilation_config_serializer: sertypes.CompilationConfigSerializer,
+    ) -> CompilationRequest:
         if data[0] == 0:
-            self._deserialize_v0(data, query_text)
+            return _deserialize_v0_comp_req(
+                data, query_text, compilation_config_serializer)
         else:
             raise errors.UnsupportedProtocolVersionError(
                 f"unsupported compile cache: version {data[0]}"
             )
-        return self
 
     def serialize(self) -> bytes:
         if self.serialized_cache is None:
@@ -187,7 +206,7 @@ cdef class CompilationRequest:
         out.write_byte(version)
 
         flags = (
-            (MASK_JSON_PARAMETERS if self.json_parameters else 0) |
+            (MASK_JSON_PARAMETERS if self.input_format is IN_FMT_JSON else 0) |
             (MASK_EXPECT_ONE if self.expect_one else 0) |
             (MASK_INLINE_TYPEIDS if self.inline_typeids else 0) |
             (MASK_INLINE_TYPENAMES if self.inline_typenames else 0) |
@@ -251,110 +270,6 @@ cdef class CompilationRequest:
 
         self.serialized_cache = bytes(out)
 
-    cdef _deserialize_v0(self, bytes data, str query_text):
-        # Format:
-        #
-        # * 1 byte of version (0)
-        # * 1 byte of bit flags:
-        #   * json_parameters
-        #   * expect_one
-        #   * inline_typeids
-        #   * inline_typenames
-        #   * inline_objectids
-        # * protocol_version (major: int64, minor: int16)
-        # * 1 byte output_format (the same as in the binary protocol)
-        # * implicit_limit: int64
-        # * Module aliases:
-        #   * length: int32 (negative means the modaliases is None)
-        #   * For each alias pair:
-        #      * 1 byte, 0 if the name is None
-        #      * else, C-String as the name
-        #      * C-String as the alias
-        # * Session config type descriptor
-        #   * 16 bytes type ID
-        #   * int32-length-prefixed serialized type descriptor
-        # * Session config: int32-length-prefixed serialized data
-        # * Serialized Source or NormalizedSource without the original query
-        #   string
-        # * 16-byte cache key = BLAKE-2b hash of:
-        #    * All above serialized,
-        #    * Except that the source is replaced with Source.cache_key(), and
-        #    * Except that the serialized session config is replaced by
-        #      serialized combined config (session -> database -> system)
-        #      that only affects compilation.
-        #    * The schema version
-        #  * OPTIONALLY, the schema version. We wanted to bump the protocol
-        #    version to include this, but 5.x hard crashes when it reads a
-        #    persistent cache with entries it doesn't understand, so instead
-        #    we stick it on the end where it will be ignored by old versions.
-
-        cdef char flags
-
-        self.serialized_cache = data
-
-        buf = ReadBuffer.new_message_parser(data)
-
-        assert buf.read_byte() == 0  # version
-
-        flags = buf.read_byte()
-        self.json_parameters = flags & MASK_JSON_PARAMETERS > 0
-        self.expect_one = flags & MASK_EXPECT_ONE > 0
-        self.inline_typeids = flags & MASK_INLINE_TYPEIDS > 0
-        self.inline_typenames = flags & MASK_INLINE_TYPENAMES > 0
-        self.inline_objectids = flags & MASK_INLINE_OBJECTIDS > 0
-
-        self.protocol_version = buf.read_int16(), buf.read_int16()
-        self.output_format = deserialize_output_format(buf.read_byte())
-        self.implicit_limit = buf.read_int64()
-
-        size = buf.read_int32()
-        if size >= 0:
-            modaliases = []
-            for _ in range(size):
-                if buf.read_byte():
-                    k = buf.read_null_str().decode("utf-8")
-                else:
-                    k = None
-                v = buf.read_null_str().decode("utf-8")
-                modaliases.append((k, v))
-            self.modaliases = immutables.Map(modaliases)
-        else:
-            self.modaliases = None
-
-        type_id = uuidgen.from_bytes(buf.read_bytes(16))
-        if type_id == self._serializer.type_id:
-            serializer = self._serializer
-            buf.read_len_prefixed_bytes()
-        else:
-            serializer = sertypes.CompilationConfigSerializer(
-                type_id, buf.read_len_prefixed_bytes(), defines.CURRENT_PROTOCOL
-            )
-            self._serializer = serializer
-
-        data = buf.read_len_prefixed_bytes()
-        if data:
-            self.session_config = immutables.Map(
-                (
-                    k,
-                    config.SettingValue(
-                        name=k,
-                        value=v,
-                        source='session',
-                        scope=qltypes.ConfigScope.SESSION,
-                    )
-                ) for k, v in serializer.decode(data).items()
-            )
-        else:
-            self.session_config = None
-
-        self.source = tokenizer.deserialize(
-            buf.read_len_prefixed_bytes(), query_text
-        )
-        self.cache_key = uuidgen.from_bytes(buf.read_bytes(16))
-
-        if buf._length >= 16:
-            self.schema_version = uuidgen.from_bytes(buf.read_bytes(16))
-
     def __hash__(self):
         return hash(self.get_cache_key())
 
@@ -363,10 +278,139 @@ cdef class CompilationRequest:
             self.source.cache_key() == other.source.cache_key() and
             self.protocol_version == other.protocol_version and
             self.output_format == other.output_format and
-            self.json_parameters == other.json_parameters and
+            self.input_format == other.input_format and
             self.expect_one == other.expect_one and
             self.implicit_limit == other.implicit_limit and
             self.inline_typeids == other.inline_typeids and
             self.inline_typenames == other.inline_typenames and
             self.inline_objectids == other.inline_objectids
         )
+
+
+cdef _deserialize_v0_comp_req(
+    data: bytes,
+    query_text: str,
+    compilation_config_serializer: sertypes.CompilationConfigSerializer,
+):
+    # Format:
+    #
+    # * 1 byte of version (0)
+    # * 1 byte of bit flags:
+    #   * json_parameters
+    #   * expect_one
+    #   * inline_typeids
+    #   * inline_typenames
+    #   * inline_objectids
+    # * protocol_version (major: int64, minor: int16)
+    # * 1 byte output_format (the same as in the binary protocol)
+    # * implicit_limit: int64
+    # * Module aliases:
+    #   * length: int32 (negative means the modaliases is None)
+    #   * For each alias pair:
+    #      * 1 byte, 0 if the name is None
+    #      * else, C-String as the name
+    #      * C-String as the alias
+    # * Session config type descriptor
+    #   * 16 bytes type ID
+    #   * int32-length-prefixed serialized type descriptor
+    # * Session config: int32-length-prefixed serialized data
+    # * Serialized Source or NormalizedSource without the original query
+    #   string
+    # * 16-byte cache key = BLAKE-2b hash of:
+    #    * All above serialized,
+    #    * Except that the source is replaced with Source.cache_key(), and
+    #    * Except that the serialized session config is replaced by
+    #      serialized combined config (session -> database -> system)
+    #      that only affects compilation.
+    #    * The schema version
+    #  * OPTIONALLY, the schema version. We wanted to bump the protocol
+    #    version to include this, but 5.x hard crashes when it reads a
+    #    persistent cache with entries it doesn't understand, so instead
+    #    we stick it on the end where it will be ignored by old versions.
+
+    cdef char flags
+
+    buf = ReadBuffer.new_message_parser(data)
+
+    assert buf.read_byte() == 0  # version
+
+    flags = buf.read_byte()
+    if flags & MASK_JSON_PARAMETERS > 0:
+        input_format = IN_FMT_JSON
+    else:
+        input_format = IN_FMT_BINARY
+    expect_one = flags & MASK_EXPECT_ONE > 0
+    inline_typeids = flags & MASK_INLINE_TYPEIDS > 0
+    inline_typenames = flags & MASK_INLINE_TYPENAMES > 0
+    inline_objectids = flags & MASK_INLINE_OBJECTIDS > 0
+
+    protocol_version = buf.read_int16(), buf.read_int16()
+    output_format = deserialize_output_format(buf.read_byte())
+    implicit_limit = buf.read_int64()
+
+    size = buf.read_int32()
+    if size >= 0:
+        modaliases = []
+        for _ in range(size):
+            if buf.read_byte():
+                k = buf.read_null_str().decode("utf-8")
+            else:
+                k = None
+            v = buf.read_null_str().decode("utf-8")
+            modaliases.append((k, v))
+        modaliases = immutables.Map(modaliases)
+    else:
+        modaliases = None
+
+    serializer = compilation_config_serializer
+    type_id = uuidgen.from_bytes(buf.read_bytes(16))
+    if type_id == serializer.type_id:
+        buf.read_len_prefixed_bytes()
+    else:
+        serializer = sertypes.CompilationConfigSerializer(
+            type_id, buf.read_len_prefixed_bytes(), defines.CURRENT_PROTOCOL
+        )
+
+    data = buf.read_len_prefixed_bytes()
+    if data:
+        session_config = immutables.Map(
+            (
+                k,
+                config.SettingValue(
+                    name=k,
+                    value=v,
+                    source='session',
+                    scope=qltypes.ConfigScope.SESSION,
+                )
+            ) for k, v in serializer.decode(data).items()
+        )
+    else:
+        session_config = None
+
+    source = tokenizer.deserialize(
+        buf.read_len_prefixed_bytes(), query_text
+    )
+
+    cache_key = uuidgen.from_bytes(buf.read_bytes(16))
+    schema_version = uuidgen.from_bytes(buf.read_bytes(16))
+
+    req = CompilationRequest(
+        source=source,
+        protocol_version=protocol_version,
+        schema_version=schema_version,
+        compilation_config_serializer=serializer,
+        output_format=output_format,
+        input_format=input_format,
+        expect_one=expect_one,
+        implicit_limit=implicit_limit,
+        inline_typeids=inline_typeids,
+        inline_typenames=inline_typenames,
+        inline_objectids=inline_objectids,
+        modaliases=modaliases,
+        session_config=session_config,
+    )
+
+    req.serialized_cache = data
+    req.cache_key = cache_key
+
+    return req

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -178,9 +178,11 @@ cdef class CompilationRequest:
         query_text: str,
         compilation_config_serializer: sertypes.CompilationConfigSerializer,
     ) -> CompilationRequest:
+        buf = ReadBuffer.new_message_parser(data)
+
         if data[0] == 0:
-            return _deserialize_v0_comp_req(
-                data, query_text, compilation_config_serializer)
+            return _deserialize_comp_req_v0(
+                buf, query_text, compilation_config_serializer)
         else:
             raise errors.UnsupportedProtocolVersionError(
                 f"unsupported compile cache: version {data[0]}"
@@ -197,78 +199,9 @@ cdef class CompilationRequest:
         return self.cache_key
 
     cdef _serialize(self):
-        # Please see _deserialize_v0 for the format doc
-
-        cdef:
-            char version = 0, flags
-            WriteBuffer out = WriteBuffer.new()
-
-        out.write_byte(version)
-
-        flags = (
-            (MASK_JSON_PARAMETERS if self.input_format is IN_FMT_JSON else 0) |
-            (MASK_EXPECT_ONE if self.expect_one else 0) |
-            (MASK_INLINE_TYPEIDS if self.inline_typeids else 0) |
-            (MASK_INLINE_TYPENAMES if self.inline_typenames else 0) |
-            (MASK_INLINE_OBJECTIDS if self.inline_objectids else 0)
-        )
-        out.write_byte(flags)
-
-        out.write_int16(self.protocol_version[0])
-        out.write_int16(self.protocol_version[1])
-        out.write_byte(serialize_output_format(self.output_format))
-        out.write_int64(self.implicit_limit)
-
-        if self.modaliases is None:
-            out.write_int32(-1)
-        else:
-            out.write_int32(len(self.modaliases))
-            for k, v in sorted(
-                self.modaliases.items(),
-                key=lambda i: (0, i[0]) if i[0] is None else (1, i[0])
-            ):
-                if k is None:
-                    out.write_byte(0)
-                else:
-                    out.write_byte(1)
-                    out.write_str(k, "utf-8")
-                out.write_str(v, "utf-8")
-
-        type_id, desc = self._serializer.describe()
-        out.write_bytes(type_id.bytes)
-        out.write_len_prefixed_bytes(desc)
-
-        hash_obj = hashlib.blake2b(memoryview(out), digest_size=16)
-        hash_obj.update(self.source.cache_key())
-
-        if self.session_config is None:
-            session_config = b""
-        else:
-            session_config = self._serializer.encode_configs(
-                self.session_config
-            )
-        out.write_len_prefixed_bytes(session_config)
-
-        # Build config that affects compilation: session -> database -> system.
-        # This is only used for calculating cache_key, while session
-        # config itself is separately stored above in the serialized format.
-        serialized_comp_config = self._serializer.encode_configs(
-            self.system_config, self.database_config, self.session_config
-        )
-        hash_obj.update(serialized_comp_config)
-
-        # Must set_schema_version() before serializing compilation request
-        assert self.schema_version is not None
-        hash_obj.update(self.schema_version.bytes)
-
-        cache_key_bytes = hash_obj.digest()
-        self.cache_key = uuidgen.from_bytes(cache_key_bytes)
-
-        out.write_len_prefixed_bytes(self.source.serialize())
-        out.write_bytes(cache_key_bytes)
-        out.write_bytes(self.schema_version.bytes)
-
-        self.serialized_cache = bytes(out)
+        cache_key, buf = _serialize_comp_req_v0(self)
+        self.cache_key = cache_key
+        self.serialized_cache = bytes(buf)
 
     def __hash__(self):
         return hash(self.get_cache_key())
@@ -287,8 +220,8 @@ cdef class CompilationRequest:
         )
 
 
-cdef _deserialize_v0_comp_req(
-    data: bytes,
+cdef _deserialize_comp_req_v0(
+    buf: ReadBuffer,
     query_text: str,
     compilation_config_serializer: sertypes.CompilationConfigSerializer,
 ):
@@ -329,8 +262,6 @@ cdef _deserialize_v0_comp_req(
     #    we stick it on the end where it will be ignored by old versions.
 
     cdef char flags
-
-    buf = ReadBuffer.new_message_parser(data)
 
     assert buf.read_byte() == 0  # version
 
@@ -414,3 +345,78 @@ cdef _deserialize_v0_comp_req(
     req.cache_key = cache_key
 
     return req
+
+
+cdef _serialize_comp_req_v0(req: CompilationRequest):
+    # Please see _deserialize_v0 for the format doc
+
+    cdef:
+        char version = 0, flags
+        WriteBuffer out = WriteBuffer.new()
+
+    out.write_byte(version)
+
+    flags = (
+        (MASK_JSON_PARAMETERS if req.input_format is IN_FMT_JSON else 0) |
+        (MASK_EXPECT_ONE if req.expect_one else 0) |
+        (MASK_INLINE_TYPEIDS if req.inline_typeids else 0) |
+        (MASK_INLINE_TYPENAMES if req.inline_typenames else 0) |
+        (MASK_INLINE_OBJECTIDS if req.inline_objectids else 0)
+    )
+    out.write_byte(flags)
+
+    out.write_int16(req.protocol_version[0])
+    out.write_int16(req.protocol_version[1])
+    out.write_byte(serialize_output_format(req.output_format))
+    out.write_int64(req.implicit_limit)
+
+    if req.modaliases is None:
+        out.write_int32(-1)
+    else:
+        out.write_int32(len(req.modaliases))
+        for k, v in sorted(
+            req.modaliases.items(),
+            key=lambda i: (0, i[0]) if i[0] is None else (1, i[0])
+        ):
+            if k is None:
+                out.write_byte(0)
+            else:
+                out.write_byte(1)
+                out.write_str(k, "utf-8")
+            out.write_str(v, "utf-8")
+
+    type_id, desc = req._serializer.describe()
+    out.write_bytes(type_id.bytes)
+    out.write_len_prefixed_bytes(desc)
+
+    hash_obj = hashlib.blake2b(memoryview(out), digest_size=16)
+    hash_obj.update(req.source.cache_key())
+
+    if req.session_config is None:
+        session_config = b""
+    else:
+        session_config = req._serializer.encode_configs(
+            req.session_config
+        )
+    out.write_len_prefixed_bytes(session_config)
+
+    # Build config that affects compilation: session -> database -> system.
+    # This is only used for calculating cache_key, while session
+    # config itreq is separately stored above in the serialized format.
+    serialized_comp_config = req._serializer.encode_configs(
+        req.system_config, req.database_config, req.session_config
+    )
+    hash_obj.update(serialized_comp_config)
+
+    # Must set_schema_version() before serializing compilation request
+    assert req.schema_version is not None
+    hash_obj.update(req.schema_version.bytes)
+
+    cache_key_bytes = hash_obj.digest()
+    cache_key = uuidgen.from_bytes(cache_key_bytes)
+
+    out.write_len_prefixed_bytes(req.source.serialize())
+    out.write_bytes(cache_key_bytes)
+    out.write_bytes(req.schema_version.bytes)
+
+    return cache_key, out

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -419,9 +419,11 @@ cdef class Database:
 
     def hydrate_cache(self, query_cache):
         for _, in_data, out_data in query_cache:
-            query_req = rpc.CompilationRequest(
-                self.server.compilation_config_serializer)
-            query_req.deserialize(in_data, "<unknown>")
+            query_req = rpc.CompilationRequest.deserialize(
+                in_data,
+                "<unknown>",
+                self.server.compilation_config_serializer,
+            )
 
             if query_req not in self._eql_to_compiled:
                 unit = dbstate.QueryUnit.deserialize(out_data)

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -206,13 +206,13 @@ async def _parse(
         )
 
     query_req = rpc.CompilationRequest(
-        db.server.compilation_config_serializer
-    ).update(
-        edgeql.Source.from_string(query),
+        source=edgeql.Source.from_string(query),
         protocol_version=edbdef.CURRENT_PROTOCOL,
+        schema_version=dbv.schema_version,
+        compilation_config_serializer=db.server.compilation_config_serializer,
         input_format=input_format,
         output_format=output_format,
-    ).set_schema_version(dbv.schema_version)
+    )
 
     compiled = await dbv.parse(
         query_req,


### PR DESCRIPTION
The current two-step initialization of `CompilationRequest` seems
unnecessary and error-prone.  Have a normal constructor and make
`deserialize` a classmethod instead.
