### PR TITLE
Revert "Use new connection pool by default (#7706)"

### DIFF
--- a/edb/server/connpool/__init__.py
+++ b/edb/server/connpool/__init__.py
@@ -22,7 +22,7 @@ from .pool2 import Pool as Pool2Impl
 # During the transition period we allow for the pool to be swapped out. The
 # current default is to use the old pool, however this will be switched to use
 # the new pool once we've fully implemented all required features.
-if os.environ.get("EDGEDB_USE_NEW_CONNPOOL", "") == "0":
+if os.environ.get("EDGEDB_USE_NEW_CONNPOOL", "") == "1":
     Pool = Pool2Impl
     Pool2 = Pool1Impl
 else:


### PR DESCRIPTION
This reverts commit eda72c0441d91ca700592a52832f964cd75375e4.

There was a logic error in this commit, and so it did not actually
make the new connection pool the default.

I tried making it the default properly, and hit a number of new test
failures, so for now let's just clarify the situation.