### PR TITLE
Enhanced query protocol in pgrust (to replace pgcon)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -254,6 +254,16 @@ name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+
+[[package]]
+name = "captive_postgres"
+version = "0.1.0"
+dependencies = [
+ "gel_auth",
+ "openssl",
+ "socket2",
+ "tempfile",
+]
 
 [[package]]
 name = "cardinality-estimator"
@@ -1560,11 +1570,13 @@ name = "pgrust"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "captive_postgres",
  "clap",
  "clap_derive",
  "derive_more",
  "futures",
  "gel_auth",
+ "hex-literal",
  "hexdump",
  "libc",
  "openssl",
@@ -1587,6 +1599,8 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "zerocopy 0.8.11",
+ "zerocopy-derive 0.8.11",
 ]
 
 [[package]]
@@ -1661,7 +1675,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2292,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3063,7 +3077,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce3b5629d87654b53a49002acc2ce64aa5aa7255f5c718374a37ac7fd98c218"
+dependencies = [
+ "zerocopy-derive 0.8.11",
 ]
 
 [[package]]
@@ -3071,6 +3094,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a82c26c3986af2623ec9eb890ff4aa19c006e30a1133dc9bd1830ec1612e20"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -242,6 +242,20 @@ name = "bytemuck"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -1570,6 +1584,7 @@ name = "pgrust"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "bytemuck",
  "captive_postgres",
  "clap",
  "clap_derive",
@@ -1589,8 +1604,6 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_derive",
- "socket2",
- "tempfile",
  "test-log",
  "thiserror 1.0.63",
  "tokio",
@@ -1599,8 +1612,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "zerocopy 0.8.11",
- "zerocopy-derive 0.8.11",
 ]
 
 [[package]]
@@ -1675,7 +1686,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3077,16 +3088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce3b5629d87654b53a49002acc2ce64aa5aa7255f5c718374a37ac7fd98c218"
-dependencies = [
- "zerocopy-derive 0.8.11",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -3094,17 +3096,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a82c26c3986af2623ec9eb890ff4aa19c006e30a1133dc9bd1830ec1612e20"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "edb/graphql-rewrite",
     "edb/server/_rust_native",
     "rust/auth",
+    "rust/captive_postgres",
     "rust/conn_pool",
     "rust/pgrust",
     "rust/http",
@@ -20,6 +21,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["registry", "env-filter"] }
 
 gel_auth = { path = "rust/auth" }
+captive_postgres = { path = "rust/captive_postgres" }
 conn_pool = { path = "rust/conn_pool" }
 pgrust = { path = "rust/pgrust" }
 http = { path = "rust/http" }

--- a/rust/captive_postgres/Cargo.toml
+++ b/rust/captive_postgres/Cargo.toml
@@ -1,0 +1,17 @@
+
+[package]
+name = "captive_postgres"
+version = "0.1.0"
+license = "MIT/Apache-2.0"
+authors = ["MagicStack Inc. <hello@magic.io>"]
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+gel_auth.workspace = true
+
+openssl = "0.10.55"
+tempfile = "3"
+socket2 = "0.5.8"

--- a/rust/captive_postgres/README.md
+++ b/rust/captive_postgres/README.md
@@ -1,0 +1,5 @@
+# captive_postgres
+
+A simple, captive Postgres server that can be used to test client connections. Each instance
+is a freshly initialized Postgres server with the specified credentials.
+

--- a/rust/captive_postgres/src/lib.rs
+++ b/rust/captive_postgres/src/lib.rs
@@ -283,13 +283,23 @@ fn run_postgres(
 }
 
 fn test_data_dir() -> std::path::PathBuf {
-    Path::new("../../tests")
-        .canonicalize()
-        .expect("Failed to canonicalize tests directory path")
+    let cargo_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests");
+    if cargo_path.exists() {
+        cargo_path
+    } else {
+        Path::new("../../tests")
+            .canonicalize()
+            .expect("Failed to canonicalize tests directory path")
+    }
 }
 
 fn postgres_bin_dir() -> std::io::Result<std::path::PathBuf> {
-    Path::new("../../build/postgres/install/bin").canonicalize()
+    let cargo_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../build/postgres/install/bin");
+    if cargo_path.exists() {
+        cargo_path.canonicalize()
+    } else {
+        Path::new("../../build/postgres/install/bin").canonicalize()
+    }
 }
 
 fn get_unix_socket_path(socket_path: &Path, port: u16) -> PathBuf {

--- a/rust/captive_postgres/src/lib.rs
+++ b/rust/captive_postgres/src/lib.rs
@@ -1,0 +1,374 @@
+// Constants
+use gel_auth::AuthType;
+use openssl::ssl::{Ssl, SslContext, SslMethod};
+use std::io::{BufRead, BufReader, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+pub const STARTUP_TIMEOUT_DURATION: Duration = Duration::from_secs(30);
+pub const PORT_RELEASE_TIMEOUT: Duration = Duration::from_secs(30);
+pub const LINGER_DURATION: Duration = Duration::from_secs(1);
+pub const HOT_LOOP_INTERVAL: Duration = Duration::from_millis(100);
+pub const DEFAULT_USERNAME: &str = "username";
+pub const DEFAULT_PASSWORD: &str = "password";
+pub const DEFAULT_DATABASE: &str = "postgres";
+
+#[derive(Debug, Clone)]
+pub enum ListenAddress {
+    Tcp(SocketAddr),
+    #[cfg(unix)]
+    Unix(PathBuf),
+}
+
+/// Represents an ephemeral port that can be allocated and released for immediate re-use by another process.
+struct EphemeralPort {
+    port: u16,
+    listener: Option<TcpListener>,
+}
+
+impl EphemeralPort {
+    /// Allocates a new ephemeral port.
+    ///
+    /// Returns a Result containing the EphemeralPort if successful,
+    /// or an IO error if the allocation fails.
+    fn allocate() -> std::io::Result<Self> {
+        let socket = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)?;
+        socket.set_reuse_address(true)?;
+        socket.set_reuse_port(true)?;
+        socket.set_linger(Some(LINGER_DURATION))?;
+        socket.bind(&std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, 0)).into())?;
+        socket.listen(1)?;
+        let listener = TcpListener::from(socket);
+        let port = listener.local_addr()?.port();
+        Ok(EphemeralPort {
+            port,
+            listener: Some(listener),
+        })
+    }
+
+    /// Consumes the EphemeralPort and returns the allocated port number.
+    fn take(self) -> u16 {
+        // Drop the listener to free up the port
+        drop(self.listener);
+
+        // Loop until the port is free
+        let start = Instant::now();
+
+        // If we can successfully connect to the port, it's not fully closed
+        while start.elapsed() < PORT_RELEASE_TIMEOUT {
+            let res = std::net::TcpStream::connect((Ipv4Addr::LOCALHOST, self.port));
+            if res.is_err() {
+                // If connection fails, the port is released
+                break;
+            }
+            std::thread::sleep(HOT_LOOP_INTERVAL);
+        }
+
+        self.port
+    }
+}
+
+struct StdioReader {
+    output: Arc<RwLock<String>>,
+}
+
+impl StdioReader {
+    fn spawn<R: BufRead + Send + 'static>(reader: R, prefix: &'static str) -> Self {
+        let output = Arc::new(RwLock::new(String::new()));
+        let output_clone = Arc::clone(&output);
+
+        thread::spawn(move || {
+            let mut buf_reader = std::io::BufReader::new(reader);
+            loop {
+                let mut line = String::new();
+                match buf_reader.read_line(&mut line) {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if let Ok(mut output) = output_clone.write() {
+                            output.push_str(&line);
+                        }
+                        eprint!("[{}]: {}", prefix, line);
+                    }
+                    Err(e) => {
+                        let error_line = format!("Error reading {}: {}\n", prefix, e);
+                        if let Ok(mut output) = output_clone.write() {
+                            output.push_str(&error_line);
+                        }
+                        eprintln!("{}", error_line);
+                    }
+                }
+            }
+        });
+
+        StdioReader { output }
+    }
+
+    fn contains(&self, s: &str) -> bool {
+        if let Ok(output) = self.output.read() {
+            output.contains(s)
+        } else {
+            false
+        }
+    }
+}
+
+fn init_postgres(initdb: &Path, data_dir: &Path, auth: AuthType) -> std::io::Result<()> {
+    let mut pwfile = tempfile::NamedTempFile::new()?;
+    writeln!(pwfile, "{}", DEFAULT_PASSWORD)?;
+    let mut command = Command::new(initdb);
+    command
+        .arg("-D")
+        .arg(data_dir)
+        .arg("-A")
+        .arg(match auth {
+            AuthType::Deny => "reject",
+            AuthType::Trust => "trust",
+            AuthType::Plain => "password",
+            AuthType::Md5 => "md5",
+            AuthType::ScramSha256 => "scram-sha-256",
+        })
+        .arg("--pwfile")
+        .arg(pwfile.path())
+        .arg("-U")
+        .arg(DEFAULT_USERNAME);
+
+    let output = command.output()?;
+
+    let status = output.status;
+    let output_str = String::from_utf8_lossy(&output.stdout).to_string();
+    let error_str = String::from_utf8_lossy(&output.stderr).to_string();
+
+    eprintln!("initdb stdout:\n{}", output_str);
+    eprintln!("initdb stderr:\n{}", error_str);
+
+    if !status.success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "initdb command failed",
+        ));
+    }
+
+    Ok(())
+}
+
+fn run_postgres(
+    postgres_bin: &Path,
+    data_dir: &Path,
+    socket_path: &Path,
+    ssl: Option<(PathBuf, PathBuf)>,
+    port: u16,
+) -> std::io::Result<std::process::Child> {
+    let mut command = Command::new(postgres_bin);
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("-D")
+        .arg(data_dir)
+        .arg("-k")
+        .arg(socket_path)
+        .arg("-h")
+        .arg(Ipv4Addr::LOCALHOST.to_string())
+        .arg("-F")
+        // Useful for debugging
+        // .arg("-d")
+        // .arg("5")
+        .arg("-p")
+        .arg(port.to_string());
+
+    if let Some((cert_path, key_path)) = ssl {
+        let postgres_cert_path = data_dir.join("server.crt");
+        let postgres_key_path = data_dir.join("server.key");
+        std::fs::copy(cert_path, &postgres_cert_path)?;
+        std::fs::copy(key_path, &postgres_key_path)?;
+        // Set permissions for the certificate and key files
+        std::fs::set_permissions(&postgres_cert_path, std::fs::Permissions::from_mode(0o600))?;
+        std::fs::set_permissions(&postgres_key_path, std::fs::Permissions::from_mode(0o600))?;
+
+        // Edit pg_hba.conf to change all "host" line prefixes to "hostssl"
+        let pg_hba_path = data_dir.join("pg_hba.conf");
+        let content = std::fs::read_to_string(&pg_hba_path)?;
+        let modified_content = content
+            .lines()
+            .filter(|line| !line.starts_with("#") && !line.is_empty())
+            .map(|line| {
+                if line.trim_start().starts_with("host") {
+                    line.replacen("host", "hostssl", 1)
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+        eprintln!("pg_hba.conf:\n==========\n{modified_content}\n==========");
+        std::fs::write(&pg_hba_path, modified_content)?;
+
+        command.arg("-l");
+    }
+
+    let mut child = command.spawn()?;
+
+    let stdout_reader = BufReader::new(child.stdout.take().expect("Failed to capture stdout"));
+    let _ = StdioReader::spawn(stdout_reader, "stdout");
+    let stderr_reader = BufReader::new(child.stderr.take().expect("Failed to capture stderr"));
+    let stderr_reader = StdioReader::spawn(stderr_reader, "stderr");
+
+    let start_time = Instant::now();
+
+    let mut tcp_socket: Option<std::net::TcpStream> = None;
+    let mut unix_socket: Option<std::os::unix::net::UnixStream> = None;
+
+    let unix_socket_path = get_unix_socket_path(socket_path, port);
+    let tcp_socket_addr = std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let mut db_ready = false;
+
+    while start_time.elapsed() < STARTUP_TIMEOUT_DURATION {
+        std::thread::sleep(HOT_LOOP_INTERVAL);
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("PostgreSQL exited with status: {}", status),
+                ))
+            }
+            Err(e) => return Err(e),
+            _ => {}
+        }
+        if !db_ready && stderr_reader.contains("database system is ready to accept connections") {
+            eprintln!("Database is ready");
+            db_ready = true;
+        } else {
+            continue;
+        }
+        if unix_socket.is_none() {
+            unix_socket = std::os::unix::net::UnixStream::connect(&unix_socket_path).ok();
+        }
+        if tcp_socket.is_none() {
+            tcp_socket = std::net::TcpStream::connect(tcp_socket_addr).ok();
+        }
+        if unix_socket.is_some() && tcp_socket.is_some() {
+            break;
+        }
+    }
+
+    if unix_socket.is_some() && tcp_socket.is_some() {
+        return Ok(child);
+    }
+
+    // Print status for TCP/unix sockets
+    if let Some(tcp) = &tcp_socket {
+        eprintln!(
+            "TCP socket at {tcp_socket_addr:?} bound successfully on {}",
+            tcp.local_addr()?
+        );
+    } else {
+        eprintln!("TCP socket at {tcp_socket_addr:?} binding failed");
+    }
+
+    if unix_socket.is_some() {
+        eprintln!("Unix socket at {unix_socket_path:?} connected successfully");
+    } else {
+        eprintln!("Unix socket at {unix_socket_path:?} connection failed");
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "PostgreSQL failed to start within 30 seconds",
+    ))
+}
+
+fn test_data_dir() -> std::path::PathBuf {
+    Path::new("../../tests")
+        .canonicalize()
+        .expect("Failed to canonicalize tests directory path")
+}
+
+fn postgres_bin_dir() -> std::io::Result<std::path::PathBuf> {
+    Path::new("../../build/postgres/install/bin").canonicalize()
+}
+
+fn get_unix_socket_path(socket_path: &Path, port: u16) -> PathBuf {
+    socket_path.join(format!(".s.PGSQL.{}", port))
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Mode {
+    Tcp,
+    TcpSsl,
+    Unix,
+}
+
+pub fn create_ssl_client() -> Result<Ssl, Box<dyn std::error::Error>> {
+    let ssl_context = SslContext::builder(SslMethod::tls_client())?.build();
+    let mut ssl = Ssl::new(&ssl_context)?;
+    ssl.set_connect_state();
+    Ok(ssl)
+}
+
+pub struct PostgresProcess {
+    child: std::process::Child,
+    pub socket_address: ListenAddress,
+    #[allow(unused)]
+    temp_dir: TempDir,
+}
+
+impl Drop for PostgresProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+    }
+}
+
+/// Creates and runs a new Postgres server process in a temporary directory.
+pub fn setup_postgres(
+    auth: AuthType,
+    mode: Mode,
+) -> Result<Option<PostgresProcess>, Box<dyn std::error::Error>> {
+    let Ok(bindir) = postgres_bin_dir() else {
+        println!("Skipping test: postgres bin dir not found");
+        return Ok(None);
+    };
+
+    let initdb = bindir.join("initdb");
+    let postgres = bindir.join("postgres");
+
+    if !initdb.exists() || !postgres.exists() {
+        println!("Skipping test: initdb or postgres not found");
+        return Ok(None);
+    }
+
+    let temp_dir = TempDir::new()?;
+    let port = EphemeralPort::allocate()?;
+    let data_dir = temp_dir.path().join("data");
+
+    init_postgres(&initdb, &data_dir, auth)?;
+    let ssl_key = match mode {
+        Mode::TcpSsl => {
+            let certs_dir = test_data_dir().join("certs");
+            let cert = certs_dir.join("server.cert.pem");
+            let key = certs_dir.join("server.key.pem");
+            Some((cert, key))
+        }
+        _ => None,
+    };
+
+    let port = port.take();
+    let child = run_postgres(&postgres, &data_dir, &data_dir, ssl_key, port)?;
+
+    let socket_address = match mode {
+        Mode::Unix => ListenAddress::Unix(get_unix_socket_path(&data_dir, port)),
+        Mode::Tcp | Mode::TcpSsl => {
+            ListenAddress::Tcp(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port))
+        }
+    };
+
+    Ok(Some(PostgresProcess {
+        child,
+        socket_address,
+        temp_dir,
+    }))
+}

--- a/rust/pgrust/Cargo.toml
+++ b/rust/pgrust/Cargo.toml
@@ -40,9 +40,9 @@ features = ["full"]
 
 [dev-dependencies]
 tracing-subscriber.workspace = true
-scopeguard = "1"
 captive_postgres.workspace = true
 
+scopeguard = "1"
 pretty_assertions = "1.2.0"
 test-log = { version = "0", features = ["trace"] }
 rstest = "0"
@@ -52,9 +52,5 @@ tempfile = "3"
 socket2 = "0.5.7"
 libc = "0.2.158"
 hex-literal = "0.4.1"
-
-[dev-dependencies.tokio]
-version = "1"
-features = ["macros", "rt-multi-thread", "time", "test-util"]
 
 [lib]

--- a/rust/pgrust/Cargo.toml
+++ b/rust/pgrust/Cargo.toml
@@ -31,6 +31,8 @@ serde = "1"
 serde_derive = "1"
 percent-encoding = "2"
 uuid = "1"
+zerocopy = "0.8.11"
+zerocopy-derive = "0.8.11"
 
 [dependencies.derive_more]
 version = "1.0.0-beta.6"
@@ -39,6 +41,7 @@ features = ["full"]
 [dev-dependencies]
 tracing-subscriber.workspace = true
 scopeguard = "1"
+captive_postgres.workspace = true
 
 pretty_assertions = "1.2.0"
 test-log = { version = "0", features = ["trace"] }
@@ -48,6 +51,7 @@ clap_derive = "4"
 tempfile = "3"
 socket2 = "0.5.7"
 libc = "0.2.158"
+hex-literal = "0.4.1"
 
 [dev-dependencies.tokio]
 version = "1"

--- a/rust/pgrust/Cargo.toml
+++ b/rust/pgrust/Cargo.toml
@@ -31,8 +31,7 @@ serde = "1"
 serde_derive = "1"
 percent-encoding = "2"
 uuid = "1"
-zerocopy = "0.8.11"
-zerocopy-derive = "0.8.11"
+bytemuck = { version = "1", features = ["derive"] }
 
 [dependencies.derive_more]
 version = "1.0.0-beta.6"
@@ -48,8 +47,6 @@ test-log = { version = "0", features = ["trace"] }
 rstest = "0"
 clap = "4"
 clap_derive = "4"
-tempfile = "3"
-socket2 = "0.5.7"
 libc = "0.2.158"
 hex-literal = "0.4.1"
 

--- a/rust/pgrust/examples/connect.rs
+++ b/rust/pgrust/examples/connect.rs
@@ -250,7 +250,7 @@ async fn run_queries(
                         Portal::default(),
                         Statement::default(),
                         &[],
-                        &[Format::Text],
+                        &[Format::text()],
                         (),
                     )
                     .describe_portal(Portal::default(), ())

--- a/rust/pgrust/examples/connect.rs
+++ b/rust/pgrust/examples/connect.rs
@@ -1,8 +1,15 @@
+use captive_postgres::{
+    setup_postgres, ListenAddress, Mode, DEFAULT_DATABASE, DEFAULT_PASSWORD, DEFAULT_USERNAME,
+};
 use clap::Parser;
 use clap_derive::Parser;
+use gel_auth::AuthType;
 use openssl::ssl::{Ssl, SslContext, SslMethod};
 use pgrust::{
-    connection::{dsn::parse_postgres_dsn_env, Client, Credentials, QuerySink, ResolvedTarget},
+    connection::{
+        dsn::parse_postgres_dsn_env, Client, Credentials, ExecuteSink, Format, MaxRows,
+        PipelineBuilder, Portal, QuerySink, ResolvedTarget, Statement,
+    },
     protocol::postgres::data::{CopyData, CopyOutResponse, DataRow, ErrorResponse, RowDescription},
 };
 use std::net::SocketAddr;
@@ -11,6 +18,10 @@ use tokio::task::LocalSet;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
+    /// Use an ephemeral database
+    #[clap(short = 'e', long = "ephemeral", conflicts_with_all = &["dsn", "unix", "tcp", "username", "password", "database"])]
+    ephemeral: bool,
+
     #[clap(short = 'D', long = "dsn", value_parser, conflicts_with_all = &["unix", "tcp", "username", "password", "database"])]
     dsn: Option<String>,
 
@@ -44,6 +55,10 @@ struct Args {
     )]
     database: String,
 
+    /// Use extended query syntax
+    #[clap(short = 'x', long = "extended")]
+    extended: bool,
+
     /// SQL statements to run
     #[clap(
         name = "statements",
@@ -54,6 +69,16 @@ struct Args {
     statements: Option<Vec<String>>,
 }
 
+fn address(address: &ListenAddress) -> ResolvedTarget {
+    match address {
+        ListenAddress::Tcp(addr) => ResolvedTarget::SocketAddr(*addr),
+        #[cfg(unix)]
+        ListenAddress::Unix(path) => ResolvedTarget::UnixSocketAddr(
+            std::os::unix::net::SocketAddr::from_pathname(path).unwrap(),
+        ),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
@@ -61,6 +86,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("{args:?}");
 
     let mut socket_address: Option<ResolvedTarget> = None;
+
+    let _ephemeral = if args.ephemeral {
+        let process = setup_postgres(AuthType::Trust, Mode::Unix)?;
+        let Some(process) = process else {
+            eprintln!("Failed to start ephemeral database");
+            return Err("Failed to start ephemeral database".into());
+        };
+        socket_address = Some(address(&process.socket_address));
+        args.username = DEFAULT_USERNAME.to_string();
+        args.password = DEFAULT_PASSWORD.to_string();
+        args.database = DEFAULT_DATABASE.to_string();
+        Some(process)
+    } else {
+        None
+    };
+
     if let Some(dsn) = args.dsn {
         let mut conn = parse_postgres_dsn_env(&dsn, std::env::vars())?;
         #[allow(deprecated)]
@@ -97,7 +138,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| vec!["select 1;".to_string()]);
     let local = LocalSet::new();
     local
-        .run_until(run_queries(socket_address, credentials, statements))
+        .run_until(run_queries(
+            socket_address,
+            credentials,
+            statements,
+            args.extended,
+        ))
         .await?;
 
     Ok(())
@@ -142,10 +188,46 @@ fn logging_sink() -> impl QuerySink {
     )
 }
 
+fn logging_sink_execute() -> impl ExecuteSink {
+    (
+        || {
+            eprintln!();
+            let guard = scopeguard::guard((), |_| {
+                eprintln!("Done");
+            });
+            move |row: DataRow<'_>| {
+                let _ = &guard;
+                eprintln!("Row:");
+                for field in row.values() {
+                    eprint!(" {:?}", field);
+                }
+                eprintln!();
+            }
+        },
+        |_: CopyOutResponse<'_>| {
+            eprintln!("\nCopy:");
+            let guard = scopeguard::guard((), |_| {
+                eprintln!("Done");
+            });
+            move |data: CopyData<'_>| {
+                let _ = &guard;
+                eprintln!("Chunk:");
+                for line in hexdump::hexdump_iter(data.data().as_ref()) {
+                    eprintln!("{line}");
+                }
+            }
+        },
+        |error: ErrorResponse<'_>| {
+            eprintln!("\nError:\n {:?}", error);
+        },
+    )
+}
+
 async fn run_queries(
     socket_address: ResolvedTarget,
     credentials: Credentials,
     statements: Vec<String>,
+    extended: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = socket_address.connect().await?;
     let ssl = SslContext::builder(SslMethod::tls_client())?.build();
@@ -158,7 +240,32 @@ async fn run_queries(
     eprintln!("Statements: {statements:?}");
 
     for statement in statements {
-        tokio::task::spawn_local(conn.query(&statement, logging_sink())).await??;
+        if extended {
+            let conn = conn.clone();
+            tokio::task::spawn_local(async move {
+                let pipeline = PipelineBuilder::default()
+                    .parse(Statement::default(), &statement, &[], ())
+                    .describe_statement(Statement::default(), ())
+                    .bind(
+                        Portal::default(),
+                        Statement::default(),
+                        &[],
+                        &[Format::Text],
+                        (),
+                    )
+                    .describe_portal(Portal::default(), ())
+                    .execute(
+                        Portal::default(),
+                        MaxRows::Unlimited,
+                        logging_sink_execute(),
+                    )
+                    .build();
+                conn.pipeline_sync(pipeline).await
+            })
+            .await??;
+        } else {
+            tokio::task::spawn_local(conn.query(&statement, logging_sink())).await??;
+        }
     }
 
     Ok(())

--- a/rust/pgrust/src/connection/conn.rs
+++ b/rust/pgrust/src/connection/conn.rs
@@ -68,6 +68,17 @@ where
     conn: Rc<PGConn<B, C>>,
 }
 
+impl<B: Stream, C: Unpin> Clone for Client<B, C>
+where
+    (B, C): StreamWithUpgrade,
+{
+    fn clone(&self) -> Self {
+        Self {
+            conn: self.conn.clone(),
+        }
+    }
+}
+
 impl<B: Stream, C: Unpin> Client<B, C>
 where
     (B, C): StreamWithUpgrade,

--- a/rust/pgrust/src/connection/conn.rs
+++ b/rust/pgrust/src/connection/conn.rs
@@ -1,18 +1,18 @@
 use super::{
     connect_raw_ssl,
+    flow::{MessageHandler, MessageResult, Pipeline, QuerySink, SyncMessageHandler},
     raw_conn::RawClient,
     stream::{Stream, StreamWithUpgrade},
     Credentials,
 };
 use crate::{
-    connection::ConnectionError,
+    connection::{flow::QueryMessageHandler, ConnectionError},
     handshake::ConnectionSslRequirement,
     protocol::{
-        match_message,
         postgres::{
             builder,
             data::{
-                CommandComplete, DataRow, ErrorResponse, Message, ReadyForQuery, RowDescription,
+                Message
             },
             meta,
         },
@@ -35,17 +35,38 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tracing::{error, trace, warn, Level};
 
 #[derive(Debug, thiserror::Error)]
-pub enum PGError {
+pub enum PGConnError {
     #[error("Invalid state")]
     InvalidState,
+    #[error("Postgres error: {0}")]
+    PgError(#[from] crate::errors::PgServerError),
     #[error("Connection failed: {0}")]
     Connection(#[from] ConnectionError),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// If an operation in a pipeline group fails, all operations up to
+    /// the next sync are skipped.
+    #[error("Operation skipped because of previous pipeline failure: {0}")]
+    Skipped(crate::errors::PgServerError),
     #[error("Connection was closed")]
     Closed,
 }
 
+/// A client for a PostgreSQL connection.
+///
+/// ```
+/// client = Client::new(credentials, socket, config);
+/// client.query("SELECT 1", logging_sink()).await;
+/// if client.pipeline(Pipeline::Flush, &[
+///     Flow::Parse("stmt1", "SELECT 1", &[Oid::Unspecified]),
+///     Flow::Bind("portal1", "stmt1", &[Param::Null], &[Format::Text]),
+///     Flow::Execute("portal1", MaxRows::Limited(NonZeroU32::new(1).unwrap())),
+/// ]).await.is_ok() {
+///     client.pipeline(Pipeline::Sync, &[
+///         Flow::Query("..."),
+///     ]).await;
+/// }
+/// ```
 pub struct Client<B: Stream, C: Unpin>
 where
     (B, C): StreamWithUpgrade,
@@ -63,7 +84,7 @@ where
         credentials: Credentials,
         socket: B,
         config: C,
-    ) -> (Self, impl Future<Output = Result<(), PGError>>) {
+    ) -> (Self, impl Future<Output = Result<(), PGConnError>>) {
         let conn = Rc::new(PGConn::new_connection(async move {
             let ssl_mode = ConnectionSslRequirement::Optional;
             let raw = connect_raw_ssl(credentials, ssl_mode, config, socket).await?;
@@ -74,104 +95,41 @@ where
     }
 
     /// Create a new PostgreSQL client and a background task.
-    pub fn new_raw(stm: RawClient<B, C>) -> (Self, impl Future<Output = Result<(), PGError>>) {
+    pub fn new_raw(stm: RawClient<B, C>) -> (Self, impl Future<Output = Result<(), PGConnError>>) {
         let conn = Rc::new(PGConn::new_raw(stm));
         let task = conn.clone().task();
         (Self { conn }, task)
     }
 
-    pub async fn ready(&self) -> Result<(), PGError> {
+    pub async fn ready(&self) -> Result<(), PGConnError> {
         self.conn.ready().await
     }
 
+    /// Performs a bare `Query` operation. The sink handles the following messages:
+    ///
+    ///  - `RowDescription`
+    ///  - `DataRow`
+    ///  - `CopyOutResponse`
+    ///  - `CopyData`
+    ///  - `ErrorResponse`
+    ///
+    /// `CopyInResponse` is not currently supported and will result in a `CopyFail` being
+    /// sent to the server.
     pub fn query(
         &self,
         query: &str,
         f: impl QuerySink + 'static,
-    ) -> impl Future<Output = Result<(), PGError>> {
-        self.conn.clone().query(query.to_owned(), f)
+    ) -> impl Future<Output = Result<(), PGConnError>> {
+        self.conn.clone().query(query, f)
     }
-}
 
-struct ErasedQuerySink<Q: QuerySink>(Q);
-
-impl<Q, S> QuerySink for ErasedQuerySink<Q>
-where
-    Q: QuerySink<Output = S>,
-    S: DataSink + 'static,
-{
-    type Output = Box<dyn DataSink>;
-    fn error(&self, error: ErrorResponse) {
-        self.0.error(error)
+    /// Performs a set of pipelined steps as a `Sync` group.
+    pub fn pipeline_sync(
+        &self,
+        pipeline: Pipeline,
+    ) -> impl Future<Output = Result<(), PGConnError>> {
+        self.conn.clone().pipeline_sync(pipeline)
     }
-    fn rows(&self, rows: RowDescription) -> Self::Output {
-        Box::new(self.0.rows(rows))
-    }
-}
-
-pub trait QuerySink {
-    type Output: DataSink;
-    fn rows(&self, rows: RowDescription) -> Self::Output;
-    fn error(&self, error: ErrorResponse);
-}
-
-impl<Q, S> QuerySink for Box<Q>
-where
-    Q: QuerySink<Output = S> + 'static,
-    S: DataSink + 'static,
-{
-    type Output = Box<dyn DataSink + 'static>;
-    fn rows(&self, rows: RowDescription) -> Self::Output {
-        Box::new(self.as_ref().rows(rows))
-    }
-    fn error(&self, error: ErrorResponse) {
-        self.as_ref().error(error)
-    }
-}
-
-impl<F1, F2, S> QuerySink for (F1, F2)
-where
-    F1: for<'a> Fn(RowDescription) -> S,
-    F2: for<'a> Fn(ErrorResponse),
-    S: DataSink,
-{
-    type Output = S;
-    fn rows(&self, rows: RowDescription) -> S {
-        (self.0)(rows)
-    }
-    fn error(&self, error: ErrorResponse) {
-        (self.1)(error)
-    }
-}
-
-pub trait DataSink {
-    fn row(&self, values: Result<DataRow, ErrorResponse>);
-}
-
-impl DataSink for () {
-    fn row(&self, _: Result<DataRow, ErrorResponse>) {}
-}
-
-impl<F> DataSink for F
-where
-    F: for<'a> Fn(Result<DataRow<'a>, ErrorResponse<'a>>),
-{
-    fn row(&self, values: Result<DataRow, ErrorResponse>) {
-        (self)(values)
-    }
-}
-
-impl DataSink for Box<dyn DataSink> {
-    fn row(&self, values: Result<DataRow, ErrorResponse>) {
-        self.as_ref().row(values)
-    }
-}
-
-struct QueryWaiter {
-    #[allow(unused)]
-    tx: tokio::sync::mpsc::UnboundedSender<()>,
-    f: Box<dyn QuerySink<Output = Box<dyn DataSink>>>,
-    data: RefCell<Option<Box<dyn DataSink>>>,
 }
 
 #[derive(derive_more::Debug)]
@@ -183,8 +141,15 @@ where
     #[allow(clippy::type_complexity)]
     Connecting(Pin<Box<dyn Future<Output = Result<RawClient<B, C>, ConnectionError>>>>),
     #[debug("Ready(..)")]
-    Ready(RawClient<B, C>, VecDeque<QueryWaiter>),
-    Error(PGError),
+    Ready(
+        RawClient<B, C>,
+        VecDeque<(
+            &'static str,
+            Box<dyn MessageHandler>,
+            Option<tokio::sync::oneshot::Sender<()>>,
+        )>,
+    ),
+    Error(PGConnError),
     Closed,
 }
 
@@ -219,7 +184,7 @@ where
         }
     }
 
-    fn check_error(&self) -> Result<(), PGError> {
+    fn check_error(&self) -> Result<(), PGConnError> {
         let state = &mut *self.state.borrow_mut();
         match state {
             ConnState::Error(..) => {
@@ -229,28 +194,46 @@ where
                 error!("Connection failed: {e:?}");
                 Err(e)
             }
-            ConnState::Closed => Err(PGError::Closed),
+            ConnState::Closed => Err(PGConnError::Closed),
             _ => Ok(()),
         }
     }
 
     #[inline(always)]
-    async fn ready(&self) -> Result<(), PGError> {
+    async fn ready(&self) -> Result<(), PGConnError> {
         let _ = self.ready_lock.lock().await;
         self.check_error()
     }
 
-    fn with_stream<T, F>(&self, f: F) -> Result<T, PGError>
+    fn with_stream<T, F>(&self, f: F) -> Result<T, PGConnError>
     where
         F: FnOnce(Pin<&mut RawClient<B, C>>) -> T,
     {
         match &mut *self.state.borrow_mut() {
             ConnState::Ready(ref mut raw_client, _) => Ok(f(Pin::new(raw_client))),
-            _ => Err(PGError::InvalidState),
+            _ => Err(PGConnError::InvalidState),
         }
     }
 
-    async fn write(&self, mut buf: &[u8]) -> Result<(), PGError> {
+    fn enqueue_handler(
+        &self,
+        name: &'static str,
+        handler: impl MessageHandler + 'static,
+        tx: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<(), PGConnError> {
+        match &mut *self.state.borrow_mut() {
+            ConnState::Ready(_, queue) => {
+                queue.push_back((name, Box::new(handler), tx));
+            }
+            x => {
+                warn!("Connection state was not ready: {x:?}");
+                return Err(PGConnError::InvalidState);
+            }
+        }
+        Ok(())
+    }
+
+    async fn write(&self, mut buf: &[u8]) -> Result<(), PGConnError> {
         let _lock = self.write_lock.lock().await;
 
         if buf.is_empty() {
@@ -267,7 +250,7 @@ where
                 self.with_stream(|stm| {
                     let n = match ready!(stm.poll_write(cx, buf)) {
                         Ok(n) => n,
-                        Err(e) => return Poll::Ready(Err(PGError::Io(e))),
+                        Err(e) => return Poll::Ready(Err(PGConnError::Io(e))),
                     };
                     Poll::Ready(Ok(n))
                 })?
@@ -281,45 +264,39 @@ where
         Ok(())
     }
 
-    fn process_message(&self, message: Option<Message>) -> Result<(), PGError> {
+    fn process_message(&self, message: Option<Message>) -> Result<(), PGConnError> {
         let state = &mut *self.state.borrow_mut();
         match state {
             ConnState::Ready(_, queue) => {
-                let message = message.ok_or(PGError::InvalidState);
-                match_message!(Ok(message?), Backend {
-                    (RowDescription as row) => {
-                        if let Some(qw) = queue.back() {
-                            let qs = qw.f.rows(row);
-                            *qw.data.borrow_mut() = Some(qs);
-                        }
-                    },
-                    (DataRow as row) => {
-                        if let Some(qw) = queue.back() {
-                            if let Some(qs) = &*qw.data.borrow() {
-                                qs.row(Ok(row))
+                let message = message.ok_or(PGConnError::InvalidState);
+                if let Some((name, handler, _tx)) = queue.front_mut() {
+                    match handler.handle(message?) {
+                        MessageResult::SkipUntilSync => {
+                            let mut found_sync = false;
+                            while let Some((name, handler, _)) = queue.front() {
+                                if let Some(sync) = handler.as_any().downcast_ref::<SyncMessageHandler>() {
+                                    found_sync = true;
+                                    break;
+                                }
+                                queue.pop_front();
+                            }
+                            if !found_sync {
+                                warn!("No sync handler found");
                             }
                         }
-                    },
-                    (CommandComplete) => {
-                        if let Some(qw) = queue.back() {
-                            *qw.data.borrow_mut() = None;
+                        MessageResult::Continue => {}
+                        MessageResult::Done => {
+                            queue.pop_front();
                         }
-                    },
-                    (ReadyForQuery) => {
-                        queue.pop_front();
-                    },
-                    (ErrorResponse as err) => {
-                        if let Some(qw) = queue.back() {
-                            qw.f.error(err);
+                        MessageResult::Unknown => {
+                            // TODO
+                            warn!("Unknown message");
                         }
-                    },
-                    unknown => {
-                        eprintln!("Unknown message: {unknown:?}");
-                    }
-                });
+                    };
+                };
             }
             ConnState::Connecting(..) => {
-                return Err(PGError::InvalidState);
+                return Err(PGConnError::InvalidState);
             }
             ConnState::Error(..) | ConnState::Closed => self.check_error()?,
         }
@@ -327,7 +304,7 @@ where
         Ok(())
     }
 
-    pub fn task(self: Rc<Self>) -> impl Future<Output = Result<(), PGError>> {
+    pub fn task(self: Rc<Self>) -> impl Future<Output = Result<(), PGConnError>> {
         let ready_lock = self.ready_lock.clone().try_lock_owned().unwrap();
 
         async move {
@@ -339,13 +316,13 @@ where
                             let raw = match result {
                                 Ok(raw) => raw,
                                 Err(e) => {
-                                    let error = PGError::Connection(e);
+                                    let error = PGConnError::Connection(e);
                                     *state = ConnState::Error(error);
-                                    return Poll::Ready(Ok::<_, PGError>(()));
+                                    return Poll::Ready(Ok::<_, PGConnError>(()));
                                 }
                             };
                             *state = ConnState::Ready(raw, VecDeque::new());
-                            Poll::Ready(Ok::<_, PGError>(()))
+                            Poll::Ready(Ok::<_, PGConnError>(()))
                         }
                         Poll::Pending => Poll::Pending,
                     },
@@ -364,7 +341,7 @@ where
                     self.with_stream(|stm| {
                         let mut buf = ReadBuf::new(&mut read_buffer);
                         let res = ready!(stm.poll_read(cx, &mut buf));
-                        Poll::Ready(res.map(|_| buf.filled().len())).map_err(PGError::Io)
+                        Poll::Ready(res.map(|_| buf.filled().len())).map_err(PGConnError::Io)
                     })?
                 })
                 .await?;
@@ -377,6 +354,14 @@ where
                 }
 
                 buffer.push_fallible(&read_buffer[..n], |message| {
+                    if let Ok(message) = &message {
+                        if tracing::enabled!(Level::TRACE) {
+                            trace!("Message ({:?})", message.mtype() as char);
+                            for s in hexdump::hexdump_iter(message.__buf) {
+                                trace!("{}", s);
+                            }
+                        }
+                    };
                     self.process_message(Some(message.map_err(ConnectionError::ParseError)?))
                 })?;
 
@@ -388,35 +373,498 @@ where
         }
     }
 
-    pub async fn query(
+    pub fn query(
         self: Rc<Self>,
-        query: String,
+        query: &str,
         f: impl QuerySink + 'static,
-    ) -> Result<(), PGError> {
+    ) -> impl Future<Output = Result<(), PGConnError>> {
         trace!("Query task started: {query}");
-        let mut rx = match &mut *self.state.borrow_mut() {
-            ConnState::Ready(_, queue) => {
-                let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-                let f = Box::new(ErasedQuerySink(f)) as _;
-                queue.push_back(QueryWaiter {
-                    tx,
-                    f,
-                    data: None.into(),
-                });
-                rx
-            }
-            x => {
-                warn!("Connection state was not ready: {x:?}");
-                return Err(PGError::InvalidState);
-            }
-        };
-
         let message = builder::Query { query: &query }.to_vec();
-        self.write(&message).await?;
-        rx.recv().await;
-        Ok(())
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let handler = QueryMessageHandler {
+            sink: f,
+            data: None.into(),
+            copy: None.into(),
+        };
+        async move {
+            self.enqueue_handler("query", handler, Some(tx))?;
+            self.write(&message).await?;
+            _ = rx.await;
+            Ok(())
+        }
+    }
+
+    pub fn pipeline_sync(
+        self: Rc<Self>,
+        pipeline: Pipeline,
+    ) -> impl Future<Output = Result<(), PGConnError>> {
+        async move {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            for handler in pipeline.handlers {
+                self.enqueue_handler("pipeline",handler, None)?;
+            }
+            self.enqueue_handler("sync", SyncMessageHandler, Some(tx))?;
+            self.write(&pipeline.messages).await?;
+            self.write(&builder::Sync::default().to_vec()).await?;
+            _ = rx.await;
+            Ok(())
+        }
     }
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use hex_literal::hex;
+    use std::{fmt::Write, time::Duration};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt, DuplexStream},
+        task::LocalSet,
+        time::timeout,
+    };
+
+    use crate::connection::{
+        flow::{CopyDataSink, DataSink, DoneHandling},
+        raw_conn::ConnectionParams,
+    };
+    use crate::protocol::postgres::data::*;
+
+    use super::*;
+
+    impl QuerySink for Rc<RefCell<String>> {
+        type Output = Self;
+        type CopyOutput = Self;
+        fn rows(&mut self, rows: RowDescription) -> Self {
+            write!(self.borrow_mut(), "[table=[").unwrap();
+            for field in rows.fields() {
+                write!(self.borrow_mut(), "{},", field.name().to_string_lossy()).unwrap();
+            }
+            write!(self.borrow_mut(), "]").unwrap();
+            self.clone()
+        }
+        fn copy(&mut self, copy: CopyOutResponse) -> Self {
+            write!(
+                self.borrow_mut(),
+                "[copy={:?} {:?}",
+                copy.format(),
+                copy.format_codes()
+            )
+            .unwrap();
+            self.clone()
+        }
+        fn error(&mut self, error: ErrorResponse) {
+            for field in error.fields() {
+                if field.etype() as char == 'C' {
+                    write!(
+                        self.borrow_mut(),
+                        "[error {}]",
+                        field.value().to_string_lossy()
+                    )
+                    .unwrap();
+                    return;
+                }
+            }
+            write!(self.borrow_mut(), "[error ??? {:?}]", error).unwrap();
+        }
+        fn protocol_violation(&mut self, message: Message, hint: &'static str) {
+            // This won't happen during these tests
+            panic!(
+                "protocol error {}: {:?} ({hint})",
+                message.mtype() as char,
+                message
+            );
+        }
+    }
+
+    impl DataSink for Rc<RefCell<String>> {
+        fn row(&mut self, row: DataRow) {
+            write!(self.borrow_mut(), "[").unwrap();
+            for value in row.values() {
+                write!(self.borrow_mut(), "{},", value.to_string_lossy()).unwrap();
+            }
+            write!(self.borrow_mut(), "]").unwrap();
+        }
+        fn done(&mut self, result: Result<CommandComplete, ErrorResponse>) -> DoneHandling {
+            match result {
+                Ok(complete) => {
+                    write!(
+                        self.borrow_mut(),
+                        " done={}]",
+                        complete.tag().to_string_lossy()
+                    )
+                    .unwrap();
+                }
+                Err(error) => {
+                    for field in error.fields() {
+                        if field.etype() as char == 'C' {
+                            write!(
+                                self.borrow_mut(),
+                                "[error {}]]",
+                                field.value().to_string_lossy()
+                            )
+                            .unwrap();
+                            return DoneHandling::Handled;
+                        }
+                    }
+                    write!(self.borrow_mut(), "[error ??? {:?}]]", error).unwrap();
+                }
+            }
+            DoneHandling::Handled
+        }
+    }
+
+    impl CopyDataSink for Rc<RefCell<String>> {
+        fn data(&mut self, data: CopyData) {
+            write!(
+                self.borrow_mut(),
+                "[{}]",
+                String::from_utf8_lossy(data.data().as_ref())
+            )
+            .unwrap();
+        }
+        fn done(&mut self, result: Result<CommandComplete, ErrorResponse>) -> DoneHandling {
+            match result {
+                Ok(complete) => {
+                    write!(
+                        self.borrow_mut(),
+                        " done={}]",
+                        complete.tag().to_string_lossy()
+                    )
+                    .unwrap();
+                }
+                Err(error) => {
+                    for field in error.fields() {
+                        if field.etype() as char == 'C' {
+                            write!(
+                                self.borrow_mut(),
+                                "[error {}]]",
+                                field.value().to_string_lossy()
+                            )
+                            .unwrap();
+                            return DoneHandling::Handled;
+                        }
+                    }
+                    write!(self.borrow_mut(), "[error ??? {:?}]]", error).unwrap();
+                }
+            }
+            DoneHandling::Handled
+        }
+    }
+
+    async fn read_expect<S: AsyncReadExt + Unpin>(stream: &mut S, expected: &[u8]) {
+        let mut buf = vec![0u8; expected.len()];
+        stream.read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf, expected);
+    }
+
+    /// Perform a test using captured binary protocol data from a real server.
+    async fn run_expect<F: Future>(
+        query_task: impl FnOnce(Client<DuplexStream, ()>, Rc<RefCell<String>>) -> F + 'static,
+        expect: &'static [(&[u8], &[u8], &str)],
+    ) {
+        let f = async move {
+            let (mut s1, s2) = tokio::io::duplex(1024 * 1024);
+
+            let (client, task) = Client::new_raw(RawClient::new(s2, ConnectionParams::default()));
+            let task_handle = tokio::task::spawn_local(task);
+
+            let handle = tokio::task::spawn_local(async move {
+                let log = Rc::new(RefCell::new(String::new()));
+                query_task(client, log.clone()).await;
+                Rc::try_unwrap(log).unwrap().into_inner()
+            });
+
+            let mut log_expect = String::new();
+            for (read, write, expect) in expect {
+                // Query[text=""]
+                eprintln!("read {read:?}");
+                read_expect(&mut s1, read).await;
+                eprintln!("write {write:?}");
+                s1.write_all(write).await.unwrap();
+                log_expect.push_str(expect);
+            }
+
+            let log = handle.await.unwrap();
+
+            assert_eq!(log, log_expect);
+
+            // EOF to trigger the task to exit
+            drop(s1);
+
+            task_handle.await.unwrap().unwrap();
+        };
+
+        let local = LocalSet::new();
+        let task = local.spawn_local(f);
+
+        timeout(Duration::from_secs(1), local).await.unwrap();
+
+        // Ensure we detect panics inside the task
+        task.await.unwrap();
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_select_1() {
+        run_expect(
+            |client, log| async move {
+                client.query("SELECT 1", log.clone()).await.unwrap();
+            },
+            &[(
+                &hex!("51000000 0d53454c 45435420 3100"),
+                // T, D, C, Z
+                &hex!("54000000 2100013f 636f6c75 6d6e3f00 00000000 00000000 00170004 ffffffff 00004400 00000b00 01000000 01314300 00000d53 454c4543 54203100 5a000000 0549"),
+                "[table=[?column?,][1,] done=SELECT 1]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_select_1_limit_0() {
+        run_expect(
+            |client, log| async move {
+                client.query("SELECT 1 LIMIT 0", log.clone()).await.unwrap();
+            },
+            &[(
+                &hex!("51000000 1553454c 45435420 31204c49 4d495420 3000"),
+                // T, C, Z
+                &hex!("54000000 2100013f 636f6c75 6d6e3f00 00000000 00000000 00170004 ffffffff 00004300 00000d53 454c4543 54203000 5a000000 0549"),
+                "[table=[?column?,] done=SELECT 0]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_copy_1() {
+        run_expect(
+            |client, log| async move {
+                client.query("copy (select 1) to stdout;", log.clone()).await.unwrap();
+            },
+            &[(
+                &hex!("51000000 1f636f70 79202873 656c6563 74203129 20746f20 7374646f 75743b00"),
+                // H, d, c, C, Z
+                &hex!("48000000 09000001 00006400 00000631 0a630000 00044300 00000b43 4f505920 31005a00 00000549"),
+                "[copy=0 [0][1\n] done=COPY 1]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_copy_1_limit_0() {
+        run_expect(
+            |client, log| async move {
+                client.query("copy (select 1 limit 0) to stdout;", log.clone()).await.unwrap();
+            },
+            &[(
+                &hex!("51000000 27636f70 79202873 656c6563 74203120 6c696d69 74203029 20746f20 7374646f 75743b00"),
+                // H, c, C, Z
+                &hex!("48000000 09000001 00006300 00000443 0000000b 434f5059 2030005a 00000005 49"),
+                "[copy=0 [0] done=COPY 0]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_copy_with_error_rows() {
+        run_expect(
+            |client, log| async move {
+                client.query("copy (select case when id = 2 then id/(id-2) else id end from (select generate_series(1,2) as id)) to stdout;", log.clone()).await.unwrap();
+            },
+            &[(
+                &hex!("""
+                    51000000 72636f70 79202873 656c6563
+                    74206361 73652077 68656e20 6964203d
+                    20322074 68656e20 69642f28 69642d32
+                    2920656c 73652069 6420656e 64206672
+                    6f6d2028 73656c65 63742067 656e6572
+                    6174655f 73657269 65732831 2c322920
+                    61732069 64292920 746f2073 74646f75
+                    743b00
+                """),
+                // H, d, E, Z
+                &hex!("""
+                    48000000 09000001 00006400 00000631
+                    0a450000 00415345 52524f52 00564552
+                    524f5200 43323230 3132004d 64697669
+                    73696f6e 20627920 7a65726f 0046696e
+                    742e6300 4c383431 0052696e 74346469
+                    7600005a 00000005 49
+                """),
+                "[copy=0 [0][1\n][error 22012]]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_error() {
+        run_expect(
+            |client, log| async move {
+                client.query("do $$begin raise exception 'hi'; end$$;", log.clone()).await.unwrap();
+            },
+            &[(
+                &hex!("51000000 2c646f20 24246265 67696e20 72616973 65206578 63657074 696f6e20 27686927 3b20656e 6424243b 00"),
+                // E, Z
+                &hex!("""
+                    45000000 75534552 524f5200 56455252
+                    4f520043 50303030 31004d68 69005750
+                    4c2f7067 53514c20 66756e63 74696f6e
+                    20696e6c 696e655f 636f6465 5f626c6f
+                    636b206c 696e6520 31206174 20524149
+                    53450046 706c5f65 7865632e 63004c33
+                    39313100 52657865 635f7374 6d745f72
+                    61697365 00005a00 00000549
+                """),
+                "[error P0001]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_empty_do() {
+        run_expect(
+            |client, log| async move {
+                client
+                    .query("do $$begin end$$;", log.clone())
+                    .await
+                    .unwrap();
+            },
+            &[(
+                &hex!("51000000 16646f20 24246265 67696e20 656e6424 243b00"),
+                // C, Z
+                &hex!("""
+                    43000000 07444f00 5a000000 0549
+                """),
+                "",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_error_with_rows() {
+        run_expect(
+            |client, log| async move {
+                client.query("select case when id = 2 then id/(id-2) else 1 end from (select 1 as id union all select 2 as id);", log.clone()).await.unwrap();
+            },
+            &[(
+                &hex!("""
+                    51000000 6673656c 65637420 63617365
+                    20776865 6e206964 203d2032 20746865
+                    6e206964 2f286964 2d322920 656c7365
+                    20312065 6e642066 726f6d20 2873656c
+                    65637420 31206173 20696420 756e696f
+                    6e20616c 6c207365 6c656374 20322061
+                    73206964 293b00
+                """),
+                // T, D, E, Z
+                &hex!("""
+                    54000000 1d000163 61736500 00000000
+                    00000000 00170004 ffffffff 00004400
+                    00000b00 01000000 01314500 00004153
+                    4552524f 52005645 52524f52 00433232
+                    30313200 4d646976 6973696f 6e206279
+                    207a6572 6f004669 6e742e63 004c3834
+                    31005269 6e743464 69760000 5a000000
+                    0549
+                """),
+                "[table=[case,][1,][error 22012]]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_second_errors() {
+        run_expect(
+            |client, log| async move {
+                client
+                    .query("select; select 1/0;", log.clone())
+                    .await
+                    .unwrap();
+            },
+            &[(
+                &hex!("51000000 1873656c 6563743b 2073656c 65637420 312f303b 00"),
+                // T, D, C, E, Z
+                &hex!("""
+                        54000000 06000044 00000006 00004300
+                        00000d53 454c4543 54203100 45000000
+                        41534552 524f5200 56455252 4f520043
+                        32323031 32004d64 69766973 696f6e20
+                        6279207a 65726f00 46696e74 2e63004c
+                        38343100 52696e74 34646976 00005a00
+                        00000549
+                    """),
+                "[table=[][] done=SELECT 1][error 22012]",
+            )],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_two_empty() {
+        run_expect(
+            |client, log| async move {
+                client.query("", log.clone()).await.unwrap();
+                client.query("", log.clone()).await.unwrap();
+            },
+            &[
+                (
+                    &hex!("51000000 0500"),
+                    // I, Z
+                    &hex!("49000000 045a0000 000549"),
+                    "",
+                ),
+                (
+                    &hex!("51000000 0500"),
+                    // I, Z
+                    &hex!("49000000 045a0000 000549"),
+                    "",
+                ),
+            ],
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_two_error() {
+        run_expect(
+            |client, log| async move {
+                client.query(".", log.clone()).await.expect_err("should fail");
+                client.query(".", log.clone()).await.expect_err("should fail");
+            },
+            &[
+                (
+                    &hex!("51000000 062e00"),
+                    // E, Z
+                    &hex!("""
+                        45000000 59534552 524f5200 56455252
+                        4f520043 34323630 31004d73 796e7461
+                        78206572 726f7220 6174206f 72206e65
+                        61722022 2e220050 31004673 63616e2e
+                        6c004c31 32343400 52736361 6e6e6572
+                        5f797965 72726f72 0000
+                    """),
+                    "",
+                ),
+                (
+                    &hex!("51000000 062e00"),
+                    // E, Z
+                    &hex!("""
+                        45000000 59534552 524f5200 56455252
+                        4f520043 34323630 31004d73 796e7461
+                        78206572 726f7220 6174206f 72206e65
+                        61722022 2e220050 31004673 63616e2e
+                        6c004c31 32343400 52736361 6e6e6572
+                        5f797965 72726f72 00005a00 00000549
+                    """),
+                    "",
+                ),
+            ],
+        )
+        .await;
+    }
+}

--- a/rust/pgrust/src/connection/flow.rs
+++ b/rust/pgrust/src/connection/flow.rs
@@ -1,0 +1,886 @@
+//! Postgres flow notes:
+//!
+//! https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-PIPELINING
+//!
+//! Extended query messages Parse, Bind, Describe, Execute, Close put the server
+//! into a "skip-til-sync" mode when erroring. All messages other than Terminate (including
+//! those not part of the extended query protocol) are skipped until an explicit Sync message is received.
+//!
+//! Sync closes _implicit_ but not _explicit_ transactions.
+//!
+//! Both Query and Execute may return COPY responses rather than rows. In the case of Query,
+//! RowDescription + DataRow is replaced by CopyOutResponse + CopyData + CopyDone. In the case
+//! of Execute, describing the portal will return NoData, but Execute will return CopyOutResponse +
+//! CopyData + CopyDone.
+
+use std::num::NonZeroU32;
+
+use tracing::warn;
+
+use crate::protocol::{
+    match_message,
+    postgres::{
+        builder,
+        data::{
+            BindComplete, CloseComplete, CommandComplete, CopyData, CopyDone, CopyOutResponse,
+            DataRow, EmptyQueryResponse, ErrorResponse, Message, ParseComplete, PortalSuspended,
+            ReadyForQuery, RowDescription,
+        },
+    },
+    Encoded,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub enum Param<'a> {
+    Null,
+    Text(&'a str),
+    Binary(&'a [u8]),
+}
+
+#[derive(Debug, Clone, Copy, zerocopy_derive::KnownLayout)]
+#[repr(u32)]
+pub enum Oid {
+    Unspecified,
+    Oid(NonZeroU32),
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(i16)]
+pub enum Format {
+    Text = 0,
+    Binary = 1,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(i32)]
+pub enum MaxRows {
+    Unlimited,
+    Limited(NonZeroU32),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Portal<'a>(pub &'a str);
+
+#[derive(Debug, Clone, Copy)]
+pub struct Statement<'a>(pub &'a str);
+
+pub trait Flow {
+    fn to_vec(&self) -> Vec<u8>;
+}
+
+/// Performs a prepared statement parse operation.
+///
+/// Handles:
+///  - `ParseComplete`
+///  - `ErrorResponse`
+#[derive(Debug, Clone, Copy)]
+struct ParseFlow<'a> {
+    pub name: Statement<'a>,
+    pub query: &'a str,
+    pub param_types: &'a [Oid],
+}
+
+/// Performs a prepared statement bind operation.
+///
+/// Handles:
+///  - `BindComplete`
+///  - `ErrorResponse`
+#[derive(Debug, Clone, Copy)]
+struct BindFlow<'a> {
+    pub portal: Portal<'a>,
+    pub statement: Statement<'a>,
+    pub params: &'a [Param<'a>],
+    pub result_format_codes: &'a [Format],
+}
+
+/// Performs a prepared statement execute operation.
+///
+/// Handles:
+///  - `CommandComplete`
+///  - `DataRow`
+///  - `PortalSuspended`
+///  - `CopyOutResponse`
+///  - `CopyData`
+///  - `CopyDone`
+///  - `ErrorResponse`
+#[derive(Debug, Clone, Copy)]
+struct ExecuteFlow<'a> {
+    pub portal: Portal<'a>,
+    pub max_rows: MaxRows,
+}
+
+/// Performs a portal describe operation.
+///
+/// Handles:
+///  - `RowDescription`
+///  - `NoData`
+///  - `ErrorResponse`
+#[derive(Debug, Clone, Copy)]
+struct DescribePortalFlow<'a> {
+    pub name: Portal<'a>,
+}
+
+/// Performs a statement describe operation.
+///
+/// Handles:
+///  - `RowDescription`
+///  - `NoData`
+///  - `ParameterDescription`
+///  - `ErrorResponse`
+#[derive(Debug, Clone, Copy)]
+struct DescribeStatementFlow<'a> {
+    pub name: Statement<'a>,
+}
+
+/// Performs a portal close operation.
+///
+/// Handles:
+///  - `CloseComplete`
+///  - `ErrorResponse`
+#[derive(Debug, Clone, Copy)]
+struct ClosePortalFlow<'a> {
+    pub name: Portal<'a>,
+}
+
+/// Performs a statement close operation.
+///
+/// Handles:
+///  - `CloseComplete`
+///  - `ErrorResponse`
+#[derive(Debug, Clone, Copy)]
+struct CloseStatementFlow<'a> {
+    pub name: Statement<'a>,
+}
+
+/// Performs a query operation.
+///
+/// Handles:
+///  - `EmptyQueryResponse`: If no queries were specified in the text
+///  - `CommandComplete`: For each fully-completed query
+///  - `RowDescription`: For each query that returns data
+///  - `DataRow`: For each row returned by a query
+///  - `CopyOutResponse`: For each query that returns copy data
+///  - `CopyData`: For each chunk of copy data returned by a query
+///  - `CopyDone`: For each query that returns copy data
+///  - `ErrorResponse`: For the first failed query
+#[derive(Debug, Clone, Copy)]
+struct QueryFlow<'a> {
+    pub query: &'a str,
+}
+
+impl<'a> Flow for ParseFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        let param_types: Vec<i32> = self
+            .param_types
+            .iter()
+            .map(|oid| match oid {
+                Oid::Unspecified => 0,
+                Oid::Oid(n) => n.get() as i32,
+            })
+            .collect();
+        builder::Parse {
+            statement: self.name.0,
+            query: self.query,
+            param_types: &param_types,
+        }
+        .to_vec()
+    }
+}
+
+impl<'a> Flow for BindFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        let mut format_codes = Vec::with_capacity(self.params.len());
+        let mut values = Vec::with_capacity(self.params.len());
+
+        for param in self.params {
+            match param {
+                Param::Null => {
+                    format_codes.push(0);
+                    values.push(Encoded::Null);
+                }
+                Param::Text(value) => {
+                    format_codes.push(0);
+                    values.push(Encoded::Value(value.as_bytes()));
+                }
+                Param::Binary(value) => {
+                    format_codes.push(1);
+                    values.push(Encoded::Value(value));
+                }
+            }
+        }
+
+        let result_format_codes: Vec<i16> =
+            self.result_format_codes.iter().map(|f| *f as i16).collect();
+
+        builder::Bind {
+            portal: self.portal.0,
+            statement: self.statement.0,
+            format_codes: &format_codes,
+            values: &values,
+            result_format_codes: &result_format_codes,
+        }
+        .to_vec()
+    }
+}
+
+impl<'a> Flow for ExecuteFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        let max_rows = match self.max_rows {
+            MaxRows::Unlimited => 0,
+            MaxRows::Limited(n) => n.get() as i32,
+        };
+        builder::Execute {
+            portal: self.portal.0,
+            max_rows,
+        }
+        .to_vec()
+    }
+}
+
+impl<'a> Flow for DescribePortalFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        builder::Describe {
+            name: self.name.0,
+            dtype: 'P' as _,
+        }
+        .to_vec()
+    }
+}
+
+impl<'a> Flow for DescribeStatementFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        builder::Describe {
+            name: self.name.0,
+            dtype: 'S' as _,
+        }
+        .to_vec()
+    }
+}
+
+impl<'a> Flow for ClosePortalFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        builder::Close {
+            name: self.name.0,
+            ctype: 'P' as _,
+        }
+        .to_vec()
+    }
+}
+
+impl<'a> Flow for CloseStatementFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        builder::Close {
+            name: self.name.0,
+            ctype: 'S' as _,
+        }
+        .to_vec()
+    }
+}
+
+impl<'a> Flow for QueryFlow<'a> {
+    fn to_vec(&self) -> Vec<u8> {
+        builder::Query { query: self.query }.to_vec()
+    }
+}
+
+pub(crate) enum MessageResult {
+    Continue,
+    Done,
+    SkipUntilSync,
+    Unknown,
+}
+
+pub(crate) trait MessageHandler {
+    fn handle(&mut self, message: Message) -> MessageResult;
+}
+
+pub(crate) struct SyncMessageHandler;
+
+impl MessageHandler for SyncMessageHandler {
+    fn handle(&mut self, _: Message) -> MessageResult {
+        MessageResult::Done
+    }
+}
+
+impl<F> MessageHandler for F
+where
+    F: for<'a> FnMut(Message<'a>) -> MessageResult,
+{
+    fn handle(&mut self, message: Message) -> MessageResult {
+        (self)(message)
+    }
+}
+
+impl MessageHandler for Box<dyn MessageHandler> {
+    fn handle(&mut self, message: Message) -> MessageResult {
+        self.as_mut().handle(message)
+    }
+}
+
+pub trait FlowWithSink {
+    fn visit_flow(&self, f: impl FnMut(&dyn Flow));
+    fn make_handler(self) -> Box<dyn MessageHandler>;
+}
+
+pub trait SimpleFlowSink {
+    fn handle(&mut self, result: Result<(), ErrorResponse>);
+}
+
+impl SimpleFlowSink for () {
+    fn handle(&mut self, _: Result<(), ErrorResponse>) {}
+}
+
+impl<F: for<'a> FnMut(Result<(), ErrorResponse>)> SimpleFlowSink for F {
+    fn handle(&mut self, result: Result<(), ErrorResponse>) {
+        (self)(result)
+    }
+}
+
+impl<S: SimpleFlowSink + 'static> FlowWithSink for (ParseFlow<'_>, S) {
+    fn visit_flow(&self, mut f: impl FnMut(&dyn Flow)) {
+        f(&self.0);
+    }
+    fn make_handler(mut self) -> Box<dyn MessageHandler> {
+        Box::new(move |message: Message<'_>| {
+            if let Some(_) = ParseComplete::try_new(&message) {
+                self.1.handle(Ok(()));
+                return MessageResult::Done;
+            }
+            if let Some(msg) = ErrorResponse::try_new(&message) {
+                self.1.handle(Err(msg));
+                return MessageResult::SkipUntilSync;
+            }
+            return MessageResult::Unknown;
+        })
+    }
+}
+
+impl<S: SimpleFlowSink + 'static> FlowWithSink for (BindFlow<'_>, S) {
+    fn visit_flow(&self, mut f: impl FnMut(&dyn Flow)) {
+        f(&self.0);
+    }
+    fn make_handler(mut self) -> Box<dyn MessageHandler> {
+        Box::new(move |message: Message<'_>| {
+            if let Some(_) = BindComplete::try_new(&message) {
+                self.1.handle(Ok(()));
+                return MessageResult::Done;
+            }
+            if let Some(msg) = ErrorResponse::try_new(&message) {
+                self.1.handle(Err(msg));
+                return MessageResult::SkipUntilSync;
+            }
+            return MessageResult::Unknown;
+        })
+    }
+}
+
+impl<S: SimpleFlowSink + 'static> FlowWithSink for (ClosePortalFlow<'_>, S) {
+    fn visit_flow(&self, mut f: impl FnMut(&dyn Flow)) {
+        f(&self.0);
+    }
+    fn make_handler(mut self) -> Box<dyn MessageHandler> {
+        Box::new(move |message: Message<'_>| {
+            if let Some(_) = CloseComplete::try_new(&message) {
+                self.1.handle(Ok(()));
+                return MessageResult::Done;
+            }
+            if let Some(msg) = ErrorResponse::try_new(&message) {
+                self.1.handle(Err(msg));
+                return MessageResult::SkipUntilSync;
+            }
+            return MessageResult::Unknown;
+        })
+    }
+}
+
+impl<S: SimpleFlowSink + 'static> FlowWithSink for (CloseStatementFlow<'_>, S) {
+    fn visit_flow(&self, mut f: impl FnMut(&dyn Flow)) {
+        f(&self.0);
+    }
+    fn make_handler(mut self) -> Box<dyn MessageHandler> {
+        Box::new(move |message: Message<'_>| {
+            if let Some(_) = CloseComplete::try_new(&message) {
+                self.1.handle(Ok(()));
+                return MessageResult::Done;
+            }
+            if let Some(msg) = ErrorResponse::try_new(&message) {
+                self.1.handle(Err(msg));
+                return MessageResult::Done;
+            }
+            return MessageResult::Unknown;
+        })
+    }
+}
+
+impl<S: ExecuteSink + 'static> FlowWithSink for (ExecuteFlow<'_>, S) {
+    fn visit_flow(&self, mut f: impl FnMut(&dyn Flow)) {
+        f(&self.0);
+    }
+    fn make_handler(self) -> Box<dyn MessageHandler> {
+        Box::new(ExecuteMessageHandler {
+            sink: self.1,
+            data: None,
+            copy: None,
+        })
+    }
+}
+
+impl<S: QuerySink + 'static> FlowWithSink for (QueryFlow<'_>, S) {
+    fn visit_flow(&self, mut f: impl FnMut(&dyn Flow)) {
+        f(&self.0);
+    }
+    fn make_handler(self) -> Box<dyn MessageHandler> {
+        Box::new(QueryMessageHandler {
+            sink: self.1,
+            data: None,
+            copy: None,
+        })
+    }
+}
+
+pub trait ExecuteSink {
+    type Output: DataSink;
+    type CopyOutput: CopyDataSink;
+
+    fn rows(&mut self) -> Self::Output;
+    fn copy(&mut self, copy: CopyOutResponse) -> Self::CopyOutput;
+    fn suspended(&mut self, _suspended: PortalSuspended) {}
+    fn complete(&mut self, _complete: CommandComplete) {}
+    fn error(&mut self, error: ErrorResponse);
+
+    fn protocol_violation(&mut self, message: Message, hint: &'static str) {
+        warn!("Protocol violation: {message:?} ({hint})");
+    }
+}
+
+impl ExecuteSink for () {
+    type Output = ();
+    type CopyOutput = ();
+    fn rows(&mut self) -> () {}
+    fn copy(&mut self, _: CopyOutResponse) -> () {}
+    fn error(&mut self, _: ErrorResponse) {}
+}
+
+/// A sink capable of handling standard query and COPY (out direction) messages.
+pub trait QuerySink {
+    type Output: DataSink;
+    type CopyOutput: CopyDataSink;
+
+    fn rows(&mut self, rows: RowDescription) -> Self::Output;
+    fn copy(&mut self, copy: CopyOutResponse) -> Self::CopyOutput;
+    fn complete(&mut self, _complete: CommandComplete) {}
+    fn error(&mut self, error: ErrorResponse);
+
+    fn protocol_violation(&mut self, message: Message, hint: &'static str) {
+        warn!("Protocol violation: {message:?} ({hint})");
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoneHandling {
+    Handled,
+    RedirectToParent,
+}
+
+pub trait DataSink {
+    /// Sink a row of data.
+    fn row(&mut self, values: DataRow);
+    /// Handle the completion of a command. If unimplemented, will be redirected to the parent.
+    #[must_use]
+    fn done(&mut self, _result: Result<CommandComplete, ErrorResponse>) -> DoneHandling {
+        DoneHandling::RedirectToParent
+    }
+}
+
+pub trait CopyDataSink {
+    /// Sink a chunk of COPY data.
+    fn data(&mut self, values: CopyData);
+    /// Handle the completion of a COPY operation. If unimplemented, will be redirected to the parent.
+    #[must_use]
+    fn done(&mut self, _result: Result<CommandComplete, ErrorResponse>) -> DoneHandling {
+        DoneHandling::RedirectToParent
+    }
+}
+
+impl<Q> QuerySink for Box<Q>
+where
+    Q: QuerySink + 'static,
+{
+    type Output = Box<dyn DataSink + 'static>;
+    type CopyOutput = Box<dyn CopyDataSink + 'static>;
+    fn rows(&mut self, rows: RowDescription) -> Self::Output {
+        Box::new(self.as_mut().rows(rows))
+    }
+    fn copy(&mut self, copy: CopyOutResponse) -> Self::CopyOutput {
+        Box::new(self.as_mut().copy(copy))
+    }
+    fn complete(&mut self, _complete: CommandComplete) {
+        self.as_mut().complete(_complete)
+    }
+    fn protocol_violation(&mut self, message: Message, hint: &'static str) {
+        self.as_mut().protocol_violation(message, hint)
+    }
+    fn error(&mut self, error: ErrorResponse) {
+        self.as_mut().error(error)
+    }
+}
+
+impl QuerySink for () {
+    type Output = ();
+    type CopyOutput = ();
+    fn rows(&mut self, _: RowDescription) -> () {}
+    fn copy(&mut self, _: CopyOutResponse) -> () {}
+    fn error(&mut self, _: ErrorResponse) {}
+}
+
+impl<F1, F2, S> QuerySink for (F1, F2)
+where
+    F1: for<'a> FnMut(RowDescription<'a>) -> S,
+    F2: for<'a> FnMut(ErrorResponse<'a>),
+    S: DataSink,
+{
+    type Output = S;
+    type CopyOutput = ();
+    fn rows(&mut self, rows: RowDescription) -> S {
+        (self.0)(rows)
+    }
+    fn copy(&mut self, _: CopyOutResponse) -> () {
+        ()
+    }
+    fn error(&mut self, error: ErrorResponse) {
+        (self.1)(error)
+    }
+}
+
+impl<F1, F2, F3, S, T> QuerySink for (F1, F2, F3)
+where
+    F1: for<'a> FnMut(RowDescription<'a>) -> S,
+    F2: for<'a> FnMut(CopyOutResponse<'a>) -> T,
+    F3: for<'a> FnMut(ErrorResponse<'a>),
+    S: DataSink,
+    T: CopyDataSink,
+{
+    type Output = S;
+    type CopyOutput = T;
+    fn rows(&mut self, rows: RowDescription) -> S {
+        (self.0)(rows)
+    }
+    fn copy(&mut self, copy: CopyOutResponse) -> T {
+        (self.1)(copy)
+    }
+    fn error(&mut self, error: ErrorResponse) {
+        (self.2)(error)
+    }
+}
+
+impl DataSink for () {
+    fn row(&mut self, _: DataRow) {}
+}
+
+impl<F> DataSink for F
+where
+    F: for<'a> Fn(DataRow<'a>),
+{
+    fn row(&mut self, values: DataRow) {
+        (self)(values)
+    }
+}
+
+impl DataSink for Box<dyn DataSink> {
+    fn row(&mut self, values: DataRow) {
+        self.as_mut().row(values)
+    }
+    fn done(&mut self, result: Result<CommandComplete, ErrorResponse>) -> DoneHandling {
+        self.as_mut().done(result)
+    }
+}
+
+impl CopyDataSink for () {
+    fn data(&mut self, _: CopyData) {}
+}
+
+impl<F> CopyDataSink for F
+where
+    F: for<'a> FnMut(CopyData<'a>),
+{
+    fn data(&mut self, values: CopyData) {
+        (self)(values)
+    }
+}
+
+impl CopyDataSink for Box<dyn CopyDataSink> {
+    fn data(&mut self, values: CopyData) {
+        self.as_mut().data(values)
+    }
+    fn done(&mut self, result: Result<CommandComplete, ErrorResponse>) -> DoneHandling {
+        self.as_mut().done(result)
+    }
+}
+
+pub(crate) struct ExecuteMessageHandler<Q: ExecuteSink> {
+    pub sink: Q,
+    pub data: Option<Q::Output>,
+    pub copy: Option<Q::CopyOutput>,
+}
+
+impl<Q: ExecuteSink> MessageHandler for ExecuteMessageHandler<Q> {
+    fn handle(&mut self, message: Message) -> MessageResult {
+        match_message!(Ok(message), Backend {
+            (CopyOutResponse as copy) => {
+                let sink = std::mem::replace(&mut self.copy, Some(self.sink.copy(copy)));
+                if sink.is_some() {
+                    self.sink.protocol_violation(message, "copy sink exists");
+                }
+            },
+            (CopyData as data) => {
+                if let Some(sink) = &mut self.copy {
+                    sink.data(data);
+                } else {
+                    self.sink.protocol_violation(message, "copy sink does not exist");
+                }
+            },
+            (CopyDone) => {
+                if self.copy.is_none() {
+                    self.sink.protocol_violation(message, "copy sink does not exist");
+                }
+            },
+
+            (DataRow as row) => {
+                if self.data.is_none() {
+                    self.data = Some(self.sink.rows());
+                }
+                let Some(sink) = &mut self.data else {
+                    unreachable!()
+                };
+                sink.row(row)
+            },
+            (PortalSuspended) => {
+                // self.sink.suspended(message);
+                return MessageResult::Done;
+            },
+            (CommandComplete as complete) => {
+                let sink = std::mem::take(&mut self.data);
+                if let Some(mut sink) = sink {
+                    if sink.done(Ok(complete)) == DoneHandling::RedirectToParent {
+                        self.sink.complete(complete);
+                    }
+                } else {
+                    let sink = std::mem::take(&mut self.copy);
+                    if let Some(mut sink) = sink {
+                        if sink.done(Ok(complete)) == DoneHandling::RedirectToParent {
+                            self.sink.complete(complete);
+                        }
+                    } else {
+                        self.sink.complete(complete);
+                    }
+                }
+                return MessageResult::Done;
+            },
+
+            (ErrorResponse as err) => {
+                return MessageResult::SkipUntilSync;
+            },
+
+            _unknown => {
+                self.sink.protocol_violation(message, "unknown message");
+            }
+        });
+        MessageResult::Continue
+    }
+}
+
+pub(crate) struct QueryMessageHandler<Q: QuerySink> {
+    pub sink: Q,
+    pub data: Option<Q::Output>,
+    pub copy: Option<Q::CopyOutput>,
+}
+
+impl<Q: QuerySink> MessageHandler for QueryMessageHandler<Q> {
+    fn handle(&mut self, message: Message) -> MessageResult {
+        match_message!(Ok(message), Backend {
+            (CopyOutResponse as copy) => {
+                let sink = std::mem::replace(&mut self.copy, Some(self.sink.copy(copy)));
+                if sink.is_some() {
+                    self.sink.protocol_violation(message, "copy sink exists");
+                }
+            },
+            (CopyData as data) => {
+                if let Some(sink) = &mut self.copy {
+                    sink.data(data);
+                } else {
+                    self.sink.protocol_violation(message, "copy sink does not exist");
+                }
+            },
+            (CopyDone) => {
+                if self.copy.is_none() {
+                    self.sink.protocol_violation(message, "copy sink does not exist");
+                }
+            },
+
+            (RowDescription as row) => {
+                let sink = std::mem::replace(&mut self.data, Some(self.sink.rows(row)));
+                if sink.is_some() {
+                    self.sink.protocol_violation(message, "data sink exists");
+                }
+            },
+            (DataRow as row) => {
+                if let Some(sink) = &mut self.data {
+                    sink.row(row)
+                } else {
+                    self.sink.protocol_violation(message, "data sink does not exist");
+                }
+            },
+            (CommandComplete as complete) => {
+                let sink = std::mem::take(&mut self.data);
+                if let Some(mut sink) = sink {
+                    if sink.done(Ok(complete)) == DoneHandling::RedirectToParent {
+                        self.sink.complete(complete);
+                    }
+                } else {
+                    let sink = std::mem::take(&mut self.copy);
+                    if let Some(mut sink) = sink {
+                        if sink.done(Ok(complete)) == DoneHandling::RedirectToParent {
+                            self.sink.complete(complete);
+                        }
+                    } else {
+                        self.sink.complete(complete);
+                    }
+                }
+            },
+
+            (EmptyQueryResponse) => {
+                // Equivalent to CommandComplete, but no data was provided
+                let sink = std::mem::take(&mut self.data);
+                if sink.is_some() {
+                    self.sink.protocol_violation(message, "data sink exists");
+                } else {
+                    let sink = std::mem::take(&mut self.copy);
+                    if sink.is_some() {
+                        self.sink.protocol_violation(message, "copy sink exists");
+                    }
+                }
+            },
+
+            (ErrorResponse as err) => {
+                // Depending on the state of the sink, we direct the error to
+                // the appropriate handler.
+                if let Some(mut sink) = std::mem::take(&mut self.data) {
+                    if sink.done(Err(err)) == DoneHandling::RedirectToParent {
+                        self.sink.error(err);
+                    }
+                } else if let Some(mut sink) = std::mem::take(&mut self.copy) {
+                    if sink.done(Err(err)) == DoneHandling::RedirectToParent {
+                        self.sink.error(err);
+                    }
+                } else {
+                    self.sink.error(err);
+                }
+            },
+
+            (ReadyForQuery) => {
+                // All operations are complete at this point.
+                if std::mem::take(&mut self.data).is_some() || std::mem::take(&mut self.copy).is_some() {
+                    self.sink.protocol_violation(message, "sink exists");
+                }
+                return MessageResult::Done;
+            },
+
+            _unknown => {
+                self.sink.protocol_violation(message, "unknown message");
+            }
+        });
+        MessageResult::Continue
+    }
+}
+
+#[derive(Default)]
+pub struct PipelineBuilder {
+    handlers: Vec<Box<dyn MessageHandler>>,
+    messages: Vec<u8>,
+}
+
+impl PipelineBuilder {
+    fn push_flow_with_sink(mut self, flow: impl FlowWithSink) -> Self {
+        flow.visit_flow(|flow| self.messages.extend_from_slice(&flow.to_vec()));
+        self.handlers.push(flow.make_handler());
+        self
+    }
+
+    pub fn bind(
+        mut self,
+        portal: Portal,
+        statement: Statement,
+        params: &[Param],
+        result_format_codes: &[Format],
+        handler: impl SimpleFlowSink + 'static,
+    ) -> Self {
+        self.push_flow_with_sink((
+            BindFlow {
+                portal,
+                statement,
+                params,
+                result_format_codes,
+            },
+            handler,
+        ))
+    }
+
+    pub fn parse(
+        mut self,
+        name: Statement,
+        query: &str,
+        param_types: &[Oid],
+        handler: impl SimpleFlowSink + 'static,
+    ) -> Self {
+        self.push_flow_with_sink((
+            ParseFlow {
+                name,
+                query,
+                param_types,
+            },
+            handler,
+        ))
+    }
+
+    pub fn execute(
+        mut self,
+        portal: Portal,
+        max_rows: MaxRows,
+        handler: impl ExecuteSink + 'static,
+    ) -> Self {
+        self.push_flow_with_sink((ExecuteFlow { portal, max_rows }, handler))
+    }
+
+    pub fn close_portal(mut self, name: Portal, handler: impl SimpleFlowSink + 'static) -> Self {
+        self.push_flow_with_sink((ClosePortalFlow { name }, handler))
+    }
+
+    pub fn close_statement(
+        mut self,
+        name: Statement,
+        handler: impl SimpleFlowSink + 'static,
+    ) -> Self {
+        self.push_flow_with_sink((CloseStatementFlow { name }, handler))
+    }
+
+    /// Add a query flow to the pipeline.
+    ///
+    /// Note that if a query fails, the pipeline will continue executing until it
+    /// completes or a non-query pipeline element fails. If a previous non-query
+    /// element of this pipeline failed, the query will not be executed.
+    pub fn query(mut self, query: &str, handler: impl QuerySink + 'static) -> Self {
+        self.push_flow_with_sink((QueryFlow { query }, handler))
+    }
+
+    pub fn build(self) -> Pipeline {
+        Pipeline {
+            handlers: self.handlers,
+            messages: self.messages,
+        }
+    }
+}
+
+pub struct Pipeline {
+    pub(crate) handlers: Vec<Box<dyn MessageHandler>>,
+    pub(crate) messages: Vec<u8>,
+}

--- a/rust/pgrust/src/connection/flow.rs
+++ b/rust/pgrust/src/connection/flow.rs
@@ -223,7 +223,7 @@ impl<'a> Flow for BindFlow<'a> {
             statement: self.statement.0,
             format_codes: &format_codes,
             values: &values,
-            result_format_codes: &result_format_codes,
+            result_format_codes,
         }
         .to_vec()
     }
@@ -983,6 +983,7 @@ impl PipelineBuilder {
         self
     }
 
+    /// Add a bind flow to the pipeline.
     pub fn bind(
         self,
         portal: Portal,
@@ -1002,6 +1003,7 @@ impl PipelineBuilder {
         ))
     }
 
+    /// Add a parse flow to the pipeline.
     pub fn parse(
         self,
         name: Statement,
@@ -1019,6 +1021,11 @@ impl PipelineBuilder {
         ))
     }
 
+    /// Add an execute flow to the pipeline.
+    ///
+    /// Note that this may be a COPY statement. In that case, the description of the portal
+    /// will not show any data returned, and this will use the `CopySink` of the provided
+    /// sink. In addition, COPY operations do not respect the `max_rows` parameter.
     pub fn execute(
         self,
         portal: Portal,
@@ -1028,18 +1035,24 @@ impl PipelineBuilder {
         self.push_flow_with_sink((ExecuteFlow { portal, max_rows }, handler))
     }
 
+    /// Add a close portal flow to the pipeline.
     pub fn close_portal(self, name: Portal, handler: impl SimpleFlowSink + 'static) -> Self {
         self.push_flow_with_sink((ClosePortalFlow { name }, handler))
     }
 
+    /// Add a close statement flow to the pipeline.
     pub fn close_statement(self, name: Statement, handler: impl SimpleFlowSink + 'static) -> Self {
         self.push_flow_with_sink((CloseStatementFlow { name }, handler))
     }
 
+    /// Add a describe portal flow to the pipeline. Note that this will describe
+    /// both parameters and rows.
     pub fn describe_portal(self, name: Portal, handler: impl DescribeSink + 'static) -> Self {
         self.push_flow_with_sink((DescribePortalFlow { name }, handler))
     }
 
+    /// Add a describe statement flow to the pipeline. Note that this will describe
+    /// only the rows of the portal.
     pub fn describe_statement(self, name: Statement, handler: impl DescribeSink + 'static) -> Self {
         self.push_flow_with_sink((DescribeStatementFlow { name }, handler))
     }

--- a/rust/pgrust/src/connection/flow.rs
+++ b/rust/pgrust/src/connection/flow.rs
@@ -833,6 +833,10 @@ impl<Q: ExecuteSink> MessageHandler for ExecuteMessageHandler<Q> {
                 }
                 return MessageResult::Done;
             },
+            (EmptyQueryResponse) => {
+                // TODO: This should be exposed to the sink
+                return MessageResult::Done;
+            },
 
             (ErrorResponse as err) => {
                 if let Some(mut sink) = std::mem::take(&mut self.copy) {

--- a/rust/pgrust/src/connection/mod.rs
+++ b/rust/pgrust/src/connection/mod.rs
@@ -16,8 +16,8 @@ pub mod tokio;
 pub use conn::Client;
 use dsn::HostType;
 pub use flow::{
-    CopyDataSink, DataSink, DoneHandling, ExecuteSink, MaxRows, Param, Pipeline, PipelineBuilder,
-    Portal, QuerySink, Statement, Format,
+    CopyDataSink, DataSink, DoneHandling, ExecuteSink, Format, MaxRows, Oid, Param, Pipeline,
+    PipelineBuilder, Portal, QuerySink, Statement,
 };
 pub use raw_conn::connect_raw_ssl;
 

--- a/rust/pgrust/src/connection/mod.rs
+++ b/rust/pgrust/src/connection/mod.rs
@@ -13,7 +13,7 @@ mod raw_conn;
 mod stream;
 pub mod tokio;
 
-pub use conn::Client;
+pub use conn::{Client, PGConnError};
 use dsn::HostType;
 pub use flow::{
     CopyDataSink, DataSink, DoneHandling, ExecuteSink, Format, MaxRows, Oid, Param, Pipeline,

--- a/rust/pgrust/src/connection/mod.rs
+++ b/rust/pgrust/src/connection/mod.rs
@@ -17,8 +17,8 @@ pub mod tokio;
 pub use conn::{Client, PGConnError};
 use dsn::HostType;
 pub use flow::{
-    CopyDataSink, DataSink, DoneHandling, ExecuteSink, Format, MaxRows, Oid, Param, Pipeline,
-    PipelineBuilder, Portal, QuerySink, Statement,
+    CopyDataSink, DataSink, DoneHandling, ExecuteSink, FlowAccumulator, Format, MaxRows, Oid,
+    Param, Pipeline, PipelineBuilder, Portal, QuerySink, Statement,
 };
 pub use raw_conn::connect_raw_ssl;
 

--- a/rust/pgrust/src/connection/mod.rs
+++ b/rust/pgrust/src/connection/mod.rs
@@ -9,6 +9,7 @@ mod conn;
 pub mod dsn;
 mod flow;
 pub mod openssl;
+pub(crate) mod queue;
 mod raw_conn;
 mod stream;
 pub mod tokio;

--- a/rust/pgrust/src/connection/queue.rs
+++ b/rust/pgrust/src/connection/queue.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 
 /// A queue of futures that can be polled in order.
 ///
-/// Only only future will be active at a time. If no futures are active, the
+/// Only one future will be active at a time. If no futures are active, the
 /// waker will be triggered when the next future is submitted to the queue.
 pub struct FutureQueue<T> {
     queue: tokio::sync::mpsc::UnboundedReceiver<Pin<Box<dyn Future<Output = T>>>>,

--- a/rust/pgrust/src/connection/queue.rs
+++ b/rust/pgrust/src/connection/queue.rs
@@ -3,22 +3,46 @@ use std::ops::DerefMut;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// A queue of futures that can be polled in order. This will trigger the waker
-/// for `poll_next` when new futures are submitted to the queue.
+/// A queue of futures that can be polled in order.
+///
+/// Only only future will be active at a time. If no futures are active, the
+/// waker will be triggered when the next future is submitted to the queue.
 pub struct FutureQueue<T> {
     queue: tokio::sync::mpsc::UnboundedReceiver<Pin<Box<dyn Future<Output = T>>>>,
     sender: tokio::sync::mpsc::UnboundedSender<Pin<Box<dyn Future<Output = T>>>>,
     current: Option<Pin<Box<dyn Future<Output = T>>>>,
 }
 
+#[cfg(test)]
+#[derive(Clone)]
+pub struct FutureQueueSender<T> {
+    sender: tokio::sync::mpsc::UnboundedSender<Pin<Box<dyn Future<Output = T>>>>,
+}
+
+#[cfg(test)]
+impl<T> FutureQueueSender<T> {
+    pub fn submit(&self, future: impl Future<Output = T> + 'static) {
+        // This will never fail because the receiver still exists
+        self.sender.send(Box::pin(future)).unwrap();
+    }
+}
+
 impl<T> FutureQueue<T> {
+    #[cfg(test)]
+    pub fn sender(&self) -> FutureQueueSender<T> {
+        FutureQueueSender {
+            sender: self.sender.clone(),
+        }
+    }
+
     pub fn submit(&self, future: impl Future<Output = T> + 'static) {
         // This will never fail because we hold both ends of the channel.
         self.sender.send(Box::pin(future)).unwrap();
     }
 
+    /// Poll the current future, or no current future, poll for the next item
+    /// from the queue (and then poll that future).
     pub fn poll_next_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        // Poll until the current future is complete, or until the queue is pending.
         loop {
             if let Some(future) = self.current.as_mut() {
                 match future.as_mut().poll(cx) {
@@ -37,6 +61,8 @@ impl<T> FutureQueue<T> {
                 Poll::Pending => return Poll::Pending,
             };
 
+            // Note that we loop around to poll this future until we get a Pending
+            // result.
             self.current = Some(next);
         }
     }
@@ -60,5 +86,81 @@ impl<T> futures::Stream for FutureQueue<T> {
         // We're Unpin
         let this = self.deref_mut();
         this.poll_next_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::{
+        task::LocalSet,
+        time::{sleep, Duration},
+    };
+
+    #[tokio::test]
+    async fn test_basic_queue() {
+        LocalSet::new()
+            .run_until(async {
+                let mut queue = FutureQueue::default();
+                let sender = queue.sender();
+
+                // Spawn a task that sends some futures
+                tokio::task::spawn_local(async move {
+                    sleep(Duration::from_millis(10)).await;
+                    sender.submit(async { 1 });
+                    sleep(Duration::from_millis(10)).await;
+                    sender.submit(async { 2 });
+                    sleep(Duration::from_millis(10)).await;
+                    sender.submit(async { 3 });
+                });
+
+                // Collect results
+                let mut results = Vec::new();
+                while let Some(value) = queue.next().await {
+                    results.push(value);
+                    if results.len() == 3 {
+                        break;
+                    }
+                }
+
+                assert_eq!(results, vec![1, 2, 3]);
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_delayed_futures() {
+        LocalSet::new()
+            .run_until(async {
+                let mut queue = FutureQueue::default();
+                let sender = queue.sender();
+
+                // Spawn task with delayed futures
+                tokio::task::spawn_local(async move {
+                    sleep(Duration::from_millis(10)).await;
+                    sender.submit(async {
+                        sleep(Duration::from_millis(50)).await;
+                        1
+                    });
+                    sleep(Duration::from_millis(10)).await;
+                    sender.submit(async {
+                        sleep(Duration::from_millis(10)).await;
+                        2
+                    });
+                });
+
+                // Even though second future completes first, results should be in order of sending
+                let mut results = Vec::new();
+                while let Some(value) = queue.next().await {
+                    results.push(value);
+                    if results.len() == 2 {
+                        break;
+                    }
+                }
+
+                assert_eq!(results, vec![1, 2]);
+            })
+            .await;
     }
 }

--- a/rust/pgrust/src/connection/queue.rs
+++ b/rust/pgrust/src/connection/queue.rs
@@ -1,0 +1,64 @@
+use std::future::Future;
+use std::ops::DerefMut;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// A queue of futures that can be polled in order. This will trigger the waker
+/// for `poll_next` when new futures are submitted to the queue.
+pub struct FutureQueue<T> {
+    queue: tokio::sync::mpsc::UnboundedReceiver<Pin<Box<dyn Future<Output = T>>>>,
+    sender: tokio::sync::mpsc::UnboundedSender<Pin<Box<dyn Future<Output = T>>>>,
+    current: Option<Pin<Box<dyn Future<Output = T>>>>,
+}
+
+impl<T> FutureQueue<T> {
+    pub fn submit(&self, future: impl Future<Output = T> + 'static) {
+        // This will never fail because we hold both ends of the channel.
+        self.sender.send(Box::pin(future)).unwrap();
+    }
+
+    pub fn poll_next_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        // Poll until the current future is complete, or until the queue is pending.
+        loop {
+            if let Some(future) = self.current.as_mut() {
+                match future.as_mut().poll(cx) {
+                    Poll::Ready(output) => {
+                        self.current = None;
+                        return Poll::Ready(Some(output));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+
+            // If there is no current future, try to receive the next one from the queue.
+            let next = match self.queue.poll_recv(cx) {
+                Poll::Ready(Some(next)) => next,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            };
+
+            self.current = Some(next);
+        }
+    }
+}
+
+impl<T> Default for FutureQueue<T> {
+    fn default() -> Self {
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        Self {
+            queue: receiver,
+            sender,
+            current: None,
+        }
+    }
+}
+
+impl<T> futures::Stream for FutureQueue<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // We're Unpin
+        let this = self.deref_mut();
+        this.poll_next_unpin(cx)
+    }
+}

--- a/rust/pgrust/src/protocol/datatypes.rs
+++ b/rust/pgrust/src/protocol/datatypes.rs
@@ -452,10 +452,10 @@ impl FieldAccess<EncodedMeta> {
         const N: usize = std::mem::size_of::<i32>();
         if let Some(len) = buf.first_chunk::<N>() {
             let len = i32::from_be_bytes(*len);
-            if len < 0 {
-                Err(ParseError::InvalidData)
-            } else if len == -1 {
+            if len == -1 {
                 Ok(N)
+            } else if len < 0 {
+                Err(ParseError::InvalidData)
             } else if buf.len() < len as usize + N {
                 Err(ParseError::TooShort)
             } else {
@@ -470,10 +470,10 @@ impl FieldAccess<EncodedMeta> {
         const N: usize = std::mem::size_of::<i32>();
         if let Some((len, array)) = buf.split_first_chunk::<N>() {
             let len = i32::from_be_bytes(*len);
-            if len < 0 {
-                Err(ParseError::InvalidData)
-            } else if len == -1 {
+            if len == -1 && array.is_empty() {
                 Ok(Encoded::Null)
+            } else if len < 0 {
+                Err(ParseError::InvalidData)
             } else if array.len() < len as _ {
                 Err(ParseError::TooShort)
             } else {

--- a/rust/pgrust/src/protocol/datatypes.rs
+++ b/rust/pgrust/src/protocol/datatypes.rs
@@ -385,6 +385,15 @@ pub enum Encoded<'a> {
     Value(&'a [u8]),
 }
 
+impl<'a> Encoded<'a> {
+    pub fn to_string_lossy(&self) -> std::borrow::Cow<'_, str> {
+        match self {
+            Encoded::Null => "".into(),
+            Encoded::Value(value) => String::from_utf8_lossy(value),
+        }
+    }
+}
+
 impl<'a> AsRef<Encoded<'a>> for Encoded<'a> {
     fn as_ref(&self) -> &Encoded<'a> {
         self

--- a/rust/pgrust/src/protocol/gen.rs
+++ b/rust/pgrust/src/protocol/gen.rs
@@ -372,7 +372,7 @@ macro_rules! protocol_builder {
                     })
                 }
 
-                pub fn to_vec(&self) -> Vec<u8> {
+                pub fn to_vec(self) -> Vec<u8> {
                     self.__buf.to_vec()
                 }
 

--- a/rust/pgrust/src/protocol/gen.rs
+++ b/rust/pgrust/src/protocol/gen.rs
@@ -276,6 +276,7 @@ macro_rules! protocol_builder {
                 $( "  (value = `", stringify!($value), "`)", )?
                 "\n\n"
             )* )]
+            #[derive(Copy, Clone)]
             pub struct $name<'a> {
                 /// Our zero-copy buffer.
                 #[doc(hidden)]

--- a/rust/pgrust/src/protocol/message_group.rs
+++ b/rust/pgrust/src/protocol/message_group.rs
@@ -21,7 +21,7 @@ macro_rules! message_group {
 
         #[allow(unused)]
         impl [<$group Builder>]<'_> {
-            pub fn to_vec(&self) -> Vec<u8> {
+            pub fn to_vec(self) -> Vec<u8> {
                 match self {
                     $(
                         Self::$message(message) => message.to_vec(),

--- a/rust/pgrust/src/protocol/mod.rs
+++ b/rust/pgrust/src/protocol/mod.rs
@@ -611,6 +611,17 @@ mod tests {
     }
 
     #[test]
+    fn test_datarow() {
+        let buf = [
+            0x44, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff,
+        ];
+        assert!(DataRow::is_buffer(&buf));
+        let message = DataRow::new(&buf).unwrap();
+        assert_eq!(message.values().len(), 1);
+        assert_eq!(message.values().into_iter().next().unwrap(), Encoded::Null);
+    }
+
+    #[test]
     fn test_edgedb_sasl() {
         use crate::protocol::edgedb::*;
 

--- a/rust/pgrust/src/protocol/postgres.rs
+++ b/rust/pgrust/src/protocol/postgres.rs
@@ -282,7 +282,7 @@ struct Close: Message {
     mtype: u8 = 'C',
     /// Length of message contents in bytes, including self.
     mlen: len,
-    /// 'xS' to close a prepared statement; 'P' to close a portal.
+    /// 'S' to close a prepared statement; 'P' to close a portal.
     ctype: u8,
     /// The name of the prepared statement or portal to close.
     name: ZTString,
@@ -564,7 +564,7 @@ struct Parse: Message {
     mlen: len,
     /// The name of the destination prepared statement.
     statement: ZTString,
-    /// The query String to be parsed.
+    /// The query string to be parsed.
     query: ZTString,
     /// OIDs of the parameter data types.
     param_types: Array<i16, i32>,

--- a/rust/pgrust/tests/query_real_postgres.rs
+++ b/rust/pgrust/tests/query_real_postgres.rs
@@ -69,7 +69,13 @@ async fn test_extended_query_success() -> Result<(), Box<dyn std::error::Error>>
                 PipelineBuilder::default()
                     .parse(Statement("test"), "SELECT $1", &[Oid::Unspecified], ())
                     .describe_statement(Statement("test"), ())
-                    .bind(Portal("test"), Statement("test"), &[Param::Null], &[], ())
+                    .bind(
+                        Portal("test"),
+                        Statement("test"),
+                        &[Param::Text("1")],
+                        &[],
+                        (),
+                    )
                     .describe_portal(Portal("test"), ())
                     .execute(
                         Portal("test"),

--- a/rust/pgrust/tests/query_real_postgres.rs
+++ b/rust/pgrust/tests/query_real_postgres.rs
@@ -1,12 +1,17 @@
+use std::cell::RefCell;
 use std::future::Future;
 use std::num::NonZero;
+use std::rc::Rc;
 
 // Constants
 use gel_auth::AuthType;
 use pgrust::connection::tokio::TokioStream;
 use pgrust::connection::{
-    Client, Credentials, MaxRows, Oid, Param, PipelineBuilder, Portal, ResolvedTarget, Statement,
+    Client, Credentials, FlowAccumulator, MaxRows, Oid, Param, PipelineBuilder, Portal,
+    ResolvedTarget, Statement,
 };
+use pgrust::protocol::match_message;
+use pgrust::protocol::postgres::data::*;
 use tokio::task::LocalSet;
 
 use captive_postgres::*;
@@ -21,13 +26,13 @@ fn address(address: &ListenAddress) -> ResolvedTarget {
     }
 }
 
-async fn with_postgres<F, R>(callback: F) -> Result<(), Box<dyn std::error::Error>>
+async fn with_postgres<F, R>(callback: F) -> Result<Option<String>, Box<dyn std::error::Error>>
 where
-    F: FnOnce(Client<TokioStream, ()>) -> R,
+    F: FnOnce(Client<TokioStream, ()>, Rc<RefCell<FlowAccumulator>>) -> R,
     R: Future<Output = Result<(), Box<dyn std::error::Error>>>,
 {
     let Some(postgres_process) = setup_postgres(AuthType::Trust, Mode::Tcp)? else {
-        return Ok(());
+        return Ok(None);
     };
 
     let credentials = Credentials {
@@ -39,130 +44,311 @@ where
 
     let socket = address(&postgres_process.socket_address).connect().await?;
     let (client, task) = Client::new(credentials, socket, ());
+    let accumulator = Rc::new(RefCell::new(FlowAccumulator::default()));
 
+    let accumulator2 = accumulator.clone();
     LocalSet::new()
         .run_until(async move {
             tokio::task::spawn_local(task);
             client.ready().await?;
-            callback(client).await?;
+            callback(client, accumulator2.clone()).await?;
             Result::<(), Box<dyn std::error::Error>>::Ok(())
         })
         .await?;
 
-    Ok(())
+    let mut s = String::new();
+    accumulator.borrow().with_messages(|message| {
+        match_message!(Ok(message), Backend {
+            (ParameterDescription as params) => {
+                // OID values are not guaranteed to be stable, so we just print "..." instead.
+                s.push_str(&format!("ParameterDescription {:?}\n", params.param_types().into_iter().map(|_| "...").collect::<Vec<_>>()));
+            },
+            (RowDescription as rows) => {
+                s.push_str(&format!("RowDescription {}\n", rows.fields().into_iter().map(|f| f.name().to_string_lossy().into_owned()).collect::<Vec<_>>().join(", ")));
+            },
+            (PortalSuspended) => {
+                s.push_str("PortalSuspended\n");
+            },
+            (ErrorResponse as err) => {
+                for field in err.fields() {
+                    if field.etype() as char == 'C' {
+                        s.push_str(&format!("ErrorResponse {}\n", field.value().to_string_lossy()));
+                        return;
+                    }
+                }
+                s.push_str(&format!("ErrorResponse {:?}\n", err));
+            },
+            (NoticeResponse as notice) => {
+                for field in notice.fields() {
+                    if field.ntype() as char == 'M' {
+                        s.push_str(&format!("NoticeResponse {}\n", field.value().to_string_lossy()));
+                        return;
+                    }
+                }
+                s.push_str(&format!("NoticeResponse {:?}\n", notice));
+            },
+            (CommandComplete as cmd) => {
+                s.push_str(&format!("CommandComplete {:?}\n", cmd.tag()));
+            },
+            (DataRow as row) => {
+                s.push_str(&format!("DataRow {}\n", row.values().into_iter().map(|v| v.to_string_lossy().into_owned()).collect::<Vec<_>>().join(", ")));
+            },
+            (CopyData as copy_data) => {
+                s.push_str(&format!("CopyData {:?}\n", String::from_utf8_lossy(&copy_data.data())));
+            },
+            (CopyOutResponse as copy_out) => {
+                s.push_str(&format!("CopyOutResponse {}\n", copy_out.format()));
+            },
+            _unknown => {
+                s.push_str("Unknown\n");
+            }
+        })
+    });
+
+    Ok(Some(s))
 }
 
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_query() -> Result<(), Box<dyn std::error::Error>> {
-    with_postgres(|client| async move {
-        client.query("SELECT 1", ()).await?;
+    if let Some(s) = with_postgres(|client, accumulator| async move {
+        client.query("SELECT 1", accumulator.clone()).await?;
         Ok(())
     })
-    .await
+    .await?
+    {
+        assert_eq!(
+            s,
+            "RowDescription ?column?\nDataRow 1\nCommandComplete \"SELECT 1\"\n"
+        );
+    }
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
 async fn test_extended_query_success() -> Result<(), Box<dyn std::error::Error>> {
-    with_postgres(|client| async move {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
         client
             .pipeline_sync(
                 PipelineBuilder::default()
-                    .parse(Statement("test"), "SELECT $1", &[Oid::unspecified()], ())
-                    .describe_statement(Statement("test"), ())
+                    .parse(
+                        Statement("test"),
+                        "SELECT $1",
+                        &[Oid::unspecified()],
+                        accumulator.clone(),
+                    )
+                    .describe_statement(Statement("test"), accumulator.clone())
                     .bind(
                         Portal("test"),
                         Statement("test"),
                         &[Param::Text("1")],
                         &[],
-                        (),
+                        accumulator.clone(),
                     )
-                    .describe_portal(Portal("test"), ())
+                    .describe_portal(Portal("test"), accumulator.clone())
                     .execute(
                         Portal("test"),
                         MaxRows::Limited(NonZero::new(1).unwrap()),
-                        (),
+                        accumulator.clone(),
                     )
                     .build(),
             )
             .await?;
         Ok(())
     })
-    .await
+    .await?
+    {
+        assert_eq!(s, "ParameterDescription [\"...\"]\nRowDescription ?column?\nRowDescription ?column?\nDataRow 1\nPortalSuspended\n");
+    }
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
 async fn test_extended_query_parse_error() -> Result<(), Box<dyn std::error::Error>> {
-    with_postgres(|client| async move {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
         client
             .pipeline_sync(
                 PipelineBuilder::default()
-                    .parse(Statement("test"), ".", &[], ())
-                    .bind(Portal("test"), Statement("test"), &[], &[], ())
-                    .query("SELECT 1", ())
+                    .parse(Statement("test"), ".", &[], accumulator.clone())
+                    .bind(
+                        Portal("test"),
+                        Statement("test"),
+                        &[],
+                        &[],
+                        accumulator.clone(),
+                    )
+                    .query("SELECT 1", accumulator.clone())
                     .build(),
             )
             .await?;
         Ok(())
     })
-    .await
+    .await?
+    {
+        assert_eq!(s, "ErrorResponse 42601\n");
+    }
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
 async fn test_extended_query_portal_suspended() -> Result<(), Box<dyn std::error::Error>> {
-    with_postgres(|client| async move {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
         client
             .pipeline_sync(
                 PipelineBuilder::default()
-                    .parse(Statement("test"), "SELECT generate_series(1,3)", &[], ())
-                    .bind(Portal("test"), Statement("test"), &[], &[], ())
-                    .execute(
+                    .parse(
+                        Statement("test"),
+                        "SELECT generate_series(1,3)",
+                        &[],
+                        accumulator.clone(),
+                    )
+                    .bind(
                         Portal("test"),
-                        MaxRows::Limited(NonZero::new(2).unwrap()),
-                        (),
+                        Statement("test"),
+                        &[],
+                        &[],
+                        accumulator.clone(),
                     )
                     .execute(
                         Portal("test"),
                         MaxRows::Limited(NonZero::new(2).unwrap()),
-                        (),
+                        accumulator.clone(),
+                    )
+                    .execute(
+                        Portal("test"),
+                        MaxRows::Limited(NonZero::new(2).unwrap()),
+                        accumulator.clone(),
                     )
                     .build(),
             )
             .await?;
         Ok(())
     })
-    .await
+    .await?
+    {
+        assert_eq!(
+            s,
+            "DataRow 1\nDataRow 2\nPortalSuspended\nDataRow 3\nCommandComplete \"SELECT 1\"\n"
+        );
+    }
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
 async fn test_extended_query_copy() -> Result<(), Box<dyn std::error::Error>> {
-    with_postgres(|client| async move {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
         client
             .pipeline_sync(
                 PipelineBuilder::default()
-                    .parse(Statement("test"), "COPY (SELECT 1) TO STDOUT", &[], ())
-                    .bind(Portal("test"), Statement("test"), &[], &[], ())
-                    .execute(Portal("test"), MaxRows::Unlimited, ())
+                    .parse(
+                        Statement("test"),
+                        "COPY (SELECT 1) TO STDOUT",
+                        &[],
+                        accumulator.clone(),
+                    )
+                    .bind(
+                        Portal("test"),
+                        Statement("test"),
+                        &[],
+                        &[],
+                        accumulator.clone(),
+                    )
+                    .execute(Portal("test"), MaxRows::Unlimited, accumulator.clone())
                     .build(),
             )
             .await?;
         Ok(())
     })
-    .await
+    .await?
+    {
+        assert_eq!(
+            s,
+            "CopyOutResponse 0\nCopyData \"1\\n\"\nCommandComplete \"COPY 1\"\n"
+        );
+    }
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
 async fn test_extended_query_empty() -> Result<(), Box<dyn std::error::Error>> {
-    with_postgres(|client| async move {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
         client
             .pipeline_sync(
                 PipelineBuilder::default()
-                    .parse(Statement("test"), "", &[], ())
-                    .bind(Portal("test"), Statement("test"), &[], &[], ())
-                    .execute(Portal("test"), MaxRows::Unlimited, ())
+                    .parse(Statement("test"), "", &[], accumulator.clone())
+                    .bind(
+                        Portal("test"),
+                        Statement("test"),
+                        &[],
+                        &[],
+                        accumulator.clone(),
+                    )
+                    .execute(Portal("test"), MaxRows::Unlimited, accumulator.clone())
                     .build(),
             )
             .await?;
         Ok(())
     })
-    .await
+    .await?
+    {
+        assert_eq!(s, "");
+    }
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_query_notice() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
+        // DO block with NOTICE RAISE generates a notice
+        client
+            .query(
+                "DO $$ BEGIN RAISE NOTICE 'test notice'; END $$;",
+                accumulator.clone(),
+            )
+            .await?;
+        Ok(())
+    })
+    .await?
+    {
+        assert_eq!(s, "NoticeResponse test notice\nCommandComplete \"DO\"\n");
+    }
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_query_warning() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
+        // DO block with WARNING RAISE generates a warning
+        client
+            .query(
+                "DO $$ BEGIN RAISE WARNING 'test warning'; END $$;",
+                accumulator.clone(),
+            )
+            .await?;
+        Ok(())
+    })
+    .await?
+    {
+        assert_eq!(s, "NoticeResponse test warning\nCommandComplete \"DO\"\n");
+    }
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_double_begin_transaction() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(s) = with_postgres(|client, accumulator| async move {
+        client
+            .pipeline_sync(
+                PipelineBuilder::default()
+                    .query("BEGIN TRANSACTION", accumulator.clone())
+                    .query("BEGIN TRANSACTION", accumulator.clone())
+                    .build(),
+            )
+            .await?;
+        Ok(())
+    })
+    .await?
+    {
+        assert_eq!(s, "CommandComplete \"BEGIN\"\nNoticeResponse there is already a transaction in progress\nCommandComplete \"BEGIN\"\n");
+    }
+    Ok(())
 }

--- a/rust/pgrust/tests/query_real_postgres.rs
+++ b/rust/pgrust/tests/query_real_postgres.rs
@@ -67,7 +67,7 @@ async fn test_extended_query_success() -> Result<(), Box<dyn std::error::Error>>
         client
             .pipeline_sync(
                 PipelineBuilder::default()
-                    .parse(Statement("test"), "SELECT $1", &[Oid::Unspecified], ())
+                    .parse(Statement("test"), "SELECT $1", &[Oid::unspecified()], ())
                     .describe_statement(Statement("test"), ())
                     .bind(
                         Portal("test"),

--- a/rust/pgrust/tests/query_real_postgres.rs
+++ b/rust/pgrust/tests/query_real_postgres.rs
@@ -5,7 +5,7 @@ use std::num::NonZero;
 use gel_auth::AuthType;
 use pgrust::connection::tokio::TokioStream;
 use pgrust::connection::{
-    Client, Credentials, MaxRows, PipelineBuilder, Portal, ResolvedTarget, Statement,
+    Client, Credentials, MaxRows, Oid, Param, PipelineBuilder, Portal, ResolvedTarget, Statement,
 };
 use tokio::task::LocalSet;
 
@@ -67,8 +67,10 @@ async fn test_extended_query_success() -> Result<(), Box<dyn std::error::Error>>
         client
             .pipeline_sync(
                 PipelineBuilder::default()
-                    .parse(Statement("test"), "SELECT generate_series(1, 10)", &[], ())
-                    .bind(Portal("test"), Statement("test"), &[], &[], ())
+                    .parse(Statement("test"), "SELECT $1", &[Oid::Unspecified], ())
+                    .describe_statement(Statement("test"), ())
+                    .bind(Portal("test"), Statement("test"), &[Param::Null], &[], ())
+                    .describe_portal(Portal("test"), ())
                     .execute(
                         Portal("test"),
                         MaxRows::Limited(NonZero::new(1).unwrap()),

--- a/rust/pgrust/tests/query_real_postgres.rs
+++ b/rust/pgrust/tests/query_real_postgres.rs
@@ -1,0 +1,103 @@
+use std::future::Future;
+use std::num::NonZero;
+
+// Constants
+use gel_auth::AuthType;
+use pgrust::connection::tokio::TokioStream;
+use pgrust::connection::{
+    Client, Credentials, MaxRows, PipelineBuilder, Portal, ResolvedTarget, Statement,
+};
+use tokio::task::LocalSet;
+
+use captive_postgres::*;
+
+fn address(address: &ListenAddress) -> ResolvedTarget {
+    match address {
+        ListenAddress::Tcp(addr) => ResolvedTarget::SocketAddr(*addr),
+        #[cfg(unix)]
+        ListenAddress::Unix(path) => ResolvedTarget::UnixSocketAddr(
+            std::os::unix::net::SocketAddr::from_pathname(path).unwrap(),
+        ),
+    }
+}
+
+async fn with_postgres<F, R>(callback: F) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: FnOnce(Client<TokioStream, ()>) -> R,
+    R: Future<Output = Result<(), Box<dyn std::error::Error>>>,
+{
+    let Some(postgres_process) = setup_postgres(AuthType::Trust, Mode::Tcp)? else {
+        return Ok(());
+    };
+
+    let credentials = Credentials {
+        username: DEFAULT_USERNAME.to_string(),
+        password: DEFAULT_PASSWORD.to_string(),
+        database: DEFAULT_DATABASE.to_string(),
+        server_settings: Default::default(),
+    };
+
+    let socket = address(&postgres_process.socket_address).connect().await?;
+    let (client, task) = Client::new(credentials, socket, ());
+
+    LocalSet::new()
+        .run_until(async move {
+            tokio::task::spawn_local(task);
+            client.ready().await?;
+            callback(client).await?;
+            Result::<(), Box<dyn std::error::Error>>::Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query() -> Result<(), Box<dyn std::error::Error>> {
+    with_postgres(|client| async move {
+        client.query("SELECT 1", ()).await?;
+        Ok(())
+    })
+    .await
+}
+
+#[test_log::test(tokio::test)]
+async fn test_extended_query_success() -> Result<(), Box<dyn std::error::Error>> {
+    with_postgres(|client| async move {
+        client
+            .pipeline_sync(
+                PipelineBuilder::default()
+                    .parse(Statement("test"), "SELECT generate_series(1, 10)", &[], ())
+                    .bind(Portal("test"), Statement("test"), &[], &[], ())
+                    .execute(
+                        Portal("test"),
+                        MaxRows::Limited(NonZero::new(1).unwrap()),
+                        (),
+                    )
+                    .build(),
+            )
+            .await?;
+        Ok(())
+    })
+    .await
+}
+
+#[test_log::test(tokio::test)]
+async fn test_extended_query_parse_error() -> Result<(), Box<dyn std::error::Error>> {
+    with_postgres(|client| async move {
+        client
+            .pipeline_sync(
+                PipelineBuilder::default()
+                    .parse(Statement("test"), ".", &[], ())
+                    .bind(Portal("test"), Statement("test"), &[], &[], ())
+                    .query("SELECT 1", ())
+                    .build(),
+            )
+            .await?;
+        Ok(())
+    })
+    .await
+}
+
+// test: execute portal suspended
+// test: execute COPY

--- a/rust/pgrust/tests/query_real_postgres.rs
+++ b/rust/pgrust/tests/query_real_postgres.rs
@@ -149,3 +149,20 @@ async fn test_extended_query_copy() -> Result<(), Box<dyn std::error::Error>> {
     })
     .await
 }
+
+#[test_log::test(tokio::test)]
+async fn test_extended_query_empty() -> Result<(), Box<dyn std::error::Error>> {
+    with_postgres(|client| async move {
+        client
+            .pipeline_sync(
+                PipelineBuilder::default()
+                    .parse(Statement("test"), "", &[], ())
+                    .bind(Portal("test"), Statement("test"), &[], &[], ())
+                    .execute(Portal("test"), MaxRows::Unlimited, ())
+                    .build(),
+            )
+            .await?;
+        Ok(())
+    })
+    .await
+}

--- a/rust/pgrust/tests/real_postgres.rs
+++ b/rust/pgrust/tests/real_postgres.rs
@@ -1,7 +1,5 @@
 // Constants
 use gel_auth::AuthType;
-use openssl::ssl::{Ssl, SslContext, SslMethod};
-use pgrust::connection::dsn::{Host, HostType};
 use pgrust::connection::{connect_raw_ssl, ConnectionError, Credentials, ResolvedTarget};
 use pgrust::errors::PgServerError;
 use pgrust::handshake::ConnectionSslRequirement;

--- a/rust/pgrust/tests/real_postgres.rs
+++ b/rust/pgrust/tests/real_postgres.rs
@@ -6,371 +6,17 @@ use pgrust::connection::{connect_raw_ssl, ConnectionError, Credentials, Resolved
 use pgrust::errors::PgServerError;
 use pgrust::handshake::ConnectionSslRequirement;
 use rstest::rstest;
-use std::io::{BufRead, BufReader, Write};
-use std::net::{Ipv4Addr, SocketAddr, TcpListener};
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::sync::{Arc, RwLock};
-use std::thread;
-use std::time::{Duration, Instant};
-use tempfile::TempDir;
 
-const STARTUP_TIMEOUT_DURATION: Duration = Duration::from_secs(30);
-const PORT_RELEASE_TIMEOUT: Duration = Duration::from_secs(30);
-const LINGER_DURATION: Duration = Duration::from_secs(1);
-const HOT_LOOP_INTERVAL: Duration = Duration::from_millis(100);
-const DEFAULT_USERNAME: &str = "username";
-const DEFAULT_PASSWORD: &str = "password";
-const DEFAULT_DATABASE: &str = "postgres";
+use captive_postgres::*;
 
-/// Represents an ephemeral port that can be allocated and released for immediate re-use by another process.
-struct EphemeralPort {
-    port: u16,
-    listener: Option<TcpListener>,
-}
-
-impl EphemeralPort {
-    /// Allocates a new ephemeral port.
-    ///
-    /// Returns a Result containing the EphemeralPort if successful,
-    /// or an IO error if the allocation fails.
-    fn allocate() -> std::io::Result<Self> {
-        let socket = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)?;
-        socket.set_reuse_address(true)?;
-        socket.set_reuse_port(true)?;
-        socket.set_linger(Some(LINGER_DURATION))?;
-        socket.bind(&std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, 0)).into())?;
-        socket.listen(1)?;
-        let listener = TcpListener::from(socket);
-        let port = listener.local_addr()?.port();
-        Ok(EphemeralPort {
-            port,
-            listener: Some(listener),
-        })
+fn address(address: &ListenAddress) -> ResolvedTarget {
+    match address {
+        ListenAddress::Tcp(addr) => ResolvedTarget::SocketAddr(*addr),
+        #[cfg(unix)]
+        ListenAddress::Unix(path) => ResolvedTarget::UnixSocketAddr(
+            std::os::unix::net::SocketAddr::from_pathname(path).unwrap(),
+        ),
     }
-
-    /// Consumes the EphemeralPort and returns the allocated port number.
-    fn take(self) -> u16 {
-        // Drop the listener to free up the port
-        drop(self.listener);
-
-        // Loop until the port is free
-        let start = Instant::now();
-
-        // If we can successfully connect to the port, it's not fully closed
-        while start.elapsed() < PORT_RELEASE_TIMEOUT {
-            let res = std::net::TcpStream::connect((Ipv4Addr::LOCALHOST, self.port));
-            if res.is_err() {
-                // If connection fails, the port is released
-                break;
-            }
-            std::thread::sleep(HOT_LOOP_INTERVAL);
-        }
-
-        self.port
-    }
-}
-
-struct StdioReader {
-    output: Arc<RwLock<String>>,
-}
-
-impl StdioReader {
-    fn spawn<R: BufRead + Send + 'static>(reader: R, prefix: &'static str) -> Self {
-        let output = Arc::new(RwLock::new(String::new()));
-        let output_clone = Arc::clone(&output);
-
-        thread::spawn(move || {
-            let mut buf_reader = std::io::BufReader::new(reader);
-            loop {
-                let mut line = String::new();
-                match buf_reader.read_line(&mut line) {
-                    Ok(0) => break,
-                    Ok(_) => {
-                        if let Ok(mut output) = output_clone.write() {
-                            output.push_str(&line);
-                        }
-                        eprint!("[{}]: {}", prefix, line);
-                    }
-                    Err(e) => {
-                        let error_line = format!("Error reading {}: {}\n", prefix, e);
-                        if let Ok(mut output) = output_clone.write() {
-                            output.push_str(&error_line);
-                        }
-                        eprintln!("{}", error_line);
-                    }
-                }
-            }
-        });
-
-        StdioReader { output }
-    }
-
-    fn contains(&self, s: &str) -> bool {
-        if let Ok(output) = self.output.read() {
-            output.contains(s)
-        } else {
-            false
-        }
-    }
-}
-
-fn init_postgres(initdb: &Path, data_dir: &Path, auth: AuthType) -> std::io::Result<()> {
-    let mut pwfile = tempfile::NamedTempFile::new()?;
-    writeln!(pwfile, "{}", DEFAULT_PASSWORD)?;
-    let mut command = Command::new(initdb);
-    command
-        .arg("-D")
-        .arg(data_dir)
-        .arg("-A")
-        .arg(match auth {
-            AuthType::Deny => "reject",
-            AuthType::Trust => "trust",
-            AuthType::Plain => "password",
-            AuthType::Md5 => "md5",
-            AuthType::ScramSha256 => "scram-sha-256",
-        })
-        .arg("--pwfile")
-        .arg(pwfile.path())
-        .arg("-U")
-        .arg(DEFAULT_USERNAME);
-
-    let output = command.output()?;
-
-    let status = output.status;
-    let output_str = String::from_utf8_lossy(&output.stdout).to_string();
-    let error_str = String::from_utf8_lossy(&output.stderr).to_string();
-
-    eprintln!("initdb stdout:\n{}", output_str);
-    eprintln!("initdb stderr:\n{}", error_str);
-
-    if !status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "initdb command failed",
-        ));
-    }
-
-    Ok(())
-}
-
-fn run_postgres(
-    postgres_bin: &Path,
-    data_dir: &Path,
-    socket_path: &Path,
-    ssl: Option<(PathBuf, PathBuf)>,
-    port: u16,
-) -> std::io::Result<std::process::Child> {
-    let mut command = Command::new(postgres_bin);
-    command
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("-D")
-        .arg(data_dir)
-        .arg("-k")
-        .arg(socket_path)
-        .arg("-h")
-        .arg(Ipv4Addr::LOCALHOST.to_string())
-        .arg("-F")
-        // Useful for debugging
-        // .arg("-d")
-        // .arg("5")
-        .arg("-p")
-        .arg(port.to_string());
-
-    if let Some((cert_path, key_path)) = ssl {
-        let postgres_cert_path = data_dir.join("server.crt");
-        let postgres_key_path = data_dir.join("server.key");
-        std::fs::copy(cert_path, &postgres_cert_path)?;
-        std::fs::copy(key_path, &postgres_key_path)?;
-        // Set permissions for the certificate and key files
-        std::fs::set_permissions(&postgres_cert_path, std::fs::Permissions::from_mode(0o600))?;
-        std::fs::set_permissions(&postgres_key_path, std::fs::Permissions::from_mode(0o600))?;
-
-        // Edit pg_hba.conf to change all "host" line prefixes to "hostssl"
-        let pg_hba_path = data_dir.join("pg_hba.conf");
-        let content = std::fs::read_to_string(&pg_hba_path)?;
-        let modified_content = content
-            .lines()
-            .filter(|line| !line.starts_with("#") && !line.is_empty())
-            .map(|line| {
-                if line.trim_start().starts_with("host") {
-                    line.replacen("host", "hostssl", 1)
-                } else {
-                    line.to_string()
-                }
-            })
-            .collect::<Vec<String>>()
-            .join("\n");
-        eprintln!("pg_hba.conf:\n==========\n{modified_content}\n==========");
-        std::fs::write(&pg_hba_path, modified_content)?;
-
-        command.arg("-l");
-    }
-
-    let mut child = command.spawn()?;
-
-    let stdout_reader = BufReader::new(child.stdout.take().expect("Failed to capture stdout"));
-    let _ = StdioReader::spawn(stdout_reader, "stdout");
-    let stderr_reader = BufReader::new(child.stderr.take().expect("Failed to capture stderr"));
-    let stderr_reader = StdioReader::spawn(stderr_reader, "stderr");
-
-    let start_time = Instant::now();
-
-    let mut tcp_socket: Option<std::net::TcpStream> = None;
-    let mut unix_socket: Option<std::os::unix::net::UnixStream> = None;
-
-    let unix_socket_path = get_unix_socket_path(socket_path, port);
-    let tcp_socket_addr = std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    let mut db_ready = false;
-
-    while start_time.elapsed() < STARTUP_TIMEOUT_DURATION {
-        std::thread::sleep(HOT_LOOP_INTERVAL);
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("PostgreSQL exited with status: {}", status),
-                ))
-            }
-            Err(e) => return Err(e),
-            _ => {}
-        }
-        if !db_ready && stderr_reader.contains("database system is ready to accept connections") {
-            eprintln!("Database is ready");
-            db_ready = true;
-        } else {
-            continue;
-        }
-        if unix_socket.is_none() {
-            unix_socket = std::os::unix::net::UnixStream::connect(&unix_socket_path).ok();
-        }
-        if tcp_socket.is_none() {
-            tcp_socket = std::net::TcpStream::connect(tcp_socket_addr).ok();
-        }
-        if unix_socket.is_some() && tcp_socket.is_some() {
-            break;
-        }
-    }
-
-    if unix_socket.is_some() && tcp_socket.is_some() {
-        return Ok(child);
-    }
-
-    // Print status for TCP/unix sockets
-    if let Some(tcp) = &tcp_socket {
-        eprintln!(
-            "TCP socket at {tcp_socket_addr:?} bound successfully on {}",
-            tcp.local_addr()?
-        );
-    } else {
-        eprintln!("TCP socket at {tcp_socket_addr:?} binding failed");
-    }
-
-    if unix_socket.is_some() {
-        eprintln!("Unix socket at {unix_socket_path:?} connected successfully");
-    } else {
-        eprintln!("Unix socket at {unix_socket_path:?} connection failed");
-    }
-
-    Err(std::io::Error::new(
-        std::io::ErrorKind::TimedOut,
-        "PostgreSQL failed to start within 30 seconds",
-    ))
-}
-
-fn test_data_dir() -> std::path::PathBuf {
-    Path::new("../../../tests")
-        .canonicalize()
-        .expect("Failed to canonicalize tests directory path")
-}
-
-fn postgres_bin_dir() -> std::io::Result<std::path::PathBuf> {
-    Path::new("../../../build/postgres/install/bin").canonicalize()
-}
-
-fn get_unix_socket_path(socket_path: &Path, port: u16) -> PathBuf {
-    socket_path.join(format!(".s.PGSQL.{}", port))
-}
-
-#[derive(Debug, Clone, Copy)]
-enum Mode {
-    Tcp,
-    TcpSsl,
-    Unix,
-}
-
-fn create_ssl_client() -> Result<Ssl, Box<dyn std::error::Error>> {
-    let ssl_context = SslContext::builder(SslMethod::tls_client())?.build();
-    let mut ssl = Ssl::new(&ssl_context)?;
-    ssl.set_connect_state();
-    Ok(ssl)
-}
-struct PostgresProcess {
-    child: std::process::Child,
-    socket_address: ResolvedTarget,
-    #[allow(unused)]
-    temp_dir: TempDir,
-}
-
-impl Drop for PostgresProcess {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-    }
-}
-
-fn setup_postgres(
-    auth: AuthType,
-    mode: Mode,
-) -> Result<Option<PostgresProcess>, Box<dyn std::error::Error>> {
-    let Ok(bindir) = postgres_bin_dir() else {
-        println!("Skipping test: postgres bin dir not found");
-        return Ok(None);
-    };
-
-    let initdb = bindir.join("initdb");
-    let postgres = bindir.join("postgres");
-
-    if !initdb.exists() || !postgres.exists() {
-        println!("Skipping test: initdb or postgres not found");
-        return Ok(None);
-    }
-
-    let temp_dir = TempDir::new()?;
-    let port = EphemeralPort::allocate()?;
-    let data_dir = temp_dir.path().join("data");
-
-    init_postgres(&initdb, &data_dir, auth)?;
-    let ssl_key = match mode {
-        Mode::TcpSsl => {
-            let certs_dir = test_data_dir().join("certs");
-            let cert = certs_dir.join("server.cert.pem");
-            let key = certs_dir.join("server.key.pem");
-            Some((cert, key))
-        }
-        _ => None,
-    };
-
-    let port = port.take();
-    let child = run_postgres(&postgres, &data_dir, &data_dir, ssl_key, port)?;
-
-    let socket_address = match mode {
-        Mode::Unix => ResolvedTarget::to_addrs_sync(&Host(
-            HostType::Path(data_dir.to_string_lossy().to_string()),
-            port,
-        ))?
-        .remove(0),
-        Mode::Tcp | Mode::TcpSsl => {
-            ResolvedTarget::SocketAddr(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port))
-        }
-    };
-
-    Ok(Some(PostgresProcess {
-        child,
-        socket_address,
-        temp_dir,
-    }))
 }
 
 #[rstest]
@@ -391,7 +37,7 @@ async fn test_auth_real(
         server_settings: Default::default(),
     };
 
-    let client = postgres_process.socket_address.connect().await?;
+    let client = address(&postgres_process.socket_address).connect().await?;
 
     let ssl_requirement = match mode {
         Mode::TcpSsl => ConnectionSslRequirement::Required,
@@ -426,7 +72,7 @@ async fn test_bad_password(
         server_settings: Default::default(),
     };
 
-    let client = postgres_process.socket_address.connect().await?;
+    let client = address(&postgres_process.socket_address).connect().await?;
 
     let ssl_requirement = match mode {
         Mode::TcpSsl => ConnectionSslRequirement::Required,
@@ -458,7 +104,7 @@ async fn test_bad_username(
         server_settings: Default::default(),
     };
 
-    let client = postgres_process.socket_address.connect().await?;
+    let client = address(&postgres_process.socket_address).connect().await?;
 
     let ssl_requirement = match mode {
         Mode::TcpSsl => ConnectionSslRequirement::Required,
@@ -490,7 +136,7 @@ async fn test_bad_database(
         server_settings: Default::default(),
     };
 
-    let client = postgres_process.socket_address.connect().await?;
+    let client = address(&postgres_process.socket_address).connect().await?;
 
     let ssl_requirement = match mode {
         Mode::TcpSsl => ConnectionSslRequirement::Required,


### PR DESCRIPTION
Support proper pipelining in the Client and the required message parsing to do so. This is not sufficient to replace `pgcon.py*` yet, but a big step towards that.

The `--example connect` now supports an `--extended` flag allowing us to send extended messages instead of `Query`.

This supports:

 - Non-extended `Query` messages
 - Extended query messages in a `Sync`-delimited pipeline (including mixing `Query` messages with those)
 - `COPY OUT` style statements in both `Query` and `Execute` (not `COPY IN` at this time, however)

Unsupported:

 - `COPY IN`
 - Async notifications and `ParameterStatus` messages are handled as `warn!` and not exposed yet
