### PR TITLE
Remove multiplicity from `QueryUnit.sql`

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_11_08_01_00
+EDGEDB_CATALOG_VERSION = 2024_11_12_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -674,6 +674,11 @@ class DDLCommand(Command, DDLOperation):
     __abstract_node__ = True
 
 
+class NonTransactionalDDLCommand(DDLCommand):
+    __abstract_node__ = True
+    __rust_ignore__ = True
+
+
 class AlterAddInherit(DDLOperation):
     position: typing.Optional[Position] = None
     bases: typing.List[TypeName]
@@ -868,7 +873,7 @@ class BranchType(s_enum.StrEnum):
     TEMPLATE = 'TEMPLATE'
 
 
-class DatabaseCommand(ExternalObjectCommand):
+class DatabaseCommand(ExternalObjectCommand, NonTransactionalDDLCommand):
 
     __abstract_node__ = True
     __rust_ignore__ = True

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -504,6 +504,35 @@ class Query(Command):
         return f'<Query {self.text!r}>'
 
 
+class PLQuery(Command):
+    def __init__(
+        self,
+        text: str,
+        *,
+        type: Optional[str | Tuple[str, str]] = None,
+        trampoline_fixup: bool = True,
+    ) -> None:
+        from ..import trampoline
+
+        super().__init__()
+        if trampoline_fixup:
+            text = trampoline.fixup_query(text)
+        self.text = text
+        self.type = type
+
+    def to_sql_expr(self) -> str:
+        if self.type:
+            return f'({self.text})::{qn(*self.type)}'
+        else:
+            return self.text
+
+    def code_with_block(self, block: PLBlock) -> str:
+        return self.text
+
+    def __repr__(self) -> str:
+        return f'<PLQuery {self.text!r}>'
+
+
 class DefaultMeta(type):
     def __bool__(cls):
         return False

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -504,33 +504,8 @@ class Query(Command):
         return f'<Query {self.text!r}>'
 
 
-class PLQuery(Command):
-    def __init__(
-        self,
-        text: str,
-        *,
-        type: Optional[str | Tuple[str, str]] = None,
-        trampoline_fixup: bool = True,
-    ) -> None:
-        from ..import trampoline
-
-        super().__init__()
-        if trampoline_fixup:
-            text = trampoline.fixup_query(text)
-        self.text = text
-        self.type = type
-
-    def to_sql_expr(self) -> str:
-        if self.type:
-            return f'({self.text})::{qn(*self.type)}'
-        else:
-            return self.text
-
-    def code_with_block(self, block: PLBlock) -> str:
-        return self.text
-
-    def __repr__(self) -> str:
-        return f'<PLQuery {self.text!r}>'
+class PLQuery(Query):
+    pass
 
 
 class DefaultMeta(type):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2953,7 +2953,7 @@ class AlterScalarType(ScalarTypeMetaCommand, adapts=s_scalars.AlterScalarType):
         return schema
 
 
-def drop_dependant_func_cache(pg_type: Tuple[str, ...]) -> dbops.Query:
+def drop_dependant_func_cache(pg_type: Tuple[str, ...]) -> dbops.PLQuery:
     if len(pg_type) == 1:
         types_cte = f'''
                     SELECT
@@ -2980,7 +2980,6 @@ def drop_dependant_func_cache(pg_type: Tuple[str, ...]) -> dbops.Query:
                         )\
         '''
     drop_func_cache_sql = textwrap.dedent(f'''
-        DO $$
         DECLARE
             qc RECORD;
         BEGIN
@@ -3014,9 +3013,9 @@ def drop_dependant_func_cache(pg_type: Tuple[str, ...]) -> dbops.Query:
             LOOP
                 PERFORM edgedb_VER."_evict_query_cache"(qc.key);
             END LOOP;
-        END $$;
+        END;
     ''')
-    return dbops.Query(drop_func_cache_sql)
+    return dbops.PLQuery(drop_func_cache_sql)
 
 
 class DeleteScalarType(ScalarTypeMetaCommand,

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -105,13 +105,13 @@ class PGConnection(Protocol):
 
     async def sql_execute(
         self,
-        sql: bytes | tuple[bytes, ...],
+        sql: bytes,
     ) -> None:
         ...
 
     async def sql_fetch(
         self,
-        sql: bytes | tuple[bytes, ...],
+        sql: bytes,
         *,
         args: tuple[bytes, ...] | list[bytes] = (),
     ) -> list[tuple[bytes, ...]]:
@@ -1493,6 +1493,50 @@ class GetCurrentDatabaseFunction(trampoline.VersionedFunction):
             returns=('text',),
             language='sql',
             volatility='stable',
+            text=self.text,
+        )
+
+
+class RaiseNoticeFunction(trampoline.VersionedFunction):
+    text = '''
+    BEGIN
+        RAISE NOTICE USING
+            MESSAGE = "msg",
+            DETAIL = COALESCE("detail", ''),
+            HINT = COALESCE("hint", ''),
+            COLUMN = COALESCE("column", ''),
+            CONSTRAINT = COALESCE("constraint", ''),
+            DATATYPE = COALESCE("datatype", ''),
+            TABLE = COALESCE("table", ''),
+            SCHEMA = COALESCE("schema", '');
+        RETURN "rtype";
+    END;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'notice'),
+            args=[
+                ('rtype', ('anyelement',)),
+                ('msg', ('text',), "''"),
+                ('detail', ('text',), "''"),
+                ('hint', ('text',), "''"),
+                ('column', ('text',), "''"),
+                ('constraint', ('text',), "''"),
+                ('datatype', ('text',), "''"),
+                ('table', ('text',), "''"),
+                ('schema', ('text',), "''"),
+            ],
+            returns=('anyelement',),
+            # NOTE: The main reason why we don't want this function to be
+            # immutable is that immutable functions can be
+            # pre-evaluated by the query planner once if they have
+            # constant arguments. This means that using this function
+            # as the second argument in a COALESCE will raise a
+            # notice regardless of whether the first argument is
+            # NULL or not.
+            volatility='stable',
+            language='plpgsql',
             text=self.text,
         )
 
@@ -4980,6 +5024,7 @@ def get_bootstrap_commands(
         dbops.CreateFunction(GetSharedObjectMetadata()),
         dbops.CreateFunction(GetDatabaseMetadataFunction()),
         dbops.CreateFunction(GetCurrentDatabaseFunction()),
+        dbops.CreateFunction(RaiseNoticeFunction()),
         dbops.CreateFunction(RaiseExceptionFunction()),
         dbops.CreateFunction(RaiseExceptionOnNullFunction()),
         dbops.CreateFunction(RaiseExceptionOnNotNullFunction()),

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1547,7 +1547,7 @@ class RaiseNoticeFunction(trampoline.VersionedFunction):
 class IndirectReturnFunction(trampoline.VersionedFunction):
     text = """
     SELECT
-        edgedb.notice(
+        edgedb_VER.notice(
             NULL::text,
             msg => 'edb:notice:indirect_return',
             detail => "value"

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -173,7 +173,7 @@ class PGConnectionProxy:
 
         return result
 
-    async def sql_execute(self, sql: bytes | tuple[bytes, ...]) -> None:
+    async def sql_execute(self, sql: bytes) -> None:
         async def _task() -> None:
             assert self._conn is not None
             await self._conn.sql_execute(sql)
@@ -181,7 +181,7 @@ class PGConnectionProxy:
 
     async def sql_fetch(
         self,
-        sql: bytes | tuple[bytes, ...],
+        sql: bytes,
         *,
         args: tuple[bytes, ...] | list[bytes] = (),
     ) -> list[tuple[bytes, ...]]:
@@ -634,8 +634,8 @@ def compile_single_query(
 ) -> str:
     ql_source = edgeql.Source.from_string(eql)
     units = edbcompiler.compile(ctx=compilerctx, source=ql_source).units
-    assert len(units) == 1 and len(units[0].sql) == 1
-    return units[0].sql[0].decode()
+    assert len(units) == 1
+    return units[0].sql.decode()
 
 
 def _get_all_subcommands(
@@ -687,7 +687,7 @@ def prepare_repair_patch(
     schema_class_layout: s_refl.SchemaClassLayout,
     backend_params: params.BackendRuntimeParams,
     config: Any,
-) -> tuple[bytes, ...]:
+) -> bytes:
     compiler = edbcompiler.new_compiler(
         std_schema=stdschema,
         reflection_schema=reflschema,
@@ -701,7 +701,7 @@ def prepare_repair_patch(
     )
     res = edbcompiler.repair_schema(compilerctx)
     if not res:
-        return ()
+        return b""
     sql, _, _ = res
 
     return sql
@@ -2111,10 +2111,10 @@ def compile_sys_queries(
         ),
         source=edgeql.Source.from_string(report_configs_query),
     ).units
-    assert len(units) == 1 and len(units[0].sql) == 1
+    assert len(units) == 1
 
     report_configs_typedesc_2_0 = units[0].out_type_id + units[0].out_type_data
-    queries['report_configs'] = units[0].sql[0].decode()
+    queries['report_configs'] = units[0].sql.decode()
 
     units = edbcompiler.compile(
         ctx=edbcompiler.new_compiler_context(
@@ -2128,7 +2128,7 @@ def compile_sys_queries(
         ),
         source=edgeql.Source.from_string(report_configs_query),
     ).units
-    assert len(units) == 1 and len(units[0].sql) == 1
+    assert len(units) == 1
     report_configs_typedesc_1_0 = units[0].out_type_id + units[0].out_type_data
 
     return (

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2664,7 +2664,6 @@ def _make_query_unit(
             unit.modaliases = comp.modaliases
 
         if comp.tx_action == dbstate.TxAction.START:
-            # units[0:0] = _make_tx_units(ctx, qlast.StartTransaction())
             if unit.tx_id is not None:
                 raise errors.InternalServerError(
                     'already in transaction')

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -429,7 +429,7 @@ class Compiler:
             sql = b'ROLLBACK;'
             unit = dbstate.QueryUnit(
                 status=b'ROLLBACK',
-                sql=(sql,),
+                sql=sql,
                 tx_rollback=True,
                 cacheable=False)
 
@@ -437,7 +437,7 @@ class Compiler:
             sql = f'ROLLBACK TO {pg_common.quote_ident(stmt.name)};'.encode()
             unit = dbstate.QueryUnit(
                 status=b'ROLLBACK TO SAVEPOINT',
-                sql=(sql,),
+                sql=sql,
                 tx_savepoint_rollback=True,
                 sp_name=stmt.name,
                 cacheable=False)
@@ -1316,12 +1316,11 @@ def _compile_schema_storage_stmt(
 
         sql_stmts = []
         for u in unit_group:
-            for stmt in u.sql:
-                stmt = stmt.strip()
-                if not stmt.endswith(b';'):
-                    stmt += b';'
+            stmt = u.sql.strip()
+            if not stmt.endswith(b';'):
+                stmt += b';'
 
-                sql_stmts.append(stmt)
+            sql_stmts.append(stmt)
 
         if len(sql_stmts) > 1:
             raise errors.InternalServerError(
@@ -1356,12 +1355,11 @@ def _compile_ql_script(
 
     sql_stmts = []
     for u in unit_group:
-        for stmt in u.sql:
-            stmt = stmt.strip()
-            if not stmt.endswith(b';'):
-                stmt += b';'
+        stmt = u.sql.strip()
+        if not stmt.endswith(b';'):
+            stmt += b';'
 
-            sql_stmts.append(stmt)
+        sql_stmts.append(stmt)
 
     return b'\n'.join(sql_stmts).decode()
 
@@ -1485,7 +1483,7 @@ def _compile_ql_explain(
             span=ql.span,
         )
 
-    assert len(query.sql) == 1, query.sql
+    assert query.sql
 
     out_type_data, out_type_id = sertypes.describe(
         schema,
@@ -1493,7 +1491,7 @@ def _compile_ql_explain(
         protocol_version=ctx.protocol_version,
     )
 
-    sql_bytes = exp_command.encode('utf-8') + query.sql[0]
+    sql_bytes = exp_command.encode('utf-8') + query.sql
     sql_hash = _hash_sql(
         sql_bytes,
         mode=str(ctx.output_format).encode(),
@@ -1503,9 +1501,9 @@ def _compile_ql_explain(
     return dataclasses.replace(
         query,
         is_explain=True,
-        append_rollback=args['execute'],
+        run_and_rollback=args['execute'],
         cacheable=False,
-        sql=(sql_bytes,),
+        sql=sql_bytes,
         sql_hash=sql_hash,
         cardinality=enums.Cardinality.ONE,
         out_type_data=out_type_data,
@@ -1531,7 +1529,7 @@ def _compile_ql_administer(
                 span=ql.expr.span,
             )
 
-        return dbstate.MaintenanceQuery(sql=(b'ANALYZE',))
+        return dbstate.MaintenanceQuery(sql=b'ANALYZE')
     elif ql.expr.func == 'schema_repair':
         return ddl.administer_repair_schema(ctx, ql)
     elif ql.expr.func == 'reindex':
@@ -1692,7 +1690,7 @@ def _compile_ql_query(
         query_asts = None
 
     return dbstate.Query(
-        sql=(sql_bytes,),
+        sql=sql_bytes,
         sql_hash=sql_hash,
         cache_sql=cache_sql,
         cache_func_call=cache_func_call,
@@ -1885,7 +1883,7 @@ def _compile_ql_transaction(
         if ql.deferrable is not None:
             sqls += f' {ql.deferrable.value}'
         sqls += ';'
-        sql = (sqls.encode(),)
+        sql = sqls.encode()
 
         action = dbstate.TxAction.START
         cacheable = False
@@ -1901,7 +1899,7 @@ def _compile_ql_transaction(
         new_state = ctx.state.commit_tx()
         modaliases = new_state.modaliases
 
-        sql = (b'COMMIT',)
+        sql = b'COMMIT'
         cacheable = False
         action = dbstate.TxAction.COMMIT
 
@@ -1909,7 +1907,7 @@ def _compile_ql_transaction(
         new_state = ctx.state.rollback_tx()
         modaliases = new_state.modaliases
 
-        sql = (b'ROLLBACK',)
+        sql = b'ROLLBACK'
         cacheable = False
         action = dbstate.TxAction.ROLLBACK
 
@@ -1918,7 +1916,7 @@ def _compile_ql_transaction(
         sp_id = tx.declare_savepoint(ql.name)
 
         pgname = pg_common.quote_ident(ql.name)
-        sql = (f'SAVEPOINT {pgname}'.encode(),)
+        sql = f'SAVEPOINT {pgname}'.encode()
 
         cacheable = False
         action = dbstate.TxAction.DECLARE_SAVEPOINT
@@ -1928,7 +1926,7 @@ def _compile_ql_transaction(
     elif isinstance(ql, qlast.ReleaseSavepoint):
         ctx.state.current_tx().release_savepoint(ql.name)
         pgname = pg_common.quote_ident(ql.name)
-        sql = (f'RELEASE SAVEPOINT {pgname}'.encode(),)
+        sql = f'RELEASE SAVEPOINT {pgname}'.encode()
         action = dbstate.TxAction.RELEASE_SAVEPOINT
 
     elif isinstance(ql, qlast.RollbackToSavepoint):
@@ -1937,7 +1935,7 @@ def _compile_ql_transaction(
         modaliases = new_state.modaliases
 
         pgname = pg_common.quote_ident(ql.name)
-        sql = (f'ROLLBACK TO SAVEPOINT {pgname};'.encode(),)
+        sql = f'ROLLBACK TO SAVEPOINT {pgname};'.encode()
         cacheable = False
         action = dbstate.TxAction.ROLLBACK_TO_SAVEPOINT
         sp_name = ql.name
@@ -1996,9 +1994,7 @@ def _compile_ql_sess_state(
 
     ctx.state.current_tx().update_modaliases(aliases)
 
-    return dbstate.SessionStateQuery(
-        sql=(),
-    )
+    return dbstate.SessionStateQuery()
 
 
 def _get_config_spec(
@@ -2170,9 +2166,7 @@ def _compile_ql_config_op(
     if pretty:
         debug.dump_code(sql_text, lexer='sql')
 
-    sql: tuple[bytes, ...] = (
-        sql_text.encode(),
-    )
+    sql = sql_text.encode()
 
     in_type_args, in_type_data, in_type_id = describe_params(
         ctx, ir, sql_res.argmap, None
@@ -2363,7 +2357,6 @@ def _try_compile(
         if text.startswith(sentinel):
             time.sleep(float(text[len(sentinel):text.index("\n")]))
 
-    default_cardinality = enums.Cardinality.NO_RESULT
     statements = edgeql.parse_block(source)
     statements_len = len(statements)
 
@@ -2399,15 +2392,6 @@ def _try_compile(
 
         _check_force_database_error(stmt_ctx, stmt)
 
-        # Initialize user_schema_version with the version this query is
-        # going to be compiled upon. This can be overwritten later by DDLs.
-        try:
-            schema_version = _get_schema_version(
-                stmt_ctx.state.current_tx().get_user_schema()
-            )
-        except errors.InvalidReferenceError:
-            schema_version = None
-
         comp, capabilities = _compile_dispatch_ql(
             stmt_ctx,
             stmt,
@@ -2416,233 +2400,20 @@ def _try_compile(
             in_script=is_script,
         )
 
-        unit = dbstate.QueryUnit(
-            sql=(),
-            status=status.get_status(stmt),
-            cardinality=default_cardinality,
+        unit, user_schema = _make_query_unit(
+            ctx=ctx,
+            stmt_ctx=stmt_ctx,
+            stmt=stmt,
+            is_script=is_script,
+            is_trailing_stmt=is_trailing_stmt,
+            comp=comp,
             capabilities=capabilities,
-            output_format=stmt_ctx.output_format,
-            cache_key=ctx.cache_key,
-            user_schema_version=schema_version,
-            warnings=comp.warnings,
         )
 
-        if not comp.is_transactional:
-            if is_script:
-                raise errors.QueryError(
-                    f'cannot execute {status.get_status(stmt).decode()} '
-                    f'with other commands in one block',
-                    span=stmt.span,
-                )
-
-            if not ctx.state.current_tx().is_implicit():
-                raise errors.QueryError(
-                    f'cannot execute {status.get_status(stmt).decode()} '
-                    f'in a transaction',
-                    span=stmt.span,
-                )
-
-            unit.is_transactional = False
-
-        if isinstance(comp, dbstate.Query):
-            unit.sql = comp.sql
-            unit.cache_sql = comp.cache_sql
-            unit.cache_func_call = comp.cache_func_call
-            unit.globals = comp.globals
-            unit.in_type_args = comp.in_type_args
-
-            unit.sql_hash = comp.sql_hash
-
-            unit.out_type_data = comp.out_type_data
-            unit.out_type_id = comp.out_type_id
-            unit.in_type_data = comp.in_type_data
-            unit.in_type_id = comp.in_type_id
-
-            unit.cacheable = comp.cacheable
-
-            if comp.is_explain:
-                unit.is_explain = True
-                unit.query_asts = comp.query_asts
-
-            if comp.append_rollback:
-                unit.append_rollback = True
-
-            if is_trailing_stmt:
-                unit.cardinality = comp.cardinality
-
-        elif isinstance(comp, dbstate.SimpleQuery):
-            unit.sql = comp.sql
-            unit.in_type_args = comp.in_type_args
-
-        elif isinstance(comp, dbstate.DDLQuery):
-            unit.sql = comp.sql
-            unit.create_db = comp.create_db
-            unit.drop_db = comp.drop_db
-            unit.drop_db_reset_connections = comp.drop_db_reset_connections
-            unit.create_db_template = comp.create_db_template
-            unit.create_db_mode = comp.create_db_mode
-            unit.ddl_stmt_id = comp.ddl_stmt_id
-            if not ctx.dump_restore_mode:
-                if comp.user_schema is not None:
-                    final_user_schema = comp.user_schema
-                    unit.user_schema = pickle.dumps(comp.user_schema, -1)
-                    unit.user_schema_version = (
-                        _get_schema_version(comp.user_schema)
-                    )
-                    unit.extensions, unit.ext_config_settings = (
-                        _extract_extensions(ctx, comp.user_schema)
-                    )
-                unit.feature_used_metrics = comp.feature_used_metrics
-                if comp.cached_reflection is not None:
-                    unit.cached_reflection = \
-                        pickle.dumps(comp.cached_reflection, -1)
-                if comp.global_schema is not None:
-                    unit.global_schema = pickle.dumps(comp.global_schema, -1)
-                    unit.roles = _extract_roles(comp.global_schema)
-
-            unit.config_ops.extend(comp.config_ops)
-
-        elif isinstance(comp, dbstate.TxControlQuery):
-            if is_script:
-                raise errors.QueryError(
-                    "Explicit transaction control commands cannot be executed "
-                    "in an implicit transaction block"
-                )
-            unit.sql = comp.sql
-            unit.cacheable = comp.cacheable
-
-            if not ctx.dump_restore_mode:
-                if comp.user_schema is not None:
-                    final_user_schema = comp.user_schema
-                    unit.user_schema = pickle.dumps(comp.user_schema, -1)
-                    unit.user_schema_version = (
-                        _get_schema_version(comp.user_schema)
-                    )
-                    unit.extensions, unit.ext_config_settings = (
-                        _extract_extensions(ctx, comp.user_schema)
-                    )
-                unit.feature_used_metrics = comp.feature_used_metrics
-                if comp.cached_reflection is not None:
-                    unit.cached_reflection = \
-                        pickle.dumps(comp.cached_reflection, -1)
-                if comp.global_schema is not None:
-                    unit.global_schema = pickle.dumps(comp.global_schema, -1)
-                    unit.roles = _extract_roles(comp.global_schema)
-
-            if comp.modaliases is not None:
-                unit.modaliases = comp.modaliases
-
-            if comp.action == dbstate.TxAction.START:
-                if unit.tx_id is not None:
-                    raise errors.InternalServerError(
-                        'already in transaction')
-                unit.tx_id = ctx.state.current_tx().id
-            elif comp.action == dbstate.TxAction.COMMIT:
-                unit.tx_commit = True
-            elif comp.action == dbstate.TxAction.ROLLBACK:
-                unit.tx_rollback = True
-            elif comp.action is dbstate.TxAction.ROLLBACK_TO_SAVEPOINT:
-                unit.tx_savepoint_rollback = True
-                unit.sp_name = comp.sp_name
-            elif comp.action is dbstate.TxAction.DECLARE_SAVEPOINT:
-                unit.tx_savepoint_declare = True
-                unit.sp_name = comp.sp_name
-                unit.sp_id = comp.sp_id
-
-        elif isinstance(comp, dbstate.MigrationControlQuery):
-            unit.sql = comp.sql
-            unit.cacheable = comp.cacheable
-
-            if not ctx.dump_restore_mode:
-                if comp.user_schema is not None:
-                    final_user_schema = comp.user_schema
-                    unit.user_schema = pickle.dumps(comp.user_schema, -1)
-                    unit.user_schema_version = (
-                        _get_schema_version(comp.user_schema)
-                    )
-                    unit.extensions, unit.ext_config_settings = (
-                        _extract_extensions(ctx, comp.user_schema)
-                    )
-                if comp.cached_reflection is not None:
-                    unit.cached_reflection = \
-                        pickle.dumps(comp.cached_reflection, -1)
-            unit.ddl_stmt_id = comp.ddl_stmt_id
-
-            if comp.modaliases is not None:
-                unit.modaliases = comp.modaliases
-
-            if comp.tx_action == dbstate.TxAction.START:
-                if unit.tx_id is not None:
-                    raise errors.InternalServerError(
-                        'already in transaction')
-                unit.tx_id = ctx.state.current_tx().id
-            elif comp.tx_action == dbstate.TxAction.COMMIT:
-                unit.tx_commit = True
-            elif comp.tx_action == dbstate.TxAction.ROLLBACK:
-                unit.tx_rollback = True
-            elif comp.action == dbstate.MigrationAction.ABORT:
-                unit.tx_abort_migration = True
-
-        elif isinstance(comp, dbstate.SessionStateQuery):
-            unit.sql = comp.sql
-            unit.globals = comp.globals
-
-            if comp.config_scope is qltypes.ConfigScope.INSTANCE:
-                if (not ctx.state.current_tx().is_implicit() or
-                        statements_len > 1):
-                    raise errors.QueryError(
-                        'CONFIGURE INSTANCE cannot be executed in a '
-                        'transaction block')
-
-                unit.system_config = True
-            elif comp.config_scope is qltypes.ConfigScope.GLOBAL:
-                unit.needs_readback = True
-
-            elif comp.config_scope is qltypes.ConfigScope.DATABASE:
-                unit.database_config = True
-                unit.needs_readback = True
-
-            if comp.is_backend_setting:
-                unit.backend_config = True
-            if comp.requires_restart:
-                unit.config_requires_restart = True
-            if comp.is_system_config:
-                unit.is_system_config = True
-
-            unit.modaliases = ctx.state.current_tx().get_modaliases()
-
-            if comp.config_op is not None:
-                unit.config_ops.append(comp.config_op)
-
-            if comp.in_type_args:
-                unit.in_type_args = comp.in_type_args
-            if comp.in_type_data:
-                unit.in_type_data = comp.in_type_data
-            if comp.in_type_id:
-                unit.in_type_id = comp.in_type_id
-
-            unit.has_set = True
-
-        elif isinstance(comp, dbstate.MaintenanceQuery):
-            unit.sql = comp.sql
-
-        elif isinstance(comp, dbstate.NullQuery):
-            pass
-
-        else:  # pragma: no cover
-            raise errors.InternalServerError('unknown compile state')
-
-        if unit.in_type_args:
-            unit.in_type_args_real_count = sum(
-                len(p.sub_params[0]) if p.sub_params else 1
-                for p in unit.in_type_args
-            )
-
-        if unit.warnings:
-            for warning in unit.warnings:
-                warning.__traceback__ = None
-
         rv.append(unit)
+
+        if user_schema is not None:
+            final_user_schema = user_schema
 
     if script_info:
         if ctx.state.current_tx().is_implicit():
@@ -2690,7 +2461,6 @@ def _try_compile(
                 f'QueryUnit {unit!r} is cacheable but has config/aliases')
 
         if not na_cardinality and (
-                len(unit.sql) > 1 or
                 unit.tx_commit or
                 unit.tx_rollback or
                 unit.tx_savepoint_rollback or
@@ -2713,6 +2483,261 @@ def _try_compile(
             f'which does not match the expected cardinality ONE')
 
     return rv
+
+
+def _make_query_unit(
+    *,
+    ctx: CompileContext,
+    stmt_ctx: CompileContext,
+    stmt: qlast.Base,
+    is_script: bool,
+    is_trailing_stmt: bool,
+    comp: dbstate.BaseQuery,
+    capabilities: enums.Capability,
+) -> tuple[dbstate.QueryUnit, Optional[s_schema.Schema]]:
+
+    # Initialize user_schema_version with the version this query is
+    # going to be compiled upon. This can be overwritten later by DDLs.
+    try:
+        schema_version = _get_schema_version(
+            stmt_ctx.state.current_tx().get_user_schema()
+        )
+    except errors.InvalidReferenceError:
+        schema_version = None
+
+    unit = dbstate.QueryUnit(
+        sql=b"",
+        status=status.get_status(stmt),
+        cardinality=enums.Cardinality.NO_RESULT,
+        capabilities=capabilities,
+        output_format=stmt_ctx.output_format,
+        cache_key=ctx.cache_key,
+        user_schema_version=schema_version,
+        warnings=comp.warnings,
+    )
+
+    if not comp.is_transactional:
+        if is_script:
+            raise errors.QueryError(
+                f'cannot execute {status.get_status(stmt).decode()} '
+                f'with other commands in one block',
+                span=stmt.span,
+            )
+
+        if not ctx.state.current_tx().is_implicit():
+            raise errors.QueryError(
+                f'cannot execute {status.get_status(stmt).decode()} '
+                f'in a transaction',
+                span=stmt.span,
+            )
+
+        unit.is_transactional = False
+
+    final_user_schema: Optional[s_schema.Schema] = None
+
+    if isinstance(comp, dbstate.Query):
+        unit.sql = comp.sql
+        unit.cache_sql = comp.cache_sql
+        unit.cache_func_call = comp.cache_func_call
+        unit.globals = comp.globals
+        unit.in_type_args = comp.in_type_args
+
+        unit.sql_hash = comp.sql_hash
+
+        unit.out_type_data = comp.out_type_data
+        unit.out_type_id = comp.out_type_id
+        unit.in_type_data = comp.in_type_data
+        unit.in_type_id = comp.in_type_id
+
+        unit.cacheable = comp.cacheable
+
+        if comp.is_explain:
+            unit.is_explain = True
+            unit.query_asts = comp.query_asts
+
+        if comp.run_and_rollback:
+            unit.run_and_rollback = True
+
+        if is_trailing_stmt:
+            unit.cardinality = comp.cardinality
+
+    elif isinstance(comp, dbstate.SimpleQuery):
+        unit.sql = comp.sql
+        unit.in_type_args = comp.in_type_args
+
+    elif isinstance(comp, dbstate.DDLQuery):
+        unit.sql = comp.sql
+        unit.db_op_trailer = comp.db_op_trailer
+        unit.create_db = comp.create_db
+        unit.drop_db = comp.drop_db
+        unit.drop_db_reset_connections = comp.drop_db_reset_connections
+        unit.create_db_template = comp.create_db_template
+        unit.create_db_mode = comp.create_db_mode
+        unit.ddl_stmt_id = comp.ddl_stmt_id
+        if not ctx.dump_restore_mode:
+            if comp.user_schema is not None:
+                final_user_schema = comp.user_schema
+                unit.user_schema = pickle.dumps(comp.user_schema, -1)
+                unit.user_schema_version = (
+                    _get_schema_version(comp.user_schema)
+                )
+                unit.extensions, unit.ext_config_settings = (
+                    _extract_extensions(ctx, comp.user_schema)
+                )
+            unit.feature_used_metrics = comp.feature_used_metrics
+            if comp.cached_reflection is not None:
+                unit.cached_reflection = \
+                    pickle.dumps(comp.cached_reflection, -1)
+            if comp.global_schema is not None:
+                unit.global_schema = pickle.dumps(comp.global_schema, -1)
+                unit.roles = _extract_roles(comp.global_schema)
+
+        unit.config_ops.extend(comp.config_ops)
+
+    elif isinstance(comp, dbstate.TxControlQuery):
+        if is_script:
+            raise errors.QueryError(
+                "Explicit transaction control commands cannot be executed "
+                "in an implicit transaction block"
+            )
+        unit.sql = comp.sql
+        unit.cacheable = comp.cacheable
+
+        if not ctx.dump_restore_mode:
+            if comp.user_schema is not None:
+                final_user_schema = comp.user_schema
+                unit.user_schema = pickle.dumps(comp.user_schema, -1)
+                unit.user_schema_version = (
+                    _get_schema_version(comp.user_schema)
+                )
+                unit.extensions, unit.ext_config_settings = (
+                    _extract_extensions(ctx, comp.user_schema)
+                )
+            unit.feature_used_metrics = comp.feature_used_metrics
+            if comp.cached_reflection is not None:
+                unit.cached_reflection = \
+                    pickle.dumps(comp.cached_reflection, -1)
+            if comp.global_schema is not None:
+                unit.global_schema = pickle.dumps(comp.global_schema, -1)
+                unit.roles = _extract_roles(comp.global_schema)
+
+        if comp.modaliases is not None:
+            unit.modaliases = comp.modaliases
+
+        if comp.action == dbstate.TxAction.START:
+            if unit.tx_id is not None:
+                raise errors.InternalServerError(
+                    'already in transaction')
+            unit.tx_id = ctx.state.current_tx().id
+        elif comp.action == dbstate.TxAction.COMMIT:
+            unit.tx_commit = True
+        elif comp.action == dbstate.TxAction.ROLLBACK:
+            unit.tx_rollback = True
+        elif comp.action is dbstate.TxAction.ROLLBACK_TO_SAVEPOINT:
+            unit.tx_savepoint_rollback = True
+            unit.sp_name = comp.sp_name
+        elif comp.action is dbstate.TxAction.DECLARE_SAVEPOINT:
+            unit.tx_savepoint_declare = True
+            unit.sp_name = comp.sp_name
+            unit.sp_id = comp.sp_id
+
+    elif isinstance(comp, dbstate.MigrationControlQuery):
+        unit.sql = comp.sql
+        unit.cacheable = comp.cacheable
+
+        if not ctx.dump_restore_mode:
+            if comp.user_schema is not None:
+                final_user_schema = comp.user_schema
+                unit.user_schema = pickle.dumps(comp.user_schema, -1)
+                unit.user_schema_version = (
+                    _get_schema_version(comp.user_schema)
+                )
+                unit.extensions, unit.ext_config_settings = (
+                    _extract_extensions(ctx, comp.user_schema)
+                )
+            if comp.cached_reflection is not None:
+                unit.cached_reflection = \
+                    pickle.dumps(comp.cached_reflection, -1)
+        unit.ddl_stmt_id = comp.ddl_stmt_id
+
+        if comp.modaliases is not None:
+            unit.modaliases = comp.modaliases
+
+        if comp.tx_action == dbstate.TxAction.START:
+            # units[0:0] = _make_tx_units(ctx, qlast.StartTransaction())
+            if unit.tx_id is not None:
+                raise errors.InternalServerError(
+                    'already in transaction')
+            unit.tx_id = ctx.state.current_tx().id
+        elif comp.tx_action == dbstate.TxAction.COMMIT:
+            unit.tx_commit = True
+            unit.append_tx_op = True
+        elif comp.tx_action == dbstate.TxAction.ROLLBACK:
+            unit.tx_rollback = True
+            unit.append_tx_op = True
+        elif comp.action == dbstate.MigrationAction.ABORT:
+            unit.tx_abort_migration = True
+
+    elif isinstance(comp, dbstate.SessionStateQuery):
+        unit.sql = comp.sql
+        unit.globals = comp.globals
+
+        if comp.config_scope is qltypes.ConfigScope.INSTANCE:
+            if not ctx.state.current_tx().is_implicit() or is_script:
+                raise errors.QueryError(
+                    'CONFIGURE INSTANCE cannot be executed in a '
+                    'transaction block')
+
+            unit.system_config = True
+        elif comp.config_scope is qltypes.ConfigScope.GLOBAL:
+            unit.needs_readback = True
+
+        elif comp.config_scope is qltypes.ConfigScope.DATABASE:
+            unit.database_config = True
+            unit.needs_readback = True
+
+        if comp.is_backend_setting:
+            unit.backend_config = True
+        if comp.requires_restart:
+            unit.config_requires_restart = True
+        if comp.is_system_config:
+            unit.is_system_config = True
+
+        unit.modaliases = ctx.state.current_tx().get_modaliases()
+
+        if comp.config_op is not None:
+            unit.config_ops.append(comp.config_op)
+
+        if comp.in_type_args:
+            unit.in_type_args = comp.in_type_args
+        if comp.in_type_data:
+            unit.in_type_data = comp.in_type_data
+        if comp.in_type_id:
+            unit.in_type_id = comp.in_type_id
+
+        unit.has_set = True
+        unit.output_format = enums.OutputFormat.NONE
+
+    elif isinstance(comp, dbstate.MaintenanceQuery):
+        unit.sql = comp.sql
+
+    elif isinstance(comp, dbstate.NullQuery):
+        pass
+
+    else:  # pragma: no cover
+        raise errors.InternalServerError('unknown compile state')
+
+    if unit.in_type_args:
+        unit.in_type_args_real_count = sum(
+            len(p.sub_params[0]) if p.sub_params else 1
+            for p in unit.in_type_args
+        )
+
+    if unit.warnings:
+        for warning in unit.warnings:
+            warning.__traceback__ = None
+
+    return unit, final_user_schema
 
 
 def _extract_params(

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -251,11 +251,11 @@ def _compile_and_apply_ddl_stmt(
             new_type_ids = [
                 f'{pg_common.quote_literal(tid)}::uuid' for tid in new_types
             ]
+            # Return newly-added type id mapping via the indirect
+            # return channel (see PGConnection.last_indirect_return)
             new_types_sql = textwrap.dedent(f"""\
-                PERFORM edgedb.notice(
-                    NULL::text,
-                    msg => 'edb:notice:indirect_return',
-                    detail => json_build_object(
+                PERFORM edgedb.indirect_return(
+                    json_build_object(
                         'ddl_stmt_id',
                         {pg_common.quote_literal(ddl_stmt_id)},
                         'new_types',

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -64,17 +64,28 @@ from edb.schema import version as s_ver
 from edb.pgsql import common as pg_common
 from edb.pgsql import delta as pg_delta
 from edb.pgsql import dbops as pg_dbops
-from edb.pgsql import trampoline
 
 from . import dbstate
 from . import compiler
 
 
+NIL_QUERY = b"SELECT LIMIT 0"
+
+
 def compile_and_apply_ddl_stmt(
     ctx: compiler.CompileContext,
-    stmt: qlast.DDLOperation,
+    stmt: qlast.DDLCommand,
     source: Optional[edgeql.Source] = None,
 ) -> dbstate.DDLQuery:
+    query, _ = _compile_and_apply_ddl_stmt(ctx, stmt, source)
+    return query
+
+
+def _compile_and_apply_ddl_stmt(
+    ctx: compiler.CompileContext,
+    stmt: qlast.DDLCommand,
+    source: Optional[edgeql.Source] = None,
+) -> tuple[dbstate.DDLQuery, Optional[pg_dbops.SQLBlock]]:
     if isinstance(stmt, qlast.GlobalObjectCommand):
         ctx._assert_not_in_migration_block(stmt)
 
@@ -127,7 +138,7 @@ def compile_and_apply_ddl_stmt(
                 )
             ],
         )
-        return compile_and_apply_ddl_stmt(ctx, cm)
+        return _compile_and_apply_ddl_stmt(ctx, cm)
 
     assert isinstance(stmt, qlast.DDLCommand)
     new_schema, delta = s_ddl.delta_and_schema_from_ddl(
@@ -175,13 +186,15 @@ def compile_and_apply_ddl_stmt(
         current_tx.update_migration_state(mstate)
         current_tx.update_schema(new_schema)
 
-        return dbstate.DDLQuery(
-            sql=(b'SELECT LIMIT 0',),
+        query = dbstate.DDLQuery(
+            sql=NIL_QUERY,
             user_schema=current_tx.get_user_schema(),
             is_transactional=True,
             warnings=tuple(delta.warnings),
             feature_used_metrics=None,
         )
+
+        return query, None
 
     store_migration_sdl = compiler._get_config_val(ctx, 'store_migration_sdl')
     if (
@@ -207,26 +220,30 @@ def compile_and_apply_ddl_stmt(
 
         current_tx.update_schema(new_schema)
 
-        return dbstate.DDLQuery(
-            sql=(b'SELECT LIMIT 0',),
+        query = dbstate.DDLQuery(
+            sql=NIL_QUERY,
             user_schema=current_tx.get_user_schema(),
             is_transactional=True,
             warnings=tuple(delta.warnings),
             feature_used_metrics=None,
         )
 
+        return query, None
+
     # Apply and adapt delta, build native delta plan, which
     # will also update the schema.
     block, new_types, config_ops = _process_delta(ctx, delta)
 
     ddl_stmt_id: Optional[str] = None
-
     is_transactional = block.is_transactional()
     if not is_transactional:
-        sql = tuple(stmt.encode('utf-8') for stmt in block.get_statements())
+        if not isinstance(stmt, qlast.DatabaseCommand):
+            raise AssertionError(
+                f"unexpected non-transaction DDL command type: {stmt}")
+        sql_stmts = block.get_statements()
+        sql = sql_stmts[0].encode("utf-8")
+        db_op_trailer = tuple(stmt.encode("utf-8") for stmt in sql_stmts[1:])
     else:
-        sql = (block.to_string().encode('utf-8'),)
-
         if new_types:
             # Inject a query returning backend OIDs for the newly
             # created types.
@@ -234,11 +251,11 @@ def compile_and_apply_ddl_stmt(
             new_type_ids = [
                 f'{pg_common.quote_literal(tid)}::uuid' for tid in new_types
             ]
-            sql = sql + (
-                trampoline.fixup_query(textwrap.dedent(
-                    f'''\
-                SELECT
-                    json_build_object(
+            new_types_sql = textwrap.dedent(f"""\
+                PERFORM edgedb.notice(
+                    NULL::text,
+                    msg => 'edb:notice:indirect_return',
+                    detail => json_build_object(
                         'ddl_stmt_id',
                         {pg_common.quote_literal(ddl_stmt_id)},
                         'new_types',
@@ -254,10 +271,14 @@ def compile_and_apply_ddl_stmt(
                                     {', '.join(new_type_ids)}
                                 ])
                         )
-                    )::text;
-            '''
-                )).encode('utf-8'),
+                    )::text
+                )"""
             )
+
+            block.add_command(pg_dbops.Query(text=new_types_sql).code())
+
+        sql = block.to_string().encode('utf-8')
+        db_op_trailer = ()
 
     create_db = None
     drop_db = None
@@ -286,10 +307,10 @@ def compile_and_apply_ddl_stmt(
         debug.dump_code(code, lexer='sql')
     if debug.flags.delta_execute:
         debug.header('Delta Script')
-        debug.dump_code(b'\n'.join(sql), lexer='sql')
+        debug.dump_code(sql + b"\n".join(db_op_trailer), lexer='sql')
 
     new_user_schema = current_tx.get_user_schema_if_updated()
-    return dbstate.DDLQuery(
+    query = dbstate.DDLQuery(
         sql=sql,
         is_transactional=is_transactional,
         create_db=create_db,
@@ -297,6 +318,7 @@ def compile_and_apply_ddl_stmt(
         drop_db_reset_connections=drop_db_reset_connections,
         create_db_template=create_db_template,
         create_db_mode=create_db_mode,
+        db_op_trailer=db_op_trailer,
         ddl_stmt_id=ddl_stmt_id,
         user_schema=new_user_schema,
         cached_reflection=current_tx.get_cached_reflection_if_updated(),
@@ -308,6 +330,8 @@ def compile_and_apply_ddl_stmt(
             if new_user_schema else None
         ),
     )
+
+    return query, block
 
 
 def _new_delta_context(
@@ -464,7 +488,7 @@ def _start_migration(
     else:
         savepoint_name = current_tx.start_migration()
         query = dbstate.MigrationControlQuery(
-            sql=(b'SELECT LIMIT 0',),
+            sql=NIL_QUERY,
             action=dbstate.MigrationAction.START,
             tx_action=None,
             cacheable=False,
@@ -573,7 +597,7 @@ def _populate_migration(
     current_tx.update_schema(schema)
 
     return dbstate.MigrationControlQuery(
-        sql=(b'SELECT LIMIT 0',),
+        sql=NIL_QUERY,
         tx_action=None,
         action=dbstate.MigrationAction.POPULATE,
         cacheable=False,
@@ -801,7 +825,7 @@ def _alter_current_migration_reject_proposed(
     current_tx.update_migration_state(mstate)
 
     return dbstate.MigrationControlQuery(
-        sql=(b'SELECT LIMIT 0',),
+        sql=NIL_QUERY,
         tx_action=None,
         action=dbstate.MigrationAction.REJECT_PROPOSED,
         cacheable=False,
@@ -876,7 +900,7 @@ def _commit_migration(
         current_tx.update_migration_rewrite_state(mrstate)
 
         return dbstate.MigrationControlQuery(
-            sql=(b'SELECT LIMIT 0',),
+            sql=NIL_QUERY,
             action=dbstate.MigrationAction.COMMIT,
             tx_action=None,
             cacheable=False,
@@ -893,16 +917,12 @@ def _commit_migration(
 
     if mstate.initial_savepoint:
         current_tx.commit_migration(mstate.initial_savepoint)
-        sql = ddl_query.sql
         tx_action = None
     else:
-        tx_cmd = qlast.CommitTransaction()
-        tx_query = compiler._compile_ql_transaction(ctx, tx_cmd)
-        sql = ddl_query.sql + tx_query.sql
-        tx_action = tx_query.action
+        tx_action = dbstate.TxAction.COMMIT
 
     return dbstate.MigrationControlQuery(
-        sql=sql,
+        sql=ddl_query.sql,
         ddl_stmt_id=ddl_query.ddl_stmt_id,
         action=dbstate.MigrationAction.COMMIT,
         tx_action=tx_action,
@@ -923,7 +943,7 @@ def _abort_migration(
 
     if mstate.initial_savepoint:
         current_tx.abort_migration(mstate.initial_savepoint)
-        sql: Tuple[bytes, ...] = (b'SELECT LIMIT 0',)
+        sql = NIL_QUERY
         tx_action = None
     else:
         tx_cmd = qlast.RollbackTransaction()
@@ -967,7 +987,7 @@ def _start_migration_rewrite(
     else:
         savepoint_name = current_tx.start_migration()
         query = dbstate.MigrationControlQuery(
-            sql=(b'SELECT LIMIT 0',),
+            sql=NIL_QUERY,
             action=dbstate.MigrationAction.START,
             tx_action=None,
             cacheable=False,
@@ -1052,25 +1072,24 @@ def _commit_migration_rewrite(
         for cm in cmds:
             cm.dump_edgeql()
 
-    sqls: List[bytes] = []
+    block = pg_dbops.PLTopBlock()
     for cmd in cmds:
-        ddl_query = compile_and_apply_ddl_stmt(ctx, cmd)
+        _, ddl_block = _compile_and_apply_ddl_stmt(ctx, cmd)
+        assert isinstance(ddl_block, pg_dbops.PLBlock)
         # We know nothing serious can be in that query
         # except for the SQL, so it's fine to just discard
         # it all.
-        sqls.extend(ddl_query.sql)
+        for stmt in ddl_block.get_statements():
+            block.add_command(stmt)
 
     if mrstate.initial_savepoint:
         current_tx.commit_migration(mrstate.initial_savepoint)
         tx_action = None
     else:
-        tx_cmd = qlast.CommitTransaction()
-        tx_query = compiler._compile_ql_transaction(ctx, tx_cmd)
-        sqls.extend(tx_query.sql)
-        tx_action = tx_query.action
+        tx_action = dbstate.TxAction.COMMIT
 
     return dbstate.MigrationControlQuery(
-        sql=tuple(sqls),
+        sql=block.to_string().encode("utf-8"),
         action=dbstate.MigrationAction.COMMIT,
         tx_action=tx_action,
         cacheable=False,
@@ -1090,7 +1109,7 @@ def _abort_migration_rewrite(
 
     if mrstate.initial_savepoint:
         current_tx.abort_migration(mrstate.initial_savepoint)
-        sql: Tuple[bytes, ...] = (b'SELECT LIMIT 0',)
+        sql = NIL_QUERY
         tx_action = None
     else:
         tx_cmd = qlast.RollbackTransaction()
@@ -1146,8 +1165,6 @@ def _reset_schema(
         current_schema=empty_schema,
     )
 
-    sqls: List[bytes] = []
-
     # diff and create migration that drops all objects
     diff = s_ddl.delta_schemas(schema, empty_schema)
     new_ddl: Tuple[qlast.DDLCommand, ...] = tuple(
@@ -1156,8 +1173,8 @@ def _reset_schema(
     create_mig = qlast.CreateMigration(  # type: ignore
         body=qlast.NestedQLBlock(commands=tuple(new_ddl)),  # type: ignore
     )
-    ddl_query = compile_and_apply_ddl_stmt(ctx, create_mig)
-    sqls.extend(ddl_query.sql)
+    ddl_query, ddl_block = _compile_and_apply_ddl_stmt(ctx, create_mig)
+    assert ddl_block is not None
 
     # delete all migrations
     schema = current_tx.get_schema(ctx.compiler_state.std_schema)
@@ -1170,11 +1187,13 @@ def _reset_schema(
         drop_mig = qlast.DropMigration(  # type: ignore
             name=qlast.ObjectRef(name=mig.get_name(schema).name),
         )
-        ddl_query = compile_and_apply_ddl_stmt(ctx, drop_mig)
-        sqls.extend(ddl_query.sql)
+        _, mig_block = _compile_and_apply_ddl_stmt(ctx, drop_mig)
+        assert isinstance(mig_block, pg_dbops.PLBlock)
+        for stmt in mig_block.get_statements():
+            ddl_block.add_command(stmt)
 
     return dbstate.MigrationControlQuery(
-        sql=tuple(sqls),
+        sql=ddl_block.to_string().encode("utf-8"),
         ddl_stmt_id=ddl_query.ddl_stmt_id,
         action=dbstate.MigrationAction.COMMIT,
         tx_action=None,
@@ -1278,7 +1297,7 @@ def produce_feature_used_metrics(
 
 def repair_schema(
     ctx: compiler.CompileContext,
-) -> Optional[tuple[tuple[bytes, ...], s_schema.Schema, Any]]:
+) -> Optional[tuple[bytes, s_schema.Schema, Any]]:
     """Repair inconsistencies in the schema caused by bug fixes
 
     Works by comparing the actual current schema to the schema we get
@@ -1340,11 +1359,11 @@ def repair_schema(
     is_transactional = block.is_transactional()
     assert not new_types
     assert is_transactional
-    sql = (block.to_string().encode('utf-8'),)
+    sql = block.to_string().encode('utf-8')
 
     if debug.flags.delta_execute:
         debug.header('Repair Delta Script')
-        debug.dump_code(b'\n'.join(sql), lexer='sql')
+        debug.dump_code(sql, lexer='sql')
 
     return sql, reloaded_schema, config_ops
 
@@ -1363,7 +1382,7 @@ def administer_repair_schema(
 
     res = repair_schema(ctx)
     if not res:
-        return dbstate.MaintenanceQuery(sql=(b'',))
+        return dbstate.MaintenanceQuery(sql=b"")
     sql, new_schema, config_ops = res
 
     current_tx.update_schema(new_schema)
@@ -1511,9 +1530,11 @@ def administer_reindex(
         for pindex in pindexes
     ]
 
-    return dbstate.MaintenanceQuery(
-        sql=tuple(q.encode('utf-8') for q in commands)
-    )
+    block = pg_dbops.PLTopBlock()
+    for command in commands:
+        block.add_command(command)
+
+    return dbstate.MaintenanceQuery(sql=block.to_string().encode("utf-8"))
 
 
 def administer_vacuum(
@@ -1663,7 +1684,7 @@ def administer_vacuum(
     command = f'VACUUM {options} ' + ', '.join(tables_and_columns)
 
     return dbstate.MaintenanceQuery(
-        sql=(command.encode('utf-8'),),
+        sql=command.encode('utf-8'),
         is_transactional=False,
     )
 

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -79,6 +79,10 @@ get_role_backend_name = pgcommon.get_role_backend_name
 
 EDGEDB_SERVER_SETTINGS = {
     'client_encoding': 'utf-8',
+    # DO NOT raise client_min_messages above NOTICE level
+    # because server indirect block return machinery relies
+    # on NoticeResponse as the data channel.
+    'client_min_messages': 'NOTICE',
     'search_path': 'edgedb',
     'timezone': 'UTC',
     'intervalstyle': 'iso_8601',
@@ -568,7 +572,7 @@ class Cluster(BaseCluster):
         else:
             log_level_map = {
                 'd': 'INFO',
-                'i': 'NOTICE',
+                'i': 'WARNING',  # NOTICE in Postgres is quite noisy
                 'w': 'WARNING',
                 'e': 'ERROR',
                 's': 'PANIC',

--- a/edb/server/pgcon/pgcon.pxd
+++ b/edb/server/pgcon/pgcon.pxd
@@ -139,6 +139,8 @@ cdef class PGConnection:
 
         object last_state
 
+        str last_indirect_return
+
     cdef before_command(self)
 
     cdef write(self, buf)

--- a/edb/server/pgcon/pgcon.pyi
+++ b/edb/server/pgcon/pgcon.pyi
@@ -53,7 +53,7 @@ class PGConnection(asyncio.Protocol):
     async def sql_execute(self, sql: bytes | tuple[bytes, ...]) -> None: ...
     async def sql_fetch(
         self,
-        sql: bytes | tuple[bytes, ...],
+        sql: bytes,
         *,
         args: tuple[bytes, ...] | list[bytes] = (),
         use_prep_stmt: bool = False,

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1582,7 +1582,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
                         if query_unit.sql:
                             if query_unit.ddl_stmt_id:
-                                ddl_ret = await pgcon.run_ddl(query_unit)
+                                await pgcon.parse_execute(query=query_unit)
+                                ddl_ret = pgcon.load_last_ddl_return(query_unit)
                                 if ddl_ret and ddl_ret['new_types']:
                                     new_types = ddl_ret['new_types']
                             else:

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -94,19 +94,14 @@ cdef class ExecutionGroup:
             if state is not None:
                 await be_conn.wait_for_state_resp(state, state_sync=0)
             for i, unit in enumerate(self.group):
-                if unit.output_format == FMT_NONE and unit.ddl_stmt_id is None:
-                    for sql in unit.sql:
-                        await be_conn.wait_for_command(
-                            unit, parse_array[i], dbver, ignore_data=True
-                        )
-                        rv = None
-                else:
-                    for sql in unit.sql:
-                        rv = await be_conn.wait_for_command(
-                            unit, parse_array[i], dbver,
-                            ignore_data=False,
-                            fe_conn=fe_conn,
-                        )
+                ignore_data = unit.output_format == FMT_NONE
+                rv = await be_conn.wait_for_command(
+                    unit,
+                    parse_array[i],
+                    dbver,
+                    ignore_data=ignore_data,
+                    fe_conn=None if ignore_data else fe_conn,
+                )
         return rv
 
 
@@ -135,13 +130,11 @@ cpdef ExecutionGroup build_cache_persistence_units(
         assert serialized_result is not None
 
         if evict:
-            group.append(compiler.QueryUnit(sql=(evict,), status=b''))
+            group.append(compiler.QueryUnit(sql=evict, status=b''))
         if persist:
-            group.append(compiler.QueryUnit(sql=(persist,), status=b''))
+            group.append(compiler.QueryUnit(sql=persist, status=b''))
         group.append(
-            compiler.QueryUnit(
-                sql=(insert_sql,), sql_hash=sql_hash, status=b'',
-            ),
+            compiler.QueryUnit(sql=insert_sql, sql_hash=sql_hash, status=b''),
             args_ser.combine_raw_args((
                 query_unit.cache_key.bytes,
                 query_unit.user_schema_version.bytes,
@@ -276,9 +269,11 @@ async def execute(
 
             if query_unit.sql:
                 if query_unit.user_schema:
-                    ddl_ret = await be_conn.run_ddl(query_unit, state)
-                    if ddl_ret and ddl_ret['new_types']:
-                        new_types = ddl_ret['new_types']
+                    await be_conn.parse_execute(query=query_unit, state=state)
+                    if query_unit.ddl_stmt_id is not None:
+                        ddl_ret = be_conn.load_last_ddl_return(query_unit)
+                        if ddl_ret and ddl_ret['new_types']:
+                            new_types = ddl_ret['new_types']
                 else:
                     bound_args_buf = args_ser.recode_bind_args(
                         dbv, compiled, bind_args)
@@ -519,35 +514,29 @@ async def execute_script(
 
                 if query_unit.sql:
                     parse = parse_array[idx]
+                    fe_output = query_unit.output_format != FMT_NONE
+                    ignore_data = (
+                        not fe_output
+                        and not query_unit.needs_readback
+                    )
+                    data = await conn.wait_for_command(
+                        query_unit,
+                        parse,
+                        dbver,
+                        ignore_data=ignore_data,
+                        fe_conn=fe_conn if fe_output else None,
+                    )
+
                     if query_unit.ddl_stmt_id:
-                        ddl_ret = await conn.handle_ddl_in_script(
-                            query_unit, parse, dbver
-                        )
+                        ddl_ret = conn.load_last_ddl_return(query_unit)
                         if ddl_ret and ddl_ret['new_types']:
                             new_types = ddl_ret['new_types']
-                    elif query_unit.needs_readback:
-                        config_data = []
-                        for sql in query_unit.sql:
-                            config_data = await conn.wait_for_command(
-                                query_unit, parse, dbver, ignore_data=False
-                            )
-                        if config_data:
-                            config_ops = [
-                                config.Operation.from_json(r[0][1:])
-                                for r in config_data
-                            ]
-                    elif query_unit.output_format == FMT_NONE:
-                        for sql in query_unit.sql:
-                            await conn.wait_for_command(
-                                query_unit, parse, dbver, ignore_data=True
-                            )
-                    else:
-                        for sql in query_unit.sql:
-                            data = await conn.wait_for_command(
-                                query_unit, parse, dbver,
-                                ignore_data=False,
-                                fe_conn=fe_conn,
-                            )
+
+                    if query_unit.needs_readback and data:
+                        config_ops = [
+                            config.Operation.from_json(r[0][1:])
+                            for r in data
+                        ]
 
                 if config_ops:
                     await dbv.apply_config_ops(conn, config_ops)
@@ -642,12 +631,7 @@ async def execute_system_config(
     await conn.sql_fetch(b'select 1', state=state)
 
     if query_unit.sql:
-        if len(query_unit.sql) > 1:
-            raise errors.InternalServerError(
-                "unexpected multiple SQL statements in CONFIGURE INSTANCE "
-                "compilation product"
-            )
-        data = await conn.sql_fetch_col(query_unit.sql[0])
+        data = await conn.sql_fetch_col(query_unit.sql)
     else:
         data = None
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1433,7 +1433,7 @@ class Server(BaseServer):
                     db_config = self._parse_db_config(config_json, user_schema)
                     try:
                         logger.info("repairing database '%s'", dbname)
-                        sql += bootstrap.prepare_repair_patch(
+                        rep_sql = bootstrap.prepare_repair_patch(
                             self._std_schema,
                             self._refl_schema,
                             user_schema,
@@ -1442,6 +1442,7 @@ class Server(BaseServer):
                             self._tenant.get_backend_runtime_params(),
                             db_config,
                         )
+                        sql += (rep_sql,)
                     except errors.EdgeDBError as e:
                         if isinstance(e, errors.InternalServerError):
                             raise
@@ -1454,7 +1455,7 @@ class Server(BaseServer):
                         ) from e
 
                 if sql:
-                    await conn.sql_fetch(sql)
+                    await conn.sql_execute(sql)
                 logger.info(
                     "finished applying patch %d to database '%s'", num, dbname)
 


### PR DESCRIPTION
Currently, `QueryUnit.sql` is a tuple representing, possibly, multiple
SQL statements corresponding to the original EdgeQL statement.  This
introduces significant complexity to consumers of `QueryUnit`, which are
mostly unprepared to handle more than one SQL statement anyway.

Originally the SQL tuple was used to represent multiple EdgeQL statements,
a task which is now handled by the `QueryUnitGroup` stuff.  Another use
case are the non-transactional commands (`CREATE BRANCH` and friends).
Finally, since this facility was available, more uses of it were added
without actually _needing_ be executed as multiple SQL statements
with no other recourse: those are mostly maintenance commands and the
DDL type_id readback.

I think the above uses are no longer a sufficient reason to keep the
tuple complexity and so I'm ripping it out here, making `QueryUnit.sql`
a `bytes` property with the invariant of _always_ containing exactly one
SQL statement and thus not needing any special handling.  The users are
fixed up as follows:

- Non-transactional branch units encode the extra SQL needed to
  represent them in the new `QueryUnit.db_op_trailer` property which is
  a tuple of SQL.  Branch commands have special handling for them
  already, so this is not a nuisance.

- The newly-added type id mappings produced by DDL commands are now
  communicated via the new "indirect return" mechanism, whereby a DDL
  PLBlock can communicate a return value via a specially-formatted
  `NoticeResponse` message.

- All other unwitting users of multi-statement `QueryUnit` are converted
  to use a single statement instead (primarily by converting them to use a
  `DO` block).
