### PR TITLE
Replace headers with annotations in Parse/Execute

### DIFF
--- a/docs/reference/protocol/messages.rst
+++ b/docs/reference/protocol/messages.rst
@@ -114,7 +114,7 @@ Format:
 See the :ref:`list of error codes <ref_protocol_error_codes>` for all possible
 error codes.
 
-Known headers:
+Known attributes:
 
 * 0x0001 ``HINT``: ``str`` -- error hint.
 * 0x0002 ``DETAILS``: ``str`` -- error details.
@@ -447,7 +447,7 @@ Format:
 
 .. eql:struct:: edb.protocol.DumpObjectDesc
 
-Known headers:
+Known attributes:
 
 * 101 ``BLOCK_TYPE`` -- block type, always "I"
 * 102 ``SERVER_TIME`` -- server time when dump is started as a floating point
@@ -473,7 +473,7 @@ Format:
 .. eql:struct:: edb.protocol.DumpBlock
 
 
-Known headers:
+Known attributes:
 
 * 101 ``BLOCK_TYPE`` -- block type, always "D"
 * 110 ``BLOCK_ID`` -- block identifier (16 bytes of UUID)

--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -94,7 +94,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
     cdef WriteBuffer make_state_data_description_msg(self)
     cdef WriteBuffer make_command_complete_msg(self, capabilities, status)
 
-    cdef inline reject_headers(self)
     cdef inline ignore_headers(self)
     cdef dict parse_headers(self)
     cdef dict parse_annotations(self)

--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -97,6 +97,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
     cdef inline reject_headers(self)
     cdef inline ignore_headers(self)
     cdef dict parse_headers(self)
+    cdef dict parse_annotations(self)
+    cdef inline ignore_annotations(self)
 
     cdef write_status(self, bytes name, bytes value)
     cdef write_edgedb_error(self, exc)


### PR DESCRIPTION
Take annotations (`dict[str, str]`) instead of headers (`dict[int, bytes]`) in Parse/Execute messages.

We forgot this in protocol 1.0 but had been ignoring headers, so it was fine until we're trying to make use of annotations now. This change is a part of the binary protocol version 3.0 (EdgeDB 6.0a1 or nightlies before this PR will not work properly with annotations).