### PR TITLE
Allow volatile WITH in dml statements.

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1205,7 +1205,7 @@ def _infer_stmt_cardinality(
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
-    for part in (ir.bindings or []):
+    for part, _ in (ir.bindings or []):
         infer_cardinality(part, scope_tree=scope_tree, ctx=ctx)
 
     result = ir.subject if isinstance(ir, irast.MutatingStmt) else ir.result
@@ -1339,7 +1339,7 @@ def __infer_insert_stmt(
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
-    for part in (ir.bindings or []):
+    for part, _ in (ir.bindings or []):
         infer_cardinality(part, scope_tree=scope_tree, ctx=ctx)
 
     infer_cardinality(

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -588,7 +588,7 @@ def _infer_stmt_multiplicity(
 ) -> inf_ctx.MultiplicityInfo:
     # WITH block bindings need to be validated; they don't have to
     # have multiplicity UNIQUE, but their sub-expressions must be valid.
-    for part in (ir.bindings or []):
+    for part, _ in (ir.bindings or []):
         infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
 
     subj = ir.subject if isinstance(ir, irast.MutatingStmt) else ir.result
@@ -688,7 +688,7 @@ def __infer_insert_stmt(
 ) -> inf_ctx.MultiplicityInfo:
     # WITH block bindings need to be validated, they don't have to
     # have multiplicity UNIQUE, but their sub-expressions must be valid.
-    for part in (ir.bindings or []):
+    for part, _ in (ir.bindings or []):
         infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
 
     # INSERT will always return a proper set, but we still want to

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -320,7 +320,7 @@ def __infer_select_stmt(
         components.append(ir.limit)
 
     if ir.bindings is not None:
-        components.extend(ir.bindings)
+        components.extend(part for part, _ in ir.bindings)
 
     return _common_volatility(components, env)
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -68,6 +68,7 @@ from . import clauses
 from . import context
 from . import config_desc
 from . import dispatch
+from . import inference
 from . import pathctx
 from . import policies
 from . import setgen
@@ -1309,7 +1310,7 @@ def process_with_block(
     *,
     ctx: context.ContextLevel,
     parent_ctx: context.ContextLevel,
-) -> List[irast.Set]:
+) -> list[tuple[irast.Set, qltypes.Volatility]]:
     if edgeql_tree.aliases is None:
         return []
 
@@ -1329,7 +1330,10 @@ def process_with_block(
                     binding_kind=irast.BindingKind.With,
                     ctx=scopectx,
                 )
-                results.append(binding)
+                volatility = inference.infer_volatility(
+                    binding, ctx.env, exclude_dml=True
+                )
+                results.append((binding, volatility))
 
                 if reason := setgen.should_materialize(binding, ctx=ctx):
                     had_materialized = True

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -69,7 +69,6 @@ from . import astutils
 from . import context
 from . import dispatch
 from . import eta_expand
-from . import inference
 from . import pathctx
 from . import schemactx
 from . import setgen
@@ -1945,27 +1944,6 @@ def _normalize_view_ptr_expr(
         ctx.env.schema = ptrcls.set_target(ctx.env.schema, ptr_target)
 
     assert ptrcls is not None
-
-    if materialized and is_mutation and any(
-        x.is_binding == irast.BindingKind.With
-        and x.expr
-        # If it is a computed pointer, look just at the definition.
-        # TODO: It is a weird artifact of how our shapes are defined
-        # that if a shape element is defined to be some WITH-bound variable,
-        # that set can is both a is_binding and an irast.Pointer. It seems like
-        # the is_binding part should be nested inside it.
-        and (y := x.expr.expr if isinstance(x.expr, irast.Pointer) else x.expr)
-        and inference.infer_volatility(
-            y, ctx.env, exclude_dml=True).is_volatile()
-
-        for reason in materialized
-        if isinstance(reason, irast.MaterializeVisible)
-        for _, x in reason.sets
-    ):
-        raise errors.QueryError(
-            f'cannot refer to volatile WITH bindings from DML',
-            span=compexpr.span if compexpr else None,
-        )
 
     if materialized and not is_mutation and ctx.qlstmt:
         assert ptrcls not in ctx.env.materialized_sets

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1143,7 +1143,7 @@ class Stmt(Expr):
     result: Set = DUMMY_SET
     parent_stmt: typing.Optional[Stmt] = None
     iterator_stmt: typing.Optional[Set] = None
-    bindings: typing.Optional[typing.List[Set]] = None
+    bindings: typing.Optional[list[tuple[Set, qltypes.Volatility]]] = None
 
     @property
     def typeref(self) -> TypeRef:

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -283,10 +283,10 @@ def compile_volatile_bindings(
             with ctx.substmt() as bctx:
                 dispatch.compile(binding, ctx=bctx)
 
-        # If something we are WITH binding is volatile, we similarly
-        # want to compile it *now*. Unlike with DML, we need to
-        # manually construct the CTE here.
-        elif volatility.is_volatile():
+        # If something we are WITH binding is volatile and the stmt contains
+        # dml, we similarly want to compile it *now*. Unlike with DML, we need
+        # to manually construct the CTE here.
+        elif volatility.is_volatile() and irutils.contains_dml(stmt):
             materialized_set = None
             if (
                 stmt.materialized_sets

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -270,7 +270,7 @@ def compile_output(
     return val
 
 
-def compile_dml_bindings(
+def compile_volatile_bindings(
         stmt: irast.Stmt, *,
         ctx: context.CompilerContextLevel) -> None:
     for binding, volatility in (stmt.bindings or ()):

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -102,7 +102,7 @@ def init_dml_stmt(
     range_cte: Optional[pgast.CommonTableExpr]
     range_rvar: Optional[pgast.RelRangeVar]
 
-    clauses.compile_dml_bindings(ir_stmt, ctx=ctx)
+    clauses.compile_volatile_bindings(ir_stmt, ctx=ctx)
 
     if isinstance(ir_stmt, (irast.UpdateStmt, irast.DeleteStmt)):
         # UPDATE and DELETE operate over a range, so generate

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -173,7 +173,7 @@ def _compile_group(
         ctx: context.CompilerContextLevel,
         parent_ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
-    clauses.compile_dml_bindings(stmt, ctx=ctx)
+    clauses.compile_volatile_bindings(stmt, ctx=ctx)
 
     query = ctx.stmt
 

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -54,7 +54,7 @@ def compile_SelectStmt(
     parent_ctx = ctx
     with parent_ctx.substmt() as ctx:
         # Common setup.
-        clauses.compile_dml_bindings(stmt, ctx=ctx)
+        clauses.compile_volatile_bindings(stmt, ctx=ctx)
 
         query = ctx.stmt
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -5828,38 +5828,1048 @@ class TestInsert(tb.QueryTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''
-                SELECT all(Person.name = Person.tag)
-            ''',
-            [True]
+            'SELECT all(Person.name = Person.tag)',
+            [True],
         )
 
     @tb.needs_factoring_weakly
     async def test_edgeql_insert_volatile_02(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                name := x ++ "!",
+            INSERT Person { name := name, tag := name };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_03(self):
+        await self.con.execute('''
+            WITH
+                x := "!",
+                name := x ++ <str>random(),
+            INSERT Person { name := name, tag := name };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_04(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                name := x ++ <str>random(),
+            INSERT Person { name := name, tag := name };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_05(self):
         await self.con.execute('''
             WITH name := <str>random(),
             SELECT (INSERT Person { name := name, tag := name });
         ''')
 
         await self.assert_query_result(
-            r'''
-                SELECT all(Person.name = Person.tag)
-            ''',
-            [True]
+            'SELECT all(Person.name = Person.tag)',
+            [True],
         )
 
     @tb.needs_factoring_weakly
-    async def test_edgeql_insert_volatile_03(self):
+    async def test_edgeql_insert_volatile_06(self):
         await self.con.execute('''
-            FOR name in {<str>random()}
+            WITH
+                x := <str>random(),
+                name := x ++ "!",
+            SELECT (INSERT Person { name := name, tag := name });
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_07(self):
+        await self.con.execute('''
+            WITH
+                x := "!",
+                name := x ++ <str>random(),
+            SELECT (INSERT Person { name := name, tag := name });
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_08(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                name := x ++ <str>random(),
+            SELECT (INSERT Person { name := name, tag := name });
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_09(self):
+        await self.con.execute('''
+            WITH x := <str>random()
+            SELECT (
+                WITH name := x ++ "!"
+                INSERT Person { name := name, tag := name }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_10(self):
+        await self.con.execute('''
+            WITH x := "!"
+            SELECT (
+                WITH name := x ++ <str>random()
+                INSERT Person { name := name, tag := name }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_11(self):
+        await self.con.execute('''
+            WITH x := <str>random()
+            SELECT (
+                WITH name := x ++ <str>random()
+                INSERT Person { name := name, tag := name }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_12(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                y := x ++ <str>random(),
+            SELECT (
+                WITH name := y ++ <str>random()
+                INSERT Person { name := name, tag := name }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_13(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := <str>random(),
+                    INSERT Person { name := name, tag := name }
+                )
+            SELECT (
+                INSERT Person { name := x.name ++ "!", tag := x.tag }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_14(self):
+        await self.con.execute('''
+            WITH
+                x := "!",
+                y := (
+                    WITH name := <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+            SELECT (
+                INSERT Person {
+                    name := x ++ y.name,
+                    tag := x ++ y.tag,
+                    tag2 := y.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_15(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                y := (
+                    WITH name := "!",
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+            SELECT (
+                INSERT Person {
+                    name := x ++ y.name,
+                    tag := x ++ y.tag,
+                    tag2 := y.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_16(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                y := (
+                    WITH name := <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+            SELECT (
+                INSERT Person {
+                    name := x ++ y.name,
+                    tag := x ++ y.tag,
+                    tag2 := y.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_17(self):
+        await self.con.execute('''
+            WITH
+                x := "!",
+                y := (
+                    WITH name := x ++ <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := x }
+                ),
+            SELECT (
+                INSERT Person {
+                    name := y.name ++ "!",
+                    tag := y.tag ++ "!",
+                    tag2 := y.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_18(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                y := (
+                    WITH name := x ++ "!",
+                    INSERT Person { name := name, tag := name, tag2 := x }
+                ),
+            SELECT (
+                INSERT Person {
+                    name := y.name ++ "!",
+                    tag := y.tag ++ "!",
+                    tag2 := y.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_19(self):
+        await self.con.execute('''
+            WITH
+                x := <str>random(),
+                y := (
+                    WITH name := x ++ <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := x }
+                ),
+            SELECT (
+                INSERT Person {
+                    name := y.name ++ "!",
+                    tag := y.tag ++ "!",
+                    tag2 := y.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_20(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := "!",
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+                y := <str>random(),
+            SELECT (
+                INSERT Person {
+                    name := x.name ++ y,
+                    tag := x.tag ++ y,
+                    tag2 := x.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_21(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+                y := "!",
+            SELECT (
+                INSERT Person {
+                    name := x.name ++ y,
+                    tag := x.tag ++ y,
+                    tag2 := x.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_22(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+                y := <str>random(),
+            SELECT (
+                INSERT Person {
+                    name := x.name ++ y,
+                    tag := x.tag ++ y,
+                    tag2 := x.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_23(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := "!",
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+                y := x.name ++ <str>random(),
+            SELECT (
+                INSERT Person {
+                    name := y,
+                    tag := y,
+                    tag2 := x.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_24(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+                y := x.name ++ "!",
+            SELECT (
+                INSERT Person {
+                    name := y,
+                    tag := y,
+                    tag2 := x.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_25(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := <str>random(),
+                    INSERT Person { name := name, tag := name, tag2 := name }
+                ),
+                y := x.name ++ <str>random(),
+            SELECT (
+                INSERT Person {
+                    name := y,
+                    tag := y,
+                    tag2 := x.tag2,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_26(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := <str>random(),
+                    INSERT Person {
+                        name := name,
+                        tag := name,
+                        tag2 := name,
+                    }
+                ),
+                y := (
+                    WITH r := <str>random(),
+                    INSERT Person {
+                        name := x.name ++ r,
+                        tag := x.tag ++ r,
+                        tag2 := x.tag,
+                    }
+                ),
+            SELECT (
+                WITH r := <str>random(),
+                INSERT Person {
+                    name := y.name ++ r,
+                    tag := y.name ++ r,
+                    tag2 := y.tag ++ r,
+                }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [3],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [3],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [2],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_27(self):
+        await self.con.execute('''
+            WITH x := "!"
+            INSERT Person {
+                name := x,
+                tag := x,
+                note := (
+                    WITH y := <str>random()
+                    insert Note { name := y, note := y }
+                )
+            };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+        await self.assert_query_result(
+            'SELECT all(Note.name = Person.note)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_28(self):
+        await self.con.execute('''
+            WITH x := <str>random(),
+            INSERT Person {
+                name := x,
+                tag := x,
+                note := (
+                    WITH y := <str>random()
+                    insert Note { name := y, note := y }
+                )
+            };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+        await self.assert_query_result(
+            'SELECT all(Note.name = Person.note)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_29(self):
+        await self.con.execute('''
+            WITH x := "!",
+            INSERT Person {
+                name := x,
+                tag := x,
+                note := (
+                    WITH y := x ++ <str>random()
+                    insert Note { name := y, note := y }
+                )
+            };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+        await self.assert_query_result(
+            'SELECT all(Note.name = Person.note)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_30(self):
+        await self.con.execute('''
+            WITH x := <str>random(),
+            INSERT Person {
+                name := x,
+                tag := x,
+                note := (
+                    WITH y := x ++ "!"
+                    insert Note { name := y, note := y }
+                )
+            };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+        await self.assert_query_result(
+            'SELECT all(Note.name = Person.note)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_31(self):
+        await self.con.execute('''
+            WITH x := <str>random(),
+            INSERT Person {
+                name := x,
+                tag := x,
+                note := (
+                    WITH y := x ++ <str>random()
+                    insert Note { name := y, note := y }
+                )
+            };
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True],
+        )
+        await self.assert_query_result(
+            'SELECT all(Note.name = Person.note)',
+            [True],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_32(self):
+        await self.con.execute('''
+            FOR name in {<str>random(), <str>random()}
             UNION (INSERT Person { name := name, tag := name });
         ''')
 
         await self.assert_query_result(
-            r'''
-                SELECT all(Person.name = Person.tag)
-            ''',
-            [True]
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_33(self):
+        await self.con.execute('''
+            WITH x := "!"
+            FOR y in {<str>random(), <str>random()}
+            UNION (
+                WITH name := x ++ y
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_34(self):
+        await self.con.execute('''
+            WITH x := <str>random()
+            FOR y in {"A", "B"}
+            UNION (
+                WITH name := x ++ y
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_35(self):
+        await self.con.execute('''
+            WITH x := <str>random()
+            FOR y in {<str>random(), <str>random()}
+            UNION (
+                WITH name := x ++ y
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_36(self):
+        await self.con.execute('''
+            WITH x := "!"
+            FOR name in {x ++ <str>random(), x ++ <str>random()}
+            UNION (
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_37(self):
+        await self.con.execute('''
+            WITH x := <str>random()
+            FOR name in {x ++ "A", x ++ "B"}
+            UNION (
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_38(self):
+        await self.con.execute('''
+            WITH x := <str>random()
+            FOR name in {x ++ <str>random(), x ++ <str>random()}
+            UNION (
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_39(self):
+        await self.con.execute('''
+            FOR x in {"A", "B"}
+            UNION (
+                WITH name := x ++ <str>random()
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [2],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_40(self):
+        await self.con.execute('''
+            FOR x in {<str>random(), <str>random()}
+            UNION (
+                WITH name := x ++ "!"
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [2],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_41(self):
+        await self.con.execute('''
+            FOR x in {<str>random(), <str>random()}
+            UNION (
+                WITH name := x ++ <str>random()
+                INSERT Person { name := name, tag := name, tag2 := x }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [2],
+        )
+
+    @tb.needs_factoring_weakly
+    async def test_edgeql_insert_volatile_42(self):
+        await self.con.execute('''
+            WITH
+                x := (
+                    WITH name := <str>random(),
+                    INSERT Person {
+                        name := name,
+                        tag := name,
+                        tag2 := name,
+                    }
+                )
+            FOR y in {<str>random(), <str>random()}
+            UNION (
+                WITH name := x.name ++ y
+                INSERT Person { name := name, tag := name, tag2 := x.tag2 }
+            );
+        ''')
+
+        await self.assert_query_result(
+            'SELECT all(Person.name = Person.tag)',
+            [True, True],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.name))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag))',
+            [2],
+        )
+        await self.assert_query_result(
+            'SELECT count(distinct(Person.tag2))',
+            [1],
         )
 
     async def test_edgeql_insert_multi_exclusive_01(self):


### PR DESCRIPTION
Given:
```
type Foo { property a -> float64; };
```

Allows the query:
```
with x := random() insert Foo { a := x };
```

Related #2809
Related #7692