### PR TITLE
Add test for previously fixed implicit limit bug

### DIFF
--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -200,6 +200,18 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         )
 
+    async def test_edgeql_for_implicit_limit_01(self):
+        await self.assert_query_result(
+            r'''
+                select sum((
+                  for i in range_unpack(range(0, 10000)) union
+                    1
+                ));
+            ''',
+            [10000],
+            implicit_limit=100,
+        )
+
     async def test_edgeql_for_filter_02(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
FOR loops used in function arguments previously had implicit limits
applied to them incorrectly, even though they weren't going to the
output.

Before #7517, some places suppressed implicit limits by setting
`inhibit_implicit_limit`. But it turns out that not all places checked
both `implicit_limit` and `inhibit_implicit_limit`, so some places
(such as FOR loops) did not have the limit correctly inhibited.

In #7517 we got rid of `inhibit_implicit_limit`, which fixed the issue
by making everything use one mechanism.

This adds a test for the bug that was fixed. We'll backport #7517 and
this.

Closes #8063.