### PR TITLE
Fix static evaluation TypeCast str->bool bug

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -422,10 +422,14 @@ def cast_const_to_python(ir: irast.TypeCast, schema: s_schema.Schema) -> Any:
     sval = evaluate_to_python_val(ir.expr, schema=schema)
     if sval is None:
         return None
-    elif isinstance(sval, tuple):
-        return tuple(pytype(elem) for elem in sval)
+    if pytype is bool and isinstance(sval, str):
+        conv = lambda v: v.lower() == 'true'
     else:
-        return pytype(sval)
+        conv = pytype
+    if isinstance(sval, tuple):
+        return tuple(conv(elem) for elem in sval)
+    else:
+        return conv(sval)
 
 
 def schema_type_to_python_type(

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -132,6 +132,11 @@ ALTER TYPE cfg::AbstractConfig {
         SET default := cfg::TestEnum.One;
     };
 
+    CREATE PROPERTY boolprop -> std::bool {
+        CREATE ANNOTATION cfg::internal := 'true';
+        SET default := true;
+    };
+
     CREATE PROPERTY __pg_max_connections -> std::int64 {
         CREATE ANNOTATION cfg::internal := 'true';
         CREATE ANNOTATION cfg::backend_setting := '"max_connections"';


### PR DESCRIPTION
`<bool>'false'` was evaluated as `True`, e.g. in a configure command:

```
_localdev:main> configure session set allow_user_specified_id := <bool>'false';
OK: CONFIGURE SESSION
_localdev:main> select cfg::Config.allow_user_specified_id;
{true}
```

This is not 100% reproducible because the statically-evaluated value is only kept in the server in-memory state (while the value in the `_edgecon_state` table is correctly SQL-evaluated `edgedb.str_to_bool('false')`) and only effective when the backend connection had a state cache-miss. See the added test for more details.