### PR TITLE
Bump uvloop, edgedb, and asyncpg deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ description = "Gel Server"
 requires-python = '>=3.12.0'
 dynamic = ["version"]
 dependencies = [
-    'edgedb==2.2.0a1',
+    'edgedb==2.2.0',
 
     'httptools>=0.6.0',
     'immutables>=0.18',
     'parsing~=2.0',
-    'uvloop~=0.19.0',
+    'uvloop~=0.21.0',
 
     'click~=8.0',
     'cryptography~=42.0',
@@ -103,7 +103,7 @@ requires = [
     "wheel",
 
     "parsing ~= 2.0",
-    'edgedb==2.2.0a1',
+    "edgedb==2.2.0",
 ]
 # Custom backend needed to set up build-time sys.path because
 # setup.py needs to import `edb.buildmeta`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = [
     'black~=24.2.0',
     'coverage~=7.4',
     'ruff==0.3.7',
-    'asyncpg~=0.29.0',
+    'asyncpg~=0.30.0',
 
     # Needed for testing asyncutil
     'async_solipsism==0.5.0',


### PR DESCRIPTION
So that we are using the same Cython version everywhere.