### PR TITLE
Fix psql "\d table" by making casting to regclass more resilient

### DIFF
--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -448,14 +448,17 @@ def cast_to_regclass(param: pgast.BaseExpr, ctx: Context) -> pgast.BaseExpr:
     """
 
     expr = eval(param, ctx=ctx)
+    res: pgast.BaseExpr
     if isinstance(expr, pgast.NullConstant):
-        return pgast.NullConstant()
-    if isinstance(expr, pgast.StringConstant):
-        return to_regclass(expr.val, ctx=ctx)
+        res = pgast.NullConstant()
+    elif isinstance(expr, pgast.StringConstant) and expr.val.isnumeric():
+        # We need to treat numeric string constants as numbers, apparently.
+        res = pgast.NumericConstant(val=expr.val)
 
-    oid: pgast.BaseExpr
-    if isinstance(expr, pgast.NumericConstant):
-        oid = expr
+    elif isinstance(expr, pgast.StringConstant):
+        res = to_regclass(expr.val, ctx=ctx)
+    elif isinstance(expr, pgast.NumericConstant):
+        res = expr
     else:
         # This is a complex expression of unknown type.
         # If we knew the type is numeric, we could lookup the internal oid by
@@ -466,7 +469,7 @@ def cast_to_regclass(param: pgast.BaseExpr, ctx: Context) -> pgast.BaseExpr:
         # So let's insert a runtime type check with an 'unsupported' message for
         # strings.
         param = dispatch.resolve(param, ctx=ctx)
-        oid = pgast.CaseExpr(
+        res = pgast.CaseExpr(
             args=[
                 pgast.CaseWhen(
                     expr=pgast.Expr(
@@ -498,7 +501,10 @@ def cast_to_regclass(param: pgast.BaseExpr, ctx: Context) -> pgast.BaseExpr:
                 ]
             )
         )
-    return oid
+    return pgast.TypeCast(
+        arg=res,
+        type_name=pgast.TypeName(name=('pg_catalog', 'regclass')),
+    )
 
 
 def to_regclass(reg_class_name: str, ctx: Context) -> pgast.BaseExpr:

--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -348,7 +348,10 @@ def eval_FuncCall(
 
     if fn_name == "to_regclass":
         arg = require_string_param(expr, ctx)
-        return to_regclass(arg, ctx=ctx)
+        return pgast.TypeCast(
+            arg=to_regclass(arg, ctx=ctx),
+            type_name=pgast.TypeName(name=('pg_catalog', 'regclass')),
+        )
 
     cast_arg_to_regclass = {
         'pg_relation_filenode',

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -16,16 +16,18 @@
 # limitations under the License.
 #
 
+import asyncio
 import csv
 import decimal
 import io
 import os.path
+import subprocess
 from typing import Coroutine, Optional, Tuple
 import unittest
 import uuid
-import asyncio
 
 from edb.tools import test
+from edb.server import pgcluster
 from edb.testbase import server as tb
 
 import edgedb
@@ -102,6 +104,32 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             os.path.dirname(__file__), 'schemas', 'movies_setup.edgeql'
         ),
     ]
+
+    async def test_sql_query_psql_describe_01(self):
+        dsn = self.get_sql_proto_dsn()
+        pg_bin_dir = await pgcluster.get_pg_bin_dir()
+
+        # Run a describe command in psql
+        cmd = [
+            pg_bin_dir / 'psql',
+            '--dbname', dsn,
+            '-c',
+            '\\d "Person"',
+        ]
+        try:
+            subprocess.run(
+                cmd,
+                input=None,
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT
+            )
+        except subprocess.CalledProcessError as e:
+            raise AssertionError(
+                f'command {cmd} returned non-zero exit status '
+                f'{e.returncode}\n{e.output}'
+            ) from e
 
     async def test_sql_query_00(self):
         # basic

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1487,8 +1487,6 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             '''
         )
         self.assertEqual(res1, res2)
-        assert isinstance(res1, int)
-        assert isinstance(res2, int)
 
         res = await self.squery_values(
             r'''


### PR DESCRIPTION
Apparently '12345'::regclass needs to be supported as interpreting the
number.

Fixes #8138.