### PR TITLE
Some more changes to reduce adjacent server flakes

### DIFF
--- a/edb/server/dbview/dbview.pyi
+++ b/edb/server/dbview/dbview.pyi
@@ -118,6 +118,9 @@ class Database:
     def lookup_config(self, name: str) -> Any:
         ...
 
+    def is_introspected(self) -> bool:
+        ...
+
 class DatabaseConnectionView:
     def in_tx(self) -> bool:
         ...

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -453,6 +453,9 @@ cdef class Database:
                 if self.user_schema_pickle is None:
                     await self.tenant.introspect_db(self.name)
 
+    def is_introspected(self):
+        return self.user_schema_pickle is not None
+
     def lookup_config(self, name: str):
         spec = self._index._sys_config_spec
         if self.user_config_spec is not None:

--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -120,7 +120,7 @@ async def http(server: edbserver.BaseServer) -> None:
                     tasks.append(
                         tenant.create_task(
                             _http_task(tenant, tenant_http[tenant]),
-                            interruptable=False,
+                            interruptable=True,
                         )
                     )
             # Remove unused tenant_http entries
@@ -310,7 +310,7 @@ async def gc(server: edbserver.BaseServer) -> None:
     while True:
         tasks = [
             tenant.create_task(
-                _gc(tenant, NET_HTTP_REQUEST_TTL), interruptable=False
+                _gc(tenant, NET_HTTP_REQUEST_TTL), interruptable=True
             )
             for tenant in server.iter_tenants()
             if tenant.accept_new_tasks

--- a/edb/server/protocol/auth_ext/email.py
+++ b/edb/server/protocol/auth_ext/email.py
@@ -131,7 +131,7 @@ async def send_fake_email(tenant: tenant.Tenant) -> None:
 async def _protected_send(
     coro: Coroutine[Any, Any, None], tenant: tenant.Tenant
 ) -> None:
-    task = tenant.create_task(coro, interruptable=False)
+    task = tenant.create_task(coro, interruptable=True)
     # Prevent timing attack
     await asyncio.sleep(random.random() * 0.5)
     # Expose e.g. configuration errors

--- a/edb/server/protocol/auth_ext/pkce.py
+++ b/edb/server/protocol/auth_ext/pkce.py
@@ -193,7 +193,7 @@ async def gc(server: edbserver.BaseServer) -> None:
     while True:
         try:
             tasks = [
-                tenant.create_task(_gc(tenant), interruptable=False)
+                tenant.create_task(_gc(tenant), interruptable=True)
                 for tenant in server.iter_tenants()
                 if tenant.accept_new_tasks
             ]


### PR DESCRIPTION
1. Make worker threads (like net) not attempt new connections
   once the server has started shutting down.
2. Don't respond to messages that prompt updating database
   metadata for database's we don't have introspected anyway.
3. Mark a lot of worker tasks as being interruptable. When they
   weren't interruptable, server exit had to wait for them to
   exit, which they didn't always do. This caused connections
   to get held open.

*Most* of the locally observable flakes I've been seeing were fixed by
these changes, though I am still getting
test_server_adjacent_database_propagation failures where it fails to
connect to the newly create database. Still working on that.