### PR TITLE
Change some pg_catalog views to be MATERIALIZED

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_12_13_99_00
+EDGEDB_CATALOG_VERSION = 2024_12_17_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -32,6 +32,7 @@ from typing import (
     cast,
 )
 
+import functools
 import json
 import re
 
@@ -6293,11 +6294,23 @@ def _generate_sql_information_schema(
     backend_version: params.BackendVersion
 ) -> List[dbops.Command]:
 
+    def make_wrapper_view(name: str) -> trampoline.VersionedView:
+        return trampoline.VersionedView(
+            name=("edgedbsql", name),
+            query=f"""
+            SELECT *,
+            'pg_catalog.{name}'::regclass::oid as tableoid,
+            xmin, cmin, xmax, cmax, ctid
+            FROM edgedbsql_VER.{name}_
+            """,
+        )
+
     # A helper view that contains all data tables we expose over SQL, excluding
     # introspection tables.
     # It contains table & schema names and associated module id.
     virtual_tables = trampoline.VersionedView(
         name=('edgedbsql', 'virtual_tables'),
+        materialized=True,
         query='''
         WITH obj_ty_pre AS (
             SELECT
@@ -6421,7 +6434,7 @@ def _generate_sql_information_schema(
                             split_part(name, '::', 2) AS name,
                             backend_id
                         FROM edgedb_VER."_SchemaScalarType"
-                        WHERE NOT builtin
+                        WHERE NOT builtin AND arg_values IS NULL
                         UNION ALL
                         -- get the tuples
                         SELECT
@@ -6636,20 +6649,15 @@ def _generate_sql_information_schema(
 
     pg_catalog_views = [
         trampoline.VersionedView(
-            name=("edgedbsql", "pg_namespace"),
+            name=("edgedbsql", "pg_namespace_"),
+            materialized=True,
             query="""
         -- system schemas
         SELECT
             oid,
             nspname,
             nspowner,
-            nspacl,
-            tableoid,
-            xmin,
-            cmin,
-            xmax,
-            cmax,
-            ctid
+            nspacl
         FROM pg_namespace
         WHERE nspname IN ('pg_catalog', 'pg_toast', 'information_schema',
                           'edgedb', 'edgedbstd', 'edgedbt',
@@ -6664,18 +6672,7 @@ def _generate_sql_information_schema(
              FROM pg_roles
              WHERE rolname = CURRENT_USER
              LIMIT 1)                           AS nspowner,
-            NULL AS nspacl,
-            (SELECT pg_class.oid
-             FROM pg_class
-             JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
-             WHERE pg_namespace.nspname = 'pg_catalog'::name
-             AND pg_class.relname = 'pg_namespace'::name
-             )                                  AS tableoid,
-            '0'::xid                            AS xmin,
-            '0'::cid                            AS cmin,
-            '0'::xid                            AS xmax,
-            '0'::cid                            AS cmax,
-            NULL                                AS ctid
+            NULL AS nspacl
         FROM (
             SELECT schema_name, module_id
             FROM edgedbsql_VER.virtual_tables
@@ -6690,8 +6687,10 @@ def _generate_sql_information_schema(
         ) t
         """,
         ),
+        make_wrapper_view("pg_namespace"),
         trampoline.VersionedView(
-            name=("edgedbsql", "pg_type"),
+            name=("edgedbsql", "pg_type_"),
+            materialized=True,
             query="""
         SELECT
             pt.oid,
@@ -6699,8 +6698,7 @@ def _generate_sql_information_schema(
                 AS typname,
             edgedbsql_VER._pg_namespace_rename(pt.oid, pt.typnamespace)
                 AS typnamespace,
-            {0},
-            pt.tableoid, pt.xmin, pt.cmin, pt.xmax, pt.cmax, pt.ctid
+            {0}
         FROM pg_type pt
         JOIN pg_namespace pn ON pt.typnamespace = pn.oid
         WHERE
@@ -6714,14 +6712,16 @@ def _generate_sql_information_schema(
                 )
             ),
         ),
+        make_wrapper_view("pg_type"),
         # pg_class that contains classes only for tables
         # This is needed so we can use it to filter pg_index to indexes only on
         # visible tables.
         trampoline.VersionedView(
             name=("edgedbsql", "pg_class_tables"),
+            materialized=True,
             query="""
         -- Postgres tables
-        SELECT pc.*, pc.tableoid, pc.xmin, pc.cmin, pc.xmax, pc.cmax, pc.ctid
+        SELECT pc.*
         FROM pg_class pc
         JOIN pg_namespace pn ON pc.relnamespace = pn.oid
         WHERE nspname IN ('pg_catalog', 'pg_toast', 'information_schema')
@@ -6762,19 +6762,14 @@ def _generate_sql_information_schema(
             relminmxid,
             relacl,
             reloptions,
-            relpartbound,
-            pc.tableoid,
-            pc.xmin,
-            pc.cmin,
-            pc.xmax,
-            pc.cmax,
-            pc.ctid
+            relpartbound
         FROM pg_class pc
         JOIN edgedbsql_VER.virtual_tables vt ON vt.pg_type_id = pc.reltype
         """,
         ),
         trampoline.VersionedView(
-            name=("edgedbsql", "pg_index"),
+            name=("edgedbsql", "pg_index_"),
+            materialized=True,
             query=f"""
         SELECT
             pi.indexrelid,
@@ -6809,8 +6804,7 @@ def _generate_sql_information_schema(
             pi.indclass,
             pi.indoption,
             pi.indexprs,
-            pi.indpred,
-            pi.tableoid, pi.xmin, pi.cmin, pi.xmax, pi.cmax, pi.ctid
+            pi.indpred
         FROM pg_index pi
 
         -- filter by tables visible in pg_class
@@ -6830,8 +6824,10 @@ def _generate_sql_information_schema(
         WHERE vt.id IS NULL OR is_id.t IS NOT NULL
         """,
         ),
+        make_wrapper_view('pg_index'),
         trampoline.VersionedView(
-            name=("edgedbsql", "pg_class"),
+            name=("edgedbsql", "pg_class_"),
+            materialized=True,
             query="""
         -- tables
         SELECT pc.*
@@ -6840,7 +6836,7 @@ def _generate_sql_information_schema(
         UNION
 
         -- indexes
-        SELECT pc.*, pc.tableoid, pc.xmin, pc.cmin, pc.xmax, pc.cmax, pc.ctid
+        SELECT pc.*
         FROM pg_class pc
         JOIN pg_index pi ON pc.oid = pi.indexrelid
 
@@ -6880,13 +6876,7 @@ def _generate_sql_information_schema(
             pc.relminmxid,
             pc.relacl,
             pc.reloptions,
-            pc.relpartbound,
-            pc.tableoid,
-            pc.xmin,
-            pc.cmin,
-            pc.xmax,
-            pc.cmax,
-            pc.ctid
+            pc.relpartbound
         FROM pg_class pc
         JOIN edgedb_VER."_SchemaTuple" tup ON tup.backend_id = pc.reltype
         JOIN (
@@ -6896,7 +6886,7 @@ def _generate_sql_information_schema(
         ) nsdef ON TRUE
         """,
         ),
-
+        make_wrapper_view("pg_class"),
         # Because we hide some columns and
         # because pg_dump expects attnum to be sequential numbers
         # we have to invent new attnums with ROW_NUMBER().
@@ -6906,6 +6896,7 @@ def _generate_sql_information_schema(
         # attnum_internal column.
         trampoline.VersionedView(
             name=("edgedbsql", "pg_attribute_ext"),
+            materialized=True,
             query=r"""
         SELECT attrelid,
             attname,
@@ -6932,13 +6923,7 @@ def _generate_sql_information_schema(
             attacl,
             attoptions,
             attfdwoptions,
-            null::int[] as attmissingval,
-            pa.tableoid,
-            pa.xmin,
-            pa.cmin,
-            pa.xmax,
-            pa.cmax,
-            pa.ctid
+            null::int[] as attmissingval
         FROM pg_attribute pa
         JOIN pg_class pc ON pa.attrelid = pc.oid
         JOIN pg_namespace pn ON pc.relnamespace = pn.oid
@@ -6979,8 +6964,7 @@ def _generate_sql_information_schema(
             attacl,
             attoptions,
             attfdwoptions,
-            null::int[] as attmissingval,
-            tableoid, xmin, cmin, xmax, cmax, ctid
+            null::int[] as attmissingval
         FROM (
         SELECT
             COALESCE(
@@ -6991,8 +6975,7 @@ def _generate_sql_information_schema(
             COALESCE(spec.position, 2) AS col_position,
             (sp.required IS TRUE OR spec.k IS NOT NULL) as required,
             pc.oid AS pc_oid,
-            pa.*,
-            pa.tableoid, pa.xmin, pa.cmin, pa.xmax, pa.cmax, pa.ctid
+            pa.*
 
         FROM edgedb_VER."_SchemaPointer" sp
         JOIN edgedbsql_VER.virtual_tables vt ON vt.id = sp.source
@@ -7032,8 +7015,7 @@ def _generate_sql_information_schema(
             spec.position as position,
             TRUE as required,
             pa.attrelid as pc_oid,
-            pa.*,
-            pa.tableoid, pa.xmin, pa.cmin, pa.xmax, pa.cmax, pa.ctid
+            pa.*
         FROM edgedb_VER."_SchemaProperty" sp
         JOIN pg_class pc ON pc.relname = sp.id::TEXT
         JOIN pg_attribute pa ON pa.attrelid = pc.oid
@@ -7056,8 +7038,7 @@ def _generate_sql_information_schema(
             pa.attnum as position,
             TRUE as required,
             pa.attrelid as pc_oid,
-            pa.*,
-            pa.tableoid, pa.xmin, pa.cmin, pa.xmax, pa.cmax, pa.ctid
+            pa.*
         FROM pg_attribute pa
         JOIN pg_class pc ON pc.oid = pa.attrelid
         JOIN edgedbsql_VER.virtual_tables vt ON vt.pg_type_id = pc.reltype
@@ -7094,7 +7075,7 @@ def _generate_sql_information_schema(
           attoptions,
           attfdwoptions,
           attmissingval,
-          tableoid,
+          'pg_catalog.pg_attribute'::regclass::oid as tableoid,
           xmin,
           cmin,
           xmax,
@@ -7350,7 +7331,7 @@ def _generate_sql_information_schema(
             NULL::real[] AS stavalues3,
             NULL::real[] AS stavalues4,
             NULL::real[] AS stavalues5,
-            tableoid, xmin, cmin, xmax, cmax, ctid
+            s.tableoid, s.xmin, s.cmin, s.xmax, s.cmax, s.ctid
         FROM pg_statistic s
         JOIN edgedbsql_VER.pg_attribute_ext a ON (
             a.attrelid = s.starelid AND a.attnum_internal = s.staattnum
@@ -7920,6 +7901,22 @@ def _generate_sql_information_schema(
         + [dbops.CreateView(view) for view in views]
         + [dbops.CreateFunction(func) for func in util_functions]
     )
+
+
+@functools.cache
+def generate_sql_information_schema_refresh(
+    backend_version: params.BackendVersion
+) -> dbops.Command:
+    refresh = dbops.CommandGroup()
+    for command in _generate_sql_information_schema(backend_version):
+        if (
+            isinstance(command, dbops.CreateView)
+            and command.view.materialized
+        ):
+            refresh.add_command(dbops.Query(
+                text=f'REFRESH MATERIALIZED VIEW {q(*command.view.name)}'
+            ))
+    return refresh
 
 
 class ObjectAncestorsView(trampoline.VersionedView):

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -396,6 +396,12 @@ def _process_delta(
     compiler.compile_schema_storage_in_delta(
         ctx, pgdelta, subblock, context=context
     )
+    if not ctx.bootstrap_mode:
+        from edb.pgsql import metaschema
+        refresh = metaschema.generate_sql_information_schema_refresh(
+            ctx.compiler_state.backend_runtime_params.instance_params.version
+        )
+        refresh.generate(subblock)
 
     return block, new_types, pgdelta.config_ops
 


### PR DESCRIPTION
This *hugely* speeds up most pg_catalog SQL introspection operations, like
`\d` and pg_dump.

Unfortunately it slows down DDL operations, because we need to refresh the
views. On my machine, it looks like it typically adds about 150ms to
applying a migration.

This is probably fine for our users, but is pretty bad for us because our
test suite is pretty heavy on DDL; this slows it down on my machine from
15.5m to 19.5m, which might be too much to merge.
Thoughts?

Fixes #8137.