### PR TITLE
[5.x] Fix NULLs in re_match/re_match_all returns (#8069)

### DIFF
--- a/edb/lib/std/30-regexpfuncs.edgeql
+++ b/edb/lib/std/30-regexpfuncs.edgeql
@@ -27,7 +27,7 @@ std::re_match(pattern: std::str, str: std::str) -> array<std::str>
         'Find the first regular expression match in a string.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT regexp_matches("str", "pattern");
+    SELECT array_replace(regexp_matches("str", "pattern"), NULL, '');
     $$;
 };
 
@@ -39,7 +39,7 @@ std::re_match_all(pattern: std::str, str: std::str) -> SET OF array<std::str>
         'Find all regular expression matches in a string.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT regexp_matches("str", "pattern", 'g');
+    SELECT array_replace(regexp_matches("str", "pattern", 'g'), NULL, '');
     $$;
 };
 

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -170,4 +170,22 @@ ALTER TYPE cfg::AbstractConfig {
     };
 }
 '''),
+    # === 5.8
+    ('edgeql', '''
+ALTER FUNCTION
+std::re_match(pattern: std::str, str: std::str)
+{
+    USING SQL $$
+    SELECT array_replace(regexp_matches("str", "pattern"), NULL, '');
+    $$;
+};
+ALTER FUNCTION
+std::re_match_all(pattern: std::str, str: std::str)
+{
+    USING SQL $$
+    SELECT array_replace(regexp_matches("str", "pattern", 'g'), NULL, '');
+    $$;
+};
+'''),
+
 ])

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1054,6 +1054,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [['Ab'], ['a']],
         )
 
+        await self.assert_query_result(
+            r'''
+            select re_match(
+                r"(foo)?bar",
+                'barbar',
+            )
+            ''',
+            [[""]],
+        )
+
     async def test_edgeql_functions_re_match_02(self):
         await self.assert_query_result(
             r'''
@@ -1133,6 +1143,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 ORDER BY x;
             ''',
             [['Ab'], ['a'], ['a'], ['aB'], ['ab']],
+        )
+
+        await self.assert_query_result(
+            r'''
+            select re_match_all(
+                r"(foo)?bar",
+                'barbar',
+            )
+            ''',
+            [[""], [""]],
         )
 
     async def test_edgeql_functions_re_test_01(self):


### PR DESCRIPTION
Replace the NULLs in the result arrays with empty strings.
Fixes #8062.