### PR TITLE
Disable NOCREATE* tests

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -31,8 +31,10 @@ jobs:
         postgres-version: [ 16 ]
         single-mode:
          - ''
-         - 'NOCREATEDB NOCREATEROLE'
-         - 'CREATEDB NOCREATEROLE'
+         # These are very broken. Disabling them for now until we
+         # decide whether to fix them or give up.
+         # - 'NOCREATEDB NOCREATEROLE'
+         # - 'CREATEDB NOCREATEROLE'
         multi-tenant-mode: [ '' ]
         include:
           - postgres-version: 14

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -341,8 +341,10 @@ jobs:
         postgres-version: [ 16 ]
         single-mode:
          - ''
-         - 'NOCREATEDB NOCREATEROLE'
-         - 'CREATEDB NOCREATEROLE'
+         # These are very broken. Disabling them for now until we
+         # decide whether to fix them or give up.
+         # - 'NOCREATEDB NOCREATEROLE'
+         # - 'CREATEDB NOCREATEROLE'
         multi-tenant-mode: [ '' ]
         include:
           - postgres-version: 14


### PR DESCRIPTION
The test suites for these modes have been broken for years and
contribute to us ignoring this suite. Disable them.

I think we should consider ripping the whole mode out.