### PR TITLE
Avoid requiring a database for test_http tests

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -433,7 +433,7 @@ class RollbackChanges:
         await self._tx.rollback()
 
 
-class BaseHTTPTestCase(TestCase):
+class TestCaseWithHttpClient(TestCase):
     @classmethod
     def get_api_prefix(cls):
         return ''
@@ -784,7 +784,7 @@ async def drop_db(conn, dbname):
     await conn.execute(f'DROP BRANCH {dbname}')
 
 
-class ClusterTestCase(BaseHTTPTestCase):
+class ClusterTestCase(TestCaseWithHttpClient):
 
     BASE_TEST_CLASS = True
     backend_dsn: Optional[str] = None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -21,14 +21,15 @@ import json
 import random
 
 from edb.server import http
-from edb.testbase import http as tb
+from edb.testbase import http as http_tb
+from edb.testbase import server as tb
 from edb.tools.test import async_timeout
 
 
-class HttpTest(tb.BaseHttpTest):
+class HttpTest(tb.TestCase):
     def setUp(self):
         super().setUp()
-        self.mock_server = tb.MockHttpServer()
+        self.mock_server = http_tb.MockHttpServer()
         self.mock_server.start()
         self.base_url = self.mock_server.get_base_url().rstrip("/")
 
@@ -170,7 +171,7 @@ class HttpTest(tb.BaseHttpTest):
             self.assertEqual(result.json(), "ok")
 
 
-class HttpSSETest(tb.BaseHttpTest):
+class HttpSSETest(tb.TestCase):
     @async_timeout(timeout=5)
     async def test_immediate_connection_drop_streaming(self):
         """Test handling of a connection that is dropped immediately by the

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1547,7 +1547,7 @@ class TestServerConfig(tb.QueryTestCase):
             await con2.aclose()
 
 
-class TestSeparateCluster(tb.BaseHTTPTestCase):
+class TestSeparateCluster(tb.TestCaseWithHttpClient):
 
     @unittest.skipIf(
         platform.system() == "Darwin",

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -70,7 +70,7 @@ class TestServerApi(tb.ClusterTestCase):
             self.assertEqual(status, http.HTTPStatus.OK)
 
 
-class TestServerOps(tb.BaseHTTPTestCase, tb.CLITestCaseMixin):
+class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
 
     async def kill_process(self, proc: asyncio.subprocess.Process):
         proc.terminate()


### PR DESCRIPTION
These use a database maybe kind of by accident.
Change the base class to not require it.

Also rename `server.BaseHTTPTestCase` to `TestCaseWithHttpClient` to
make it more distinct from `http.BaseHttpTest`.