### PR TITLE
Fix builds on systems where protobuf-c package isn't in the default location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /tmp
 __pycache__/
 .d8_history
+/.venv
 /.eggs
 /*.egg
 /*.egg-info


### PR DESCRIPTION
Use a procedure similar to other library lookup to set up CFLAGS for protobuf-c.
