### PR TITLE
Improve format_type over SQL adapter

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4747,53 +4747,6 @@ class FTSToRegconfig(trampoline.VersionedFunction):
         )
 
 
-class FormatTypeFunction(trampoline.VersionedFunction):
-    """Used instead of pg_catalog.format_type in pg_dump."""
-
-    text = r'''
-    SELECT
-        CASE WHEN t.typcategory = 'A'
-        THEN (
-            SELECT
-                quote_ident(nspname) || '.' ||
-                quote_ident(el.typname) || tm.mod || '[]'
-            FROM edgedbsql_VER.pg_namespace
-            WHERE oid = el.typnamespace
-        )
-        ELSE (
-            SELECT
-                quote_ident(nspname) || '.' ||
-                quote_ident(t.typname) || tm.mod
-            FROM edgedbsql_VER.pg_namespace
-            WHERE oid = t.typnamespace
-        )
-        END
-    FROM
-        (
-            SELECT
-                CASE WHEN typemod >= 0
-                THEN '(' || typemod::text || ')'
-                ELSE ''
-                END AS mod
-        ) as tm,
-        edgedbsql_VER.pg_type t
-    LEFT JOIN edgedbsql_VER.pg_type el ON t.typelem = el.oid
-    WHERE t.oid = typeoid
-    '''
-
-    def __init__(self) -> None:
-        super().__init__(
-            name=('edgedb', '_format_type'),
-            args=[
-                ('typeoid', ('oid',)),
-                ('typemod', ('integer',)),
-            ],
-            returns=('text',),
-            volatility='stable',
-            text=self.text,
-        )
-
-
 class UuidGenerateV1mcFunction(trampoline.VersionedFunction):
     def __init__(self, ext_schema: str) -> None:
         super().__init__(
@@ -6017,7 +5970,7 @@ def _generate_sql_information_schema(
         volatility='stable',
         text=r'''
             SELECT COALESCE (
-                -- is the nmae in virtual_tables?
+                -- is the name in virtual_tables?
                 (
                     SELECT vt.table_name::name
                     FROM edgedbsql_VER.virtual_tables vt
@@ -7181,6 +7134,57 @@ def _generate_sql_information_schema(
                 FROM edgedbsql_VER.pg_class pc
                 WHERE id = pc.oid
             '''
+        ),
+        trampoline.VersionedFunction(
+            # Used instead of pg_catalog.format_type in pg_dump.
+            name=('edgedbsql', '_format_type'),
+            args=[
+                ('typeoid', ('oid',)),
+                ('typemod', ('integer',)),
+            ],
+            returns=('text',),
+            volatility='STABLE',
+            text=r'''
+                SELECT
+                    CASE
+                        -- arrays
+                        WHEN t.typcategory = 'A' THEN (
+                            SELECT
+                                quote_ident(nspname) || '.' ||
+                                quote_ident(el.typname) || tm.mod || '[]'
+                            FROM edgedbsql_VER.pg_namespace
+                            WHERE oid = el.typnamespace
+                        )
+
+                        -- composite (tuples) and types in irregular schemas
+                        WHEN (
+                            t.typcategory = 'C' OR COALESCE(tn.nspname IN (
+                                'edgedb', 'edgedbt', 'edgedbpub', 'edgedbstd',
+                                'edgedb_VER', 'edgedbstd_VER'
+                            ), TRUE)
+                        ) THEN (
+                            SELECT
+                                quote_ident(nspname) || '.' ||
+                                quote_ident(t.typname) || tm.mod
+                            FROM edgedbsql_VER.pg_namespace
+                            WHERE oid = t.typnamespace
+                        )
+                        ELSE format_type(typeoid, typemod)
+                    END
+                FROM edgedbsql_VER.pg_type t
+                LEFT JOIN pg_namespace tn ON t.typnamespace = tn.oid
+                LEFT JOIN edgedbsql_VER.pg_type el ON t.typelem = el.oid
+
+                CROSS JOIN (
+                    SELECT
+                        CASE
+                            WHEN typemod >= 0 THEN '(' || typemod::text || ')'
+                            ELSE ''
+                        END AS mod
+                ) as tm
+
+                WHERE t.oid = typeoid
+            ''',
         )
     ]
 
@@ -7406,7 +7410,6 @@ async def generate_support_functions(
         dbops.CreateFunction(IssubclassFunction()),
         dbops.CreateFunction(IssubclassFunction2()),
         dbops.CreateFunction(GetSchemaObjectNameFunction()),
-        dbops.CreateFunction(FormatTypeFunction()),
     ]
     commands.add_commands(cmds)
 

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -406,7 +406,14 @@ func_calls_remapping: Dict[Tuple[str, ...], Tuple[str, ...]] = {
         common.versioned_schema('edgedbsql'),
         '_pg_truetypmod',
     ),
-    ('pg_catalog', 'format_type'): ('edgedb', '_format_type'),
+    ('pg_catalog', 'format_type'): (
+        common.versioned_schema('edgedbsql'),
+        '_format_type',
+    ),
+    ('format_type',): (
+        common.versioned_schema('edgedbsql'),
+        '_format_type',
+    ),
 }
 
 


### PR DESCRIPTION
We have a custom implementation for pg_catalog.format_type, which takes
renames of our schema into account. There were a few problems:
- pg_catalog.format_type and format_type were being resolved to different functions,
- format_type was too verbose for simple types.

I think we should simplify the exposed schemas a bit. We should probably merge some of them,
so that:
- `public` schema contains only things from the `default` module,
- `edgedb`, `edgedbt`, `edgedbstd`, `edgedb_VER`, `edgedbstd_VER` are merged into `std` and `schema` modules.
