### PR TITLE
[5.x] Fix strchrnul build failures on recent glibc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,5 +7,4 @@
 	url = https://github.com/MagicStack/py-pgproto.git
 [submodule "edb/pgsql/parser/libpg_query"]
 	path = edb/pgsql/parser/libpg_query
-	url = https://github.com/pganalyze/libpg_query.git
-	branch = 13-latest
+	url = https://github.com/edgedb/libpg_query.git


### PR DESCRIPTION
This now includes github actions runners, so we need to.