### PR TITLE
Fix an error where schema_links wasn't properly namespaced

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_10_28_00_00
+EDGEDB_CATALOG_VERSION = 2024_11_01_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -6056,14 +6056,14 @@ class UpdateEndpointDeleteActions(MetaCommand):
                                     || linkname || ' of ' || endname || ' ('
                                     || srcid || ').';
                     END IF;
-                ''')).format(
+                '''.format(
                     tables=tables,
                     id='id',
                     tgtname=target.get_displayname(schema),
                     near_endpoint=near_endpoint,
                     far_endpoint=far_endpoint,
                     prefix=prefix,
-                )
+                )))
 
                 chunks.append(text)
 
@@ -6287,14 +6287,14 @@ class UpdateEndpointDeleteActions(MetaCommand):
                                     || linkname || ' of ' || endname || ' ('
                                     || srcid || ').';
                     END IF;
-                ''')).format(
+                '''.format(
                     tables=tables,
                     id='id',
                     tgtname=target.get_displayname(schema),
                     near_endpoint=near_endpoint,
                     far_endpoint=far_endpoint,
                     prefix=prefix,
-                )
+                )))
 
                 chunks.append(text)
 


### PR DESCRIPTION
The issue is we were running `trampoline.fixup_query` *before*
substituting in the schema name.

This probably *shouldn't* show up in any real situations, since
it is only used to produce an error message, and we shouldn't
actually be hitting link policy error messages for the schema.

No real way to test this as a result. I tested it against a bug I had
introduced while working on something else.