### PR TITLE
Fix config bugs with env vars and default checking

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -32,7 +32,6 @@ from typing import (
     FrozenSet,
 )
 
-import dataclasses
 import decimal
 import functools
 
@@ -531,7 +530,7 @@ def object_type_to_spec(
         default = p.get_default(schema)
         if default is None:
             if p.get_required(schema):
-                default = dataclasses.MISSING
+                default = statypes.MISSING
         else:
             default = qlcompiler.evaluate_to_python_val(
                 default.text, schema=schema)

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -889,6 +889,8 @@ def initialize_static_cfg(
             env_value = env_value == 'true'
         elif not issubclass(setting.type, statypes.ScalarType):  # type: ignore
             env_value = setting.type(env_value)  # type: ignore
+        if setting.set_of:
+            env_value = (env_value,)
         add_config(cfg_name, env_value, environment_variable)
 
     if args.bind_addresses:

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -2165,6 +2165,7 @@ class TestStaticServerConfig(tb.TestCase):
             "EDGEDB_SERVER_CONFIG_cfg::session_idle_timeout": "1m22s",
             "EDGEDB_SERVER_CONFIG_cfg::query_execution_timeout": "403",
             "EDGEDB_SERVER_CONFIG_cfg::apply_access_policies": "false",
+            "EDGEDB_SERVER_CONFIG_cfg::multiprop": "single",
         }
         async with tb.start_edgedb_server(env=env) as sd:
             conn = await sd.connect()
@@ -2192,6 +2193,12 @@ class TestStaticServerConfig(tb.TestCase):
                     await conn.query_single("""\
                         select assert_single(cfg::Config.apply_access_policies)
                     """)
+                )
+                self.assertEqual(
+                    await conn.query("""\
+                        select assert_single(cfg::Config).multiprop
+                    """),
+                    ["single"],
                 )
             finally:
                 await conn.aclose()


### PR DESCRIPTION
With:

```
$ EDGEDB_SERVER_CONFIG_cfg::multiprop=single edb server
```

the value was wrongly parsed:

```
> select assert_single(cfg::Config).multiprop;
{'s', 'i', 'n', 'g', 'l', 'e'}
```

And there's another missing default type change that I encountered in implementing the config file, when this error wasn't raised as expected:

https://github.com/edgedb/edgedb/blob/7c74e268a21b8df6e5542f952f15af126af87bf4/edb/server/config/types.py#L215-L221

Refs #5266, #5913