### PR TITLE
Add constraints to auth app config

### DIFF
--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -106,7 +106,7 @@ def get_config_typename(config_value: edb_config.SettingValue) -> str:
 def escape_and_truncate(input_str: str | None, max_len: int) -> str | None:
     if input_str is None:
         return None
-    return html.escape(input_str)[:max_len]
+    return html.escape(input_str[:max_len])
 
 
 def get_app_details_config(db: Any) -> config.AppDetailsConfig:

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import base64
 import urllib.parse
 import datetime
+import html
+
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
 from cryptography.hazmat.backends import default_backend
@@ -101,6 +103,12 @@ def get_config_typename(config_value: edb_config.SettingValue) -> str:
     return config_value._tspec.name  # type: ignore
 
 
+def escape_and_truncate(input_str: str | None, max_len: int) -> str | None:
+    if input_str is None:
+        return None
+    return html.escape(input_str)[:max_len]
+
+
 def get_app_details_config(db: Any) -> config.AppDetailsConfig:
     ui_config = cast(
         Optional[config.UIConfig],
@@ -108,21 +116,25 @@ def get_app_details_config(db: Any) -> config.AppDetailsConfig:
     )
 
     return config.AppDetailsConfig(
-        app_name=(
+        app_name=escape_and_truncate(
             maybe_get_config(db, "ext::auth::AuthConfig::app_name")
-            or (ui_config.app_name if ui_config else None)
+            or (ui_config.app_name if ui_config else None),
+            100,
         ),
-        logo_url=(
+        logo_url=escape_and_truncate(
             maybe_get_config(db, "ext::auth::AuthConfig::logo_url")
-            or (ui_config.logo_url if ui_config else None)
+            or (ui_config.logo_url if ui_config else None),
+            2000,
         ),
-        dark_logo_url=(
+        dark_logo_url=escape_and_truncate(
             maybe_get_config(db, "ext::auth::AuthConfig::dark_logo_url")
-            or (ui_config.dark_logo_url if ui_config else None)
+            or (ui_config.dark_logo_url if ui_config else None),
+            2000,
         ),
-        brand_color=(
+        brand_color=escape_and_truncate(
             maybe_get_config(db, "ext::auth::AuthConfig::brand_color")
-            or (ui_config.brand_color if ui_config else None)
+            or (ui_config.brand_color if ui_config else None),
+            8,
         ),
     )
 

--- a/edb/server/protocol/auth_ext/util.py
+++ b/edb/server/protocol/auth_ext/util.py
@@ -106,7 +106,12 @@ def get_config_typename(config_value: edb_config.SettingValue) -> str:
 def escape_and_truncate(input_str: str | None, max_len: int) -> str | None:
     if input_str is None:
         return None
-    return html.escape(input_str[:max_len])
+    trunc = (
+        f"{input_str[:max_len]}..."
+        if len(input_str) > max_len
+        else input_str
+    )
+    return html.escape(trunc)
 
 
 def get_app_details_config(db: Any) -> config.AppDetailsConfig:

--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -75,7 +75,8 @@ class Client(local.Client):
         )
 
     def _get_app_name(self) -> Optional[str]:
-        return util.maybe_get_config(self.db, "ext::auth::AuthConfig::app_name")
+        app_config = util.get_app_details_config(self.db)
+        return app_config.app_name
 
     async def create_registration_options_for_email(
         self, email: str,

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -4031,7 +4031,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             body_str = body.decode()
 
-            self.assertIn(APP_NAME[:100], body_str)
+            self.assertIn(f"{APP_NAME[:100]}...", body_str)
             self.assertIn(LOGO_URL, body_str)
             self.assertIn(BRAND_COLOR, body_str)
 
@@ -4065,7 +4065,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             self.assertIsInstance(body_json["rp"], dict)
             self.assertIn("name", body_json["rp"])
-            self.assertEqual(body_json["rp"]["name"], APP_NAME[:100])
+            self.assertEqual(body_json["rp"]["name"], f"{APP_NAME[:100]}...")
             self.assertIn("id", body_json["rp"])
             self.assertEqual(body_json["rp"]["id"], "example.com")
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -235,7 +235,7 @@ APPLE_SECRET = 'c' * 32
 DISCORD_SECRET = 'd' * 32
 SLACK_SECRET = 'd' * 32
 GENERIC_OIDC_SECRET = 'e' * 32
-APP_NAME = "Test App"
+APP_NAME = "Test App" * 13
 LOGO_URL = "http://example.com/logo.png"
 DARK_LOGO_URL = "http://example.com/darklogo.png"
 BRAND_COLOR = "f0f8ff"
@@ -4031,7 +4031,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             body_str = body.decode()
 
-            self.assertIn(APP_NAME, body_str)
+            self.assertIn(APP_NAME[:100], body_str)
             self.assertIn(LOGO_URL, body_str)
             self.assertIn(BRAND_COLOR, body_str)
 
@@ -4065,7 +4065,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
             self.assertIsInstance(body_json["rp"], dict)
             self.assertIn("name", body_json["rp"])
-            self.assertEqual(body_json["rp"]["name"], APP_NAME)
+            self.assertEqual(body_json["rp"]["name"], APP_NAME[:100])
             self.assertIn("id", body_json["rp"])
             self.assertEqual(body_json["rp"]["id"], "example.com")
 


### PR DESCRIPTION
Since these values end up in user-facing templates, ensure that they are limited to sane lengths and are also well sanitized.