### PR TITLE
Warn when a FILTER clause has `many` cardinality

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1219,6 +1219,19 @@ def _infer_stmt_cardinality(
         ir.where_card = infer_cardinality(
             ir.where, scope_tree=scope_tree, ctx=ctx,
         )
+
+        if (
+            ir.where_card.is_multi()
+            # Don't generate warnings against internally generated code
+            and ir.where.span
+        ):
+            ctx.env.warnings.append(errors.QueryError(
+                'possibly more than one element returned by an expression '
+                'in a FILTER clause',
+                hint='If this is intended, try using any()',
+                span=ir.where.span,
+            ))
+
         # Cross with AT_MOST_ONE to ensure result can be empty
         result_card = cartesian_cardinality([result_card, AT_MOST_ONE])
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -962,6 +962,17 @@ class ClusterTestCase(BaseHTTPTestCase):
         return tls_context
 
 
+def ignore_warnings(warning_message=None):
+    def w(f):
+        async def wf(self, *args, **kwargs):
+            with self.ignore_warnings(warning_message):
+                return await f(self, *args, **kwargs)
+
+        return wf
+
+    return w
+
+
 class ConnectedTestCase(ClusterTestCase):
 
     BASE_TEST_CLASS = True
@@ -981,6 +992,21 @@ class ConnectedTestCase(ClusterTestCase):
             cls.loop.run_until_complete(cls.teardown_and_disconnect())
         finally:
             super().tearDownClass()
+
+    @contextlib.contextmanager
+    def ignore_warnings(self, warning_message=None):
+        old = self.con._capture_warnings
+        warnings = []
+        self.con._capture_warnings = warnings
+        try:
+            yield
+        finally:
+            self.con._capture_warnings = old
+
+        if warning_message is not None:
+            for warning in warnings:
+                with self.assertRaisesRegex(Exception, warning_message):
+                    raise warning
 
     @classmethod
     async def setup_and_connect(cls):

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -103,22 +103,22 @@ alias EarthOrFireCard {
 
 alias AliceCard := (
     SELECT Card
-    FILTER Card.<deck[IS User].name = 'Alice'
+    FILTER 'Alice' IN Card.<deck[IS User].name
 );
 
 alias BobCard := (
     SELECT Card
-    FILTER Card.<deck[IS User].name = 'Bob'
+    FILTER 'Bob' IN Card.<deck[IS User].name
 );
 
 alias CarolCard := (
     SELECT Card
-    FILTER Card.<deck[IS User].name = 'Carol'
+    FILTER 'Carol' IN Card.<deck[IS User].name
 );
 
 alias DaveCard := (
     SELECT Card
-    FILTER Card.<deck[IS User].name = 'Dave'
+    FILTER 'Dave' IN Card.<deck[IS User].name
 );
 
 alias AliasedFriends := (

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -687,7 +687,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
         ):
             await self.con.execute("""
                 update UniqueName
-                filter .translated_labels_tgt.text = 'x'
+                filter 'x' in .translated_labels_tgt.text
                 set { translated_labels_tgt :=
                     .translated_labels_tgt { @lang := '!' }
                 }
@@ -695,7 +695,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
 
         await self.con.execute("""
             update UniqueName
-            filter .translated_labels_tgt.text = 'x'
+            filter 'x' in .translated_labels_tgt.text
             set { translated_labels_tgt :=
                 .translated_labels_tgt { @lang := @lang }
             }

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -249,7 +249,7 @@ class DumpTestCaseMixin:
                         FILTER EXISTS .annotations
                         ORDER BY .name,
                     } # keep only links with user-annotated props
-                    FILTER .properties.annotations.name = 'std::title'
+                    FILTER 'std::title' IN .properties.annotations.name
                     ORDER BY .name,
                 }
                 FILTER

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2912,7 +2912,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 property name -> str;
                 multi link tweets := (
                     WITH U := User
-                    SELECT Tweet FILTER .author = U
+                    SELECT Tweet FILTER .author IN U
                 );
             }
             type Tweet {
@@ -2948,7 +2948,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 property name -> str;
                 multi link tweets := (
                     WITH U := DETACHED User
-                    SELECT Tweet FILTER .author = U
+                    SELECT Tweet FILTER .author IN U
                 );
             }
             type Tweet {
@@ -3059,6 +3059,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_migration_computed_04(self):
         await self.migrate(r'''
             type User {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -749,7 +749,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 SELECT schema::Link {
                     pnames := .properties.name
-                } FILTER .name = {"connected", '__type__'}
+                } FILTER .name IN {"connected", '__type__'}
                   AND .source.name = 'default::Alias2'
             """,
             [
@@ -6149,8 +6149,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 }
                 FILTER
                     .name = 'default::+++'
-                    AND .annotations.name = 'std::description'
-                    AND .annotations@value = 'my plus';
+                    AND any(
+                        .annotations.name = 'std::description'
+                        AND .annotations@value = 'my plus'
+                    );
             ''',
             [{
                 'name': 'default::+++',
@@ -12022,9 +12024,10 @@ type default::Foo {
             r"""
                 WITH MODULE schema
                 SELECT Constraint {name}
-                FILTER
+                FILTER any(
                     .annotations.name = 'std::description'
-                    AND .annotations@value = 'test_delta_drop_01_constraint';
+                    AND .annotations@value = 'test_delta_drop_01_constraint'
+                )
             """,
             [
                 {
@@ -12041,9 +12044,10 @@ type default::Foo {
             r"""
                 WITH MODULE schema
                 SELECT Constraint {name}
-                FILTER
+                FILTER any(
                     .annotations.name = 'std::description'
-                    AND .annotations@value = 'test_delta_drop_01_constraint';
+                    AND .annotations@value = 'test_delta_drop_01_constraint'
+                )
             """,
             []
         )
@@ -12063,9 +12067,10 @@ type default::Foo {
             r"""
                 WITH MODULE schema
                 SELECT Property {name}
-                FILTER
+                FILTER any(
                     .annotations.name = 'std::description'
-                    AND .annotations@value = 'test_delta_drop_02_link';
+                    AND .annotations@value = 'test_delta_drop_02_link'
+                )
             """,
             [
                 {
@@ -12082,9 +12087,10 @@ type default::Foo {
             r"""
                 WITH MODULE schema
                 SELECT Property {name}
-                FILTER
+                FILTER any(
                     .annotations.name = 'std::description'
-                    AND .annotations@value = 'test_delta_drop_02_link';
+                    AND .annotations@value = 'test_delta_drop_02_link'
+                )
             """,
             []
         )

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -269,7 +269,7 @@ class TestDelete(tb.QueryTestCase):
                 SELECT DeleteTest2 {
                     name,
                     foo := 'bar'
-                } FILTER DeleteTest2.name LIKE D.name[:2] ++ '%';
+                } FILTER any(DeleteTest2.name LIKE D.name[:2] ++ '%');
             """,
             [{
                 'name': 'dt2.1',

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -250,7 +250,7 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 SELECT FireCard {name}
-                FILTER FireCard = DaveCard
+                FILTER FireCard IN DaveCard
                 ORDER BY FireCard.name;
             ''',
             [{'name': 'Dragon'}],
@@ -882,7 +882,7 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
                     name,
                     owned_by_alice,
                 }
-                FILTER .name ILIKE {'%turtle%', 'dwarf'}
+                FILTER any(.name ILIKE {'%turtle%', 'dwarf'})
                 ORDER BY .name;
             """,
             [
@@ -902,7 +902,7 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
                 SELECT EarthOrFireCard {
                     name,
                 }
-                FILTER .name = {'Imp', 'Dwarf'}
+                FILTER .name IN {'Imp', 'Dwarf'}
                 ORDER BY .name;
             """,
             [

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -8832,6 +8832,7 @@ aa \
             [5],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_expr_alias_01(self):
         await self.assert_query_result(
             r"""
@@ -8844,6 +8845,7 @@ aa \
             [2],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_expr_alias_02(self):
         await self.assert_query_result(
             r"""
@@ -9566,9 +9568,9 @@ aa \
         await self.assert_query_result(
             """
                 SELECT assert_distinct((
-                    (SELECT Issue FILTER .references[IS File].name = "File 1")
+                    (SELECT Issue FILTER "File 1" IN .references[IS File].name)
                     UNION
-                    (SELECT Issue FILTER .references[IS File].name = "File 2")
+                    (SELECT Issue FILTER "File 2" IN .references[IS File].name)
                 )) {
                     number
                 }

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -32,6 +32,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
                          'issues_filter_setup.edgeql')
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_two_scalar_conditions01(self):
         await self.assert_query_result(
             r'''
@@ -105,6 +106,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [{'name': 'Yury'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_two_scalar_conditions04(self):
         await self.assert_query_result(
             r'''
@@ -159,6 +161,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [{'name': 'Elvis'}, {'name': 'Yury'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_not_exists03(self):
         await self.assert_query_result(
             r'''
@@ -177,6 +180,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [{'name': 'Elvis'}, {'name': 'Yury'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_not_exists04(self):
         await self.assert_query_result(
             r'''
@@ -245,6 +249,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [{'name': 'Yury'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_two_scalar_exists03(self):
         await self.assert_query_result(
             r'''
@@ -321,6 +326,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [{}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_flow01(self):
         await self.assert_query_result(
             r'''
@@ -341,6 +347,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             ['1', '2', '3', '4'],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_flow02(self):
         await self.assert_query_result(
             r'''
@@ -361,6 +368,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_flow03(self):
         await self.assert_query_result(
             r'''
@@ -448,6 +456,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [4],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_aggregate04(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -212,6 +212,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
             implicit_limit=100,
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_for_filter_02(self):
         await self.assert_query_result(
             r'''
@@ -235,6 +236,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_for_filter_03(self):
         await self.assert_query_result(
             r'''
@@ -1076,6 +1078,8 @@ class TestEdgeQLFor(tb.QueryTestCase):
             [{"key": {"element": "Earth"}}, {"key": {"element": "Water"}}]
         )
 
+    # XXX: This is *wrong*, I think
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_for_fake_group_01c(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -1204,7 +1204,7 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             with module cards
             insert User {
                 name := 'Sully',
-                deck := (select Card filter .element = {'Water', 'Air'})
+                deck := (select Card filter .element IN {'Water', 'Air'})
             };
         ''')
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1350,6 +1350,7 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_insert_for_02(self):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined
@@ -1822,6 +1823,7 @@ class TestInsert(tb.QueryTestCase):
                                   INSERT Note {name := y ++ x.name}))))));
             """)
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_insert_default_01(self):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined
@@ -2315,6 +2317,7 @@ class TestInsert(tb.QueryTestCase):
             }],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_insert_linkprops_with_for_01(self):
         await self.con.execute(r"""
             FOR i IN {'1', '2', '3'} UNION (

--- a/tests/test_edgeql_internal_group.py
+++ b/tests/test_edgeql_internal_group.py
@@ -405,6 +405,7 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_igroup_returning_04(self):
         await self.assert_query_result(
             r'''
@@ -520,6 +521,7 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_igroup_returning_07(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -170,6 +170,8 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
+    # XXX: This warning is wrong
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_introspection_objtype_05(self):
         await self.assert_query_result(
             r"""
@@ -262,7 +264,7 @@ class TestIntrospection(tb.QueryTestCase):
                 FILTER
                     ObjectType.name LIKE 'default::%'
                     AND
-                    ObjectType.links.cardinality = <Cardinality>'Many'
+                    <Cardinality>'Many' IN ObjectType.links.cardinality
                 ORDER BY ObjectType.name;
             """,
             [
@@ -290,7 +292,7 @@ class TestIntrospection(tb.QueryTestCase):
                 FILTER
                     `ObjectType`.name LIKE 'default::%'
                     AND
-                    ObjectType.links.cardinality = <Cardinality>'Many'
+                    <Cardinality>'Many' IN ObjectType.links.cardinality
                 ORDER BY `ObjectType`.name;
             """,
             [
@@ -854,6 +856,7 @@ class TestIntrospection(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_introspection_volatility_02(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -1295,6 +1295,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             }]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_json_cast_object_to_json_03(self):
         # Test that object-to-json cast works in tuples as well.
         await self.assert_query_result(
@@ -1321,6 +1322,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             [True],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_json_cast_object_to_json_04(self):
         # Test that object-to-json cast works in arrays as well.
         await self.assert_query_result(

--- a/tests/test_edgeql_linkatoms.py
+++ b/tests/test_edgeql_linkatoms.py
@@ -228,7 +228,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 SELECT Item {name}
-                FILTER 'plastic' = .tag_set1
+                FILTER 'plastic' IN .tag_set1
                 ORDER BY .name;
             ''',
             [
@@ -240,7 +240,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 SELECT Item {name}
-                FILTER 'plastic' = .tag_set2
+                FILTER 'plastic' IN .tag_set2
                 ORDER BY .name;
             ''',
             [
@@ -304,6 +304,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_links_set_04(self):
         await self.assert_query_result(
             r'''
@@ -329,6 +330,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_links_set_05(self):
         await self.assert_query_result(
             r'''
@@ -356,6 +358,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_links_set_06(self):
         await self.assert_query_result(
             r'''
@@ -645,6 +648,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_links_set_15(self):
         await self.assert_query_result(
             r'''
@@ -754,6 +758,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_links_array_04(self):
         await self.assert_query_result(
             r'''
@@ -904,6 +909,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_links_array_11(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -259,6 +259,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_props_basic_03(self):
         await self.assert_query_result(
             r'''
@@ -347,7 +348,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                     cost
                 }
                 FILTER
-                    .cost = .<deck[IS User]@count
+                    .cost IN .<deck[IS User]@count
                 ORDER BY .name;
             ''',
             [
@@ -415,6 +416,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_props_cross_01(self):
         await self.assert_query_result(
             r'''
@@ -431,6 +433,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_props_cross_02(self):
         await self.assert_query_result(
             r'''
@@ -459,6 +462,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_props_cross_03(self):
         await self.assert_query_result(
             r'''
@@ -514,6 +518,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_props_implication_01(self):
         await self.assert_query_result(
             r'''
@@ -593,6 +598,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_props_implication_02(self):
         await self.assert_query_result(
             r'''
@@ -614,6 +620,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_props_implication_03(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -920,10 +920,10 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             alter type Issue {
                 create access policy foo_1 deny all using (
                     not exists (select .watchers { foo := .todo }
-                                filter .foo.name = "x"));
+                                filter "x" in .foo.name));
                 create access policy foo_2 deny all using (
                     not exists (select .watchers { todo }
-                                filter .todo.name = "x"));
+                                filter "x" in .todo.name));
              };
         ''')
 

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -1222,6 +1222,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             [9],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_filter_01(self):
         await self.assert_query_result(
             r'''
@@ -1338,6 +1339,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_filter_04(self):
         await self.assert_query_result(
             r'''
@@ -1361,6 +1363,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_filter_05(self):
         await self.assert_query_result(
             r'''
@@ -1372,6 +1375,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             {'Alice', 'Bob', 'Carol', 'Dave'}
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_filter_06(self):
         await self.assert_query_result(
             r'''
@@ -1383,6 +1387,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             {'Alice', 'Bob', 'Carol', 'Dave'}
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_filter_07(self):
         await self.assert_query_result(
             r'''
@@ -1394,6 +1399,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             {'Alice', 'Bob', 'Carol', 'Dave'}
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_filter_08(self):
         await self.assert_query_result(
             r'''
@@ -1450,6 +1456,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     # NOTE: LIMIT tests are largely identical to OFFSET tests, any
     # time there is a new OFFSET test, there should be a corresponding
     # LIMIT one.
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_offset_01(self):
         await self.assert_query_result(
             r'''
@@ -1539,6 +1546,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_limit_01(self):
         await self.assert_query_result(
             r'''
@@ -1978,6 +1986,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 ).friends@nickname = 'Firefighter';
                 """)
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_detached_05(self):
         await self.assert_query_result(
             r"""
@@ -2048,6 +2057,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_detached_06(self):
         # this is very similar to test_edgeql_scope_filter_01
         await self.assert_query_result(
@@ -2351,6 +2361,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             sort=True
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_union_02(self):
         await self.assert_query_result(
             r'''
@@ -2412,6 +2423,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_computables_02(self):
         # Test that expressions in link computables
         # of the type variant do not leak out into the query.
@@ -3890,6 +3902,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ])
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_shape_intersection_semijoin_01(self):
         await self.assert_query_result(
             r'''
@@ -3936,6 +3949,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_scope_schema_computed_01(self):
         await self.con.execute('''
             alter type User

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2534,7 +2534,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # equivalent to ?=
             SELECT Issue {number}
-            FILTER
+            FILTER any((
                 # Issue.priority.name ?= 'High'
                 # equivalent to this via an if/else translation
                 (SELECT Issue.priority.name = 'High'
@@ -2542,6 +2542,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 UNION
                 (SELECT EXISTS Issue.priority.name = TRUE
                  FILTER NOT EXISTS Issue.priority.name)
+            ))
             ORDER BY Issue.number;
             """,
             [{'number': '2'}],
@@ -2696,6 +2697,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_setops_10(self):
         await self.assert_query_result(
             r"""
@@ -3190,6 +3192,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 ORDER BY User.<owner[IS Issue].number;
             """)
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_where_01(self):
         await self.assert_query_result(
             r'''
@@ -3201,6 +3204,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '1'}, {'number': '4'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_where_02(self):
         await self.assert_query_result(
             r'''
@@ -3771,15 +3775,17 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             WITH
                 I2 := Issue
             SELECT Issue {number}
-            FILTER
+            FILTER any(
                 I2 != Issue
                 AND
                 I2.priority.name ?= Issue.priority.name
+            )
             ORDER BY Issue.number;
             ''',
             [{'number': '1'}, {'number': '4'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_equivalence_02b(self):
         await self.assert_query_result(
             r'''
@@ -4946,11 +4952,12 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 Issue {
                     number
                 }
-            FILTER
+            FILTER any(
                 Issue != Issue2
                 AND
                 # NOTE: this condition is false when one of the sides is empty
                 Issue.priority = Issue2.priority
+            )
             ORDER BY
                 Issue.number;
             """,
@@ -4969,14 +4976,16 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 Issue {
                     number
                 }
-            FILTER
+            FILTER any(
                 Issue != Issue2 AND Issue.priority ?= Issue2.priority
+            )
             ORDER BY
                 Issue.number;
             """,
             [{'number': '1'}, {'number': '4'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_subqueries_07(self):
         await self.assert_query_result(
             r"""
@@ -5000,6 +5009,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '2'}, {'number': '3'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_subqueries_08(self):
         await self.assert_query_result(
             r"""
@@ -5140,6 +5150,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'name': 'Elvis'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_subqueries_15(self):
         await self.assert_query_result(
             r"""
@@ -5188,6 +5199,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'body': 'EdgeDB needs to happen soon.'}],
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_subqueries_17(self):
         await self.assert_query_result(
             r"""
@@ -6060,6 +6072,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_select_tuple_03(self):
         await self.assert_query_result(
             r"""
@@ -6546,6 +6559,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 SELECT Issue.number FILTER .number > '1';
             ''')
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_union_target_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -373,7 +373,7 @@ class TestTree(tb.QueryTestCase):
             r"""
                 SELECT Tree {val}
                 FILTER
-                    .children.children.val = '000'
+                    any(.children.children.val = '000')
                 ORDER BY .val;
             """,
             [{'val': '0'}],
@@ -384,7 +384,7 @@ class TestTree(tb.QueryTestCase):
             r"""
                 SELECT Eert {val}
                 FILTER
-                    .children.children.val = '000'
+                    any(.children.children.val = '000')
                 ORDER BY .val;
             """,
             [{'val': '0'}],
@@ -1082,7 +1082,7 @@ class TestTree(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                select (
-                    update Tree filter .val = {"0", "00"}
+                    update Tree filter .val IN {"0", "00"}
                     set { parent := {} }
                ) {
                    val, children: {val} order by .val

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -279,6 +279,7 @@ class TestTriggers(tb.QueryTestCase):
 
     # MULTI!
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_triggers_multi_insert_01(self):
         await self.con.execute('''
             alter type InsertTest {
@@ -297,6 +298,7 @@ class TestTriggers(tb.QueryTestCase):
             {'name': "insert", 'notes': set("abcdef")},
         ])
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_triggers_multi_mixed_01(self):
         # Install triggers for everything
         await self.con.execute('''
@@ -333,6 +335,7 @@ class TestTriggers(tb.QueryTestCase):
             {'name': "update", 'notes': set(f'{x} -> {x}!' for x in "abcdef")},
         ])
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_triggers_multi_mixed_02(self):
         # Install double and triple triggers
         await self.con.execute('''
@@ -1283,6 +1286,7 @@ class TestTriggers(tb.QueryTestCase):
             tb.bag(['a!', 'b', 'b!', 'c', 'c!', 'd', 'd!', 'e', 'e!', 'f']),
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_triggers_when_02(self):
         await self.con.execute('''
             alter type InsertTest {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -550,6 +550,7 @@ class TestUpdate(tb.QueryTestCase):
                 UPDATE schema::Migration SET { script := 'foo'};
             ''')
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_update_filter_01(self):
         await self.assert_query_result(
             r"""
@@ -571,6 +572,7 @@ class TestUpdate(tb.QueryTestCase):
             ['bad test'] * 3,
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_update_filter_02(self):
         await self.assert_query_result(
             r"""
@@ -875,6 +877,7 @@ class TestUpdate(tb.QueryTestCase):
             ]
         )
 
+    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_update_multiple_08(self):
         await self.con.execute("""
             INSERT UpdateTest {
@@ -3476,7 +3479,7 @@ class TestUpdate(tb.QueryTestCase):
             UPDATE UpdateTestSubType
             FILTER .name = "update-covariant"
             SET {
-                statuses := (SELECT Status FILTER .name = {
+                statuses := (SELECT Status FILTER .name IN {
                                  "Broke a Type System",
                                  "Downloaded a Car",
                              })
@@ -3492,7 +3495,7 @@ class TestUpdate(tb.QueryTestCase):
                 UPDATE UpdateTestSubType
                 FILTER .name = "update-covariant"
                 SET {
-                    statuses := (SELECT Status FILTER .name = {
+                    statuses := (SELECT Status FILTER .name IN {
                                      "Broke a Type System",
                                      "Downloaded a Car",
                                      "Open",

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -4345,8 +4345,10 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     SELECT EXISTS (
                         SELECT ext::auth::WebAuthnAuthenticationChallenge
                         filter .challenge = <bytes>$challenge
-                        AND .factors.email = <str>$email
-                        AND .factors.user_handle = <bytes>$user_handle
+                        AND any(
+                            .factors.email = <str>$email
+                            AND .factors.user_handle = <bytes>$user_handle
+                        )
                     )
                     ''',
                     challenge=challenge_bytes,


### PR DESCRIPTION
This is kind of a footgun, and we worry it will be more of a footgun
with simple_scoping enabled.