### PR TITLE
stats: take PG_CONFIG from environment variable

### DIFF
--- a/edb_stat_statements/Makefile
+++ b/edb_stat_statements/Makefile
@@ -64,6 +64,6 @@ installcheck: \
 	expected/utility.out \
 	expected/wal.out
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
This allows edgedb-pkg to build this extension properly.