### PR TITLE
Drop asyncpg.transaction import from testbase/server

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -63,7 +63,6 @@ import time
 import unittest
 import urllib
 
-import asyncpg.transaction
 import edgedb
 
 from edb.edgeql import quote as qlquote


### PR DESCRIPTION
It shouldn't be needed and it breaks nightlies

(Maybe we should run nightly tests with all the test dependencies.)