### PR TITLE
Export metric about schema feature use

### DIFF
--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -140,7 +140,7 @@ class Property(
     def is_link_property(self, schema: s_schema.Schema) -> bool:
         source = self.get_source(schema)
         if source is None:
-            raise ValueError(f'{self.get_verbosename(schema)} is abstract')
+            return False
         return isinstance(source, pointers.Pointer)
 
     def allow_ref_propagation(

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -506,6 +506,7 @@ class Schema(abc.ABC):
         *,
         exclude_stdlib: bool = False,
         exclude_global: bool = False,
+        exclude_extensions: bool = False,
         exclude_internal: bool = True,
         included_modules: Optional[Iterable[sn.Name]] = None,
         excluded_modules: Optional[Iterable[sn.Name]] = None,
@@ -1499,6 +1500,7 @@ class FlatSchema(Schema):
         *,
         exclude_stdlib: bool = False,
         exclude_global: bool = False,
+        exclude_extensions: bool = False,
         exclude_internal: bool = True,
         included_modules: Optional[Iterable[sn.Name]] = None,
         excluded_modules: Optional[Iterable[sn.Name]] = None,
@@ -1512,6 +1514,7 @@ class FlatSchema(Schema):
             self._id_to_type,
             exclude_stdlib=exclude_stdlib,
             exclude_global=exclude_global,
+            exclude_extensions=exclude_extensions,
             exclude_internal=exclude_internal,
             included_modules=included_modules,
             excluded_modules=excluded_modules,
@@ -1613,6 +1616,7 @@ class SchemaIterator(Generic[so.Object_T]):
         *,
         exclude_stdlib: bool = False,
         exclude_global: bool = False,
+        exclude_extensions: bool = False,
         exclude_internal: bool = True,
         included_modules: Optional[Iterable[sn.Name]],
         excluded_modules: Optional[Iterable[sn.Name]],
@@ -1661,6 +1665,12 @@ class SchemaIterator(Generic[so.Object_T]):
         if exclude_stdlib:
             filters.append(
                 lambda schema, obj: not isinstance(obj, s_pseudo.PseudoType)
+            )
+
+        if exclude_extensions:
+            filters.append(
+                lambda schema, obj:
+                obj.get_name(schema).get_root_module_name() != EXT_MODULE
             )
 
         if exclude_global:
@@ -2138,6 +2148,7 @@ class ChainedSchema(Schema):
         *,
         exclude_stdlib: bool = False,
         exclude_global: bool = False,
+        exclude_extensions: bool = False,
         exclude_internal: bool = True,
         included_modules: Optional[Iterable[sn.Name]] = None,
         excluded_modules: Optional[Iterable[sn.Name]] = None,
@@ -2151,6 +2162,7 @@ class ChainedSchema(Schema):
             self._get_object_ids(),
             exclude_global=exclude_global,
             exclude_stdlib=exclude_stdlib,
+            exclude_extensions=exclude_extensions,
             exclude_internal=exclude_internal,
             included_modules=included_modules,
             excluded_modules=excluded_modules,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -814,6 +814,9 @@ class Compiler:
             ext_config_settings=ext_config_settings,
             protocol_version=defines.CURRENT_PROTOCOL,
             state_serializer=state_serializer,
+            feature_used_metrics=ddl.produce_feature_used_metrics(
+                self.state, user_schema
+            ),
         )
 
     def make_state_serializer(
@@ -1945,6 +1948,11 @@ def _compile_ql_transaction(
         global_schema=final_global_schema,
         sp_name=sp_name,
         sp_id=sp_id,
+        feature_used_metrics=(
+            ddl.produce_feature_used_metrics(
+                ctx.compiler_state, final_user_schema
+            ) if final_user_schema else None
+        ),
     )
 
 
@@ -2477,6 +2485,7 @@ def _try_compile(
                     unit.extensions, unit.ext_config_settings = (
                         _extract_extensions(ctx, comp.user_schema)
                     )
+                unit.feature_used_metrics = comp.feature_used_metrics
                 if comp.cached_reflection is not None:
                     unit.cached_reflection = \
                         pickle.dumps(comp.cached_reflection, -1)
@@ -2505,6 +2514,7 @@ def _try_compile(
                     unit.extensions, unit.ext_config_settings = (
                         _extract_extensions(ctx, comp.user_schema)
                     )
+                unit.feature_used_metrics = comp.feature_used_metrics
                 if comp.cached_reflection is not None:
                     unit.cached_reflection = \
                         pickle.dumps(comp.cached_reflection, -1)

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -159,7 +159,8 @@ class SessionStateQuery(BaseQuery):
 @dataclasses.dataclass(frozen=True)
 class DDLQuery(BaseQuery):
 
-    user_schema: s_schema.FlatSchema
+    user_schema: Optional[s_schema.FlatSchema]
+    feature_used_metrics: Optional[dict[str, float]]
     global_schema: Optional[s_schema.FlatSchema] = None
     cached_reflection: Any = None
     is_transactional: bool = True
@@ -184,6 +185,7 @@ class TxControlQuery(BaseQuery):
     user_schema: Optional[s_schema.Schema] = None
     global_schema: Optional[s_schema.Schema] = None
     cached_reflection: Any = None
+    feature_used_metrics: Optional[dict[str, float]] = None
 
     sp_name: Optional[str] = None
     sp_id: Optional[int] = None
@@ -336,6 +338,10 @@ class QueryUnit:
     # If present, represents the future schema state after
     # the command is run. The schema is pickled.
     user_schema: Optional[bytes] = None
+    # If present, represents updated metrics about feature use induced
+    # by the new user_schema.
+    feature_used_metrics: Optional[dict[str, float]] = None
+
     # Unlike user_schema, user_schema_version usually exist, pointing to the
     # latest user schema, which is self.user_schema if changed, or the user
     # schema this QueryUnit was compiled upon.
@@ -619,6 +625,7 @@ class ParsedDatabase:
     schema_version: uuid.UUID
     database_config: immutables.Map[str, config.SettingValue]
     ext_config_settings: list[config.Setting]
+    feature_used_metrics: dict[str, float]
 
     protocol_version: defines.ProtocolVersion
     state_serializer: sertypes.StateSerializer

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -91,6 +91,7 @@ cdef class Database:
         readonly object reflection_cache
         readonly object backend_ids
         readonly object extensions
+        readonly object _feature_used_metrics
 
     cdef _invalidate_caches(self)
     cdef _cache_compiled_query(self, key, compiled)
@@ -102,12 +103,14 @@ cdef class Database:
         self,
         extensions,
     )
+    cdef _set_feature_used_metrics(self, feature_used_metrics)
     cdef _set_and_signal_new_user_schema(
         self,
         new_schema_pickle,
         schema_version,
         extensions,
         ext_config_settings,
+        feature_used_metrics,
         reflection_cache=?,
         backend_ids=?,
         db_config=?,
@@ -208,6 +211,7 @@ cdef class DatabaseConnectionView:
         global_schema,
         roles,
         cached_reflection,
+        feature_used_metrics,
     )
 
     cdef get_user_config_spec(self)

--- a/edb/server/dbview/dbview.pyi
+++ b/edb/server/dbview/dbview.pyi
@@ -186,6 +186,7 @@ class DatabaseIndex:
         extensions: Optional[set[str]],
         ext_config_settings: Optional[list[config.Setting]],
         early: bool = False,
+        feature_used_metrics: Optional[Mapping[str, float]] = ...,
     ) -> Database:
         ...
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -126,6 +126,7 @@ cdef class Database:
         object backend_ids,
         object extensions,
         object ext_config_settings,
+        object feature_used_metrics,
     ):
         self.name = name
 
@@ -163,6 +164,9 @@ cdef class Database:
         self._set_extensions(extensions)
         self._observe_auth_ext_config()
 
+        self._feature_used_metrics = {}
+        self._set_feature_used_metrics(feature_used_metrics)
+
         self._cache_worker_task = self._cache_queue = None
         self._cache_notify_task = self._cache_notify_queue = None
         self._cache_queue = asyncio.Queue()
@@ -188,6 +192,7 @@ cdef class Database:
             self._cache_notify_task.cancel()
             self._cache_notify_task = None
         self._set_extensions(set())
+        self._set_feature_used_metrics({})
         self.start_stop_extensions()
 
     async def monitor(self, worker, name):
@@ -315,12 +320,34 @@ cdef class Database:
 
         self.extensions = extensions
 
+    cdef _set_feature_used_metrics(self, feature_used_metrics):
+        # Update metrics about feature use
+        #
+        # We store the old feature use metrics so that we can
+        # incrementally update them after DDL without needing to look
+        # at the other database branches
+        if feature_used_metrics is None:
+            return
+
+        tname = self.tenant.get_instance_name()
+        keys = self._feature_used_metrics.keys() | feature_used_metrics.keys()
+        for key in keys:
+            metrics.feature_used.inc(
+                feature_used_metrics.get(key, 0.0)
+                - self._feature_used_metrics.get(key, 0.0),
+                tname,
+                key,
+            )
+
+        self._feature_used_metrics = feature_used_metrics
+
     cdef _set_and_signal_new_user_schema(
         self,
         new_schema_pickle,
         schema_version,
         extensions,
         ext_config_settings,
+        feature_used_metrics,
         reflection_cache=None,
         backend_ids=None,
         db_config=None,
@@ -335,6 +362,8 @@ cdef class Database:
         self.user_schema_pickle = new_schema_pickle
         self._set_extensions(extensions)
         self.user_config_spec = config.FlatSpec(*ext_config_settings)
+
+        self._set_feature_used_metrics(feature_used_metrics)
 
         if backend_ids is not None:
             self.backend_ids = backend_ids
@@ -986,9 +1015,10 @@ cdef class DatabaseConnectionView:
                     query_unit.user_schema_version,
                     query_unit.extensions,
                     query_unit.ext_config_settings,
+                    query_unit.feature_used_metrics,
                     pickle.loads(query_unit.cached_reflection)
                         if query_unit.cached_reflection is not None
-                        else None
+                        else None,
                 )
                 side_effects |= SideEffects.SchemaChanges
             if query_unit.system_config:
@@ -1028,9 +1058,10 @@ cdef class DatabaseConnectionView:
                     query_unit.user_schema_version,
                     query_unit.extensions,
                     query_unit.ext_config_settings,
+                    query_unit.feature_used_metrics,  # XXX? does this get set?
                     pickle.loads(query_unit.cached_reflection)
                         if query_unit.cached_reflection is not None
-                        else None
+                        else None,
                 )
                 side_effects |= SideEffects.SchemaChanges
             if self._in_tx_with_sysconfig:
@@ -1061,6 +1092,7 @@ cdef class DatabaseConnectionView:
         global_schema,
         roles,
         cached_reflection,
+        feature_used_metrics,
     ):
         assert self._in_tx
         side_effects = 0
@@ -1077,6 +1109,7 @@ cdef class DatabaseConnectionView:
                 self._in_tx_user_schema_version,
                 extensions,
                 ext_config_settings,
+                feature_used_metrics,
                 pickle.loads(cached_reflection)
                     if cached_reflection is not None
                     else None
@@ -1551,6 +1584,7 @@ cdef class DatabaseIndex:
         extensions,
         ext_config_settings,
         early=False,
+        feature_used_metrics=None,
     ):
         cdef Database db
         db = self._dbs.get(dbname)
@@ -1560,6 +1594,7 @@ cdef class DatabaseIndex:
                 schema_version,
                 extensions,
                 ext_config_settings,
+                feature_used_metrics,
                 reflection_cache,
                 backend_ids,
                 db_config,
@@ -1576,6 +1611,7 @@ cdef class DatabaseIndex:
                 backend_ids=backend_ids,
                 extensions=extensions,
                 ext_config_settings=ext_config_settings,
+                feature_used_metrics=feature_used_metrics,
             )
             self._dbs[dbname] = db
             if not early:

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -200,6 +200,12 @@ extension_used = registry.new_labeled_gauge(
     labels=('tenant', 'extension'),
 )
 
+feature_used = registry.new_labeled_gauge(
+    'feature_used_branch_count_current',
+    'How many branches a schema feature is used by.',
+    labels=('tenant', 'feature'),
+)
+
 auth_successful_logins = registry.new_labeled_counter(
     "auth_successful_logins_total",
     "Number of successful logins in the Auth extension.",

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -420,6 +420,7 @@ async def execute_script(
         bint parse
 
     user_schema = extensions = ext_config_settings = cached_reflection = None
+    feature_used_metrics = None
     global_schema = roles = None
     unit_group = compiled.query_unit_group
 
@@ -496,6 +497,7 @@ async def execute_script(
                     extensions = query_unit.extensions
                     ext_config_settings = query_unit.ext_config_settings
                     cached_reflection = query_unit.cached_reflection
+                    feature_used_metrics = query_unit.feature_used_metrics
 
                 if query_unit.global_schema:
                     global_schema = query_unit.global_schema
@@ -577,6 +579,7 @@ async def execute_script(
                 global_schema,
                 roles,
                 cached_reflection,
+                feature_used_metrics,
             )
             if side_effects:
                 await process_side_effects(dbv, side_effects, conn)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1218,6 +1218,7 @@ class Tenant(ha_base.ClusterProtocol):
             backend_ids=backend_ids,
             extensions=extensions,
             ext_config_settings=parsed_db.ext_config_settings,
+            feature_used_metrics=parsed_db.feature_used_metrics,
         )
         db.set_state_serializer(
             parsed_db.protocol_version,

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -789,29 +789,81 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
                 f'{{tenant="localtest",extension="{extension}"}}'
             )
 
+        def _featkey(feature: str) -> str:
+            return (
+                f'edgedb_server_feature_used_branch_count_current'
+                f'{{tenant="localtest",feature="{feature}"}}'
+            )
+
         async with tb.start_edgedb_server(
             default_auth_method=args.ServerAuthMethod.Trust,
             net_worker_mode='disabled',
         ) as sd:
             con = await sd.connect()
+            con2 = None
             try:
                 metrics = tb.parse_metrics(sd.fetch_metrics())
                 self.assertEqual(metrics.get(_extkey('graphql'), 0), 0)
                 self.assertEqual(metrics.get(_extkey('pg_trgm'), 0), 0)
+                self.assertEqual(metrics.get(_featkey('function'), 0), 0)
 
                 await con.execute('create extension graphql')
                 await con.execute('create extension pg_trgm')
                 metrics = tb.parse_metrics(sd.fetch_metrics())
                 self.assertEqual(metrics.get(_extkey('graphql'), 0), 1)
                 self.assertEqual(metrics.get(_extkey('pg_trgm'), 0), 1)
+                # The innards of extensions shouldn't be counted in
+                # feature use metrics. (pg_trgm has functions.)
+                self.assertEqual(metrics.get(_featkey('function'), 0), 0)
 
                 await con.execute('drop extension graphql')
                 metrics = tb.parse_metrics(sd.fetch_metrics())
                 self.assertEqual(metrics.get(_extkey('graphql'), 0), 0)
                 self.assertEqual(metrics.get(_extkey('pg_trgm'), 0), 1)
 
+                self.assertEqual(metrics.get(_extkey('global'), 0), 0)
+
+                await con.execute('create global foo -> str;')
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_featkey('global'), 0), 1)
+
+                # Make sure it works after a transaction
+                await con.execute('start transaction;')
+                await con.execute('drop global foo;')
+                await con.execute('commit;')
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_featkey('global'), 0), 0)
+
+                # And inside a script
+                await con.execute('create global foo -> str; select 1;')
+                await con.execute('create function asdf() -> int64 using (0)')
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_featkey('global'), 0), 1)
+                self.assertEqual(metrics.get(_featkey('function'), 0), 1)
+
+                # Check in a second branch
+                await con.execute('create empty branch b2')
+                con2 = await sd.connect(database='b2')
+                await con2.execute('create function asdf() -> int64 using (0)')
+                await con2.execute('create extension graphql')
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_extkey('graphql'), 0), 1)
+                self.assertEqual(metrics.get(_featkey('global'), 0), 1)
+                self.assertEqual(metrics.get(_featkey('function'), 0), 2)
+
+                await con2.aclose()
+                con2 = None
+
+                # Dropping the other branch clears them out
+                await con.execute('drop branch b2')
+                metrics = tb.parse_metrics(sd.fetch_metrics())
+                self.assertEqual(metrics.get(_extkey('graphql'), 0), 0)
+                self.assertEqual(metrics.get(_featkey('function'), 0), 1)
+
             finally:
                 await con.aclose()
+                if con2:
+                    await con2.aclose()
 
     async def test_server_ops_downgrade_to_cleartext(self):
         async with tb.start_edgedb_server(


### PR DESCRIPTION
Currently report whether the following are used:
 - policies
 - triggers
 - rewrites
 - globals
 - computed globals
 - aliases
 - functions
 - computed pointers
 - FTS