### PR TITLE
Fix SQL normalization

### DIFF
--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -269,7 +269,9 @@ cdef class NormalizedSource(Source):
         serialized: Optional[bytes] = None,
     ) -> None:
         super().__init__(text=normalized.text, serialized=serialized)
-        self._extracted_constants = normalized.extracted_constants
+        self._extracted_constants = list(
+            sorted(normalized.extracted_constants, key=lambda i: i[0]),
+        )
         self._highest_extern_param_id = normalized.highest_extern_param_id
         self._orig_text = orig_text
 

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2337,7 +2337,6 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             [{'a': 1, 'x_a': 2}],
         )
 
-    @test.xfail('bug: probably something with constant extraction')
     async def test_native_sql_query_10(self):
         await self.assert_sql_query_result(
             '''
@@ -2348,7 +2347,6 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             [{'a': 1, 'b': 2, 'c': 3}],  # values are swapped around
         )
 
-    @test.xerror('bug: probably something with constant extraction')
     async def test_native_sql_query_11(self):
         # JOIN ... ON TRUE fails, saying it expects bool, but it got an int
         await self.assert_sql_query_result(


### PR DESCRIPTION
Extracted constants are not always reported in order of parameters,
so sort them explicitly.
