### PR TITLE
Fix function cache of box2d

### DIFF
--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -446,6 +446,8 @@ def pg_type_from_ir_typeref(
                 return ('uuid',)
         elif irtyputils.is_abstract(material):
             return ('anynonarray',)
+        elif material.custom_sql_serialization and serialized:
+            return tuple(material.custom_sql_serialization.split('.'))
         elif material.sql_type:
             return tuple(material.sql_type.split('.'))
         else:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1880,7 +1880,8 @@ def _build_cache_function(
                 returns_record = True
             else:
                 return_type = pg_types.pg_type_from_ir_typeref(
-                    ir.expr.typeref.base_type or ir.expr.typeref
+                    ir.expr.typeref.base_type or ir.expr.typeref,
+                    serialized=True,
                 )
                 if ir.stype.is_tuple(ir.schema):
                     returns_record = return_type == ('record',)


### PR DESCRIPTION
box2d uses `custom_sql_serialization` to return `geometry` from the
query, since `box2d` lacks an output function. (Why??)

Make sure we use `custom_sql_serialization` when computing the type to
use for the cached functions as well.

Fixes #8007. I'll try to add a test to edgedb-postgis later.