### PR TITLE
Disable normalization for SQL over EdgeDB proto

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -474,10 +474,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             else:
                 return edgeql.NormalizedSource.from_string(text)
         elif lang is LANG_SQL:
-            if debug.flags.edgeql_disable_normalization:
-                return pgparser.Source.from_string(text)
-            else:
-                return pgparser.NormalizedSource.from_string(text)
+            # TODO: enable normalization
+            return pgparser.Source.from_string(text)
         else:
             raise errors.UnsupportedFeatureError(
                 f"unsupported input language: {lang}")


### PR DESCRIPTION
Currently, there are queries that work without normalization
but fail with normalization, so I'll disable it for now.
