### PR TITLE
Tweak compilation cache for SQL queries

### DIFF
--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -687,7 +687,7 @@ def _build_keyword(name: str) -> Builder[pgast.Keyword]:
 
 
 def _build_param_ref(n: Node, c: Context) -> pgast.ParamRef:
-    return pgast.ParamRef(number=n["number"], span=_build_span(n, c))
+    return pgast.ParamRef(number=n.get("number", 0), span=_build_span(n, c))
 
 
 def _build_collate_clause(n: Node, c: Context) -> pgast.CollateClause:

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -34,7 +34,7 @@ from edb.server.pgproto.pgproto cimport (
     WriteBuffer,
 )
 
-from libc.stdint cimport int8_t, uint8_t, int32_t, uint64_t
+from libc.stdint cimport int8_t, uint8_t, int32_t
 
 
 cdef extern from "pg_query.h":
@@ -61,20 +61,11 @@ cdef extern from "pg_query.h":
         int clocations_count
         int highest_extern_param_id
 
-    ctypedef struct PgQueryFingerprintResult:
-        uint64_t fingerprint
-        char *fingerprint_str
-        char *stderr_buffer
-        PgQueryError *error
-
     PgQueryParseResult pg_query_parse(const char *input)
     void pg_query_free_parse_result(PgQueryParseResult result)
 
     PgQueryNormalizeResult pg_query_normalize(const char *input)
     void pg_query_free_normalize_result(PgQueryNormalizeResult result)
-
-    PgQueryFingerprintResult pg_query_fingerprint(const char* input)
-    void pg_query_free_fingerprint_result(PgQueryFingerprintResult result)
 
 
 cdef extern from "protobuf/pg_query.pb-c.h":
@@ -129,7 +120,6 @@ class PgLiteralTypeOID(enum.IntEnum):
 
 class NormalizedQuery(NamedTuple):
     text: str
-    cache_key: bytes
     highest_extern_param_id: int
     extracted_constants: list[tuple[int, LiteralTokenType, bytes]]
 
@@ -183,22 +173,8 @@ def pg_normalize(query: str) -> NormalizedQuery:
                         bytes(loc.val),
                     ))
 
-        fp_result = pg_query_fingerprint(result.normalized_query)
-        try:
-            if fp_result.error:
-                error = PSqlParseError(
-                    fp_result.error.message.decode('utf8'),
-                    fp_result.error.lineno,
-                    fp_result.error.cursorpos,
-                )
-                raise error
-        finally:
-            pg_query_free_fingerprint_result(fp_result)
-        fingerprint = fp_result.fingerprint
-
         return NormalizedQuery(
             text=normalized_query,
-            cache_key=fingerprint.to_bytes(length=8, byteorder='big'),
             highest_extern_param_id=result.highest_extern_param_id,
             extracted_constants=consts,
         )
@@ -297,7 +273,6 @@ cdef class NormalizedSource(Source):
             sorted(normalized.extracted_constants, key=lambda i: i[0]),
         )
         self._highest_extern_param_id = normalized.highest_extern_param_id
-        self._cache_key = normalized.cache_key
         self._orig_text = orig_text
 
     @classmethod
@@ -315,13 +290,8 @@ cdef class NormalizedSource(Source):
             buf.write_int32(<int32_t>param_id)
             buf.write_len_prefixed_utf8(token.value)
             buf.write_len_prefixed_bytes(val)
-        assert len(self._cache_key) == 8
-        buf.write_bytes(self._cache_key)
 
         return buf
-
-    def cache_key(self) -> bytes:
-        return self._cache_key
 
     def variables(self) -> dict[str, bytes]:
         return {f"${n}": v for n, _, v in self._extracted_constants}
@@ -388,12 +358,10 @@ cdef class NormalizedSource(Source):
             token = buf.read_len_prefixed_utf8()
             val = buf.read_len_prefixed_bytes()
             consts.append((param_id, LiteralTokenType(token), val))
-        cache_key = buf.read_bytes(8)
 
         return NormalizedSource(
             NormalizedQuery(
                 text=text,
-                cache_key=cache_key,
                 highest_extern_param_id=highest_extern_param_id,
                 extracted_constants=consts,
             ),

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -294,7 +294,7 @@ cdef class NormalizedSource(Source):
         return buf
 
     def variables(self) -> dict[str, bytes]:
-        return {f"${n}": v[1] for n, _, v in self._extracted_constants}
+        return {f"${n}": v for n, _, v in self._extracted_constants}
 
     def first_extra(self) -> Optional[int]:
         return (

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -145,6 +145,7 @@ def pg_normalize(query: str) -> NormalizedQuery:
             raise error
 
         normalized_query = result.normalized_query.decode('utf8')
+        print("normalized_query", normalized_query)
         consts = []
         for i in range(result.clocations_count):
             loc = result.clocations[i]

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -235,7 +235,9 @@ cdef class Source:
 
     def cache_key(self) -> bytes:
         if not self._cache_key:
-            self._cache_key = hashlib.blake2b(self.serialize()).digest()
+            h = hashlib.blake2b(self._tag().to_bytes())
+            h.update(bytes(self.text(), 'UTF-8'))
+            self._cache_key = h.digest()
         return self._cache_key
 
     def variables(self) -> dict[str, Any]:

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -145,7 +145,6 @@ def pg_normalize(query: str) -> NormalizedQuery:
             raise error
 
         normalized_query = result.normalized_query.decode('utf8')
-        print("normalized_query", normalized_query)
         consts = []
         for i in range(result.clocations_count):
             loc = result.clocations[i]

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2526,7 +2526,7 @@ def compile_sql_as_unit_group(
 
     qug = dbstate.QueryUnitGroup(
         cardinality=sql_units[-1].cardinality,
-        cacheable=False,
+        cacheable=True,
     )
 
     for sql_unit in sql_units:
@@ -2592,7 +2592,7 @@ def compile_sql_as_unit_group(
                 tx_state.release_savepoint(sql_unit.sp_name)
                 unit.sp_name = sql_unit.sp_name
             case None:
-                pass
+                unit.cacheable = True
             case _:
                 raise AssertionError(
                     f"unexpected SQLQueryUnit.tx_action: {sql_unit.tx_action}"

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1339,6 +1339,11 @@ cdef class DatabaseConnectionView:
             self._check_in_tx_error(query_unit_group)
 
             if query_req.input_language is enums.InputLanguage.SQL:
+                if len(query_unit_group) > 1:
+                    raise errors.UnsupportedFeatureError(
+                        "multi-statement SQL scripts are not supported yet"
+                    )
+
                 if pgcon is None:
                     raise errors.InternalServerError(
                         "a valid backend connection is required to fully "

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -953,10 +953,6 @@ cdef class EdgeConnection(frontend.FrontendConnection):
 
         compiled.tag = tag
 
-        if query_req.input_language is LANG_SQL and len(query_unit_group) > 1:
-            raise errors.UnsupportedFeatureError(
-                "multi-statement SQL scripts are not supported yet")
-
         self._query_count += 1
 
         # Clear the _last_anon_compiled so that the next Execute - if

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -415,6 +415,7 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
             change = after - before
             self.assertEqual(expected_change, change)
 
+
 class RollbackException(Exception):
     pass
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -34,6 +34,7 @@ from typing import (
     NamedTuple,
     TYPE_CHECKING,
 )
+import typing
 
 import asyncio
 import atexit
@@ -401,6 +402,18 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
             'fail_notes': getattr(self, 'fail_notes', None),
         }
 
+    @contextlib.contextmanager
+    def assertChange(
+        self, measure_fn: typing.Callable[[], int | float],
+        expected_change: int | float
+    ):
+        before = measure_fn()
+        try:
+            yield
+        finally:
+            after = measure_fn()
+            change = after - before
+            self.assertEqual(expected_change, change)
 
 class RollbackException(Exception):
     pass

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -809,7 +809,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
 
                     # constant extraction: cache hit
                     with self.assertChange(measure_compilations(sd), 0):
-                       await con.query_sql('select 2')
+                        await con.query_sql('select 2')
 
                     # TODO: this does not behave the way I though it should
                     # changing certain config options: compiler call

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Tuple, Mapping, NamedTuple
+from typing import Any, Tuple, Mapping, NamedTuple, Callable
 
 import asyncio
 import http
@@ -719,7 +719,9 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
         )
 
     async def test_server_ops_cache_recompile_01(self):
-        def measure_compilations(sd: tb._EdgeDBServer) -> int:
+        def measure_compilations(
+            sd: tb._EdgeDBServerData
+        ) -> Callable[[], float | int]:
             return lambda: tb.parse_metrics(sd.fetch_metrics()).get(
                 'edgedb_server_edgeql_query_compilations_total'
                 '{tenant="localtest",path="compiler"}'

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -803,7 +803,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
                         con_g = con.with_globals({'g': 'hello'})
                         await con_g.query_sql('select 1')
 
-                    # normalization: libpg_query::pg_query_normalize is shite
+                    # normalization: pg_query_normalize is underwhelming
                     with self.assertChange(measure_compilations(sd), 1):
                         await con.query_sql('sElEct  1')
 

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -983,6 +983,41 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         self.assertEqual(await count_table("", "B.vals"), 4)
         self.assertEqual(await count_table("ONLY", "B.vals"), 0)
 
+    async def test_sql_query_53(self):
+        await self.scon.execute(
+            '''
+            SELECT 'hello' as t;
+            SELECT 42 as i;
+            '''
+        )
+
+        # query params will make asyncpg use the extended protocol,
+        # where you can issue only one statement.
+        with self.assertRaisesRegex(
+            asyncpg.PostgresSyntaxError,
+            'cannot insert multiple commands into a prepared statement'
+        ):
+            await self.scon.execute(
+                '''
+                SELECT $1::text as t;
+                SELECT $2::int as i;
+                ''',
+                'hello',
+                42
+            )
+
+    async def test_sql_query_54(self):
+        with self.assertRaisesRegex(
+            asyncpg.UndefinedParameterError,
+            'there is no parameter \\$0'
+        ):
+            await self.scon.fetch(
+                '''
+                SELECT $0::text as t;
+                ''',
+                'hello'
+            )
+
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname
         res = await self.squery_values(
@@ -2720,3 +2755,50 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             'SELECT title FROM "Content" ORDER BY title',
             [{'title': 'Forrest Gump'}]
         )
+
+    async def test_native_sql_query_16(self):
+        with self.assertRaisesRegex(
+            edgedb.UnsupportedFeatureError,
+            'multi-statement SQL scripts are not supported yet',
+        ):
+            await self.assert_sql_query_result(
+                """
+                SELECT 'Hello' as t;
+                SELECT 42 as i;
+                """,
+                [
+                    {"t": "Hello"}
+                ],
+                apply_access_policies=False,
+            )
+
+        await self.assert_sql_query_result(
+            """SELECT $1::text as t, $2::int as i""",
+            [
+                {"t": "Hello", "i": 42}
+            ],
+            variables={
+                "0": "Hello",
+                "1": 42,
+            },
+            apply_access_policies=False,
+        )
+
+        with self.assertRaisesRegex(
+            edgedb.UnsupportedFeatureError,
+            'multi-statement SQL scripts are not supported yet',
+        ):
+            await self.assert_sql_query_result(
+                """
+                SELECT $1::text as t;
+                SELECT $2::int as i;
+                """,
+                [
+                    {"t": "Hello"}
+                ],
+                variables={
+                    "0": "Hello",
+                    "1": 42,
+                },
+                apply_access_policies=False,
+            )

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2757,21 +2757,6 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         )
 
     async def test_native_sql_query_16(self):
-        with self.assertRaisesRegex(
-            edgedb.UnsupportedFeatureError,
-            'multi-statement SQL scripts are not supported yet',
-        ):
-            await self.assert_sql_query_result(
-                """
-                SELECT 'Hello' as t;
-                SELECT 42 as i;
-                """,
-                [
-                    {"t": "Hello"}
-                ],
-                apply_access_policies=False,
-            )
-
         await self.assert_sql_query_result(
             """SELECT $1::text as t, $2::int as i""",
             [
@@ -2790,12 +2775,55 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         ):
             await self.assert_sql_query_result(
                 """
+                SELECT 'Hello' as t;
+                SELECT 42 as i;
+                """,
+                [],
+                apply_access_policies=False,
+            )
+
+        with self.assertRaisesRegex(
+            edgedb.UnsupportedFeatureError,
+            'multi-statement SQL scripts are not supported yet',
+        ):
+            await self.assert_sql_query_result(
+                """
+                SELECT 'hello'::text as t;
+                SELECT $1::int as i;
+                """,
+                [],
+                variables={
+                    "0": 42,
+                },
+                apply_access_policies=False,
+            )
+
+        with self.assertRaisesRegex(
+            edgedb.UnsupportedFeatureError,
+            'multi-statement SQL scripts are not supported yet',
+        ):
+            await self.assert_sql_query_result(
+                """
+                SELECT $1::text as t;
+                SELECT 42::int as i;
+                """,
+                [],
+                variables={
+                    "0": "Hello",
+                },
+                apply_access_policies=False,
+            )
+
+        with self.assertRaisesRegex(
+            edgedb.UnsupportedFeatureError,
+            'multi-statement SQL scripts are not supported yet',
+        ):
+            await self.assert_sql_query_result(
+                """
                 SELECT $1::text as t;
                 SELECT $2::int as i;
                 """,
-                [
-                    {"t": "Hello"}
-                ],
+                [],
                 variables={
                     "0": "Hello",
                     "1": 42,


### PR DESCRIPTION
- we had `QueryUnit.cachable` set to False for sql-over-edgedb-protocol,
- we were using the hash of the whole `NormalizedSource` as cache key, which includes extracted constants, which defeats (most) of the purpose of caching

Commits:
- **fix NormalizedSource.variables**
- **compute cache_key from pg_query_fingerprint**
- **Revert "compute cache_key from pg_query_fingerprint"**
- **pgsql Source.cache_key**
- **more tests**

