### PR TITLE
Allow OAuth callback to be specified directly

### DIFF
--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -499,6 +499,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             provider_name = provider_config.name
             client_id = provider_config.client_id
             redirect_to = f"{self.http_addr}/some/path"
+            callback_url = f"{self.http_addr}/some/callback/url"
             challenge = (
                 base64.urlsafe_b64encode(
                     hashlib.sha256(
@@ -512,6 +513,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 "provider": provider_name,
                 "redirect_to": redirect_to,
                 "challenge": challenge,
+                "callback_url": callback_url,
             }
 
             _, headers, status = self.http_con_request(
@@ -540,7 +542,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             self.assertEqual(claims.get("redirect_to"), redirect_to)
 
             self.assertEqual(
-                qs.get("redirect_uri"), [f"{self.http_addr}/callback"]
+                qs.get("redirect_uri"), [callback_url]
             )
             self.assertEqual(qs.get("client_id"), [client_id])
 


### PR DESCRIPTION
Currently, we expect that the OAuth Identity Provider should always redirect back to the auth extension's server endpoint, so we build this URL ourselves. However, there might be times when users want to control the OAuth flow themselves, so the callback should redirect to some URL that they've specified.

One confusing thing here is that sometimes the URL provided at `redirect_to` might be refered to as the "callback" URL, but that URL specifies where the auth extension server should call the application at the end of the flow.