### PR TITLE
stats: support building stats extension on PG 16 and lower

### DIFF
--- a/edb_stat_statements/edb_stat_statements.c
+++ b/edb_stat_statements/edb_stat_statements.c
@@ -651,7 +651,11 @@ edbss_extract_stmt_info(const char* query_str, int query_len) {
 					PG_UTF8,
 					true);
 			JsonParseErrorType parse_rv = pg_parse_json(lex, &sem);
+#if PG_VERSION_NUM >= 170000
 			freeJsonLexContext(lex);
+#else
+			pfree(lex);
+#endif
 
 			if (parse_rv == JSON_SUCCESS)
 				if ((state.found & EDB_STMT_INFO_PARSE_REQUIRED) == EDB_STMT_INFO_PARSE_REQUIRED)


### PR DESCRIPTION
Looks like PG 16 don't yet have the fields freed by `freeJsonLexContext` in PG 17, so just `pfree(lex)` on PG 16 and lower.