### PR TITLE
Fix extension package installation on non `--testmode` servers

### DIFF
--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -348,7 +348,7 @@ def _get_delta_context_args(ctx: compiler.CompileContext) -> dict[str, Any]:
     """Get the args needed for delta_and_schema_from_ddl"""
     return dict(
         stdmode=ctx.bootstrap_mode,
-        testmode=compiler._get_config_val(ctx, '__internal_testmode'),
+        testmode=ctx.is_testmode(),
         store_migration_sdl=(
             compiler._get_config_val(ctx, 'store_migration_sdl')
         ) == 'AlwaysStore',
@@ -510,7 +510,7 @@ def _start_migration(
             ql.target,
             base_schema=base_schema,
             current_schema=schema,
-            testmode=(compiler._get_config_val(ctx, '__internal_testmode')),
+            testmode=ctx.is_testmode(),
         )
         query = dataclasses.replace(query, warnings=tuple(warnings))
 
@@ -551,7 +551,7 @@ def _populate_migration(
             schema,
             mstate.target_schema,
             diff,
-            testmode=compiler._get_config_val(ctx, '__internal_testmode'),
+            testmode=ctx.is_testmode(),
         ),
     )
     all_ddl = mstate.accepted_cmds + new_ddl

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -536,20 +536,12 @@ class Tenant(ha_base.ClusterProtocol):
             global_schema=global_schema,
             user_schema=s_schema.FlatSchema(),
             internal_schema_mode=True,
+            # Extension installation only works if stdmode or testmode is
+            # set.  Force testmode to be set, since we don't want to set
+            # stdmode, because we want any externally loaded extensions to
+            # be marked as *not* builtin.
+            force_testmode=True,
         )
-
-        # Extension installation only works if stdmode or testmode is
-        # set.  Force testmode to be set, since we don't want to set
-        # stdmode, because we want any externally loaded extensions to
-        # be marked as *not* builtin.
-        compilerctx.state.current_tx().update_session_config(immutables.Map({
-            '__internal_testmode': config.SettingValue(
-                name='__internal_testmode',
-                value=True,
-                source='hack',
-                scope=None,  # type: ignore
-            )
-        }))
 
         script = '\n'.join(scripts)
         _, sql_script = edbcompiler.compile_edgeql_script(compilerctx, script)


### PR DESCRIPTION
We were trying to pass `testmode` into the delta code by way of
`__internal_testmode`, but that config value doesn't exist unless the
instance was created with `--testmode`.

Pass it in more honestly.