### PR TITLE
workflows: Pin Python to 3.12 when building on macOS

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -152,7 +152,7 @@
       uses: actions/setup-python@v5
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -994,7 +994,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4
@@ -1065,7 +1065,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -999,7 +999,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4
@@ -1070,7 +1070,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -541,7 +541,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4
@@ -610,7 +610,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -563,7 +563,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4
@@ -633,7 +633,7 @@ jobs:
       uses: actions/setup-python@v5
       if: true
       with:
-        python-version: "3.x"
+        python-version: "3.12"
 
     - name: Set up NodeJS
       uses: actions/setup-node@v4


### PR DESCRIPTION
Python 3.13 is broken at the moment.
