### PR TITLE
Fix an obscure bug deleting doubly nested alias tuples

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3844,8 +3844,7 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
 
         with self.new_context(schema, context, scls):
             if (
-                not self.canonical
-                and self.if_unused
+                self.if_unused
                 and self._has_outside_references(schema, context)
             ):
                 parent_ctx = context.parent()

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -989,7 +989,6 @@ class Collection(Type, s_abc.Collection):
         if not isinstance(self, CollectionExprAlias):
             delta.if_exists = True
             delta.if_unused = True
-            delta.canonical = False
         return delta
 
     @classmethod

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -11029,6 +11029,12 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             alias X := (Bar { z := 10 }, 30);
         ''')
 
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+            alias X := ((Bar { z := 10 }, 30), 20);
+        ''')
+
         # delete it
         await self.migrate(r'''
             type Foo;


### PR DESCRIPTION
We were setting `canonical = False` on the delta created in
`Collection.as_delete_delta` in order to make sure that `if_unused`
was respected. The problem with this is that it caused extra deletes
of the *contents* of the tuple to be generated, which caused trouble
during migration generation.