### PR TITLE
Changes Dump to use flags instead of headers in Protocol 3.0

### DIFF
--- a/docs/reference/protocol/messages.rst
+++ b/docs/reference/protocol/messages.rst
@@ -229,6 +229,13 @@ Format:
 
 .. eql:struct:: edb.protocol.Annotation
 
+.. eql:struct:: edb.protocol.DumpFlag
+
+Use:
+
+* ``DUMP_SECRETS`` to include secrets in the backup. By default, secrets are
+  not included.
+
 
 .. _ref_protocol_msg_command_data_description:
 

--- a/edb/protocol/messages.py
+++ b/edb/protocol/messages.py
@@ -519,6 +519,11 @@ class CompilationFlag(enum.IntFlag):
     INJECT_OUTPUT_OBJECT_IDS = 1 << 2    # noqa
 
 
+class DumpFlag(enum.IntFlag):
+
+    DUMP_SECRETS = 1 << 0    # noqa
+
+
 class ErrorSeverity(enum.Enum):
     ERROR = 120
     FATAL = 200
@@ -746,6 +751,7 @@ class Dump(ClientMessage):
     mtype = MessageType('>')
     message_length = MessageLength
     annotations = Annotations
+    flags = EnumOf(UInt64, DumpFlag, 'A bit mask of dump options.')
 
 
 class Sync(ClientMessage):


### PR DESCRIPTION
Refs #6106

The test is failing because the CLI doesn't support it, added in edgedb/edgedb-rust#365