### PR TITLE
Rename net_http_max_connections to http_max_connections

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -74,9 +74,8 @@ Resource usage
 :eql:synopsis:`shared_buffers -> cfg::memory`
   The amount of memory used for shared memory buffers.
 
-:eql:synopsis:`net_http_max_connections -> int64`
-  The maximum number of concurrent HTTP connections to allow when using the
-  ``std::net::http`` module.
+:eql:synopsis:`http_max_connections -> int64`
+  The maximum number of concurrent outbound HTTP connections to allow.
 
 Query planning
 --------------

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_10_17_00_00
+EDGEDB_CATALOG_VERSION = 2024_10_23_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -238,8 +238,8 @@ ALTER TYPE cfg::AbstractConfig {
             'Where the query cache is finally stored';
     };
 
-    # std::net::http Configuration
-    CREATE PROPERTY net_http_max_connections -> std::int64 {
+    # HTTP Worker Configuration
+    CREATE PROPERTY http_max_connections -> std::int64 {
         SET default := 10;
         CREATE ANNOTATION std::description :=
             'The maximum number of concurrent HTTP connections.';

--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -47,10 +47,10 @@ NET_HTTP_REQUEST_TTL = statypes.Duration(
 
 
 async def _http_task(tenant: edbtenant.Tenant, http_client) -> None:
-    net_http_max_connections = tenant._server.config_lookup(
-        'net_http_max_connections', tenant.get_sys_config()
+    http_max_connections = tenant._server.config_lookup(
+        'http_max_connections', tenant.get_sys_config()
     )
-    http_client._update_limit(net_http_max_connections)
+    http_client._update_limit(http_max_connections)
     try:
         async with (asyncio.TaskGroup() as g,):
             for db in tenant.iter_dbs():
@@ -171,10 +171,10 @@ class HttpClient:
 
 
 def create_http(tenant: edbtenant.Tenant):
-    net_http_max_connections = tenant._server.config_lookup(
-        'net_http_max_connections', tenant.get_sys_config()
+    http_max_connections = tenant._server.config_lookup(
+        'http_max_connections', tenant.get_sys_config()
     )
-    return HttpClient(net_http_max_connections)
+    return HttpClient(http_max_connections)
 
 
 async def http(server: edbserver.BaseServer) -> None:


### PR DESCRIPTION
We're going to use it to cap other outgoing http connections also.