### PR TITLE
pg-ext: fix initial client_encoding

### DIFF
--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -82,6 +82,7 @@ from edb.server import metrics
 from edb.server.protocol cimport frontend
 
 from edb.common import debug
+from edb.common import typeutils
 
 from . import errors as pgerror
 
@@ -3016,6 +3017,7 @@ cdef EdegDBCodecContext DEFAULT_CODEC_CONTEXT = EdegDBCodecContext()
 
 
 cdef setting_to_sql(setting):
+    assert typeutils.is_container(setting)
     return ', '.join(setting_val_to_sql(v) for v in setting)
 
 

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -687,7 +687,7 @@ cdef class PgConnection(frontend.FrontendConnection):
                     f'invalid value for parameter "client_encoding": "{encoding}"',
                 )
             self._dbview._settings = self._dbview._settings.set(
-                "client_encoding", client_encoding
+                "client_encoding", (client_encoding,)
             )
         else:
             client_encoding = "UTF8"
@@ -1804,7 +1804,7 @@ cdef write_arg(
     elif pg_type == ('bool',):
         is_truthy = is_setting_truthy(value)
         if is_truthy == None:
-            buf.write_int32(-1)    
+            buf.write_int32(-1)
         else:
             buf.write_int32(1)
             buf.write_byte(1 if is_truthy else 0)


### PR DESCRIPTION
PR #7747 changed SQL settings to always be a tuple, and missed this one.

The added tests don't fail without this fix, because PostgreSQL is actually happy with `'\"U\", \"T\", \"F\", \"-\", \"8\"'` as UTF-8; The assertion in `setting_to_sql()` will fail without the fix.