### PR TITLE
Fix aliases always being considered Immutable.

### DIFF
--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -209,7 +209,7 @@ def __infer_set(
             vol,
         ])
 
-    if ir.is_binding:
+    if ir.is_binding and ir.is_binding != irast.BindingKind.Schema:
         vol = IMMUTABLE
 
     return vol

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -816,9 +816,13 @@ def _declare_view_from_schema(
         view_ql = view_expr.parse()
         viewcls_name = viewcls.get_name(ctx.env.schema)
         assert isinstance(view_ql, qlast.Expr), 'expected qlast.Expr'
-        view_set = declare_view(view_ql, alias=viewcls_name,
-                                binding_kind=irast.BindingKind.With,
-                                fully_detached=True, ctx=subctx)
+        view_set = declare_view(
+            view_ql,
+            alias=viewcls_name,
+            binding_kind=irast.BindingKind.Schema,
+            fully_detached=True,
+            ctx=subctx,
+        )
         # The view path id _itself_ should not be in the nested namespace.
         view_set.path_id = view_set.path_id.replace_namespace(frozenset())
         view_set.is_schema_alias = True

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -521,6 +521,7 @@ class BindingKind(s_enum.StrEnum):
     With = 'With'
     For = 'For'
     Select = 'Select'
+    Schema = 'Schema'
 
 
 class TypeRoot(Expr):

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -159,3 +159,14 @@ alias UserAlias := (
 alias SpecialCardAlias := SpecialCard {
     el_cost := (.element, .cost)
 };
+
+alias AliasOne := 1;
+global GlobalOne := 1;
+
+global HighestCost := (
+    SELECT max(Card.cost)
+);
+
+global CardsWithText := (
+    SELECT Card FILTER exists(.text)
+);

--- a/tests/test_edgeql_ir_volatility_inference.py
+++ b/tests/test_edgeql_ir_volatility_inference.py
@@ -156,3 +156,38 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         Volatile
         """
+
+    def test_edgeql_ir_volatility_inference_12(self):
+        """
+        select AliasOne
+% OK %
+        Immutable
+        """
+
+    def test_edgeql_ir_volatility_inference_13(self):
+        """
+        select global GlobalOne
+% OK %
+        Stable
+        """
+
+    def test_edgeql_ir_volatility_inference_14(self):
+        """
+        select AirCard
+% OK %
+        Stable
+        """
+
+    def test_edgeql_ir_volatility_inference_15(self):
+        """
+        select global HighestCost
+% OK %
+        Stable
+        """
+
+    def test_edgeql_ir_volatility_inference_16(self):
+        """
+        select global CardsWithText
+% OK %
+        Stable
+        """


### PR DESCRIPTION
Adds `BindingKind.Schema` to represent schema level bindings.

close #8003