### PR TITLE
Bump edgedb-python to 3.0.0b4

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -222,7 +222,8 @@ def get_extension_dir_path() -> pathlib.Path:
 def hash_dirs(
     dirs: Sequence[Tuple[str, str]],
     *,
-    extra_files: Optional[Sequence[Union[str, pathlib.Path]]]=None
+    extra_files: Optional[Sequence[Union[str, pathlib.Path]]]=None,
+    extra_data: Optional[bytes] = None,
 ) -> bytes:
     def hash_dir(dirname, ext, paths):
         with os.scandir(dirname) as it:
@@ -247,6 +248,8 @@ def hash_dirs(
         with open(path, 'rb') as f:
             h.update(f.read())
     h.update(str(sys.version_info[:2]).encode())
+    if extra_data is not None:
+        h.update(extra_data)
     return h.digest()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Gel Server"
 requires-python = '>=3.12.0'
 dynamic = ["version"]
 dependencies = [
-    'edgedb==3.0.0b3',
+    'edgedb==3.0.0b4',
 
     'httptools>=0.6.0',
     'immutables>=0.18',
@@ -103,7 +103,7 @@ requires = [
     "wheel",
 
     "parsing ~= 2.0",
-    "edgedb==3.0.0b3",
+    "edgedb==3.0.0b4",
 ]
 # Custom backend needed to set up build-time sys.path because
 # setup.py needs to import `edb.buildmeta`.

--- a/setup.py
+++ b/setup.py
@@ -691,12 +691,18 @@ class ci_helper(setuptools.Command):
             print(binascii.hexlify(rust_hash).decode())
 
         elif self.type == 'ext':
-            ext_hash = hash_dirs([
-                (pkg_dir, '.pyx'),
-                (pkg_dir, '.pyi'),
-                (pkg_dir, '.pxd'),
-                (pkg_dir, '.pxi'),
-            ])
+            import gel
+
+            ext_hash = hash_dirs(
+                [
+                    (pkg_dir, '.pyx'),
+                    (pkg_dir, '.pyi'),
+                    (pkg_dir, '.pxd'),
+                    (pkg_dir, '.pxi'),
+                ],
+                # protocol.pyx for tests links to edgedb-python binary
+                extra_data=gel.__version__.encode(),
+            )
             print(
                 binascii.hexlify(ext_hash).decode() + '-'
                 + _get_libpg_query_source_stamp()


### PR DESCRIPTION
I incorrectly thought that edgedb/edgedb-python#552 was going to
require matching changes to testbase/connection.py, so I did an
edgedb-python release so we could easily upgrade.

It *didn't* require changes, and this was all a waste of time.
Oh well.