### PR TITLE
Fix pg-versions CI

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres-version: [ 16 ]
+        postgres-version: [ 17 ]
         single-mode:
          - ''
          # These are very broken. Disabling them for now until we
@@ -45,8 +45,11 @@ jobs:
             multi-tenant-mode: ''
           - postgres-version: 16
             single-mode: ''
+            multi-tenant-mode: ''
+          - postgres-version: 17
+            single-mode: ''
             multi-tenant-mode: 'remote-compiler'
-          - postgres-version: 16
+          - postgres-version: 17
             single-mode: ''
             multi-tenant-mode: 'multi-tenant'
     services:

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -338,7 +338,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres-version: [ 16 ]
+        postgres-version: [ 17 ]
         single-mode:
          - ''
          # These are very broken. Disabling them for now until we
@@ -355,8 +355,11 @@ jobs:
             multi-tenant-mode: ''
           - postgres-version: 16
             single-mode: ''
+            multi-tenant-mode: ''
+          - postgres-version: 17
+            single-mode: ''
             multi-tenant-mode: 'remote-compiler'
-          - postgres-version: 16
+          - postgres-version: 17
             single-mode: ''
             multi-tenant-mode: 'multi-tenant'
     services:
@@ -410,7 +413,7 @@ jobs:
       with:
         path: ~/.cache/uv
         key: uv-cache-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
-    
+
     - name: Download requirements.txt
       uses: actions/cache@v4
       with:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -898,6 +898,7 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
         async with tb.start_edgedb_server(
             default_auth_method=args.ServerAuthMethod.Trust,
             net_worker_mode='disabled',
+            force_new=True,
         ) as sd:
             con = await sd.connect()
             con2 = None


### PR DESCRIPTION
* Bump to include PG 17
* Run shared compiler and multitenant CI with PG 17
* Fix default test password issue
* Fix 2 tests for multitenant CI

[Sample run](https://github.com/edgedb/edgedb/actions/runs/12322185327)