### PR TITLE
Fix load-ext when .zip filename doesn't match internal folder name

### DIFF
--- a/edb/load_ext/main.py
+++ b/edb/load_ext/main.py
@@ -166,7 +166,7 @@ def install_edgedb_extension(
 
         print("Installing", target)
 
-        ttarget = pathlib.Path(tdir) / pkg.stem
+        ttarget = pathlib.Path(tdir) / dirname
         os.mkdir(ttarget)
 
         with z.open(str(dirname / 'MANIFEST.toml')) as m:


### PR DESCRIPTION
There was a mismatch that was causing trouble.