### PR TITLE
Send `identity_id` on require_verification

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -492,7 +492,7 @@ class Router:
             else:
                 response.status = http.HTTPStatus.CREATED
                 response.content_type = b"application/json"
-                response.body = json.dumps(response_dict)
+                response.body = json.dumps(response_dict).encode()
         except Exception as ex:
             redirect_on_failure = data.get(
                 "redirect_on_failure", maybe_redirect_to


### PR DESCRIPTION
During the sign up flow, we want to allow applications to still create and associate an Identity, since further flows like the verification flow might happen as a sign in, such as when the user verifies their email from a different device than they signed up with. That changes the semantics a bit from "we hide the identity from the application until the email is verified" to "we do not give the application an auth token until the email is verified" which seems more honest.

Backport from #8129 