### PR TITLE
Fix embedding data being stored with the wrong entry

### DIFF
--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -211,6 +211,30 @@ class MistralTokenizer(Tokenizer):
         return cast(str, self.tokenizer.decode(tokens))
 
 
+class TestTokenizer(Tokenizer):
+
+    _instances: dict[str, TestTokenizer] = {}
+
+    @classmethod
+    def for_model(cls, model_name: str) -> TestTokenizer:
+        if model_name in cls._instances:
+            return cls._instances[model_name]
+
+        tokenizer = TestTokenizer()
+        cls._instances[model_name] = tokenizer
+
+        return tokenizer
+
+    def encode(self, text: str) -> list[int]:
+        return [ord(c) for c in text]
+
+    def encode_padding(self) -> int:
+        return 0
+
+    def decode(self, tokens: list[int]) -> str:
+        return ''.join(chr(c) for c in tokens)
+
+
 @dataclass
 class ProviderConfig:
     name: str
@@ -600,6 +624,11 @@ async def _generate_embeddings_params(
     elif provider_name == 'builtin::mistral':
         model_tokenizers = {
             model_name: MistralTokenizer.for_model(model_name)
+            for model_name in provider_models
+        }
+    elif provider_name == 'custom::test':
+        model_tokenizers = {
+            model_name: TestTokenizer.for_model(model_name)
             for model_name in provider_models
         }
 

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -411,7 +411,7 @@ class TestExtAIUtils(unittest.TestCase):
                 ['1', '22', '333', '4444'],
                 10
             ),
-            [(['4444', '1', '22', '333'], 10)],
+            [([3, 0, 1, 2], 10)],
         )
         self.assertEqual(
             ai_ext._batch_embeddings_inputs(
@@ -420,8 +420,8 @@ class TestExtAIUtils(unittest.TestCase):
                 10
             ),
             [
-                (['55555', '1', '22'], 8),
-                (['4444', '333'], 7),
+                ([4, 0, 1], 8),
+                ([3, 2], 7),
             ],
         )
         self.assertEqual(
@@ -431,9 +431,9 @@ class TestExtAIUtils(unittest.TestCase):
                 10
             ),
             [
-                (['666666', '1', '22'], 9),
-                (['55555', '333'], 8),
-                (['4444'], 4),
+                ([5, 0, 1], 9),
+                ([4, 2], 8),
+                ([3], 4),
             ],
         )
         self.assertEqual(
@@ -443,9 +443,9 @@ class TestExtAIUtils(unittest.TestCase):
                 10
             ),
             [
-                (['666666', '1', '22'], 9),
-                (['55555', '333'], 8),
-                (['4444'], 4),
+                ([5, 0, 1], 9),
+                ([4, 2], 8),
+                ([3], 4),
             ],
         )
         self.assertEqual(
@@ -455,7 +455,7 @@ class TestExtAIUtils(unittest.TestCase):
                 10
             ),
             [
-                (['55555', '1', '22'], 8),
-                (['4444', '333'], 7),
+                ([4, 0, 1], 8),
+                ([3, 2], 7),
             ],
         )


### PR DESCRIPTION
The batching of inputs based on token limits implemented in #7574 introduced a bug where the embeddings ids would not be reliably paired with the embeddings. This causes the wrong results to be returned in ai searches.

This error was not caught in the existing tests because the `custom::test` provider used in tests does not have a tokenizer and so it doesn't use the batching. The last commit adds a tokenizer, and the added test will fail if cherry picked to master.