### PR TITLE
Fix schema reflection issue in _redo_everything path

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2821,7 +2821,12 @@ class AlterScalarType(ScalarTypeMetaCommand, adapts=s_scalars.AlterScalarType):
 
         # do an apply of the schema-level command to force it to canonicalize,
         # which prunes out duplicate deletions
+        #
+        # HACK: Clear out the context's stack so that
+        # context.canonical is false while doing this.
+        stack, context.stack = context.stack, []
         cmd.apply(schema, context)
+        context.stack = stack
 
         for sub in cmd.get_subcommands():
             acmd2 = CommandMeta.adapt(sub)


### PR DESCRIPTION
In _redo_everything, we need to delete all of the temporary collection
types we may have created in _undo_everything. Currently, when we run
those deletion commands, context.canonical is True, so nested
collections aren't deleted.