### PR TITLE
Pass through source OIDC id_token

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_10_28_00_00
+EDGEDB_CATALOG_VERSION = 2024_11_01_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -130,6 +130,10 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             create annotation std::description :=
                 "Identity provider's refresh token.";
         };
+        create property id_token: std::str {
+            create annotation std::description :=
+                "Identity provider's OpenID Connect id_token.";
+        };
         create link identity: ext::auth::Identity {
             on target delete delete source;
         };

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -173,6 +173,7 @@ class OpenIDConnectProvider(BaseProvider):
             name=payload.get("name"),
             email=payload.get("email"),
             picture=payload.get("picture"),
+            source_id_token=id_token,
         )
 
     async def _get_oidc_config(self) -> data.OpenIDConfig:

--- a/edb/server/protocol/auth_ext/data.py
+++ b/edb/server/protocol/auth_ext/data.py
@@ -51,6 +51,7 @@ class UserInfo:
     phone_number_verified: Optional[bool] = None
     address: Optional[dict[str, str]] = None
     updated_at: Optional[float] = None
+    source_id_token: Optional[str] = None
 
     def __str__(self) -> str:
         return self.sub

--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -409,6 +409,7 @@ class Router:
             new_identity,
             auth_token,
             refresh_token,
+            id_token,
         ) = await oauth_client.handle_callback(code, self._get_callback_url())
         pkce_code = await pkce.link_identity_challenge(
             self.db, identity.id, challenge
@@ -419,6 +420,7 @@ class Router:
                 id=pkce_code,
                 auth_token=auth_token,
                 refresh_token=refresh_token,
+                id_token=id_token,
             )
         new_url = util.join_url_params(
             (
@@ -486,6 +488,7 @@ class Router:
                     "identity_id": pkce_object.identity_id,
                     "provider_token": pkce_object.auth_token,
                     "provider_refresh_token": pkce_object.refresh_token,
+                    "provider_id_token": pkce_object.id_token,
                 }
             ).encode()
         else:

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -104,16 +104,18 @@ class Client:
 
     async def handle_callback(
         self, code: str, redirect_uri: str
-    ) -> tuple[data.Identity, bool, str | None, str | None]:
+    ) -> tuple[data.Identity, bool, str | None, str | None, str | None]:
         response = await self.provider.exchange_code(code, redirect_uri)
         user_info = await self.provider.fetch_user_info(response)
         auth_token = response.access_token
         refresh_token = response.refresh_token
+        source_id_token = user_info.source_id_token
 
         return (
             *(await self._handle_identity(user_info)),
             auth_token,
             refresh_token,
+            source_id_token,
         )
 
     async def _handle_identity(

--- a/edb/server/protocol/auth_ext/pkce.py
+++ b/edb/server/protocol/auth_ext/pkce.py
@@ -46,6 +46,7 @@ class PKCEChallenge:
     challenge: str
     auth_token: str | None
     refresh_token: str | None
+    id_token: str | None
     identity_id: str | None
 
 
@@ -95,6 +96,7 @@ async def add_provider_tokens(
     id: str,
     auth_token: str | None,
     refresh_token: str | None,
+    id_token: str | None,
 ) -> str:
     r = await execute.parse_execute_json(
         db,
@@ -104,12 +106,14 @@ async def add_provider_tokens(
         set {
             auth_token := <optional str>$auth_token,
             refresh_token := <optional str>$refresh_token,
+            id_token := <optional str>$id_token,
         }
         """,
         variables={
             "id": id,
             "auth_token": auth_token,
             "refresh_token": refresh_token,
+            "id_token": id_token,
         },
         cached_globally=True,
     )
@@ -129,6 +133,7 @@ async def get_by_id(db: edbtenant.dbview.Database, id: str) -> PKCEChallenge:
             challenge,
             auth_token,
             refresh_token,
+            id_token,
             identity_id := .identity.id
         }
         filter .id = <uuid>$id

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -3474,6 +3474,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                             challenge := <str>$challenge,
                             auth_token := <str>$auth_token,
                             refresh_token := <str>$refresh_token,
+                            id_token := <str>$id_token,
                             identity := (
                                 insert ext::auth::Identity {
                                     issuer := "https://example.com",
@@ -3486,12 +3487,14 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                         challenge,
                         auth_token,
                         refresh_token,
+                        id_token,
                         identity_id := .identity.id
                     }
                     """,
                     challenge=challenge.decode(),
                     auth_token="a_provider_token",
                     refresh_token="a_refresh_token",
+                    id_token="an_id_token",
                 )
 
                 # Correct code, random verifier
@@ -3530,6 +3533,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                         "identity_id": str(pkce.identity_id),
                         "provider_token": "a_provider_token",
                         "provider_refresh_token": "a_refresh_token",
+                        "provider_id_token": "an_id_token",
                     },
                 )
                 async for tr in self.try_until_succeeds(


### PR DESCRIPTION
We currently only use a small amount of data from the identity provider's ID token, but applications might want to use different bits of this data for their own user profile information. We currently require them to fetch this on their own, but this will make this process slightly easier by returning the ID token, if we have one.

Closes #7557 

---

Another strategy which I considered, but ended up rejecting, is to make a `UserInfo` type that matches our existing `UserInfo` data type, and have it be an optional single link on `Identity`. However:

1. It's not clear from the data model, if you just have an identity, whether there will be anything at all in the `UserInfo` type, so you have to treat it as extremely optional, since all of the values are also optional.
2. We don't expose an mechanism to synchronize this data with the identity provider. Since developers will need to do that anyway, seems best to let the design their own "profile" or "user" type and figure out how to update it, either by synchronizing with an IdP, or by allowing editing from the end user (or both).
