### PR TITLE
Add structured config compilation

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -512,7 +512,8 @@ def python_cast_str(sval: str, pytype: type) -> Any:
             return False
         else:
             raise errors.InvalidValueError(
-                f"invalid input syntax for type bool: {sval!r}"
+                f"invalid input syntax for type bool: {sval!r}",
+                hint="bool value can only be one of: true, false"
             )
     else:
         return pytype(sval)

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -34,6 +34,7 @@ from typing import (
 
 import decimal
 import functools
+import uuid
 
 import immutables
 
@@ -43,6 +44,7 @@ from edb import errors
 from edb.common import typeutils
 from edb.common import parsing
 from edb.common import uuidgen
+from edb.common import value_dispatch
 from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
@@ -52,6 +54,7 @@ from edb.ir import typeutils as irtyputils
 from edb.ir import statypes as statypes
 from edb.ir import utils as irutils
 
+from edb.schema import name as sn
 from edb.schema import objects as s_obj
 from edb.schema import objtypes as s_objtypes
 from edb.schema import types as s_types
@@ -100,6 +103,40 @@ def evaluate_SelectStmt(
             'expression is not constant', span=ir_stmt.span)
 
 
+@evaluate.register(irast.InsertStmt)
+def evaluate_InsertStmt(
+    ir: irast.InsertStmt, schema: s_schema.Schema
+) -> EvaluationResult:
+    # XXX: raise for unsupported InsertStmt?
+
+    return irast.Tuple(
+        named=True,
+        typeref=ir.subject.typeref,
+        elements=[
+            irast.TupleElement(
+                name=ptr_set.expr.ptrref.shortname.name,
+                val=irast.Set(
+                    expr=evaluate(ptr_set.expr.expr, schema),
+                    typeref=ptr_set.typeref,
+                    path_id=ptr_set.path_id,
+                ),
+            )
+            for ptr_set, _ in ir.subject.shape
+            if ptr_set.expr.ptrref.shortname.name != "id"
+            and ptr_set.expr.expr is not None
+        ],
+    )
+
+
+@evaluate.register(irast.TypeIntrospection)
+def evaluate_TypeIntrospection(
+    ir: irast.TypeIntrospection, schema: s_schema.Schema
+) -> EvaluationResult:
+    return irast.StaticIntrospection(
+        named=True, ir=ir, schema=schema, elements=[], typeref=ir.typeref
+    )
+
+
 @evaluate.register(irast.TypeCast)
 def evaluate_TypeCast(
     ir_cast: irast.TypeCast, schema: s_schema.Schema
@@ -108,7 +145,7 @@ def evaluate_TypeCast(
     schema, from_type = irtyputils.ir_typeref_to_type(
         schema, ir_cast.from_type)
     schema, to_type = irtyputils.ir_typeref_to_type(
-        schema, ir_cast.from_type)
+        schema, ir_cast.to_type)
 
     if (
         not isinstance(from_type, s_scalars.ScalarType)
@@ -141,9 +178,37 @@ def evaluate_Pointer(
 ) -> EvaluationResult:
     if ptr.expr is not None:
         return evaluate(ptr.expr, schema=schema)
+
+    elif (
+        ptr.direction == s_pointers.PointerDirection.Outbound
+        and isinstance(ptr.ptrref, irast.PointerRef)
+        and ptr.ptrref.out_cardinality.is_single()
+        and ptr.ptrref.out_target.is_scalar
+    ):
+        return evaluate_pointer_ref(
+            evaluate(ptr.source.expr, schema=schema), ptr.ptrref
+        )
+
     else:
         raise UnsupportedExpressionError(
             'expression is not constant', span=ptr.span)
+
+
+@functools.singledispatch
+def evaluate_pointer_ref(
+    evaluated_source: EvaluationResult, ptrref: irast.PointerRef
+) -> EvaluationResult:
+    raise UnsupportedExpressionError(
+        f'unsupported PointerRef on source {evaluated_source}',
+        span=ptrref.span,
+    )
+
+
+@evaluate_pointer_ref.register(irast.StaticIntrospection)
+def evaluate_pointer_ref_StaticIntrospection(
+    source: irast.StaticIntrospection, ptrref: irast.PointerRef
+) -> EvaluationResult:
+    return source.get_field_value(ptrref.shortname)
 
 
 @evaluate.register(irast.ConstExpr)
@@ -644,4 +709,72 @@ def evaluate_config_reset(
         scope=ir.scope,
         setting_name=ir.name,
         value=None,
+    )
+
+
+@evaluate_to_config_op.register(irast.ConfigInsert)
+def evaluate_config_insert(
+    ir: irast.ConfigInsert, schema: s_schema.Schema
+) -> config.Operation:
+    return config.Operation(
+        opcode=config.OpCode.CONFIG_ADD,
+        scope=ir.scope,
+        setting_name=ir.name,
+        value=evaluate_to_python_val(
+            irast.InsertStmt(subject=ir.expr), schema=schema
+        ),
+    )
+
+
+@value_dispatch.value_dispatch
+def coerce_py_const(
+    type_id: uuid.UUID, val: Any
+) -> irast.ConstExpr | irast.TypeCast:
+    raise UnsupportedExpressionError(f"unimplemented coerce type: {type_id}")
+
+
+@coerce_py_const.register(s_obj.get_known_type_id("std::str"))
+def evaluate_std_str(
+    type_id: uuid.UUID, val: Any
+) -> irast.ConstExpr | irast.TypeCast:
+    return irast.StringConstant(
+        typeref=irast.TypeRef(
+            id=type_id, name_hint=sn.name_from_string("std::str")
+        ),
+        value=str(val),
+    )
+
+
+@coerce_py_const.register(s_obj.get_known_type_id("std::bool"))
+def evaluate_std_bool(
+    type_id: uuid.UUID, val: Any
+) -> irast.ConstExpr | irast.TypeCast:
+    return irast.BooleanConstant(
+        typeref=irast.TypeRef(
+            id=type_id, name_hint=sn.name_from_string("std::bool")
+        ),
+        value=str(bool(val)).lower(),
+    )
+
+
+@coerce_py_const.register(s_obj.get_known_type_id("std::uuid"))
+def evaluate_std_uuid(
+    type_id: uuid.UUID, val: Any
+) -> irast.ConstExpr | irast.TypeCast:
+    str_type_id = s_obj.get_known_type_id("std::str")
+    str_typeref = irast.TypeRef(
+        id=str_type_id, name_hint=sn.name_from_string("std::str")
+    )
+    return irast.TypeCast(
+        from_type=str_typeref,
+        to_type=irast.TypeRef(
+            id=type_id, name_hint=sn.name_from_string("std::uuid")
+        ),
+        expr=irast.Set(
+            expr=irast.StringConstant(typeref=str_typeref, value=str(val)),
+            typeref=str_typeref,
+            path_id=irast.PathId.from_typeref(str_typeref),
+        ),
+        sql_cast=True,
+        sql_expr=False,
     )

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1295,6 +1295,7 @@ class Compiler:
         self,
         objects: Mapping[str, config_compiler.ConfigObject],
         source: str | None = None,
+        allow_nested: bool = False,
     ) -> dict[str, immutables.Map[str, config.SettingValue]]:
         # XXX: only config in the stdlib is supported currently, so the only
         # key allowed in objects is "cfg::Config". API for future compatibility
@@ -1309,6 +1310,7 @@ class Compiler:
             spec=self.state.config_spec,
             schema=self.state.std_schema,
             source=source,
+            allow_nested=allow_nested,
         )
 
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -96,6 +96,7 @@ from edb.pgsql import patches as pg_patches
 from edb.pgsql import types as pg_types
 from edb.pgsql import delta as pg_delta
 
+from . import config as config_compiler
 from . import dbstate
 from . import enums
 from . import explain
@@ -1288,6 +1289,26 @@ class Compiler:
             pickle.loads(schema_a),
             pickle.loads(schema_b),
             pickle.loads(global_schema),
+        )
+
+    def compile_structured_config(
+        self,
+        objects: Mapping[str, config_compiler.ConfigObject],
+        source: str | None = None,
+    ) -> dict[str, immutables.Map[str, config.SettingValue]]:
+        # XXX: only config in the stdlib is supported currently, so the only
+        # key allowed in objects is "cfg::Config". API for future compatibility
+        if list(objects) != ["cfg::Config"]:
+            difference = set(objects) - {"cfg::Config"}
+            raise NotImplementedError(
+                f"unsupported config: {', '.join(difference)}"
+            )
+
+        return config_compiler.compile_structured_config(
+            objects,
+            spec=self.state.config_spec,
+            schema=self.state.std_schema,
+            source=source,
         )
 
 

--- a/edb/server/compiler/config.py
+++ b/edb/server/compiler/config.py
@@ -1,0 +1,292 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2024-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import Iterable, Mapping, Sequence, Type
+
+import dataclasses
+import datetime
+import functools
+
+import immutables
+
+from edb import errors
+from edb.common import typeutils
+from edb.edgeql import ast as qlast
+from edb.edgeql import parser as qlparser
+from edb.edgeql import qltypes
+from edb.edgeql import compiler as qlcompiler
+from edb.ir import ast as irast
+from edb.ir import staeval as ireval
+from edb.server import config
+from edb.schema import name as sn
+from edb.schema import objtypes as s_objtypes
+from edb.schema import pointers as s_pointers
+from edb.schema import schema as s_schema
+from edb.schema import types as s_types
+from edb.schema import utils as s_utils
+
+ConfigInput = (
+    str
+    | int
+    | float
+    | bool
+    | datetime.datetime
+    | datetime.date
+    | datetime.time
+    | Sequence["ConfigInput"]
+    | Mapping[str, "ConfigInput"]
+    | None
+)
+ConfigObject = Mapping[str, ConfigInput]
+
+
+@dataclasses.dataclass
+class Context:
+    schema: s_schema.Schema
+    obj_type: s_objtypes.ObjectType
+    qual_name: str
+    options: qlcompiler.CompilerOptions
+
+    def get_ptr(self, name: str) -> s_pointers.Pointer:
+        un = sn.UnqualName(name)
+        schema = self.schema
+        ty = self.obj_type
+        ancestors = ty.get_ancestors(schema).objects(schema)
+        for t in (ty,) + ancestors:
+            if (rv := t.maybe_get_ptr(schema, un)) is not None:
+                return rv
+        raise errors.ConfigurationError(
+            f"{ty.get_shortname(schema)!s} does not have field: {name!r}"
+        )
+
+    def get_full_name(self, ptr: s_pointers.Pointer) -> str:
+        return f"{self.qual_name}::{ptr.get_local_name(self.schema)}"
+
+    def is_multi(self, ptr: s_pointers.Pointer) -> bool:
+        return ptr.get_cardinality(self.schema).is_multi()
+
+    def get_type(
+        self, ptr: s_pointers.Pointer, *, type: Type[s_types.TypeT]
+    ) -> s_types.TypeT:
+        rv = ptr.get_target(self.schema)
+        if not isinstance(rv, type):
+            raise TypeError(f"{ptr!r}.target is not {type:r}")
+        return rv
+
+    def get_ref(self, ptr: s_pointers.Pointer) -> qlast.ObjectRef:
+        ty = self.get_type(ptr, type=s_types.QualifiedType)
+        ty_name = ty.get_shortname(self.schema)
+        return qlast.ObjectRef(name=ty_name.name, module=ty_name.module)
+
+    def cast(
+        self, expr: qlast.Expr, *, ptr: s_pointers.Pointer
+    ) -> qlast.TypeCast:
+        return qlast.TypeCast(
+            expr=expr,
+            type=qlast.TypeName(maintype=self.get_ref(ptr)),
+        )
+
+
+@functools.singledispatch
+def compile_input_to_ast(
+    value: ConfigInput, *, ptr: s_pointers.Pointer, ctx: Context
+) -> qlast.Expr:
+    raise errors.ConfigurationError(
+        f"unsupported input type {type(value)!r} for {ctx.get_full_name(ptr)}"
+    )
+
+
+@compile_input_to_ast.register
+def compile_input_str(
+    value: str, *, ptr: s_pointers.Pointer, ctx: Context
+) -> qlast.Expr:
+    if value.startswith("{{") and value.endswith("}}"):
+        return qlparser.parse_fragment(value[2:-2])
+    ty = ctx.get_type(ptr, type=s_types.QualifiedType)
+    if ty.is_enum(ctx.schema):
+        ty_name = ty.get_shortname(ctx.schema)
+        return qlast.Path(
+            steps=[
+                qlast.ObjectRef(name=ty_name.name, module=ty_name.module),
+                qlast.Ptr(name=value),
+            ]
+        )
+    else:
+        return ctx.cast(qlast.Constant.string(value), ptr=ptr)
+
+
+@compile_input_to_ast.register
+def compile_input_scalar(
+    value: int | float | bool, *, ptr: s_pointers.Pointer, ctx: Context
+) -> qlast.Expr:
+    return ctx.cast(s_utils.const_ast_from_python(value), ptr=ptr)
+
+
+@compile_input_to_ast.register(dict)
+@compile_input_to_ast.register(immutables.Map)
+def compile_input_mapping(
+    value: Mapping[str, ConfigInput],
+    *,
+    ptr: s_pointers.Pointer,
+    ctx: Context,
+) -> qlast.Expr:
+    if "_tname" in value:
+        tname = value["_tname"]
+        if not isinstance(tname, str):
+            raise errors.ConfigurationError(
+                f"type of `_tname` must be str, got: {type(tname)!r}"
+            )
+        obj_type = ctx.schema.get(tname, type=s_objtypes.ObjectType)
+    else:
+        try:
+            obj_type = ctx.get_type(ptr, type=s_objtypes.ObjectType)
+        except TypeError:
+            raise errors.ConfigurationError(
+                f"unsupported input type {type(value)!r} "
+                f"for {ctx.get_full_name(ptr)}"
+            )
+    obj_name = obj_type.get_shortname(ctx.schema)
+    new_ctx = Context(
+        schema=ctx.schema,
+        obj_type=obj_type,
+        qual_name=ctx.get_full_name(ptr),
+        options=ctx.options,
+    )
+    return qlast.InsertQuery(
+        subject=qlast.ObjectRef(name=obj_name.name, module=obj_name.module),
+        shape=list(compile_dict_to_shape(value, ctx=new_ctx).values()),
+    )
+
+
+def compile_dict_to_shape(
+    values: Mapping[str, ConfigInput], *, ctx: Context
+) -> dict[str, qlast.ShapeElement]:
+    rv = {}
+    for name, value in values.items():
+        if name == "_tname":
+            continue
+        ptr = ctx.get_ptr(name)
+        expr: qlast.Expr
+        if ctx.is_multi(ptr) and not isinstance(value, str):
+            if not typeutils.is_container(value) or isinstance(value, Mapping):
+                raise errors.ConfigurationError(
+                    f"{ctx.get_full_name(ptr)} must be a sequence, "
+                    f"got type: {type(value)!r}"
+                )
+            assert isinstance(value, Iterable)
+            expr = qlast.Set(
+                elements=[
+                    compile_input_to_ast(v, ptr=ptr, ctx=ctx) for v in value
+                ]
+            )
+        else:
+            expr = compile_input_to_ast(value, ptr=ptr, ctx=ctx)
+        rv[name] = qlast.ShapeElement(
+            expr=qlast.Path(steps=[qlast.Ptr(name=name)]), compexpr=expr
+        )
+    return rv
+
+
+def compile_ast_to_operation(
+    obj_name: str,
+    field_name: str,
+    expr: qlast.Expr,
+    *,
+    schema: s_schema.Schema,
+    options: qlcompiler.CompilerOptions,
+) -> config.Operation:
+    cmd: qlast.ConfigOp
+    if isinstance(expr, qlast.InsertQuery):
+        cmd = qlast.ConfigInsert(
+            name=expr.subject,
+            scope=qltypes.ConfigScope.INSTANCE,
+            shape=expr.shape,
+        )
+    else:
+        field_name_ref = qlast.ObjectRef(name=field_name)
+        if obj_name != "cfg::Config":
+            field_name_ref.module = obj_name
+        cmd = qlast.ConfigSet(
+            name=field_name_ref,
+            scope=qltypes.ConfigScope.INSTANCE,
+            expr=expr,
+        )
+    ir = qlcompiler.compile_ast_to_ir(cmd, schema=schema, options=options)
+    if (
+        isinstance(ir, irast.ConfigSet)
+        or isinstance(ir, irast.Statement)
+        and isinstance((ir := ir.expr.expr), irast.ConfigInsert)
+    ):
+        return ireval.evaluate_to_config_op(ir, schema=schema)
+
+    raise errors.InternalServerError(f"unrecognized IR: {type(ir)!r}")
+
+
+def compile_structured_config(
+    objects: Mapping[str, ConfigObject],
+    *,
+    spec: config.Spec,
+    schema: s_schema.Schema,
+    source: str | None = None,
+) -> dict[str, immutables.Map[str, config.SettingValue]]:
+    options = qlcompiler.CompilerOptions(
+        modaliases={None: "cfg"},
+        in_server_config_op=True,
+    )
+    rv = {}
+    for obj_name, input_values in objects.items():
+        storage: immutables.Map[str, config.SettingValue] = immutables.Map()
+        ctx = Context(
+            schema=schema,
+            obj_type=schema.get(obj_name, type=s_objtypes.ObjectType),
+            qual_name=obj_name,
+            options=options,
+        )
+        shape = compile_dict_to_shape(input_values, ctx=ctx)
+        for field_name, shape_el in shape.items():
+            if isinstance(shape_el.compexpr, qlast.Set):
+                elements = shape_el.compexpr.elements
+                if not elements:
+                    continue
+
+                if isinstance(elements[0], qlast.InsertQuery):
+                    for ast in shape_el.compexpr.elements:
+                        op = compile_ast_to_operation(
+                            obj_name,
+                            field_name,
+                            ast,
+                            schema=schema,
+                            options=options,
+                        )
+                        storage = op.apply(spec, storage, source=source)
+                    continue
+
+            assert shape_el.compexpr is not None
+            op = compile_ast_to_operation(
+                obj_name,
+                field_name,
+                shape_el.compexpr,
+                schema=schema,
+                options=options,
+            )
+            storage = op.apply(spec, storage, source=source)
+
+        rv[obj_name] = storage
+
+    return rv

--- a/edb/server/compiler/config.py
+++ b/edb/server/compiler/config.py
@@ -210,9 +210,14 @@ def compile_ast_to_operation(
     *,
     schema: s_schema.Schema,
     options: qlcompiler.CompilerOptions,
+    allow_nested: bool = True,
 ) -> config.Operation:
     cmd: qlast.ConfigOp
     if isinstance(expr, qlast.InsertQuery):
+        if not allow_nested:
+            raise errors.ConfigurationError(
+                "nested config object is not allowed"
+            )
         cmd = qlast.ConfigInsert(
             name=expr.subject,
             scope=qltypes.ConfigScope.INSTANCE,
@@ -244,6 +249,7 @@ def compile_structured_config(
     spec: config.Spec,
     schema: s_schema.Schema,
     source: str | None = None,
+    allow_nested: bool = True,
 ) -> dict[str, immutables.Map[str, config.SettingValue]]:
     options = qlcompiler.CompilerOptions(
         modaliases={None: "cfg"},
@@ -273,6 +279,7 @@ def compile_structured_config(
                             ast,
                             schema=schema,
                             options=options,
+                            allow_nested=allow_nested,
                         )
                         storage = op.apply(spec, storage, source=source)
                     continue
@@ -284,6 +291,7 @@ def compile_structured_config(
                 shape_el.compexpr,
                 schema=schema,
                 options=options,
+                allow_nested=allow_nested,
             )
             storage = op.apply(spec, storage, source=source)
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -607,6 +607,10 @@ class AbstractPool:
         return await self._simple_call(
             'validate_schema_equivalence', *args, **kwargs)
 
+    async def compile_structured_config(self, *args, **kwargs):
+        return await self._simple_call(
+            'compile_structured_config', *args, **kwargs)
+
     def get_debug_info(self):
         return {}
 

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -29,7 +29,7 @@ from .ops import OpCode, Operation, SettingValue
 from .ops import (
     spec_to_json, to_json_obj, to_json, from_json, set_value, to_edgeql
 )
-from .ops import value_from_json, value_to_json_value, coerce_single_value
+from .ops import value_from_json, value_to_json_value
 from .spec import (
     Spec, FlatSpec, ChainedSpec, Setting,
     load_spec_from_schema, load_ext_spec_from_schema,
@@ -49,7 +49,6 @@ __all__ = (
     'load_spec_from_schema', 'load_ext_spec_from_schema',
     'load_ext_settings_from_schema',
     'get_compilation_config',
-    'coerce_single_value',
     'QueryCacheMode',
 )
 

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -193,9 +193,15 @@ class CompositeConfigType(ConfigType, statypes.CompositeType):
 
                 value = cls.from_pyvalue(value, tspec=actual_f_type, spec=spec)
 
-            elif _issubclass(f_type, statypes.Duration):
+            elif (
+                _issubclass(f_type, statypes.Duration)
+                and isinstance(value, str)
+            ):
                 value = statypes.Duration.from_iso8601(value)
-            elif _issubclass(f_type, statypes.ConfigMemory):
+            elif (
+                _issubclass(f_type, statypes.ConfigMemory)
+                and isinstance(value, str | int)
+            ):
                 value = statypes.ConfigMemory(value)
 
             elif not isinstance(f_type, type) or not isinstance(value, f_type):

--- a/edb/server/inplace_upgrade.py
+++ b/edb/server/inplace_upgrade.py
@@ -516,7 +516,7 @@ async def _upgrade_all(
 ) -> None:
     cluster = ctx.cluster
 
-    state = await bootstrap._bootstrap(ctx)
+    state = (await bootstrap._bootstrap(ctx)).state
     databases = await _get_databases(ctx)
 
     assert ctx.args.inplace_upgrade_prepare

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -255,12 +255,8 @@ async def _run_server(
         )
         magic_smtp = os.getenv('EDGEDB_MAGIC_SMTP_CONFIG')
         if magic_smtp:
-            magic_smtp = json.loads(magic_smtp)
-            if isinstance(magic_smtp, dict):
-                # for backward compatibility
-                magic_smtp = [magic_smtp]
             await tenant.load_sidechannel_configs(
-                magic_smtp, compiler=compiler
+                json.loads(magic_smtp), compiler=compiler
             )
         # This coroutine runs as long as the server,
         # and compiler(.state) is *heavy*, so make sure we don't

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -36,6 +36,7 @@ early_setup()
 
 import asyncio
 import contextlib
+import enum
 import logging
 import os
 import os.path
@@ -171,7 +172,7 @@ def _internal_state_dir(
 
 async def _init_cluster(
     cluster, args: srvargs.ServerConfig
-) -> tuple[bool, edbcompiler.CompilerState]:
+) -> tuple[bool, edbcompiler.Compiler]:
     from edb.server import bootstrap
 
     new_instance = await bootstrap.ensure_bootstrapped(cluster, args)
@@ -501,6 +502,7 @@ async def run_server(
                 user_schema=stdlib.reflschema,
                 reflection=reflection,
             )
+            del reflection
             compiler_state = edbcompiler.CompilerState(
                 std_schema=compiler.state.std_schema,
                 refl_schema=compiler.state.refl_schema,
@@ -512,6 +514,7 @@ async def run_server(
                 local_intro_query=local_intro_sql,
                 global_intro_query=global_intro_sql,
             )
+            del local_intro_sql, global_intro_sql
             (
                 sys_queries,
                 report_configs_typedesc_1_0,
@@ -525,8 +528,9 @@ async def run_server(
             sys_config, backend_settings = initialize_static_cfg(
                 args,
                 is_remote_cluster=True,
-                config_spec=compiler_state.config_spec,
+                compiler=compiler,
             )
+            del compiler
             with _internal_state_dir(runstate_dir, args) as (
                 int_runstate_dir,
                 args,
@@ -604,12 +608,12 @@ async def run_server(
             await inplace_upgrade.inplace_upgrade(cluster, args)
             return
 
-        new_instance, compiler_state = await _init_cluster(cluster, args)
+        new_instance, compiler = await _init_cluster(cluster, args)
 
         _, backend_settings = initialize_static_cfg(
             args,
             is_remote_cluster=not is_local_cluster,
-            config_spec=compiler_state.config_spec,
+            compiler=compiler,
         )
 
         if is_local_cluster and (new_instance or backend_settings):
@@ -662,7 +666,7 @@ async def run_server(
                     int_runstate_dir,
                     do_setproctitle=do_setproctitle,
                     new_instance=new_instance,
-                    compiler_state=compiler_state,
+                    compiler_state=compiler.state,
                 )
 
     except server.StartupError as e:
@@ -797,108 +801,84 @@ def main_dev():
     main()
 
 
-def _coerce_cfg_value(setting: config.Setting, value):
-    if setting.set_of:
-        return frozenset(
-            config.coerce_single_value(setting, v) for v in value
-        )
-    else:
-        return config.coerce_single_value(setting, value)
+class Source(enum.StrEnum):
+    command_line_argument = "A"
+    environment_variable = "E"
+
+
+sources = {
+    Source.command_line_argument: "command line argument",
+    Source.environment_variable: "environment variable",
+}
 
 
 def initialize_static_cfg(
     args: srvargs.ServerConfig,
     is_remote_cluster: bool,
-    config_spec: config.Spec
+    compiler: edbcompiler.Compiler,
 ) -> Tuple[Mapping[str, config.SettingValue], Dict[str, str]]:
     result = {}
     init_con_script_data = []
     backend_settings = {}
-    command_line_argument = "A"
-    environment_variable = "E"
-    sources = {
-        command_line_argument: "command line argument",
-        environment_variable: "environment variable",
+    config_spec = compiler.state.config_spec
+
+    def add_config_values(obj: dict[str, Any], source: Source):
+        settings = compiler.compile_structured_config(
+            {"cfg::Config": obj}, source=sources[source]
+        )["cfg::Config"]
+        for name, value in settings.items():
+            setting = config_spec[name]
+
+            if is_remote_cluster:
+                if setting.backend_setting and setting.requires_restart:
+                    if source == Source.command_line_argument:
+                        where = "on command line"
+                    else:
+                        where = "as an environment variable"
+                    raise server.StartupError(
+                        f"Can't set config {name!r} {where} when using "
+                        f"a remote Postgres cluster"
+                    )
+            init_con_script_data.append({
+                "name": name,
+                "value": config.value_to_json_value(setting, value.value),
+                "type": source,
+            })
+            result[name] = value
+            if setting.backend_setting:
+                backend_val = value.value
+                if isinstance(backend_val, statypes.ScalarType):
+                    backend_val = backend_val.to_backend_str()
+                backend_settings[setting.backend_setting] = str(backend_val)
+
+    values: dict[str, Any] = {}
+    translate_env = {
+        "EDGEDB_SERVER_BIND_ADDRESS": "listen_addresses",
+        "EDGEDB_SERVER_PORT": "listen_port",
+        "GEL_SERVER_BIND_ADDRESS": "listen_addresses",
+        "GEL_SERVER_PORT": "listen_port",
     }
-
-    def add_config(name, value, type_):
-        setting = config_spec[name]
-        if is_remote_cluster:
-            if setting.backend_setting and setting.requires_restart:
-                if type_ == command_line_argument:
-                    where = "on command line"
-                else:
-                    where = "as an environment variable"
-                raise server.StartupError(
-                    f"Can't set config {name!r} {where} when using "
-                    f"a remote Postgres cluster"
-                )
-        value = _coerce_cfg_value(setting, value)
-        init_con_script_data.append({
-            "name": name,
-            "value": config.value_to_json_value(setting, value),
-            "type": type_,
-        })
-        result[name] = config.SettingValue(
-            name=name,
-            value=value,
-            source=sources[type_],
-            scope=config.ConfigScope.INSTANCE,
-        )
-        if setting.backend_setting:
-            if isinstance(value, statypes.ScalarType):
-                value = value.to_backend_str()
-            backend_settings[setting.backend_setting] = str(value)
-
-    def iter_environ():
-        translate_env = {
-            "EDGEDB_SERVER_BIND_ADDRESS": "listen_addresses",
-            "EDGEDB_SERVER_PORT": "listen_port",
-            "GEL_SERVER_BIND_ADDRESS": "listen_addresses",
-            "GEL_SERVER_PORT": "listen_port",
-        }
-        for name, value in os.environ.items():
-            if cfg := translate_env.get(name):
-                yield name, value, cfg
+    for name, value in os.environ.items():
+        if cfg := translate_env.get(name):
+            values[cfg] = value
+        else:
+            cfg = name.removeprefix("EDGEDB_SERVER_CONFIG_cfg::")
+            if cfg != name:
+                values[cfg] = value
             else:
-                cfg = name.removeprefix("EDGEDB_SERVER_CONFIG_cfg::")
+                cfg = name.removeprefix("GEL_SERVER_CONFIG_cfg::")
                 if cfg != name:
-                    yield name, value, cfg
-                else:
-                    cfg = name.removeprefix("GEL_SERVER_CONFIG_cfg::")
-                    if cfg != name:
-                        yield name, value, cfg
+                    values[cfg] = value
+    if values:
+        add_config_values(values, Source.environment_variable)
 
-    env_value: Any
-    setting: config.Setting
-    for env_name, env_value, cfg_name in iter_environ():
-        try:
-            setting = config_spec[cfg_name]
-        except KeyError:
-            continue
-        choices = setting.enum_values
-        if setting.type is bool:
-            choices = ['true', 'false']
-            env_value = env_value.lower()
-        if choices is not None and env_value not in choices:
-            raise server.StartupError(
-                f"Environment variable {env_name!r} can only be one of: " +
-                ", ".join(choices)
-            )
-        if setting.type is bool:
-            env_value = env_value == 'true'
-        elif not issubclass(setting.type, statypes.ScalarType):  # type: ignore
-            env_value = setting.type(env_value)  # type: ignore
-        if setting.set_of:
-            env_value = (env_value,)
-        add_config(cfg_name, env_value, environment_variable)
-
+    values = {}
     if args.bind_addresses:
-        add_config(
-            "listen_addresses", args.bind_addresses, command_line_argument
-        )
+        values["listen_addresses"] = args.bind_addresses
     if args.port:
-        add_config("listen_port", args.port, command_line_argument)
+        values["listen_port"] = args.port
+    if values:
+        add_config_values(values, Source.command_line_argument)
 
     if init_con_script_data:
         from . import pgcon

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1274,7 +1274,6 @@ class Server(BaseServer):
         await self._load_instance_data()
         await self._maybe_patch()
         await self._tenant.init()
-        self._load_sidechannel_configs()
         await super().init()
 
     def get_default_tenant(self) -> edbtenant.Tenant:
@@ -1282,20 +1281,6 @@ class Server(BaseServer):
 
     def iter_tenants(self) -> Iterator[edbtenant.Tenant]:
         yield self._tenant
-
-    def _load_sidechannel_configs(self) -> None:
-        # TODO(fantix): Do something like this for multitenant
-        magic_smtp = os.getenv('EDGEDB_MAGIC_SMTP_CONFIG')
-        if magic_smtp:
-            email_type = self._config_settings['email_providers'].type
-            assert not isinstance(email_type, type)
-            configs = [
-                config.CompositeConfigType.from_json_value(
-                    entry, tspec=email_type, spec=self._config_settings
-                )
-                for entry in json.loads(magic_smtp)
-            ]
-            self._tenant.set_sidechannel_configs(configs)
 
     async def _get_patch_log(
         self, conn: pgcon.PGConnection, idx: int

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+from typing import Any
+
 import asyncio
 import contextlib
 import os
@@ -31,6 +33,8 @@ import uuid
 import immutables
 
 from edb import edgeql
+from edb import errors
+from edb.ir import statypes
 from edb.testbase import lang as tb
 from edb.testbase import server as tbs
 from edb.pgsql import params as pg_params
@@ -60,10 +64,13 @@ class TestServerCompiler(tb.BaseSchemaLoadTest):
         super().setUpClass()
         cls._std_schema = tb._load_std_schema()
 
+    def setUp(self):
+        super().setUp()
+        self.compiler = tb.new_compiler()
+
     def test_server_compiler_compile_edgeql_script(self):
-        compiler = tb.new_compiler()
         context = edbcompiler.new_compiler_context(
-            compiler_state=compiler.state,
+            compiler_state=self.compiler.state,
             user_schema=self.schema,
             modaliases={None: 'default'},
         )
@@ -76,6 +83,142 @@ class TestServerCompiler(tb.BaseSchemaLoadTest):
                 }
             ''',
         )
+
+    def _test_compile_structured_config(
+        self,
+        values: dict[str, Any],
+        *,
+        source: str = "config file",
+        **expected: Any,
+    ) -> dict[str, config.SettingValue]:
+        result = self.compiler.compile_structured_config(
+            {"cfg::Config": values}, source=source
+        )
+        rv = dict(result["cfg::Config"])
+        for name, setting in rv.items():
+            self.assertEqual(setting.name, name)
+            self.assertEqual(setting.scope, config.ConfigScope.INSTANCE)
+            self.assertEqual(setting.source, source)
+        self.assertDictEqual({k: v.value for k, v in rv.items()}, expected)
+        return rv
+
+    def composite_obj(self, _type_name, **values):
+        return config.CompositeConfigType(
+            self.compiler.state.config_spec.get_type_by_name(_type_name),
+            **values,
+        )
+
+    def test_server_compiler_compile_structured_config_01(self):
+        self._test_compile_structured_config(
+            {
+                "singleprop": "value",
+                "memprop": 512,
+                "durprop": "16 seconds",
+                "enumprop": "One",
+                "multiprop": ["v1", "v2", "v3"],
+                "listen_port": 5,
+                "sysobj": [
+                    {
+                        "name": "1",
+                        "obj": {
+                            "_tname": "cfg::Subclass1",
+                            "name": "aa",
+                            "sub1": "bb",
+                        },
+                    },
+                    {
+                        "name": "2",
+                        "_tname": "cfg::TestInstanceConfigStatTypes",
+                        "memprop": 128,
+                    },
+                ],
+            },
+            singleprop="value",
+            memprop=statypes.ConfigMemory(512),
+            durprop=statypes.Duration.from_microseconds(16 * 1_000_000),
+            enumprop="One",
+            multiprop=frozenset(["v1", "v2", "v3"]),
+            listen_port=5,
+            sysobj=frozenset([
+                self.composite_obj(
+                    "cfg::TestInstanceConfig",
+                    name="1",
+                    obj=self.composite_obj(
+                        "cfg::Subclass1", name="aa", sub1="bb",
+                    ),
+                ),
+                self.composite_obj(
+                    "cfg::TestInstanceConfigStatTypes",
+                    name="2",
+                    memprop=statypes.ConfigMemory(128),
+                ),
+            ])
+        )
+
+    def test_server_compiler_compile_structured_config_02(self):
+        self._test_compile_structured_config(
+            {"singleprop": 42}, singleprop="42"
+        )
+
+    def test_server_compiler_compile_structured_config_03(self):
+        self._test_compile_structured_config(
+            {"singleprop": "{{'4' ++ <str>2}}"}, singleprop="42"
+        )
+
+    def test_server_compiler_compile_structured_config_04(self):
+        with self.assertRaisesRegex(
+            errors.ConfigurationError, "unsupported input type"
+        ):
+            self._test_compile_structured_config({"singleprop": ["1", "2"]})
+
+    def test_server_compiler_compile_structured_config_05(self):
+        with self.assertRaisesRegex(
+            errors.ConfigurationError, "unsupported input type"
+        ):
+            self._test_compile_structured_config({"singleprop": {"a": "x"}})
+
+    def test_server_compiler_compile_structured_config_06(self):
+        self._test_compile_structured_config(
+            {"listen_port": "8080"}, listen_port=8080
+        )
+
+    def test_server_compiler_compile_structured_config_07(self):
+        self._test_compile_structured_config(
+            {"multiprop": "single"}, multiprop=frozenset(["single"])
+        )
+
+    def test_server_compiler_compile_structured_config_08(self):
+        with self.assertRaisesRegex(
+            errors.ConfigurationError, "must be a sequence"
+        ):
+            self._test_compile_structured_config({"multiprop": {"a": 1}})
+
+    def test_server_compiler_compile_structured_config_09(self):
+        with self.assertRaisesRegex(
+            errors.InvalidReferenceError, "has no member"
+        ):
+            self._test_compile_structured_config({"enumprop": "non_exist"})
+
+    def test_server_compiler_compile_structured_config_10(self):
+        with self.assertRaisesRegex(
+            errors.ConfigurationError, "does not have field"
+        ):
+            self._test_compile_structured_config({"non_exist": 123})
+
+    def test_server_compiler_compile_structured_config_11(self):
+        with self.assertRaisesRegex(
+            errors.ConfigurationError, "type of `_tname` must be str"
+        ):
+            self._test_compile_structured_config({"sysobj": [{"_tname": 123}]})
+
+    def test_server_compiler_compile_structured_config_12(self):
+        with self.assertRaisesRegex(
+            errors.ConstraintViolationError,
+            "name violates exclusivity constraint",
+        ):
+            self._test_compile_structured_config(
+                {"sysobj": [{"name": "same"}, {"name": "same"}]}
+            )
 
 
 class ServerProtocol(amsg.ServerProtocol):

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -92,7 +92,7 @@ class TestServerCompiler(tb.BaseSchemaLoadTest):
         **expected: Any,
     ) -> dict[str, config.SettingValue]:
         result = self.compiler.compile_structured_config(
-            {"cfg::Config": values}, source=source
+            {"cfg::Config": values}, source=source, allow_nested=True
         )
         rv = dict(result["cfg::Config"])
         for name, setting in rv.items():

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -2248,7 +2248,7 @@ class TestStaticServerConfig(tb.TestCase):
         }
         with self.assertRaisesRegex(
             cluster.ClusterError,
-            "can only be one of: AlwaysAllow, NeverAllow"
+            "'cfg::AllowBareDDL' enum has no member called 'illegal_input'"
         ):
             async with tb.start_edgedb_server(env=env):
                 pass


### PR DESCRIPTION
Structured config values are Python objects from environment variables or (future) TOML config files. The compilation re- assembles the objects into `ConfigOp` ASTs and uses the static evaluation mechanism to generate verified config values.

This supersedes #8059 as a less-hacky way to validate config values.

As a side-effect, such config sources now support specifying EdgeQL values directly in a double-braces, for example:

    env GEL_SERVER_CONFIG_cfg::session_idle_timeout="{{<duration>'8 minutes 32 seconds'}}"

Or even simpler:

    env GEL_SERVER_CONFIG_cfg::session_idle_timeout='8 minutes 32 seconds'

(because the typecast is included by default)

This allows setting nested config objects with INSERT statements too:

    env GEL_SERVER_CONFIG_cfg::email_providers="{{ { (insert cfg::SMTPProviderConfig { name := 'gmail'}) } }}"

Sample:

```python
ops = compile_structured_config(
    {
        "cfg::Config": {
            "singleprop": "value",
            "memprop": 512,
            "durprop": "16s",
            "enumprop": "One",
            "multiprop": ["v1", "v2", "v3"],
            "listen_port": 5,
            "email_providers": [
                {"_tname": "cfg::SMTPProviderConfig", "name": "gmail"},
                {"_tname": "cfg::SMTPProviderConfig", "name": "outlook"},
            ],
            "sysobj": [
                {
                    "name": "1",
                    "obj": {
                        "_tname": "cfg::Subclass1",
                        "name": "aa",
                        "sub1": "aa",
                    },
                },
                {
                    "name": "2",
                    "_tname": "cfg::TestInstanceConfigStatTypes",
                    "memprop": 128,
                },
            ],
        },
    },
    spec=spec,
    schema=stdlib.stdschema,
    source="config file",
)
print(ops)
```

```
{
 'cfg::Config': immutables.Map({
  'durprop': SettingValue(name='durprop', value=<statypes.Duration 'PT16S'>, source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False),
  'email_providers': SettingValue(name='email_providers', value=frozenset({cfg::SMTPProviderConfig(timeout_per_email=<statypes.Duration 'PT1M'>, security='STARTTLSOrPlainText', sender=None, name='outlook', port=None, timeout_per_attempt=<statypes.Duration 'PT15S'>, validate_certs=True, password=None, host=None, username=None), cfg::SMTPProviderConfig(timeout_per_email=<statypes.Duration 'PT1M'>, security='STARTTLSOrPlainText', sender=None, name='gmail', port=None, timeout_per_attempt=<statypes.Duration 'PT15S'>, validate_certs=True, password=None, host=None, username=None)}), source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False),
  'enumprop': SettingValue(name='enumprop', value='One', source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False),
  'listen_port': SettingValue(name='listen_port', value=5, source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False),
  'memprop': SettingValue(name='memprop', value=<statypes.ConfigMemory '512B'>, source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False),
  'multiprop': SettingValue(name='multiprop', value=frozenset({'v3'}), source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False),
  'singleprop': SettingValue(name='singleprop', value='value', source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False),
  'sysobj': SettingValue(name='sysobj', value=frozenset({cfg::TestInstanceConfigStatTypes(obj=None, name='2', durprop=None, memprop=<statypes.ConfigMemory '128B'>), cfg::TestInstanceConfig(obj=cfg::Subclass1(sub1='aa', name='aa'), name='1')}), source='config file', scope=<ConfigScope.INSTANCE: 'INSTANCE'>, secret=False)
 })
}
```