### PR TITLE
Reject putting an "unknown" link as a link property

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1009,6 +1009,40 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(
+        errors.InvalidPropertyTargetError,
+        "got object type"
+    )
+    def test_schema_object_as_lprop_01(self):
+        """
+        type Tgt;
+        type Tgt2;
+        type Src {
+          multi tgts: Tgt {
+            lprop: Tgt2;
+          }
+        };
+        """
+
+    @tb.must_fail(
+        errors.InvalidPropertyTargetError,
+        "got object type"
+    )
+    def test_schema_object_as_lprop_02(self):
+        """
+        type Tgt;
+        type Tgt2;
+        type Src {
+          multi tgts: Tgt {
+          }
+        };
+        type Src2 extending Src {
+          overloaded multi tgts: Tgt {
+            lprop: Tgt2;
+          }
+        };
+        """
+
+    @tb.must_fail(
         errors.InvalidFunctionDefinitionError,
         r"cannot create the `test::foo\(VARIADIC bar: "
         r"OPTIONAL array<std::int64>\)` function: "


### PR DESCRIPTION
Currently, if you have an "unknown" pointer on a link that points to
an object, it will be created as a link on the *enclosing* object,
which is pretty silly.

Reject it propertly instead.

Fixes #8087.