### PR TITLE
Fix email button background

### DIFF
--- a/edb/server/protocol/auth_ext/ui/__init__.py
+++ b/edb/server/protocol/auth_ext/ui/__init__.py
@@ -704,9 +704,9 @@ def render_password_reset_email(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = "007bff",
+    brand_color: Optional[str] = render.DEFAULT_BRAND_COLOR,
 ) -> email.message.EmailMessage:
-    brand_color = brand_color if brand_color is not None else "007bff"
+    brand_color = brand_color or render.DEFAULT_BRAND_COLOR
     msg = email.message.EmailMessage()
     msg["To"] = to_addr
     msg["Subject"] = "Reset password"
@@ -950,9 +950,9 @@ def render_verification_email(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = "007bff",
+    brand_color: Optional[str] = render.DEFAULT_BRAND_COLOR,
 ) -> email.message.EmailMessage:
-    brand_color = brand_color if brand_color is not None else "007bff"
+    brand_color = brand_color or render.DEFAULT_BRAND_COLOR
     msg = email.message.EmailMessage()
     msg["To"] = to_addr
     msg["Subject"] = (
@@ -1114,9 +1114,9 @@ def render_magic_link_email(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = "007bff",
+    brand_color: Optional[str] = render.DEFAULT_BRAND_COLOR,
 ) -> email.message.EmailMessage:
-    brand_color = brand_color if brand_color is not None else "007bff"
+    brand_color = brand_color or render.DEFAULT_BRAND_COLOR
     msg = email.message.EmailMessage()
     msg["To"] = to_addr
     msg["Subject"] = "Sign in link"

--- a/edb/server/protocol/auth_ext/ui/__init__.py
+++ b/edb/server/protocol/auth_ext/ui/__init__.py
@@ -704,8 +704,9 @@ def render_password_reset_email(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = "#007bff",
+    brand_color: Optional[str] = "007bff",
 ) -> email.message.EmailMessage:
+    brand_color = brand_color if brand_color is not None else "007bff"
     msg = email.message.EmailMessage()
     msg["To"] = to_addr
     msg["Subject"] = "Reset password"
@@ -839,14 +840,14 @@ email address:
                 <tr>
                   <td
                     align="center"
-                    bgcolor="{brand_color}"
+                    bgcolor="#{brand_color}"
                     role="presentation"
                     style="
                       border: none;
                       border-radius: 4px;
                       cursor: auto;
                       mso-padding-alt: 10px 25px;
-                      background: {brand_color};
+                      background: #{brand_color};
                     "
                     valign="middle"
                   >
@@ -854,7 +855,7 @@ email address:
                       href="{reset_url}"
                       style="
                         display: inline-block;
-                        background: {brand_color};
+                        background: #{brand_color};
                         color: #ffffff;
                         font-family: open Sans Helvetica, Arial, sans-serif;
                         font-size: 18px;
@@ -949,8 +950,9 @@ def render_verification_email(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = "#007bff",
+    brand_color: Optional[str] = "007bff",
 ) -> email.message.EmailMessage:
+    brand_color = brand_color if brand_color is not None else "007bff"
     msg = email.message.EmailMessage()
     msg["To"] = to_addr
     msg["Subject"] = (
@@ -1029,14 +1031,14 @@ email address:
       <tr>
         <td
           align="center"
-          bgcolor="{brand_color}"
+          bgcolor="#{brand_color}"
           role="presentation"
           style="
             border: none;
             border-radius: 4px;
             cursor: auto;
             mso-padding-alt: 10px 25px;
-            background: {brand_color};
+            background: #{brand_color};
           "
           valign="middle"
         >
@@ -1044,7 +1046,7 @@ email address:
             href="{verify_url}"
             style="
               display: inline-block;
-              background: {brand_color};
+              background: #{brand_color};
               color: #ffffff;
               font-family:
                 open Sans Helvetica,
@@ -1112,8 +1114,9 @@ def render_magic_link_email(
     app_name: Optional[str] = None,
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = "#007bff",
+    brand_color: Optional[str] = "007bff",
 ) -> email.message.EmailMessage:
+    brand_color = brand_color if brand_color is not None else "007bff"
     msg = email.message.EmailMessage()
     msg["To"] = to_addr
     msg["Subject"] = "Sign in link"
@@ -1158,14 +1161,14 @@ your account:
       <tr>
         <td
           align="center"
-          bgcolor="{brand_color}"
+          bgcolor="#{brand_color}"
           role="presentation"
           style="
             border: none;
             border-radius: 4px;
             cursor: auto;
             mso-padding-alt: 10px 25px;
-            background: {brand_color};
+            background: #{brand_color};
           "
           valign="middle"
         >
@@ -1173,7 +1176,7 @@ your account:
             href="{link}"
             style="
               display: inline-block;
-              background: {brand_color};
+              background: #{brand_color};
               color: #ffffff;
               font-family: open Sans Helvetica, Arial, sans-serif;
               font-size: 18px;

--- a/edb/server/protocol/auth_ext/ui/components.py
+++ b/edb/server/protocol/auth_ext/ui/components.py
@@ -37,6 +37,9 @@ known_oauth_provider_names = [
 ]
 
 
+DEFAULT_BRAND_COLOR = "1f8aed"
+
+
 def base_page(
     *,
     content: str,
@@ -44,7 +47,7 @@ def base_page(
     cleanup_search_params: list[str],
     logo_url: Optional[str] = None,
     dark_logo_url: Optional[str] = None,
-    brand_color: Optional[str] = None,
+    brand_color: Optional[str] = DEFAULT_BRAND_COLOR,
 ) -> bytes:
     logo = ''
     if logo_url:
@@ -73,7 +76,7 @@ def base_page(
         brand_color is None or
         util.hex_color_regexp.fullmatch(brand_color) is None
     ):
-        brand_color = '1f8aed'
+        brand_color = DEFAULT_BRAND_COLOR
 
     return f'''
 <!DOCTYPE html>


### PR DESCRIPTION
When passing `None` explicitly, which we are always doing, the fallback color was not being set. It was also the wrong format considering that we store them without the leading `#`.

---

I tried for an unreasonable amount of time to add tests for this, but the configuration was not stable when running the full test suite, so I just reverted back to no additional tests.