### PR TITLE
[5.x] Disable downgrade test

### DIFF
--- a/.github/workflows.src/tests-patches.tpl.yml
+++ b/.github/workflows.src/tests-patches.tpl.yml
@@ -69,11 +69,12 @@ jobs:
         # Should we run *all* the tests?
         edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py tests/test_ext_ai_rc1.py
 
-    - name: Test downgrading a database after an upgrade
-      if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}
-      env:
-        EDGEDB_VERSION: ${{ matrix.edgedb-version }}
-      run: python3 .github/scripts/patches/test-downgrade.py
+    # We screwed up on this one with caches, for 5.x.
+    # - name: Test downgrading a database after an upgrade
+    #   if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}
+    #   env:
+    #     EDGEDB_VERSION: ${{ matrix.edgedb-version }}
+    #   run: python3 .github/scripts/patches/test-downgrade.py
 
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -512,11 +512,12 @@ jobs:
         # Should we run *all* the tests?
         edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py tests/test_ext_ai_rc1.py
 
-    - name: Test downgrading a database after an upgrade
-      if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}
-      env:
-        EDGEDB_VERSION: ${{ matrix.edgedb-version }}
-      run: python3 .github/scripts/patches/test-downgrade.py
+    # We screwed up on this one with caches, for 5.x.
+    # - name: Test downgrading a database after an upgrade
+    #   if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}
+    #   env:
+    #     EDGEDB_VERSION: ${{ matrix.edgedb-version }}
+    #   run: python3 .github/scripts/patches/test-downgrade.py
 
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'


### PR DESCRIPTION
The way cache entry version numbers work basically breaks downgrade
for 5.6.