### PR TITLE
Automatically create array types for all scalars

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_11_08_00_00
+EDGEDB_CATALOG_VERSION = 2024_11_08_01_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4456,8 +4456,13 @@ class GetPgTypeForEdgeDBTypeFunction2(trampoline.VersionedFunction):
                     'invalid_parameter_value',
                     msg => (
                         format(
-                            'cannot determine OID of Gel type %L',
-                            "typeid"::text
+                            'cannot determine Postgres OID of Gel %s(%L)%s',
+                            "kind",
+                            "typeid"::text,
+                            (case when "elemid" is not null
+                             then ' with element type ' || "elemid"::text
+                             else ''
+                             end)
                         )
                     )
                 )

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -3222,7 +3222,7 @@ class InheritingObject(SubclassableObject):
     def allow_ref_propagation(
         self,
         schema: s_schema.Schema,
-        constext: sd.CommandContext,
+        context: sd.CommandContext,
         refdict: RefDict,
     ) -> bool:
         return True

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -324,7 +324,7 @@ class ObjectType(
     def allow_ref_propagation(
         self,
         schema: s_schema.Schema,
-        constext: sd.CommandContext,
+        context: sd.CommandContext,
         refdict: so.RefDict,
     ) -> bool:
         return not self.is_view(schema) or refdict.attr == 'pointers'
@@ -333,9 +333,7 @@ class ObjectType(
         self,
         schema: s_schema.Schema,
     ) -> Optional[sd.DeleteObject[ObjectType]]:
-        if not schema.get_by_id(self.id, default=None):
-            # this type was already deleted by some other op
-            # (probably alias types cleanup)
+        if not self._is_deletable(schema):
             return None
 
         # References to aliases can only occur inside other aliases,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -857,7 +857,7 @@ class Pointer(referencing.NamedReferencedInheritingObject,
     def allow_ref_propagation(
         self,
         schema: s_schema.Schema,
-        constext: sd.CommandContext,
+        context: sd.CommandContext,
         refdict: so.RefDict,
     ) -> bool:
         object_type = self.get_source(schema)

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -146,7 +146,7 @@ class Property(
     def allow_ref_propagation(
         self,
         schema: s_schema.Schema,
-        constext: sd.CommandContext,
+        context: sd.CommandContext,
         refdict: so.RefDict,
     ) -> bool:
         source = self.get_source(schema)

--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -19,8 +19,8 @@
 
 SET MODULE default;
 
-CREATE MIGRATION m12hdldnmvzj5weaevxsmizppnl2poo6nconx2hcfkklbwcghqsmaq
-ONTO m1vyvlra26tef6oe6yu37m7lfw7i3ef3n62m6om353dvnbm3mynqqa {
+CREATE MIGRATION m1t2phsw6j2rgl4ieihm6mnvoln3ssayxncjzl2kwkxmunn2f6aqha
+ONTO m1iej6dr3hk33wykqwqgg4xxo3tivpiznpb2mto7qsw2zgipsbfihq {
     CREATE TYPE default::Migrated;
     create type default::Migrated2 {};
 };


### PR DESCRIPTION
This is mostly for the benefit of introspection so that we always have
a corresponding schema type for every backend type (identified by
`backend_id`).
