### PR TITLE
Reduce compiler RPC surface

### DIFF
--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     SourceOrPathId = s_types.Type | s_pointers.Pointer | pathid.PathId
 
 
-@dataclass
+@dataclass(kw_only=True)
 class GlobalCompilerOptions:
     """Compiler toggles that affect compilation as a whole."""
 
@@ -102,7 +102,7 @@ class GlobalCompilerOptions:
     dump_restore_mode: bool = False
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CompilerOptions(GlobalCompilerOptions):
 
     #: Module name aliases.

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -30,9 +30,11 @@ from .enums import Capability, Cardinality
 from .enums import InputFormat, OutputFormat
 from .explain import analyze_explain_output
 from .ddl import repair_schema
+from .rpc import CompilationRequest
 
 __all__ = (
     'Cardinality',
+    'CompilationRequest',
     'Compiler',
     'CompilerState',
     'CompileContext',

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -565,7 +565,7 @@ class Compiler:
             apply_access_policies_sql=apply_access_policies_sql,
         )
 
-    def compile_request(
+    def compile_serialized_request(
         self,
         user_schema: s_schema.Schema,
         global_schema: s_schema.Schema,
@@ -584,48 +584,28 @@ class Compiler:
         )
 
         units, cstate = self.compile(
-            user_schema,
-            global_schema,
-            reflection_cache,
-            database_config,
-            system_config,
-            request.source,
-            request.modaliases,
-            request.session_config,
-            request.output_format,
-            request.expect_one,
-            request.implicit_limit,
-            request.inline_typeids,
-            request.inline_typenames,
-            request.protocol_version,
-            request.inline_objectids,
-            request.input_format is enums.InputFormat.JSON,
-            cache_key=request.get_cache_key(),
+            user_schema=user_schema,
+            global_schema=global_schema,
+            reflection_cache=reflection_cache,
+            database_config=database_config,
+            system_config=system_config,
+            request=request,
         )
         return units, cstate
 
     def compile(
         self,
+        *,
         user_schema: s_schema.Schema,
         global_schema: s_schema.Schema,
         reflection_cache: immutables.Map[str, Tuple[str, ...]],
         database_config: Optional[immutables.Map[str, config.SettingValue]],
         system_config: Optional[immutables.Map[str, config.SettingValue]],
-        source: edgeql.Source,
-        sess_modaliases: Optional[immutables.Map[Optional[str], str]],
-        sess_config: Optional[immutables.Map[str, config.SettingValue]],
-        output_format: enums.OutputFormat,
-        expect_one: bool,
-        implicit_limit: int,
-        inline_typeids: bool,
-        inline_typenames: bool,
-        protocol_version: defines.ProtocolVersion,
-        inline_objectids: bool = True,
-        json_parameters: bool = False,
-        cache_key: Optional[uuid.UUID] = None,
+        request: rpc.CompilationRequest,
     ) -> Tuple[dbstate.QueryUnitGroup,
                Optional[dbstate.CompilerConnectionState]]:
 
+        sess_config = request.session_config
         if sess_config is None:
             sess_config = EMPTY_MAP
 
@@ -635,6 +615,7 @@ class Compiler:
         if system_config is None:
             system_config = EMPTY_MAP
 
+        sess_modaliases = request.modaliases
         if sess_modaliases is None:
             sess_modaliases = DEFAULT_MODULE_ALIASES_MAP
 
@@ -651,19 +632,19 @@ class Compiler:
         ctx = CompileContext(
             compiler_state=self.state,
             state=state,
-            output_format=output_format,
-            expected_cardinality_one=expect_one,
-            implicit_limit=implicit_limit,
-            inline_typeids=inline_typeids,
-            inline_typenames=inline_typenames,
-            inline_objectids=inline_objectids,
-            json_parameters=json_parameters,
-            source=source,
-            protocol_version=protocol_version,
-            cache_key=cache_key,
+            output_format=request.output_format,
+            expected_cardinality_one=request.expect_one,
+            implicit_limit=request.implicit_limit,
+            inline_typeids=request.inline_typeids,
+            inline_typenames=request.inline_typenames,
+            inline_objectids=request.inline_objectids,
+            json_parameters=request.input_format is enums.InputFormat.JSON,
+            source=request.source,
+            protocol_version=request.protocol_version,
+            cache_key=request.get_cache_key(),
         )
 
-        unit_group = compile(ctx=ctx, source=source)
+        unit_group = compile(ctx=ctx, source=request.source)
         tx_started = False
         for unit in unit_group:
             if unit.tx_id:
@@ -675,7 +656,7 @@ class Compiler:
         else:
             return unit_group, None
 
-    def compile_in_tx_request(
+    def compile_serialized_request_in_tx(
         self,
         state: dbstate.CompilerConnectionState,
         txid: int,
@@ -690,7 +671,23 @@ class Compiler:
             original_query,
             self.state.compilation_config_serializer,
         )
+        return self.compile_in_tx(
+            state=state,
+            txid=txid,
+            request=request,
+            expect_rollback=expect_rollback,
+        )
 
+    def compile_in_tx(
+        self,
+        *,
+        state: dbstate.CompilerConnectionState,
+        txid: int,
+        request: rpc.CompilationRequest,
+        expect_rollback: bool = False,
+    ) -> Tuple[
+        dbstate.QueryUnitGroup, Optional[dbstate.CompilerConnectionState]
+    ]:
         # Apply session differences if any
         if (
             request.modaliases is not None
@@ -703,39 +700,6 @@ class Compiler:
         ):
             state.current_tx().update_session_config(session_config)
 
-        units, cstate = self.compile_in_tx(
-            state,
-            txid,
-            request.source,
-            request.output_format,
-            request.expect_one,
-            request.implicit_limit,
-            request.inline_typeids,
-            request.inline_typenames,
-            request.protocol_version,
-            request.inline_objectids,
-            request.input_format is enums.InputFormat.JSON,
-            expect_rollback=expect_rollback,
-            cache_key=request.get_cache_key(),
-        )
-        return units, cstate
-
-    def compile_in_tx(
-        self,
-        state: dbstate.CompilerConnectionState,
-        txid: int,
-        source: edgeql.Source,
-        output_format: enums.OutputFormat,
-        expect_one: bool,
-        implicit_limit: int,
-        inline_typeids: bool,
-        inline_typenames: bool,
-        protocol_version: defines.ProtocolVersion,
-        inline_objectids: bool = True,
-        json_parameters: bool = False,
-        expect_rollback: bool = False,
-        cache_key: Optional[uuid.UUID] = None,
-    ) -> Tuple[dbstate.QueryUnitGroup, dbstate.CompilerConnectionState]:
         if (
             expect_rollback and
             state.current_tx().id != txid and
@@ -743,27 +707,28 @@ class Compiler:
         ):
             # This is a special case when COMMIT MIGRATION fails, the compiler
             # doesn't have the right transaction state, so we just roll back.
-            return self._try_compile_rollback(source)[0], state
+            return self._try_compile_rollback(request.source)[0], state
         else:
             state.sync_tx(txid)
 
         ctx = CompileContext(
             compiler_state=self.state,
             state=state,
-            output_format=output_format,
-            expected_cardinality_one=expect_one,
-            implicit_limit=implicit_limit,
-            inline_typeids=inline_typeids,
-            inline_typenames=inline_typenames,
-            inline_objectids=inline_objectids,
-            source=source,
-            protocol_version=protocol_version,
-            json_parameters=json_parameters,
+            output_format=request.output_format,
+            expected_cardinality_one=request.expect_one,
+            implicit_limit=request.implicit_limit,
+            inline_typeids=request.inline_typeids,
+            inline_typenames=request.inline_typenames,
+            inline_objectids=request.inline_objectids,
+            source=request.source,
+            protocol_version=request.protocol_version,
+            json_parameters=request.input_format is enums.InputFormat.JSON,
             expect_rollback=expect_rollback,
-            cache_key=cache_key,
+            cache_key=request.get_cache_key(),
         )
 
-        return compile(ctx=ctx, source=source), ctx.state
+        units = compile(ctx=ctx, source=request.source)
+        return units, ctx.state
 
     def interpret_backend_error(
         self,

--- a/edb/server/compiler/rpc.pyi
+++ b/edb/server/compiler/rpc.pyi
@@ -44,6 +44,8 @@ class CompilationRequest:
         *,
         source: edgeql.Source,
         protocol_version: defines.ProtocolVersion,
+        schema_version: uuid.UUID,
+        compilation_config_serializer: sertypes.CompilationConfigSerializer,
         output_format: enums.OutputFormat = enums.OutputFormat.BINARY,
         input_format: enums.InputFormat = enums.InputFormat.BINARY,
         expect_one: bool = False,
@@ -51,12 +53,10 @@ class CompilationRequest:
         inline_typeids: bool = False,
         inline_typenames: bool = False,
         inline_objectids: bool = True,
-        schema_version: uuid.UUID | None = None,
         modaliases: typing.Mapping[str | None, str] | None = None,
         session_config: typing.Mapping[str, config.SettingValue] | None = None,
         database_config: typing.Mapping[str, config.SettingValue] | None = None,
         system_config: typing.Mapping[str, config.SettingValue] | None = None,
-        compilation_config_serializer: sertypes.CompilationConfigSerializer,
     ):
         ...
 

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -33,6 +33,7 @@ import immutables
 from edb import edgeql
 from edb.testbase import lang as tb
 from edb.testbase import server as tbs
+from edb.pgsql import params as pg_params
 from edb.server import args as edbargs
 from edb.server import compiler as edbcompiler
 from edb.server.compiler import rpc
@@ -392,14 +393,16 @@ class TestCompilerPool(tbs.TestCase):
         super().setUpClass()
         cls._std_schema = tb._load_std_schema()
         result = tb._load_reflection_schema()
-        cls._refl_schema, cls._schema_class_layout = result
+        cls._refl_schema, _schema_class_layout = result
+        assert _schema_class_layout is not None
+        cls._schema_class_layout = _schema_class_layout
 
     async def _test_pool_disconnect_queue(self, pool_class):
         with tempfile.TemporaryDirectory() as td:
             pool_ = await pool.create_compiler_pool(
                 runstate_dir=td,
                 pool_size=2,
-                backend_runtime_params=None,
+                backend_runtime_params=pg_params.get_default_runtime_params(),
                 std_schema=self._std_schema,
                 refl_schema=self._refl_schema,
                 schema_class_layout=self._schema_class_layout,


### PR DESCRIPTION
The server is now mostly passing the compilation parameters in
`CompilationRequest`, so convert the remaining users of the old
`compile()` API to benefit from reduction in argument count.
