### PR TITLE
Export metrics about extension use

### DIFF
--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -98,6 +98,10 @@ cdef class Database:
     cdef _remove_view(self, view)
     cdef _observe_auth_ext_config(self)
     cdef _update_backend_ids(self, new_types)
+    cdef _set_extensions(
+        self,
+        extensions,
+    )
     cdef _set_and_signal_new_user_schema(
         self,
         new_schema_pickle,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -307,15 +307,11 @@ cdef class Database:
         tname = self.tenant.get_instance_name()
         for ext in self.extensions:
             if ext not in extensions:
-                metrics.extension_used.dec(
-                    1, self.tenant.get_instance_name(), ext
-                )
+                metrics.extension_used.dec(1, tname, ext)
 
         for ext in extensions:
             if ext not in self.extensions:
-                metrics.extension_used.inc(
-                    1, self.tenant.get_instance_name(), ext
-                )
+                metrics.extension_used.inc(1, tname, ext)
 
         self.extensions = extensions
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -159,7 +159,8 @@ cdef class Database:
             self.user_config_spec = config.FlatSpec(*ext_config_settings)
         self.reflection_cache = reflection_cache
         self.backend_ids = backend_ids
-        self.extensions = extensions
+        self.extensions = set()
+        self._set_extensions(extensions)
         self._observe_auth_ext_config()
 
         self._cache_worker_task = self._cache_queue = None
@@ -186,7 +187,7 @@ cdef class Database:
         if self._cache_notify_task:
             self._cache_notify_task.cancel()
             self._cache_notify_task = None
-        self.extensions = set()
+        self._set_extensions(set())
         self.start_stop_extensions()
 
     async def monitor(self, worker, name):
@@ -301,6 +302,23 @@ cdef class Database:
             max_batch_size=100,
         )
 
+    cdef _set_extensions(self, extensions):
+        # Update metrics about extension use
+        tname = self.tenant.get_instance_name()
+        for ext in self.extensions:
+            if ext not in extensions:
+                metrics.extension_used.dec(
+                    1, self.tenant.get_instance_name(), ext
+                )
+
+        for ext in extensions:
+            if ext not in self.extensions:
+                metrics.extension_used.inc(
+                    1, self.tenant.get_instance_name(), ext
+                )
+
+        self.extensions = extensions
+
     cdef _set_and_signal_new_user_schema(
         self,
         new_schema_pickle,
@@ -319,7 +337,7 @@ cdef class Database:
         self.dbver = next_dbver()
 
         self.user_schema_pickle = new_schema_pickle
-        self.extensions = extensions
+        self._set_extensions(extensions)
         self.user_config_spec = config.FlatSpec(*ext_config_settings)
 
         if backend_ids is not None:

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -194,6 +194,12 @@ auth_providers = registry.new_labeled_gauge(
     labels=('tenant', 'branch'),
 )
 
+extension_used = registry.new_labeled_gauge(
+    'extension_used',
+    'How many branches an extension is used by.',
+    labels=('tenant', 'extension'),
+)
+
 auth_successful_logins = registry.new_labeled_counter(
     "auth_successful_logins_total",
     "Number of successful logins in the Auth extension.",

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -195,7 +195,7 @@ auth_providers = registry.new_labeled_gauge(
 )
 
 extension_used = registry.new_labeled_gauge(
-    'extension_used',
+    'extension_used_branch_count_current',
     'How many branches an extension is used by.',
     labels=('tenant', 'extension'),
 )

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -785,7 +785,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
     async def test_server_ops_schema_metrics_01(self):
         def _extkey(extension: str) -> str:
             return (
-                f'edgedb_server_extension_used'
+                f'edgedb_server_extension_used_branch_count_current'
                 f'{{tenant="localtest",extension="{extension}"}}'
             )
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -782,6 +782,37 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
                 finally:
                     await con.aclose()
 
+    async def test_server_ops_schema_metrics_01(self):
+        def _extkey(extension: str) -> str:
+            return (
+                f'edgedb_server_extension_used'
+                f'{{tenant="localtest",extension="{extension}"}}'
+            )
+
+        async with tb.start_edgedb_server(
+            default_auth_method=args.ServerAuthMethod.Trust,
+            net_worker_mode='disabled',
+        ) as sd:
+            con = await sd.connect()
+            try:
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_extkey('graphql'), 0), 0)
+                self.assertEqual(metrics.get(_extkey('pg_trgm'), 0), 0)
+
+                await con.execute('create extension graphql')
+                await con.execute('create extension pg_trgm')
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_extkey('graphql'), 0), 1)
+                self.assertEqual(metrics.get(_extkey('pg_trgm'), 0), 1)
+
+                await con.execute('drop extension graphql')
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_extkey('graphql'), 0), 0)
+                self.assertEqual(metrics.get(_extkey('pg_trgm'), 0), 1)
+
+            finally:
+                await con.aclose()
+
     async def test_server_ops_downgrade_to_cleartext(self):
         async with tb.start_edgedb_server(
             binary_endpoint_security=args.ServerEndpointSecurityMode.Optional,


### PR DESCRIPTION
Export a per-extension metric indicating which extensions are in use.
Really it reports how many branches each extension is in use by.