### PR TITLE
tests: fix nightly "asyncpg" import

### DIFF
--- a/tests/test_edgeql_sys.py
+++ b/tests/test_edgeql_sys.py
@@ -17,7 +17,6 @@
 #
 
 
-import asyncpg
 import edgedb
 
 from edb.pgsql import common
@@ -154,6 +153,8 @@ class TestSQLSys(tb.SQLQueryTestCase, TestQueryStatsMixin):
         )
 
     async def _bad_query_for_stats(self):
+        import asyncpg
+
         with self.assertRaisesRegex(
             asyncpg.InvalidColumnReferenceError, "cannot find column"
         ):


### PR DESCRIPTION
`asyncpg` is not installed in nightly tests, so don't import in the file directly (SQL test suites will skip running when `asyncpg` is not installed).