### PR TITLE
 Disable normalization for SQL over EdgeDB proto

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -474,10 +474,8 @@ cdef class EdgeConnection(frontend.FrontendConnection):
             else:
                 return edgeql.NormalizedSource.from_string(text)
         elif lang is LANG_SQL:
-            if debug.flags.edgeql_disable_normalization:
-                return pgparser.Source.from_string(text)
-            else:
-                return pgparser.NormalizedSource.from_string(text)
+            # TODO: enable normalization
+            return pgparser.Source.from_string(text)
         else:
             raise errors.UnsupportedFeatureError(
                 f"unsupported input language: {lang}")

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -817,9 +817,10 @@ class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
                     with self.assertChange(measure_compilations(sd), 1):
                         await con.query_sql('sElEct  1')
 
-                    # constant extraction: cache hit
-                    with self.assertChange(measure_compilations(sd), 0):
-                        await con.query_sql('select 2')
+                    # Disabled since we have extraction turned off temporarily.
+                    # # constant extraction: cache hit
+                    # with self.assertChange(measure_compilations(sd), 0):
+                    #     await con.query_sql('select 2')
 
                     # TODO: this does not behave the way I though it should
                     # changing certain config options: compiler call

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2110,12 +2110,14 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         )
 
     async def test_sql_native_query_00(self):
+        # to_json fails when we *don't* have constant extraction turned on.
+        # It also fails normally in postgres.
         await self.assert_sql_query_result(
             """
                 SELECT
                     1 AS a,
                     'two' AS b,
-                    to_json('three') AS c,
+                    -- to_json('three') AS c,
                     timestamp '2000-12-16 12:21:13' AS d,
                     timestamp with time zone '2000-12-16 12:21:13' AS e,
                     date '0001-01-01 AD' AS f,
@@ -2127,7 +2129,7 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                 {
                     "a": 1,
                     "b": "two",
-                    "c": '"three"',
+                    # "c": '"three"',
                     "d": "2000-12-16T12:21:13",
                     "e": "2000-12-16T12:21:13+00:00",
                     "f": "0001-01-01",


### PR DESCRIPTION
Currently, there are queries that work without normalization
but fail with normalization, so I'll disable it for now.

---

This was originally https://github.com/edgedb/edgedb/pull/8104, but that PR got destroyed due to github "features".