### PR TITLE
Disable pyright type checking altogether

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,3 +268,4 @@ lint.flake8-bugbear.extend-immutable-calls = [
 [tool.pyright]
 # Pyright has no idea about metaclass-generated getters for schema fields.
 reportAttributeAccessIssue = false
+typeCheckingMode = "off"


### PR DESCRIPTION
We rely on mypy for our typechecking rules and pyright is often too
noisy and wrong.
