### PR TITLE
Fix ISE when enumerating a call to an aggregate function.

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2828,7 +2828,7 @@ def process_set_as_enumerate(
             for _, f_arg in arg_subj.args.items()
         )
     ):
-        # Enumeration of a non-aggregate SET-returning function
+        # Enumeration of a non-aggregate function
         rvars = process_set_as_func_enumerate(ir_set, ctx=ctx)
     else:
         rvars = process_set_as_simple_enumerate(ir_set, ctx=ctx)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2823,9 +2823,12 @@ def process_set_as_enumerate(
                 or arg_expr.limit
                 or arg_expr.offset
             )
+        ) and not any(
+            f_arg.param_typemod == qltypes.TypeModifier.SetOfType
+            for _, f_arg in arg_subj.args.items()
         )
     ):
-        # Enumeration of a SET-returning function
+        # Enumeration of a non-aggregate SET-returning function
         rvars = process_set_as_func_enumerate(ir_set, ctx=ctx)
     else:
         rvars = process_set_as_simple_enumerate(ir_set, ctx=ctx)

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -851,6 +851,23 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             ])
         )
 
+    async def test_edgeql_functions_enumerate_09(self):
+        await self.assert_query_result(
+            'SELECT enumerate(sum({1,2,3}))',
+            [[0, 6]]
+        )
+        await self.assert_query_result(
+            'SELECT enumerate(count(Issue))',
+            [[0, 4]]
+        )
+        await self.assert_query_result(
+            '''
+            WITH x := (SELECT enumerate(array_agg((select User)))),
+            SELECT (x.0, array_unpack(x.1).name)
+            ''',
+            [[0, 'Elvis'], [0, 'Yury']]
+        )
+
     async def test_edgeql_functions_array_get_01(self):
         await self.assert_query_result(
             r'''SELECT array_get([1, 2, 3], 2);''',


### PR DESCRIPTION
Aggregate functions are not allowed in `ROWS FROM (...)`.

Related #7983 