### PR TITLE
Fix params of globals over SQL adapter

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -494,6 +494,9 @@ class TupleVar(TupleVarBase):
 class ParamRef(ImmutableBaseExpr):
     """Query parameter ($0..$n)."""
 
+    __ast_mutable_fields__ = (
+        ImmutableBaseExpr.__ast_mutable_fields__ | frozenset(['number']))
+
     # Number of the parameter.
     number: int
 

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -2121,8 +2121,8 @@ class ParamMapper(ast.NodeVisitor):
         super().__init__()
         self.mapping = mapping
 
-    def visit_Param(self, p: pgast.Param) -> None:
-        p.index = self.mapping[p.index]
+    def visit_ParamRef(self, p: pgast.ParamRef) -> None:
+        p.number = self.mapping[p.number]
 
 
 def init_external_params(query: pgast.Base, ctx: Context):

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -90,6 +90,14 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                 set default := global glob_mod::glob_float32
             };
         };
+
+        create global glob_mod::a: str;
+        create global glob_mod::b: str;
+        create type glob_mod::Computed {
+            create property a := global glob_mod::a;
+            create property b := global glob_mod::b;
+        };
+        insert glob_mod::Computed;
         ''',
         os.path.join(
             os.path.dirname(__file__), 'schemas', 'movies_setup.edgeql'
@@ -2058,6 +2066,35 @@ class TestSQLQuery(tb.SQLQueryTestCase):
 
         await tran.rollback()
 
+    async def test_sql_query_computed_12(self):
+        # globals
+
+        tran = self.scon.transaction()
+        await tran.start()
+        try:
+            res = await self.squery_values(
+                '''
+                SELECT a, b FROM glob_mod."Computed"
+                '''
+            )
+            self.assertEqual(res, [[None, None]])
+
+            await self.scon.execute(
+                f"""
+                SET LOCAL "global glob_mod::a" TO hello;
+                SET LOCAL "global glob_mod::b" TO world;
+                """
+            )
+
+            res = await self.squery_values(
+                '''
+                SELECT a, b FROM glob_mod."Computed"
+                '''
+            )
+            self.assertEqual(res, [["hello", "world"]])
+        finally:
+            await tran.rollback()
+
     async def test_sql_query_access_policy_01(self):
         tran = self.scon.transaction()
         await tran.start()
@@ -2579,4 +2616,113 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                 {'a': 5, 'b': 2},
                 {'a': 5, 'b': 3},
             ],
+        )
+
+    @test.xfail('todo')
+    async def test_native_sql_query_13(self):
+        # globals
+
+        await self.assert_sql_query_result(
+            """
+            SELECT username FROM "Person"
+            ORDER BY first_name LIMIT 1
+            """,
+            [{'username': "u_robin"}]
+        )
+
+        await self.con.execute(
+            '''
+            SET GLOBAL default::username_prefix := 'user_';
+            '''
+        )
+
+        await self.assert_sql_query_result(
+            """
+            SELECT username FROM "Person"
+            ORDER BY first_name LIMIT 1
+            """,
+            [{'username': "user_robin"}]
+        )
+
+    @test.xfail('todo')
+    async def test_native_sql_query_14(self):
+        # globals
+
+        await self.con.execute(
+            f"""
+            SET GLOBAL glob_mod::glob_str := 'hello';
+            SET GLOBAL glob_mod::glob_uuid :=
+                <uuid>'f527c032-ad4c-461e-95e2-67c4e2b42ca7';
+            SET GLOBAL glob_mod::glob_int64 := 42;
+            SET GLOBAL glob_mod::glob_int32 := 42;
+            SET GLOBAL glob_mod::glob_int16 := 42;
+            SET GLOBAL glob_mod::glob_bool := true;
+            SET GLOBAL glob_mod::glob_float64 := 42.1;
+            SET GLOBAL glob_mod::glob_float32 := 42.1;
+            """
+        )
+        await self.scon.execute('INSERT INTO glob_mod."G" DEFAULT VALUES')
+
+        await self.assert_sql_query_result(
+            '''
+            SELECT
+                p_str,
+                p_uuid,
+                p_int64,
+                p_int32,
+                p_int16,
+                p_bool,
+                p_float64,
+                p_float32
+            FROM glob_mod."G"
+            ''',
+            [
+                {
+                    'p_str': 'hello',
+                    'p_uuid': uuid.UUID('f527c032-ad4c-461e-95e2-67c4e2b42ca7'),
+                    'p_int64': 42,
+                    'p_int32': 42,
+                    'p_int16': 42,
+                    'p_bool': True,
+                    'p_float64': 42.1,
+                    'p_float32': 42.099998474121094,
+                }
+            ],
+        )
+
+    @test.xfail('todo')
+    async def test_native_sql_query_15(self):
+        # no access policies
+        await self.assert_sql_query_result(
+            'SELECT title FROM "Content" ORDER BY title',
+            [
+                {'title': 'Chronicles of Narnia'},
+                {'title': 'Forrest Gump'},
+                {'title': 'Halo 3'},
+                {'title': 'Hunger Games'},
+                {'title': 'Saving Private Ryan'},
+            ],
+        )
+
+        await self.con.execute(
+            'CONFIGURE SESSION SET apply_access_policies_sql := true'
+        )
+
+        # access policies applied
+        await self.assert_sql_query_result(
+            'SELECT title FROM "Content" ORDER BY title',
+            []
+        )
+
+        # access policies use globals
+        await self.con.execute(
+            "SET global default::filter_title := 'Forrest Gump'"
+        )
+        await self.assert_sql_query_result(
+            'SELECT title FROM "Content" ORDER BY title',
+            [{'title': 'Forrest Gump'}]
+        )
+
+        await self.con.execute(
+            'CONFIGURE SESSION SET apply_access_policies_sql := false'
         )


### PR DESCRIPTION
Steals the solution from #8051, I've just added a test.

> `ParamMapper` was trying to mend `Param` and not `ParamRef` whereas only
the latter is the actual AST node.

Kind of embarrassing that ParamMapper had 0 test coverage, but also being quite crucial piece of code. The problem was that in the simple case, where you have only one computed/DML/access policy in a query, param mapper is not even needed. But even if you have more than one, if they reference the same global, ParamMapper basically does a no-op. So even if we had automated test coverage reports, we would see ParamMapper being covered.
