### PR TITLE
Fix NULLs in re_match/re_match_all returns

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_11_26_22_08
+EDGEDB_CATALOG_VERSION = 2024_12_03_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/lib/std/30-regexpfuncs.edgeql
+++ b/edb/lib/std/30-regexpfuncs.edgeql
@@ -27,7 +27,7 @@ std::re_match(pattern: std::str, str: std::str) -> array<std::str>
         'Find the first regular expression match in a string.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT regexp_matches("str", "pattern");
+    SELECT array_replace(regexp_matches("str", "pattern"), NULL, '');
     $$;
 };
 
@@ -39,7 +39,7 @@ std::re_match_all(pattern: std::str, str: std::str) -> SET OF array<std::str>
         'Find all regular expression matches in a string.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT regexp_matches("str", "pattern", 'g');
+    SELECT array_replace(regexp_matches("str", "pattern", 'g'), NULL, '');
     $$;
 };
 

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1309,6 +1309,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [['Ab'], ['a']],
         )
 
+        await self.assert_query_result(
+            r'''
+            select re_match(
+                r"(foo)?bar",
+                'barbar',
+            )
+            ''',
+            [[""]],
+        )
+
     async def test_edgeql_functions_re_match_02(self):
         await self.assert_query_result(
             r'''
@@ -1388,6 +1398,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 ORDER BY x;
             ''',
             [['Ab'], ['a'], ['a'], ['aB'], ['ab']],
+        )
+
+        await self.assert_query_result(
+            r'''
+            select re_match_all(
+                r"(foo)?bar",
+                'barbar',
+            )
+            ''',
+            [[""], [""]],
         )
 
     async def test_edgeql_functions_re_test_01(self):


### PR DESCRIPTION
Replace the NULLs in the result arrays with empty strings.
Fixes #8062.