### PR TITLE
Fix static types in subtypes under sysconfig

### DIFF
--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -100,6 +100,9 @@ class ScalarType:
     def to_backend_str(self) -> str:
         raise NotImplementedError
 
+    def to_json(self) -> str:
+        raise NotImplementedError
+
     def encode(self) -> bytes:
         raise NotImplementedError
 
@@ -372,6 +375,9 @@ class Duration(ScalarType):
     def to_backend_str(self) -> str:
         return f'{self.to_microseconds()}us'
 
+    def to_json(self) -> str:
+        return self.to_iso8601()
+
     def __repr__(self) -> str:
         return f'<statypes.Duration {self.to_iso8601()!r}>'
 
@@ -487,6 +493,9 @@ class ConfigMemory(ScalarType):
             return f'{self._value // self.KiB}kB'
 
         return f'{self._value}B'
+
+    def to_json(self) -> str:
+        return self.to_str()
 
     def __repr__(self) -> str:
         return f'<statypes.ConfigMemory {self.to_str()!r}>'

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -50,6 +50,11 @@ CREATE TYPE cfg::TestInstanceConfig EXTENDING cfg::ConfigObject {
     CREATE LINK obj -> cfg::Base;
 };
 
+CREATE TYPE cfg::TestInstanceConfigStatTypes EXTENDING cfg::TestInstanceConfig {
+    CREATE PROPERTY memprop -> cfg::memory;
+    CREATE PROPERTY durprop -> std::duration;
+};
+
 
 CREATE SCALAR TYPE cfg::TestEnum extending enum<One, Two, Three>;
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -1409,7 +1409,17 @@ def get_config_type_shape(
     path: List[qlast.PathElement],
 ) -> List[qlast.ShapeElement]:
     from . import objtypes as s_objtypes
-    shape = []
+    shape = [
+        qlast.ShapeElement(
+            expr=qlast.Path(steps=[qlast.Ptr(name='_tname')], ),
+            compexpr=qlast.Path(
+                steps=path + [
+                    qlast.Ptr(name='__type__'),
+                    qlast.Ptr(name='name'),
+                ],
+            ),
+        ),
+    ]
     seen: Set[str] = set()
 
     stypes = [stype] + list(stype.ordered_descendants(schema))
@@ -1446,17 +1456,6 @@ def get_config_type_shape(
             if isinstance(ptype, s_objtypes.ObjectType):
                 subshape = get_config_type_shape(
                     schema, ptype, path + elem_path)
-                subshape.append(
-                    qlast.ShapeElement(
-                        expr=qlast.Path(steps=[qlast.Ptr(name='_tname')],),
-                        compexpr=qlast.Path(
-                            steps=path + elem_path + [
-                                qlast.Ptr(name='__type__'),
-                                qlast.Ptr(name='name'),
-                            ],
-                        ),
-                    ),
-                )
             else:
                 subshape = []
 

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -378,11 +378,9 @@ def value_to_json_value(setting: spec.Setting, value: Any):
             # if they are single, because it simplifies things in the
             # config handling SQL.
             return [value.to_json_value()] if value is not None else []
-        elif _issubclass(setting.type, statypes.Duration) and value is not None:
-            return value.to_iso8601()
-        elif (_issubclass(setting.type, statypes.ConfigMemory) and
+        elif (_issubclass(setting.type, statypes.ScalarType) and
                 value is not None):
-            return value.to_str()
+            return value.to_json()
         else:
             return value
 

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -247,6 +247,9 @@ class CompositeConfigType(ConfigType, statypes.CompositeType):
                 value = value.to_json_value(redacted=redacted)
             elif typing_inspect.is_generic_type(f_type):
                 value = list(value) if value is not None else []
+            elif (_issubclass(f_type, statypes.ScalarType) and
+                  value is not None):
+                value = value.to_json()
 
             dct[f.name] = value
 

--- a/edb/server/protocol/server_info.py
+++ b/edb/server/protocol/server_info.py
@@ -46,10 +46,8 @@ class ImmutableEncoder(json.JSONEncoder):
             return dict(obj.items())
         if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             return dataclasses.asdict(obj)
-        if isinstance(obj, statypes.Duration):
-            return obj.to_iso8601()
-        if isinstance(obj, statypes.ConfigMemory):
-            return obj.to_str()
+        if isinstance(obj, statypes.ScalarType):
+            return obj.to_json()
         if isinstance(obj, statypes.CompositeType):
             return obj.to_json_value()
         return super().default(obj)

--- a/edb/testbase/serutils.py
+++ b/edb/testbase/serutils.py
@@ -111,3 +111,8 @@ def _range(o: edgedb.Range):
 @serialize.register
 def _multirane(o: edgedb.MultiRange):
     return [serialize(el) for el in o]
+
+
+@serialize.register
+def _cfg_memory(o: edgedb.ConfigMemory):
+    return str(o)

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -726,6 +726,38 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query(f'''
+            CONFIGURE {scope} INSERT TestInstanceConfigStatTypes {{
+                name := 'test_03_02',
+                memprop := <cfg::memory>'108MiB',
+                durprop := <duration>'108 seconds',
+            }}
+        ''')
+        await self.assert_query_result(
+            '''
+            SELECT cfg::Config.sysobj {
+                name,
+                [IS cfg::TestInstanceConfigStatTypes].memprop,
+                [IS cfg::TestInstanceConfigStatTypes].durprop,
+            }
+            FILTER .name = 'test_03_02';
+            ''',
+            [
+                {
+                    'name': 'test_03_02',
+                    'memprop': '108MiB',
+                    'durprop': 'PT1M48S',
+                },
+            ],
+            [
+                {
+                    'name': 'test_03_02',
+                    'memprop': '108MiB',
+                    'durprop': datetime.timedelta(seconds=108),
+                },
+            ],
+        )
+
+        await self.con.query(f'''
             CONFIGURE {scope} RESET TestInstanceConfig
             FILTER .name ILIKE 'test_03%';
         ''')


### PR DESCRIPTION
This PR fixes 2 issues with static types in config subtypes at system level.

`sysconfig` is stored in database metadata as JSON, while static types weren't serialized properly, causing failure in:

```
                    CONFIGURE INSTANCE INSERT cfg::SMTPProviderConfig {
                        name := '...',
                        sender := 'bob@example.com',
                        timeout_per_email := <duration>'88 seconds',
                    };
```

Another issue with returning subtype fields on config reset is that, the `_tname` wasn't injected in the config shape and this was critical if the object is of a subtype with extra fields. Not having `_tname` will then fail this query:

```
                    CONFIGURE INSTANCE RESET cfg::SMTPProviderConfig
                    FILTER .name = '...';
```

The fix is to add proper JSON serialization when handling static scalar types (done in a more generic way), and always include `_tname` calculating config type shapes.