### PR TITLE
Avoid computing globals json if not needed for inlined function.

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -542,6 +542,28 @@ class ArgumentInliner(ast.NodeTransformer):
 
         return cast(irast.Base, self.generic_visit(node))
 
+    # Don't transform pointer refs.
+    # They are updated in other places, such as cardinality inference.
+    def visit_PointerRef(
+        self, node: irast.PointerRef
+    ) -> irast.Base:
+        return node
+
+    def visit_TupleIndirectionPointerRef(
+        self, node: irast.TupleIndirectionPointerRef
+    ) -> irast.Base:
+        return node
+
+    def visit_SpecialPointerRef(
+        self, node: irast.SpecialPointerRef
+    ) -> irast.Base:
+        return node
+
+    def visit_TypeIntersectionPointerRef(
+        self, node: irast.TypeIntersectionPointerRef
+    ) -> irast.Base:
+        return node
+
 
 class _SpecialCaseFunc(Protocol):
     def __call__(

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -337,7 +337,25 @@ def compile_FunctionCall(
     else:
         tuple_path_ids = []
 
-    global_args = get_globals(expr, matched_call, candidates=funcs, ctx=ctx)
+    global_args = None
+    if inline_func:
+        def find_using_global(node: irast.FunctionCall) -> bool:
+            return node.global_args is not None and len(node.global_args) > 0
+
+        if ast.find_children(
+            inline_func,
+            irast.FunctionCall,
+            test_func=find_using_global,
+            terminate_early=True,
+        ):
+            global_args = get_globals(
+                expr, matched_call, candidates=funcs, ctx=ctx
+            )
+
+    else:
+        global_args = get_globals(
+            expr, matched_call, candidates=funcs, ctx=ctx
+        )
 
     fcall = irast.FunctionCall(
         args=final_args,

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -338,21 +338,7 @@ def compile_FunctionCall(
         tuple_path_ids = []
 
     global_args = None
-    if inline_func:
-        def find_using_global(node: irast.FunctionCall) -> bool:
-            return node.global_args is not None and len(node.global_args) > 0
-
-        if ast.find_children(
-            inline_func,
-            irast.FunctionCall,
-            test_func=find_using_global,
-            terminate_early=True,
-        ):
-            global_args = get_globals(
-                expr, matched_call, candidates=funcs, ctx=ctx
-            )
-
-    else:
+    if not inline_func:
         global_args = get_globals(
             expr, matched_call, candidates=funcs, ctx=ctx
         )


### PR DESCRIPTION
related #7692