### PR TITLE
Drop use of httpx as a test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,6 @@ test = [
     'sphinxcontrib-serializinghtml<1.1.10',
     'sphinxcontrib-qthelp<1.0.7',
     'sphinx_code_tabs~=0.5.3',
-
-    'httpx~=0.24.1',
 ]
 
 docs = [


### PR DESCRIPTION
We only use it in one test and are getting rid of it as a real
dependency (see #7927), so let's just drop it.