### PR TITLE
Fix clippy complaints

### DIFF
--- a/edb/edgeql-parser/src/helpers/bytes.rs
+++ b/edb/edgeql-parser/src/helpers/bytes.rs
@@ -1,6 +1,6 @@
 pub fn unquote_bytes(value: &str) -> Result<Vec<u8>, String> {
     let idx = value
-        .find(|c| c == '\'' || c == '"')
+        .find(['\'', '"'])
         .ok_or_else(|| "invalid bytes literal: missing quotes".to_string())?;
     let prefix = &value[..idx];
     match prefix {

--- a/edb/edgeql-parser/src/position.rs
+++ b/edb/edgeql-parser/src/position.rs
@@ -124,7 +124,7 @@ impl InflatedPos {
             let prefix_s = from_utf8(prefix).map_err(InflatingError::Utf8)?;
             let line_offset;
             let line;
-            if let Some(loff) = prefix_s.rfind(|c| c == '\r' || c == '\n') {
+            if let Some(loff) = prefix_s.rfind(['\r', '\n']) {
                 line_offset = loff + 1;
                 let mut lines = &prefix[..loff];
                 if data[loff] == b'\n' && loff > 0 && data[loff - 1] == b'\r' {

--- a/edb/edgeql-parser/src/validation.rs
+++ b/edb/edgeql-parser/src/validation.rs
@@ -167,7 +167,7 @@ pub fn parse_value(token: &Token) -> Result<Option<Value>, String> {
                         return Err("number is out of range for std::float64".to_string());
                     }
                     if num == 0.0 {
-                        let mend = text.find(|c| c == 'e' || c == 'E').unwrap_or(text.len());
+                        let mend = text.find(['e', 'E']).unwrap_or(text.len());
                         let mantissa = &text[..mend];
                         if mantissa.chars().any(|c| c != '0' && c != '.') {
                             return Err("number is out of range for std::float64".to_string());


### PR DESCRIPTION
These are firing on my machine

    error: this manual char comparison can be written more succinctly
       --> edb/edgeql-parser/src/position.rs:127:48
        |
    127 |             if let Some(loff) = prefix_s.rfind(|c| c == '\r' || c == '\n') {
        |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['\r', '\n']`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_pattern_char_comparison

Not sure why these aren't picked up in CI, but the fixes seem to make
sense.
