### PR TITLE
Factoring of columns in USING clause over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/context.py
+++ b/edb/pgsql/resolver/context.py
@@ -73,7 +73,7 @@ class Scope:
     ctes: List[CTE] = field(default_factory=lambda: [])
 
     # Pairs of columns of the same name that have been compared in a USING
-    # clause. This makes unqualified references to their name them un-ambagious.
+    # clause. This makes unqualified references to their name them un-ambiguous.
     # The fourth tuple element is the join type.
     factored_columns: List[Tuple[str, Table, Table, str]] = field(
         default_factory=lambda: []

--- a/edb/pgsql/resolver/context.py
+++ b/edb/pgsql/resolver/context.py
@@ -72,6 +72,13 @@ class Scope:
     # Common Table Expressions
     ctes: List[CTE] = field(default_factory=lambda: [])
 
+    # Pairs of columns of the same name that have been compared in a USING
+    # clause. This makes unqualified references to their name them un-ambagious,
+    # it resolves to the column in the left (first) table.
+    factored_columns: List[Tuple[str, Table, Table]] = field(
+        default_factory=lambda: []
+    )
+
 
 @dataclass(kw_only=True)
 class Table:

--- a/edb/pgsql/resolver/context.py
+++ b/edb/pgsql/resolver/context.py
@@ -73,9 +73,9 @@ class Scope:
     ctes: List[CTE] = field(default_factory=lambda: [])
 
     # Pairs of columns of the same name that have been compared in a USING
-    # clause. This makes unqualified references to their name them un-ambagious,
-    # it resolves to the column in the left (first) table.
-    factored_columns: List[Tuple[str, Table, Table]] = field(
+    # clause. This makes unqualified references to their name them un-ambagious.
+    # The fourth tuple element is the join type.
+    factored_columns: List[Tuple[str, Table, Table, str]] = field(
         default_factory=lambda: []
     )
 
@@ -156,6 +156,12 @@ class ColumnComputable(ColumnKind):
     # An EdgeQL computable property. To get the AST for this column, EdgeQL
     # compiler needs to be invoked.
     pointer: s_pointers.Pointer
+
+
+@dataclass(kw_only=True)
+class ColumnPgExpr(ColumnKind):
+    # Value that was provided by some special resolver path.
+    expr: pgast.BaseExpr
 
 
 @dataclass(kw_only=True, eq=False, slots=True, repr=False)

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -141,8 +141,8 @@ def resolve_column_kind(
         case context.ColumnStaticVal(val=val):
             # special case: __type__ static value
             return _uuid_const(val)
-        case context.ColumnPgExpr(expr=expr):
-            return expr
+        case context.ColumnPgExpr(expr=e):
+            return e
         case context.ColumnComputable(pointer=pointer):
 
             expr = pointer.get_expr(ctx.schema)

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -271,7 +271,7 @@ def _lookup_column(
         ]
 
     # when ambiguous references have been used in USING clause,
-    # pick the column from the left table
+    # we resolve them to first or the second column or a COALESCE of the two.
     if (
         len(matched_columns) == 2
         and matched_columns[0][1].name == matched_columns[1][1].name

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -191,7 +191,9 @@ def _resolve_JoinExpr(
                 subctx.scope.tables = [rtable]
                 r_expr = dispatch.resolve(c, ctx=subctx)
 
-            ctx.scope.factored_columns.append((c_name, ltable, rtable))
+            ctx.scope.factored_columns.append(
+                (c_name, ltable, rtable, join.type)
+            )
 
             quals = pgastutils.extend_binop(
                 quals,

--- a/edb/pgsql/resolver/range_var.py
+++ b/edb/pgsql/resolver/range_var.py
@@ -180,12 +180,19 @@ def _resolve_JoinExpr(
 
     if join.using_clause:
         for c in join.using_clause:
+            assert len(c.name) == 1
+            assert isinstance(c.name[-1], str)
+            c_name = c.name[-1]
+
             with ctx.child() as subctx:
                 subctx.scope.tables = [ltable]
                 l_expr = dispatch.resolve(c, ctx=subctx)
             with ctx.child() as subctx:
                 subctx.scope.tables = [rtable]
                 r_expr = dispatch.resolve(c, ctx=subctx)
+
+            ctx.scope.factored_columns.append((c_name, ltable, rtable))
+
             quals = pgastutils.extend_binop(
                 quals,
                 pgast.Expr(

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -816,6 +816,50 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         )
         self.assertEqual(res, [[1, 'a', 1, 'a', 1, 'a']])
 
+        res = await self.squery_values(
+            '''
+            WITH
+                a(id) AS (SELECT 1 UNION SELECT 2),
+                b(id) AS (SELECT 1 UNION SELECT 3)
+            SELECT a.id, b.id, id
+            FROM a INNER JOIN b USING (id);
+            '''
+        )
+        self.assertEqual(res, [[1, 1, 1]])
+
+        res = await self.squery_values(
+            '''
+            WITH
+                a(id) AS (SELECT 1 UNION SELECT 2),
+                b(id) AS (SELECT 1 UNION SELECT 3)
+            SELECT a.id, b.id, id
+            FROM a RIGHT JOIN b USING (id);
+            '''
+        )
+        self.assertEqual(res, [[1, 1, 1], [None, 3, 3]])
+
+        res = await self.squery_values(
+            '''
+            WITH
+                a(id) AS (SELECT 1 UNION SELECT 2),
+                b(id) AS (SELECT 1 UNION SELECT 3)
+            SELECT a.id, b.id, id
+            FROM a RIGHT OUTER JOIN b USING (id);
+            '''
+        )
+        self.assertEqual(res, [[1, 1, 1], [None, 3, 3]])
+
+        res = await self.squery_values(
+            '''
+            WITH
+                a(id) AS (SELECT 1 UNION SELECT 2),
+                b(id) AS (SELECT 1 UNION SELECT 3)
+            SELECT a.id, b.id, id
+            FROM a FULL JOIN b USING (id);
+            '''
+        )
+        self.assertEqual(res, [[1, 1, 1], [2, None, 2], [None, 3, 3]])
+
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname
         res = await self.squery_values(

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -791,6 +791,31 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         self.assertEqual(res, 'UPDATE 1')
         await tran.rollback()
 
+    async def test_sql_query_43(self):
+        # USING factoring
+
+        res = await self.squery_values(
+            '''
+            WITH
+                a(id) AS (SELECT 1 UNION SELECT 2),
+                b(id) AS (SELECT 1 UNION SELECT 3)
+            SELECT a.id, b.id, id
+            FROM a LEFT JOIN b USING (id);
+            '''
+        )
+        self.assertEqual(res, [[1, 1, 1], [2, None, 2]])
+
+        res = await self.squery_values(
+            '''
+            WITH
+                a(id, sub_id) AS (SELECT 1, 'a' UNION SELECT 2, 'b'),
+                b(id, sub_id) AS (SELECT 1, 'a' UNION SELECT 3, 'c')
+            SELECT a.id, a.sub_id, b.id, b.sub_id, id, sub_id
+            FROM a JOIN b USING (id, sub_id);
+            '''
+        )
+        self.assertEqual(res, [[1, 'a', 1, 'a', 1, 'a']])
+
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname
         res = await self.squery_values(


### PR DESCRIPTION
This PR makes the last `id` identifier in this query:
```
SELECT
FROM x
JOIN y USING (id)
WHERE id = 4  -- this id is not ambiguous 
```
... not ambiguous, but instead equivalent to `x.id`.