### PR TITLE
Try to fix test suite on old pg versions

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_12_04_00_00
+EDGEDB_CATALOG_VERSION = 2024_12_11_00_00
 EDGEDB_MAJOR_VERSION = 6
 
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -290,6 +290,17 @@ sys::_sleep(duration: std::duration) -> std::bool
 
 
 CREATE FUNCTION
+sys::_postgres_version() -> std::str
+{
+    CREATE ANNOTATION std::description :=
+        'Get the postgres version string';
+    USING SQL $$
+    SELECT version()
+    $$;
+};
+
+
+CREATE FUNCTION
 sys::_advisory_lock(key: std::int64) -> std::bool
 {
     CREATE ANNOTATION std::description :=

--- a/tests/test_edgeql_extensions.py
+++ b/tests/test_edgeql_extensions.py
@@ -17,10 +17,12 @@
 #
 
 import json
+import re
 import textwrap
 
 import edgedb
 
+import edb.buildmeta
 from edb.testbase import server as tb
 
 
@@ -112,6 +114,13 @@ class TestDDLExtensions(tb.DDLTestCase):
         ''')
 
     async def test_edgeql_extensions_01(self):
+        pg_ver = edb.buildmeta.parse_pg_version(await self.con.query_single('''
+            select sys::_postgres_version();
+        '''))
+        # Skip if postgres is old, since it doesn't have ltree 1.3
+        if pg_ver.major < 17:
+            self.skipTest('Postgres version too old')
+
         # Make an extension that wraps a tiny bit of the ltree package.
         await self.con.execute('''
         create extension package ltree VERSION '1.0' {

--- a/tests/test_edgeql_extensions.py
+++ b/tests/test_edgeql_extensions.py
@@ -17,7 +17,6 @@
 #
 
 import json
-import re
 import textwrap
 
 import edgedb

--- a/tests/test_edgeql_sys.py
+++ b/tests/test_edgeql_sys.py
@@ -38,6 +38,11 @@ class TestQueryStatsMixin:
         raise NotImplementedError
 
     async def _test_sys_query_stats(self):
+        if self.backend_dsn:
+            self.skipTest(
+                "can't run query stats test when extension isn't present"
+            )
+
         stats_query = f'''
             with stats := (
                 select


### PR DESCRIPTION
- Skip extension test that uses ltree on older postgres versions
 - Skip restore part of pg_dump tests