### PR TITLE
Remove Postgres NOTICE spew generated by `DROP FUNCTION IF EXISTS`

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5370,10 +5370,10 @@ class PropertyMetaCommand(PointerMetaCommand[s_props.Property]):
 
         id = sn.QualName(
             module=prop.get_name(schema).module, name=str(prop.id))
-        index_name = common.convert_name(id, 'idx0', catenate=True)
+        index_name = common.convert_name(id, 'idx0', catenate=False)
 
         pg_index = dbops.Index(
-            name=index_name, table_name=new_table_name,
+            name=index_name[1], table_name=new_table_name,
             unique=False, columns=[src_col],
             metadata={'code': DEFAULT_INDEX_CODE},
         )

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -485,7 +485,13 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
         return [dbops.CreateFunction(func, or_replace=True)]
 
     def drop_constr_trigger_function(self, proc_name: Tuple[str, ...]):
-        return [dbops.DropFunction(name=proc_name, args=(), if_exists=True)]
+        return [dbops.DropFunction(
+            name=proc_name,
+            args=(),
+            # Use a condition instead of if_exists ot reduce annoying
+            # debug spew from postgres.
+            conditions=[dbops.FunctionExists(name=proc_name, args=())],
+        )]
 
     def create_constraint(self, constraint: SchemaConstraintTableConstraint):
         # Add the constraint normally to our table

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1243,7 +1243,14 @@ def compile_schema_storage_in_delta(
                 # We drop first instead of using or_replace, in case
                 # something about the arguments changed.
                 df = pg_dbops.DropFunction(
-                    name=func.name, args=func.args or (), if_exists=True
+                    name=func.name,
+                    args=func.args or (),
+                    # Use a condition instead of if_exists ot reduce annoying
+                    # debug spew from postgres.
+                    conditions=[pg_dbops.FunctionExists(
+                        name=func.name,
+                        args=func.args or (),
+                    )],
                 )
                 df.generate(funcblock)
 


### PR DESCRIPTION
Use an explicit conditional when using `DropFunction` in various places
of bootstrap and for reflection cache functions.  This makes it actually
possible to NOTICE postgres messages in bootstrap (pun intended).  Equipped
with this new visibility fix the name of the indexes we place on
properties.
