### PR TITLE
Fix `OutputFormat.NONE` in SQL mode

### DIFF
--- a/edb/protocol/__init__.py
+++ b/edb/protocol/__init__.py
@@ -24,6 +24,7 @@ import typing
 
 from . import messages
 from . import render_utils
+from .protocol import Connection  # NoQA
 
 from .messages import *  # NoQA
 

--- a/edb/protocol/protocol.pyi
+++ b/edb/protocol/protocol.pyi
@@ -16,32 +16,33 @@
 # limitations under the License.
 #
 
+from typing import Any
 
-from __future__ import annotations
+from . import messages
 
-from edb.testbase import server
+class Connection:
+    async def connect(self) -> None:
+        ...
 
-from edb.protocol import protocol  # type: ignore
+    async def execute(self, query: str, state_id: bytes, state: bytes) -> None:
+        ...
 
+    async def sync(self) -> bytes:
+        ...
 
-class ProtocolTestCase(server.DatabaseTestCase):
+    async def recv(self) -> messages.ServerMessage:
+        ...
 
-    PARALLELISM_GRANULARITY = 'database'
-    BASE_TEST_CLASS = True
+    async def recv_match(
+        self,
+        msgcls: type[messages.ServerMessage],
+        _ignore_msg: type[messages.ServerMessage] | None,
+        **fields: Any,
+    ) -> messages.ServerMessage:
+        ...
 
-    con: protocol.Connection
+    async def send(self, *msgs: messages.ClientMessage) -> None:
+        ...
 
-    def setUp(self):
-        self.con = self.loop.run_until_complete(
-            protocol.new_connection(
-                **self.get_connect_args(database=self.get_database_name())
-            )
-        )
-
-    def tearDown(self):
-        try:
-            self.loop.run_until_complete(
-                self.con.aclose()
-            )
-        finally:
-            self.con = None
+    async def aclose(self) -> None:
+        ...

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2698,7 +2698,11 @@ def compile_sql_as_unit_group(
             sql=value_sql,
             introspection_sql=intro_sql,
             status=status,
-            cardinality=sql_unit.cardinality,
+            cardinality=(
+                enums.Cardinality.NO_RESULT
+                if ctx.output_format is enums.OutputFormat.NONE
+                else sql_unit.cardinality
+            ),
             capabilities=sql_unit.capabilities,
             globals=[
                 (str(sp.global_name), False) for sp in sql_unit.params
@@ -2706,7 +2710,10 @@ def compile_sql_as_unit_group(
             ] if sql_unit.params else [],
             output_format=(
                 enums.OutputFormat.NONE
-                if sql_unit.cardinality is enums.Cardinality.NO_RESULT
+                if (
+                    ctx.output_format is enums.OutputFormat.NONE
+                    or sql_unit.cardinality is enums.Cardinality.NO_RESULT
+                )
                 else enums.OutputFormat.BINARY
             ),
             source_map=sql_unit.source_map,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1474,9 +1474,6 @@ cdef class DatabaseConnectionView:
             all_type_oids = []
 
         for i, query_unit in enumerate(qug):
-            if query_unit.cardinality is enums.Cardinality.NO_RESULT:
-                continue
-
             intro_sql = query_unit.introspection_sql
             if intro_sql is None:
                 intro_sql = query_unit.sql
@@ -1526,8 +1523,11 @@ cdef class DatabaseConnectionView:
 
             for i, desc_qu in enumerate(desc_qug):
                 qu_i = desc_map[i]
-                qug[qu_i].out_type_data = desc_qu[1][0]
-                qug[qu_i].out_type_id = desc_qu[1][1]
+
+                if query_req.output_format is not enums.OutputFormat.NONE:
+                    qug[qu_i].out_type_data = desc_qu[1][0]
+                    qug[qu_i].out_type_id = desc_qu[1][1]
+
                 qug[qu_i].in_type_data = desc_qu[0][0]
                 qug[qu_i].in_type_id = desc_qu[0][1]
                 qug[qu_i].in_type_args = desc_qu[0][2]
@@ -1539,8 +1539,10 @@ cdef class DatabaseConnectionView:
             # a group of ONE now.)
             # In near future we'll need to properly implement arg
             # remap.
-            qug.out_type_data = desc_qug[-1][1][0]
-            qug.out_type_id = desc_qug[-1][1][1]
+            if query_req.output_format is not enums.OutputFormat.NONE:
+                qug.out_type_data = desc_qug[-1][1][0]
+                qug.out_type_id = desc_qug[-1][1][1]
+
             qug.in_type_data = desc_qug[-1][0][0]
             qug.in_type_id = desc_qug[-1][0][1]
             qug.in_type_args = desc_qug[-1][0][2]


### PR DESCRIPTION
Make sure `output_format`, `cardinality`, `out_type_id` and
`out_type_data` are correct for when `output_format` is `NONE` and
`input_language` is `SQL`.

Fixes: #8185
