### PR TITLE
Fix cache collision in normalized SQL queries

### DIFF
--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -236,11 +236,14 @@ cdef class Source:
     def original_text(self) -> str:
         return self._text
 
+    def _compute_cache_key(self) -> bytes:
+        h = hashlib.blake2b(self._tag().to_bytes())
+        h.update(bytes(self.text(), 'UTF-8'))
+        return h.digest()
+
     def cache_key(self) -> bytes:
         if not self._cache_key:
-            h = hashlib.blake2b(self._tag().to_bytes())
-            h.update(bytes(self.text(), 'UTF-8'))
-            self._cache_key = h.digest()
+            self._cache_key = self._compute_cache_key()
         return self._cache_key
 
     def variables(self) -> dict[str, Any]:
@@ -345,6 +348,13 @@ cdef class NormalizedSource(Source):
                 raise AssertionError(f"unexpected literal token type: {token}")
 
         return oids
+
+    def _compute_cache_key(self) -> bytes:
+        h = hashlib.blake2b(super()._compute_cache_key())
+        # Include the types of the extracted constants
+        for oid in self.extra_type_oids():
+            h.update(oid.to_bytes(length=2))
+        return h.digest()
 
     @classmethod
     def from_string(cls, text: str) -> NormalizedSource:

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -222,7 +222,7 @@ cdef class Source:
         return self._serialized
 
     @classmethod
-    def from_serialized(cls, serialized: bytes) -> NormalizedSource:
+    def from_serialized(cls, serialized: bytes) -> Source:
         cdef ReadBuffer buf
 
         buf = _init_deserializer(serialized, cls._tag(), cls.__name__)

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -474,12 +474,10 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             else:
                 return edgeql.NormalizedSource.from_string(text)
         elif lang is LANG_SQL:
-            # FIXME: Temporarily disabled, due to #8099
-            return pgparser.Source.from_string(text)
-            # if debug.flags.edgeql_disable_normalization:
-            #     return pgparser.Source.from_string(text)
-            # else:
-            #     return pgparser.NormalizedSource.from_string(text)
+            if debug.flags.edgeql_disable_normalization:
+                return pgparser.Source.from_string(text)
+            else:
+                return pgparser.NormalizedSource.from_string(text)
         else:
             raise errors.UnsupportedFeatureError(
                 f"unsupported input language: {lang}")

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -474,10 +474,12 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             else:
                 return edgeql.NormalizedSource.from_string(text)
         elif lang is LANG_SQL:
-            if debug.flags.edgeql_disable_normalization:
-                return pgparser.Source.from_string(text)
-            else:
-                return pgparser.NormalizedSource.from_string(text)
+            # FIXME: Temporarily disabled, due to #8099
+            return pgparser.Source.from_string(text)
+            # if debug.flags.edgeql_disable_normalization:
+            #     return pgparser.Source.from_string(text)
+            # else:
+            #     return pgparser.NormalizedSource.from_string(text)
         else:
             raise errors.UnsupportedFeatureError(
                 f"unsupported input language: {lang}")

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2543,6 +2543,21 @@ class TestSQLQuery(tb.SQLQueryTestCase):
 select title, 'aaaaaaaaaaaaaaaaa', ('goo'::text::integer) from "Content";'''
             )
 
+    async def test_sql_native_query_21(self):
+        await self.assert_sql_query_result(
+            """
+                SELECT 1
+            """,
+            [{'col~1': 1}],
+        )
+
+        await self.assert_sql_query_result(
+            """
+                SELECT 'test'
+            """,
+            [{'col~1': 'test'}],
+        )
+
 
 class TestSQLQueryNonTransactional(tb.SQLQueryTestCase):
 


### PR DESCRIPTION
Currently the cache key is just based on the normalized text, which
means that queries that differ only in the types of extracted
constants will collide.

Include the type oids in the key.

Fixes #8099.