### PR TITLE
Fix issue in SQL-over-native where normalization is required

### DIFF
--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -169,8 +169,9 @@ cdef WriteBuffer recode_bind_args(
             for _ in range(recv_args):
                 out_buf.write_int16(0x0001)
             # and extracted SQL constants are in text
-            for _ in range(compiled.extra_counts[0]):
-                out_buf.write_int16(0x0000)
+            if compiled.extra_counts:
+                for _ in range(compiled.extra_counts[0]):
+                    out_buf.write_int16(0x0000)
             # and injected globals are binary again
             for _ in range(num_globals):
                 out_buf.write_int16(0x0001)


### PR DESCRIPTION
We index into extra_counts unconditionally, which is wrong.
This will fix #8104.

I'm splitting it out because if we merge #8104, we will want to revert
it eventually, but we want this fix to survive.