### PR TITLE
Include edb/buildmeta.py in CI bootstrap cache

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1491,7 +1491,11 @@ def compile_intro_queries_stdlib(
 
 def _calculate_src_hash() -> bytes:
     return buildmeta.hash_dirs(
-        buildmeta.get_cache_src_dirs(), extra_files=[__file__],
+        buildmeta.get_cache_src_dirs(),
+        extra_files=[
+            __file__,
+            pathlib.Path(__file__).parent.parent / 'buildmeta.py',
+        ],
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -667,7 +667,10 @@ class ci_helper(setuptools.Command):
         elif self.type == 'bootstrap':
             bootstrap_hash = hash_dirs(
                 get_cache_src_dirs(),
-                extra_files=[pkg_dir / 'server/bootstrap.py'],
+                extra_files=[
+                    pkg_dir / 'server/bootstrap.py',
+                    pkg_dir / 'buildmeta.py',
+                ],
             )
             print(binascii.hexlify(bootstrap_hash).decode())
 


### PR DESCRIPTION
Otherwise, when the catalog changes but nothing else triggers a cache
invalidation, we will fail to rebuild and the schema names will be
wrong.

(See CI failures in #8071.)