### PR TITLE
More thoroughly protect redirects

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -30,6 +30,7 @@ import hashlib
 import os
 import mimetypes
 import uuid
+import dataclasses
 
 from typing import (
     Any,
@@ -289,15 +290,12 @@ class Router:
         redirect_to_on_signup = _maybe_get_search_param(
             query, "redirect_to_on_signup"
         )
-        if not self._is_url_allowed(redirect_to):
-            raise errors.InvalidData(
-                "Redirect URL does not match any allowed URLs.",
-            )
-        if redirect_to_on_signup and not self._is_url_allowed(
-            redirect_to_on_signup
-        ):
-            raise errors.InvalidData(
-                "Redirect URL does not match any allowed URLs.",
+        allowed_redirect_to = self._make_allowed_url(redirect_to)
+        allowed_redirect_to_on_signup: Optional[AllowedUrl] = None
+
+        if redirect_to_on_signup:
+            allowed_redirect_to_on_signup = self._make_allowed_url(
+                redirect_to_on_signup
             )
         challenge = _get_search_param(
             query, "challenge", fallback_keys=["code_challenge"]
@@ -312,11 +310,19 @@ class Router:
         authorize_url = await oauth_client.get_authorize_url(
             redirect_uri=self._get_callback_url(),
             state=self._make_state_claims(
-                provider_name, redirect_to, redirect_to_on_signup, challenge
+                provider_name,
+                allowed_redirect_to.url,
+                (
+                    allowed_redirect_to_on_signup.url
+                    if allowed_redirect_to_on_signup
+                    else None
+                ),
+                challenge,
             ),
         )
-        response.status = http.HTTPStatus.FOUND
-        response.custom_headers["Location"] = authorize_url
+        # n.b. Explicitly allow authorization URL to be outside of allowed
+        # URLs because it is a trusted URL from the identity provider.
+        self._do_redirect(response, AllowedUrl(authorize_url))
 
     async def handle_callback(
         self,
@@ -361,11 +367,6 @@ class Router:
             except Exception:
                 raise errors.InvalidData("Invalid state token")
 
-            if not self._is_url_allowed(redirect_to):
-                raise errors.InvalidData(
-                    "Redirect URL does not match any allowed URLs.",
-                )
-
             params = {
                 "error": error,
             }
@@ -375,11 +376,10 @@ class Router:
                 error_str += f": {error_description}"
 
             logger.debug(f"OAuth provider returned an error: {error_str}")
-            response.custom_headers["Location"] = util.join_url_params(
-                redirect_to, params
+            return self._try_redirect(
+                response,
+                util.join_url_params(redirect_to, params),
             )
-            response.status = http.HTTPStatus.FOUND
-            return
 
         if code is None:
             raise errors.InvalidData(
@@ -393,15 +393,11 @@ class Router:
             redirect_to_on_signup = cast(
                 Optional[str], claims.get("redirect_to_on_signup")
             )
-            if not self._is_url_allowed(redirect_to):
-                raise errors.InvalidData(
-                    "Redirect URL does not match any allowed URLs.",
-                )
-            if redirect_to_on_signup and not self._is_url_allowed(
-                redirect_to_on_signup
-            ):
-                raise errors.InvalidData(
-                    "Redirect URL does not match any allowed URLs.",
+            allowed_redirect_to = self._make_allowed_url(redirect_to)
+            allowed_redirect_to_on_signup: Optional[AllowedUrl] = None
+            if redirect_to_on_signup:
+                allowed_redirect_to_on_signup = self._make_allowed_url(
+                    redirect_to_on_signup
                 )
             challenge = cast(str, claims["challenge"])
         except Exception:
@@ -428,20 +424,20 @@ class Router:
                 auth_token=auth_token,
                 refresh_token=refresh_token,
             )
-        new_url = util.join_url_params(
-            (
-                (redirect_to_on_signup or redirect_to)
-                if new_identity
-                else redirect_to
-            ),
-            {"code": pkce_code, "provider": provider_name},
+        new_url = (
+            (allowed_redirect_to_on_signup or allowed_redirect_to)
+            if new_identity
+            else allowed_redirect_to
+        ).map(
+            lambda u: util.join_url_params(
+                u, {"code": pkce_code, "provider": provider_name}
+            )
         )
         logger.info(
             "OAuth callback successful: "
             f"identity_id={identity.id}, new_identity={new_identity}"
         )
-        response.status = http.HTTPStatus.FOUND
-        response.custom_headers["Location"] = new_url
+        self._do_redirect(response, new_url)
 
     async def handle_token(
         self,
@@ -491,9 +487,7 @@ class Router:
                 )
             )
             session_token = self._make_session_token(identity_id)
-            logger.info(
-                f"Token exchange successful: identity_id={identity_id}"
-            )
+            logger.info(f"Token exchange successful: identity_id={identity_id}")
             response.status = http.HTTPStatus.OK
             response.content_type = b"application/json"
             response.body = json.dumps(
@@ -515,10 +509,10 @@ class Router:
         data = self._get_data_from_request(request)
 
         maybe_redirect_to = cast(Optional[str], data.get("redirect_to"))
-        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.InvalidData(
-                "Redirect URL does not match any allowed URLs.",
-            )
+        allowed_redirect_to: Optional[AllowedUrl] = None
+        if maybe_redirect_to:
+            allowed_redirect_to = self._make_allowed_url(maybe_redirect_to)
+
         maybe_challenge = cast(Optional[str], data.get("challenge"))
         register_provider_name = cast(Optional[str], data.get("provider"))
         if register_provider_name is None:
@@ -601,10 +595,12 @@ class Router:
                 f"pkce_id={pkce_code!r}"
             )
 
-            if maybe_redirect_to is not None:
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = util.join_url_params(
-                    maybe_redirect_to, response_dict
+            if allowed_redirect_to is not None:
+                self._do_redirect(
+                    response,
+                    allowed_redirect_to.map(
+                        lambda u: util.join_url_params(u, response_dict)
+                    ),
                 )
             else:
                 response.status = http.HTTPStatus.CREATED
@@ -615,20 +611,20 @@ class Router:
                 "redirect_on_failure", maybe_redirect_to
             )
             if redirect_on_failure is not None:
-                response.status = http.HTTPStatus.FOUND
                 error_message = str(ex)
                 email = data.get("email", "")
                 logger.error(
                     f"Error creating identity: error={error_message}, "
                     f"email={email}"
                 )
-                redirect_params = {
-                    "error": error_message,
-                    "email": email,
-                }
-                response.custom_headers["Location"] = util.join_url_params(
-                    redirect_on_failure, redirect_params
+                error_redirect_url = util.join_url_params(
+                    redirect_on_failure,
+                    {
+                        "error": error_message,
+                        "email": email,
+                    },
                 )
+                return self._try_redirect(response, error_redirect_url)
             else:
                 raise ex
 
@@ -647,10 +643,9 @@ class Router:
         await pkce.create(self.db, challenge)
 
         maybe_redirect_to = data.get("redirect_to")
-        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.InvalidData(
-                "Redirect URL does not match any allowed URLs.",
-            )
+        allowed_redirect_to: Optional[AllowedUrl] = None
+        if maybe_redirect_to:
+            allowed_redirect_to = self._make_allowed_url(maybe_redirect_to)
 
         email_password_client = email_password.Client(db=self.db)
         try:
@@ -676,10 +671,12 @@ class Router:
                 f"Authentication successful: identity_id={local_identity.id}, "
                 f"pkce_id={pkce_code}"
             )
-            if maybe_redirect_to:
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = util.join_url_params(
-                    maybe_redirect_to, response_dict
+            if allowed_redirect_to:
+                self._do_redirect(
+                    response,
+                    allowed_redirect_to.map(
+                        lambda u: util.join_url_params(u, response_dict)
+                    ),
                 )
             else:
                 response.status = http.HTTPStatus.OK
@@ -690,24 +687,20 @@ class Router:
                 "redirect_on_failure", maybe_redirect_to
             )
             if redirect_on_failure is not None:
-                if not self._is_url_allowed(redirect_on_failure):
-                    raise errors.InvalidData(
-                        "Redirect URL does not match any allowed URLs.",
-                    )
                 error_message = str(ex)
                 email = data.get("email", "")
                 logger.error(
                     f"Error authenticating: error={error_message}, "
                     f"email={email}"
                 )
-                response.status = http.HTTPStatus.FOUND
-                redirect_params = {
-                    "error": error_message,
-                    "email": email,
-                }
-                response.custom_headers["Location"] = util.join_url_params(
-                    redirect_on_failure, redirect_params
+                error_redirect_url = util.join_url_params(
+                    redirect_on_failure,
+                    {
+                        "error": error_message,
+                        "email": email,
+                    },
                 )
+                return self._try_redirect(response, error_redirect_url)
             else:
                 raise ex
 
@@ -763,9 +756,9 @@ class Router:
                 code = await pkce.link_identity_challenge(
                     self.db, identity_id, challenge
                 )
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = _with_appended_qs(
-                    redirect_to, {"code": [code]}
+                return self._try_redirect(
+                    response,
+                    util.join_url_params(redirect_to, {"code": code}),
                 )
             case (str(challenge), _):
                 await pkce.create(self.db, challenge)
@@ -775,11 +768,12 @@ class Router:
                 response.status = http.HTTPStatus.OK
                 response.content_type = b"application/json"
                 response.body = json.dumps({"code": code}).encode()
+                return
             case (_, str(redirect_to)):
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = redirect_to
+                return self._try_redirect(response, redirect_to)
             case (_, _):
                 response.status = http.HTTPStatus.NO_CONTENT
+                return
 
     async def handle_resend_verification_email(
         self,
@@ -907,10 +901,9 @@ class Router:
                 "Redirect URL does not match any allowed URLs.",
             )
         maybe_redirect_to = data.get("redirect_to")
-        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.InvalidData(
-                "Redirect URL does not match any allowed URLs.",
-            )
+        allowed_redirect_to: Optional[AllowedUrl] = None
+        if maybe_redirect_to:
+            allowed_redirect_to = self._make_allowed_url(maybe_redirect_to)
 
         try:
             try:
@@ -961,10 +954,12 @@ class Router:
                 "email_sent": email,
             }
 
-            if maybe_redirect_to:
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = util.join_url_params(
-                    maybe_redirect_to, return_data
+            if allowed_redirect_to:
+                return self._do_redirect(
+                    response,
+                    allowed_redirect_to.map(
+                        lambda u: util.join_url_params(u, return_data)
+                    ),
                 )
             else:
                 response.status = http.HTTPStatus.OK
@@ -982,22 +977,21 @@ class Router:
                 "redirect_on_failure", maybe_redirect_to
             )
             if redirect_on_failure is not None:
-                if not self._is_url_allowed(redirect_on_failure):
-                    raise errors.InvalidData(
-                        "Redirect URL does not match any allowed URLs.",
-                    )
                 error_message = str(ex)
                 logger.error(
                     f"Error sending reset email: error={error_message}, "
                     f"email={email}"
                 )
-                response.status = http.HTTPStatus.FOUND
-                redirect_params = {
-                    "error": error_message,
-                    "email": email,
-                }
-                response.custom_headers["Location"] = util.join_url_params(
-                    redirect_on_failure, redirect_params
+                redirect_url = util.join_url_params(
+                    redirect_on_failure,
+                    {
+                        "error": error_message,
+                        "email": email,
+                    },
+                )
+                return self._try_redirect(
+                    response,
+                    redirect_url,
                 )
             else:
                 raise ex
@@ -1015,10 +1009,9 @@ class Router:
         email_password_client = email_password.Client(db=self.db)
 
         maybe_redirect_to = data.get("redirect_to")
-        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.InvalidData(
-                "Redirect URL does not match any allowed URLs.",
-            )
+        allowed_redirect_to: Optional[AllowedUrl] = None
+        if maybe_redirect_to:
+            allowed_redirect_to = self._make_allowed_url(maybe_redirect_to)
 
         try:
 
@@ -1038,10 +1031,12 @@ class Router:
                 f"Reset password: identity_id={identity_id}, pkce_id={code}"
             )
 
-            if maybe_redirect_to:
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = util.join_url_params(
-                    maybe_redirect_to, response_dict
+            if allowed_redirect_to:
+                return self._do_redirect(
+                    response,
+                    allowed_redirect_to.map(
+                        lambda u: util.join_url_params(u, response_dict)
+                    ),
                 )
             else:
                 response.status = http.HTTPStatus.OK
@@ -1052,23 +1047,19 @@ class Router:
                 "redirect_on_failure", maybe_redirect_to
             )
             if redirect_on_failure is not None:
-                if not self._is_url_allowed(redirect_on_failure):
-                    raise errors.InvalidData(
-                        "Redirect URL does not match any allowed URLs.",
-                    )
                 error_message = str(ex)
                 logger.error(
                     f"Error resetting password: error={error_message}, "
                     f"reset_token={reset_token}"
                 )
-                response.status = http.HTTPStatus.FOUND
-                redirect_params = {
-                    "error": error_message,
-                    "reset_token": reset_token,
-                }
-                response.custom_headers["Location"] = util.join_url_params(
-                    redirect_on_failure, redirect_params
+                redirect_url = util.join_url_params(
+                    redirect_on_failure,
+                    {
+                        "error": error_message,
+                        "reset_token": reset_token,
+                    },
                 )
+                return self._try_redirect(response, redirect_url)
             else:
                 raise ex
 
@@ -1093,20 +1084,21 @@ class Router:
         email = data["email"]
         challenge = data["challenge"]
         callback_url = data["callback_url"]
-        redirect_on_failure = data["redirect_on_failure"]
         if not self._is_url_allowed(callback_url):
             raise errors.InvalidData(
                 "Callback URL does not match any allowed URLs.",
             )
-        if not self._is_url_allowed(redirect_on_failure):
-            raise errors.InvalidData(
-                "Error redirect URL does not match any allowed URLs.",
-            )
+
+        redirect_on_failure = data["redirect_on_failure"]
+        allowed_redirect_on_failure = self._make_allowed_url(
+            redirect_on_failure
+        )
+
         maybe_redirect_to = data.get("redirect_to")
-        if maybe_redirect_to and not self._is_url_allowed(maybe_redirect_to):
-            raise errors.InvalidData(
-                "Redirect URL does not match any allowed URLs.",
-            )
+        allowed_redirect_to: Optional[AllowedUrl] = None
+        if maybe_redirect_to:
+            allowed_redirect_to = self._make_allowed_url(maybe_redirect_to)
+
         magic_link_client = magic_link.Client(
             db=self.db,
             issuer=self.base_path,
@@ -1173,10 +1165,12 @@ class Router:
                 response.status = http.HTTPStatus.OK
                 response.content_type = b"application/json"
                 response.body = json.dumps(return_data).encode()
-            elif maybe_redirect_to:
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = util.join_url_params(
-                    maybe_redirect_to, return_data
+            elif allowed_redirect_to:
+                return self._do_redirect(
+                    response,
+                    allowed_redirect_to.map(
+                        lambda u: util.join_url_params(u, return_data)
+                    ),
                 )
             else:
                 # This should not happen since we check earlier for this case
@@ -1188,20 +1182,21 @@ class Router:
             if request_accepts_json:
                 raise ex
 
-            response.status = http.HTTPStatus.FOUND
-
             error_message = str(ex)
             logger.error(
                 f"Error sending magic link: error={error_message}, "
                 f"email={email}"
             )
-            redirect_params = {
-                "error": error_message,
-                "email": email,
-            }
-            response.custom_headers["Location"] = util.join_url_params(
-                redirect_on_failure, redirect_params
+            redirect_url = allowed_redirect_on_failure.map(
+                lambda u: util.join_url_params(
+                    u,
+                    {
+                        "error": error_message,
+                        "email": email,
+                    },
+                )
             )
+            return self._do_redirect(response, redirect_url)
 
     async def handle_magic_link_email(
         self,
@@ -1236,12 +1231,10 @@ class Router:
                 )
 
             maybe_redirect_to = data.get("redirect_to")
-            if maybe_redirect_to and not self._is_url_allowed(
-                maybe_redirect_to
-            ):
-                raise errors.InvalidData(
-                    "Redirect URL does not match any allowed URLs.",
-                )
+            allowed_redirect_to: Optional[AllowedUrl] = None
+            if maybe_redirect_to:
+                allowed_redirect_to = self._make_allowed_url(maybe_redirect_to)
+
             magic_link_client = magic_link.Client(
                 db=self.db,
                 issuer=self.base_path,
@@ -1288,10 +1281,12 @@ class Router:
                 "email_sent": email,
             }
 
-            if maybe_redirect_to:
-                response.status = http.HTTPStatus.FOUND
-                response.custom_headers["Location"] = util.join_url_params(
-                    maybe_redirect_to, return_data
+            if allowed_redirect_to:
+                return self._do_redirect(
+                    response,
+                    allowed_redirect_to.map(
+                        lambda u: util.join_url_params(u, return_data)
+                    ),
                 )
             else:
                 response.status = http.HTTPStatus.OK
@@ -1309,14 +1304,14 @@ class Router:
                     f"Error sending magic link email: error={error_message}, "
                     f"email={email}"
                 )
-                response.status = http.HTTPStatus.FOUND
-                redirect_params = {
-                    "error": error_message,
-                    "email": email,
-                }
-                response.custom_headers["Location"] = util.join_url_params(
-                    redirect_on_failure, redirect_params
+                error_redirect_url = util.join_url_params(
+                    redirect_on_failure,
+                    {
+                        "error": error_message,
+                        "email": email,
+                    },
                 )
+                self._try_redirect(response, error_redirect_url)
 
     async def handle_magic_link_authenticate(
         self,
@@ -1346,10 +1341,11 @@ class Router:
                 identity_id, datetime.datetime.now(datetime.timezone.utc)
             )
 
-            response.status = http.HTTPStatus.FOUND
-            response.custom_headers["Location"] = util.join_url_params(
-                callback_url, {"code": code}
+            return self._try_redirect(
+                response,
+                util.join_url_params(callback_url, {"code": code}),
             )
+
         except Exception as ex:
             redirect_on_failure = _maybe_get_search_param(
                 query, "redirect_on_failure"
@@ -1357,22 +1353,18 @@ class Router:
             if redirect_on_failure is None:
                 raise ex
             else:
-                if not self._is_url_allowed(redirect_on_failure):
-                    raise errors.InvalidData(
-                        "Redirect URL does not match any allowed URLs.",
-                    )
-                response.status = http.HTTPStatus.FOUND
                 error_message = str(ex)
                 logger.error(
                     f"Error authenticating magic link: error={error_message}, "
                     f"token={token}"
                 )
-                redirect_params = {
-                    "error": error_message,
-                }
-                response.custom_headers["Location"] = util.join_url_params(
-                    redirect_on_failure, redirect_params
+                redirect_url = util.join_url_params(
+                    redirect_on_failure,
+                    {
+                        "error": error_message,
+                    },
                 )
+                return self._try_redirect(response, redirect_url)
 
     async def handle_webauthn_register_options(
         self,
@@ -1883,10 +1875,10 @@ class Router:
 
                     redirect_to = maybe_redirect_to or redirect_to
                     redirect_to = (
-                        _with_appended_qs(
+                        util.join_url_params(
                             redirect_to,
                             {
-                                "code": [maybe_pkce_code],
+                                "code": maybe_pkce_code,
                             },
                         )
                         if maybe_pkce_code
@@ -1912,9 +1904,7 @@ class Router:
 
         # Only redirect back if verification succeeds
         if is_valid:
-            response.status = http.HTTPStatus.FOUND
-            response.custom_headers["Location"] = redirect_to
-            return
+            return self._try_redirect(response, redirect_to)
 
         app_details_config = self._get_app_details_config()
         response.status = http.HTTPStatus.OK
@@ -2445,6 +2435,31 @@ class Router:
 
         return False
 
+    def _do_redirect(
+        self, response: protocol.HttpResponse, allowed_url: AllowedUrl
+    ) -> None:
+        response.status = http.HTTPStatus.FOUND
+        response.custom_headers["Location"] = allowed_url.url
+
+    def _try_redirect(self, response: protocol.HttpResponse, url: str) -> None:
+        allowed_url = self._make_allowed_url(url)
+        self._do_redirect(response, allowed_url)
+
+    def _make_allowed_url(self, url: str) -> AllowedUrl:
+        if not self._is_url_allowed(url):
+            raise errors.InvalidData(
+                "Redirect URL does not match any allowed URLs.",
+            )
+        return AllowedUrl(url)
+
+
+@dataclasses.dataclass
+class AllowedUrl:
+    url: str
+
+    def map(self, f: Callable[[str], str]) -> "AllowedUrl":
+        return AllowedUrl(f(self.url))
+
 
 def _fail_with_error(
     *,
@@ -2532,15 +2547,6 @@ def _set_cookie(
     if path is not None:
         val["path"] = path
     response.custom_headers["Set-Cookie"] = val.OutputString()
-
-
-def _with_appended_qs(url: str, query: dict[str, list[str]]) -> str:
-    url_parts = list(urllib.parse.urlparse(url))
-    existing_query = urllib.parse.parse_qs(url_parts[4])
-    existing_query.update(query)
-
-    url_parts[4] = urllib.parse.urlencode(existing_query, doseq=True)
-    return urllib.parse.urlunparse(url_parts)
 
 
 def _check_keyset(candidate: dict[str, Any], keyset: set[str]) -> None:


### PR DESCRIPTION
Ensure that URLs are checked against the allow list before sending a
redirect. Make a separate type for checked URLs, and centralize the
checking of URLs and constructing of redirects.