### PR TITLE
Add logs to auth extension

### DIFF
--- a/edb/server/protocol/auth_ext/email_password.py
+++ b/edb/server/protocol/auth_ext/email_password.py
@@ -94,12 +94,7 @@ class Client(local.Client):
         assert len(result_json) == 1
         return data.EmailFactor(**result_json[0])
 
-    async def authenticate(self, input: dict[str, Any]) -> data.LocalIdentity:
-        if 'email' not in input or 'password' not in input:
-            raise errors.InvalidData("Missing 'email' or 'password' in data")
-
-        password = input["password"]
-        email = input["email"]
+    async def authenticate(self, email: str, password: str) -> data.LocalIdentity:
         r = await execute.parse_execute_json(
             db=self.db,
             query="""\
@@ -151,12 +146,8 @@ set { password_hash := new_hash };""",
 
     async def get_email_factor_and_secret(
         self,
-        input: dict[str, Any],
+        email: str,
     ) -> tuple[data.EmailFactor, str]:
-        if 'email' not in input:
-            raise errors.InvalidData("Missing 'email' in data")
-
-        email = input["email"]
         r = await execute.parse_execute_json(
             db=self.db,
             query="""
@@ -215,13 +206,8 @@ filter .identity.id = identity_id;""",
         return local_identity if secret == current_secret else None
 
     async def update_password(
-        self, identity_id: str, secret: str, input: dict[str, Any]
+        self, identity_id: str, secret: str, password: str
     ) -> data.LocalIdentity:
-        if 'password' not in input:
-            raise errors.InvalidData("Missing 'password' in data")
-
-        password = input["password"]
-
         local_identity = await self.validate_reset_secret(identity_id, secret)
 
         if local_identity is None:

--- a/edb/server/protocol/auth_ext/email_password.py
+++ b/edb/server/protocol/auth_ext/email_password.py
@@ -94,7 +94,9 @@ class Client(local.Client):
         assert len(result_json) == 1
         return data.EmailFactor(**result_json[0])
 
-    async def authenticate(self, email: str, password: str) -> data.LocalIdentity:
+    async def authenticate(
+        self, email: str, password: str
+    ) -> data.LocalIdentity:
         r = await execute.parse_execute_json(
             db=self.db,
             query="""\

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -2044,7 +2044,8 @@ class Router:
                     event=event,
                 )
                 logger.info(
-                    f"Sent webhook request {request_id} for event {event!r}"
+                    f"Sent webhook request {request_id} "
+                    f"to {webhook_config.url} for event {event!r}"
                 )
 
     def _get_callback_url(self) -> str:

--- a/edb/server/protocol/auth_ext/smtp.py
+++ b/edb/server/protocol/auth_ext/smtp.py
@@ -24,6 +24,7 @@ import email.message
 import os
 import pickle
 import hashlib
+import logging
 
 import aiosmtplib
 
@@ -34,6 +35,9 @@ from . import util
 
 
 _semaphore: asyncio.BoundedSemaphore | None = None
+
+
+logger = logging.getLogger('edb.server.smtp')
 
 
 async def send_email(
@@ -132,19 +136,6 @@ async def send_email(
                 # Currently we are not reusing SMTP connections, but ideally we
                 # should replace this with a pool of connections, and drop idle
                 # connections after configured time.
-                args = dict(
-                    message=message,
-                    sender=sender,
-                    recipients=recipients,
-                    hostname=host,
-                    port=port,
-                    username=username,
-                    password=password,
-                    timeout=req_timeout,
-                    use_tls=use_tls,
-                    start_tls=start_tls,
-                    validate_certs=validate_certs,
-                )
                 if test_mode:
                     recipients_list: list[str]
                     if isinstance(recipients, str):
@@ -166,6 +157,40 @@ async def send_email(
                     if os.path.exists(test_file):
                         os.unlink(test_file)
                     with open(test_file, "wb") as f:
+                        args = dict(
+                            message=message,
+                            sender=sender,
+                            recipients=recipients,
+                            hostname=host,
+                            port=port,
+                            username=username,
+                            password=password,
+                            timeout=req_timeout,
+                            use_tls=use_tls,
+                            start_tls=start_tls,
+                            validate_certs=validate_certs,
+                        )
                         pickle.dump(args, f)
                 else:
-                    await aiosmtplib.send(**args)  # type: ignore
+                    logger.info(f"Sending SMTP message to {host}:{port}")
+                    errors, response = await aiosmtplib.send(
+                        message,
+                        sender=sender,
+                        recipients=recipients,
+                        hostname=host,
+                        port=port,
+                        username=username,
+                        password=password,
+                        timeout=req_timeout,
+                        use_tls=use_tls,
+                        start_tls=start_tls,
+                        validate_certs=validate_certs,
+                    )
+                    if errors:
+                        logger.error(
+                            f"Errors occurred while sending SMTP message: {errors}"
+                        )
+                    else:
+                        logger.info(
+                            f"SMTP message sent successfully: {response}"
+                        )

--- a/edb/server/protocol/auth_ext/smtp.py
+++ b/edb/server/protocol/auth_ext/smtp.py
@@ -188,7 +188,7 @@ async def send_email(
                     )
                     if errors:
                         logger.error(
-                            f"Errors occurred while sending SMTP message: {errors}"
+                            f"SMTP server returned errors: {errors}"
                         )
                     else:
                         logger.info(

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -42,8 +42,9 @@ class Event(abc.ABC):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}("
-            f"event_id={self.event_id!r}, "
-            f"timestamp={self.timestamp!r})"
+            f"timestamp={self.timestamp!r}, "
+            f"event_id={self.event_id!r}"
+            ")"
         )
 
 
@@ -64,6 +65,15 @@ class IdentityCreated(Event, HasIdentity):
         init=False,
     )
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"timestamp={self.timestamp}, "
+            f"event_id={self.event_id}, "
+            f"identity_id={self.identity_id}"
+            ")"
+        )
+
 
 @dataclasses.dataclass
 class IdentityAuthenticated(Event, HasIdentity):
@@ -72,6 +82,15 @@ class IdentityAuthenticated(Event, HasIdentity):
         init=False,
     )
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"timestamp={self.timestamp}, "
+            f"event_id={self.event_id}, "
+            f"identity_id={self.identity_id}"
+            ")"
+        )
+
 
 @dataclasses.dataclass
 class EmailFactorCreated(Event, HasIdentity, HasEmailFactor):
@@ -79,6 +98,16 @@ class EmailFactorCreated(Event, HasIdentity, HasEmailFactor):
         default="EmailFactorCreated",
         init=False,
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"timestamp={self.timestamp}, "
+            f"event_id={self.event_id}, "
+            f"identity_id={self.identity_id}, "
+            f"email_factor_id={self.email_factor_id}"
+            ")"
+        )
 
 
 @dataclasses.dataclass
@@ -91,6 +120,16 @@ class EmailVerificationRequested(Event, HasIdentity, HasEmailFactor):
     )
     verification_token: str
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"timestamp={self.timestamp}, "
+            f"event_id={self.event_id}, "
+            f"identity_id={self.identity_id}, "
+            f"email_factor_id={self.email_factor_id}"
+            ")"
+        )
+
 
 @dataclasses.dataclass
 class EmailVerified(Event, HasIdentity, HasEmailFactor):
@@ -98,6 +137,16 @@ class EmailVerified(Event, HasIdentity, HasEmailFactor):
         default="EmailVerified",
         init=False,
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"timestamp={self.timestamp}, "
+            f"event_id={self.event_id}, "
+            f"identity_id={self.identity_id}, "
+            f"email_factor_id={self.email_factor_id}"
+            ")"
+        )
 
 
 @dataclasses.dataclass
@@ -108,6 +157,16 @@ class PasswordResetRequested(Event, HasIdentity, HasEmailFactor):
     )
     reset_token: str
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"timestamp={self.timestamp}, "
+            f"event_id={self.event_id}, "
+            f"identity_id={self.identity_id}, "
+            f"email_factor_id={self.email_factor_id}"
+            ")"
+        )
+
 
 @dataclasses.dataclass
 class MagicLinkRequested(Event, HasIdentity, HasEmailFactor):
@@ -116,6 +175,16 @@ class MagicLinkRequested(Event, HasIdentity, HasEmailFactor):
         init=False,
     )
     magic_link_token: str
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"timestamp={self.timestamp}, "
+            f"event_id={self.event_id}, "
+            f"identity_id={self.identity_id}, "
+            f"email_factor_id={self.email_factor_id}"
+            ")"
+        )
 
 
 class DateTimeEncoder(json.JSONEncoder):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'hishel==0.0.24',
     'webauthn~=2.0.0',
     'argon2-cffi~=23.1.0',
-    'aiosmtplib~=2.0',
+    'aiosmtplib~=3.0',
     'tiktoken~=0.7.0',
     'mistral_common~=1.2.1',
 ]


### PR DESCRIPTION
To help with debugging, troubleshooting, and observability.

The general logging strategy is:
- Add info message for when the auth extension is attempting to handle an HTTP request
- Add logging to the main `except` block that catches uncaught exceptions so that you get server logs when a request fails
- Add logging to every authentication endpoint for both success (`info` messages) and failures (`debug` and/or `error` messages)
- Logs include information like identity IDs, and other useful identifying information (`email`, `email_factor_id`, `credential_id`, etc).

---

I ended up doing a little bit of unnecessary refactoring to some of the endpoints that made some cases a bit easier to log errors from, but also aligned endpoints written earlier in the extensions life with more recent innovations. Apologies for the noise.