### PR TITLE
[DEBUG] Debug HTTP failures

### DIFF
--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -5,153 +5,64 @@ publications:
 
 targets:
     linux:
-        - name: debian-buster-x86_64
-          arch: x86_64
-          platform: debian
-          platform_version: buster
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: debian-buster-aarch64
-          arch: aarch64
-          platform: debian
-          platform_version: buster
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: debian-bullseye-x86_64
-          arch: x86_64
-          platform: debian
-          platform_version: bullseye
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: debian-bullseye-aarch64
-          arch: aarch64
-          platform: debian
-          platform_version: bullseye
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: debian-bookworm-x86_64
-          arch: x86_64
-          platform: debian
-          platform_version: bookworm
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, x64]
-          docker_arch: linux/amd64
-        - name: debian-bookworm-aarch64
-          arch: aarch64
-          platform: debian
-          platform_version: bookworm
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, arm64]
-          docker_arch: linux/arm64
-        - name: ubuntu-bionic-x86_64
-          arch: x86_64
-          platform: ubuntu
-          platform_version: bionic
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: ubuntu-bionic-aarch64
-          arch: aarch64
-          platform: ubuntu
-          platform_version: bionic
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: ubuntu-focal-x86_64
-          arch: x86_64
-          platform: ubuntu
-          platform_version: focal
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: ubuntu-focal-aarch64
-          arch: aarch64
-          platform: ubuntu
-          platform_version: focal
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: ubuntu-jammy-x86_64
-          arch: x86_64
-          platform: ubuntu
-          platform_version: jammy
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: ubuntu-jammy-aarch64
-          arch: aarch64
-          platform: ubuntu
-          platform_version: jammy
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: ubuntu-noble-x86_64
-          arch: x86_64
-          platform: ubuntu
-          platform_version: noble
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: ubuntu-noble-aarch64
-          arch: aarch64
-          platform: ubuntu
-          platform_version: noble
-          family: debian
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: centos-8-x86_64
-          arch: x86_64
-          platform: centos
-          platform_version: 8
-          family: redhat
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: centos-8-aarch64
-          arch: aarch64
-          platform: centos
-          platform_version: 8
-          family: redhat
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: rockylinux-9-x86_64
-          arch: x86_64
-          platform: rockylinux
-          platform_version: 9
-          family: redhat
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: rockylinux-9-aarch64
-          arch: aarch64
-          platform: rockylinux
-          platform_version: 9
-          family: redhat
-          runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: linux-x86_64
-          arch: x86_64
-          platform: linux
-          platform_version: x86_64
-          family: generic
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: linux-aarch64
+        - name: linux-aarch64-00
           arch: aarch64
           platform: linux
           platform_version: aarch64
           family: generic
           runs_on: [package-builder, self-hosted, linux, arm64]
-        - name: linuxmusl-x86_64
-          arch: x86_64
-          platform: linux
-          platform_version: x86_64
-          platform_libc: musl
-          family: generic
-          runs_on: [package-builder, self-hosted, linux, x64]
-        - name: linuxmusl-aarch64
+        - name: linux-aarch64-01
           arch: aarch64
           platform: linux
           platform_version: aarch64
-          platform_libc: musl
           family: generic
           runs_on: [package-builder, self-hosted, linux, arm64]
-
-    macos:
-        - name: macos-x86_64
-          arch: x86_64
-          platform: macos
-          platform_version: x86_64
-          family: generic
-          runs_on: [macos-13]
-        - name: macos-aarch64
+        - name: linux-aarch64-02
           arch: aarch64
-          platform: macos
+          platform: linux
           platform_version: aarch64
           family: generic
-          runs_on: [macos-14]
+          runs_on: [package-builder, self-hosted, linux, arm64]
+        - name: linux-aarch64-03
+          arch: aarch64
+          platform: linux
+          platform_version: aarch64
+          family: generic
+          runs_on: [package-builder, self-hosted, linux, arm64]
+        - name: linux-aarch64-04
+          arch: aarch64
+          platform: linux
+          platform_version: aarch64
+          family: generic
+          runs_on: [package-builder, self-hosted, linux, arm64]
+        - name: linux-aarch64-05
+          arch: aarch64
+          platform: linux
+          platform_version: aarch64
+          family: generic
+          runs_on: [package-builder, self-hosted, linux, arm64]
+        - name: linux-aarch64-06
+          arch: aarch64
+          platform: linux
+          platform_version: aarch64
+          family: generic
+          runs_on: [package-builder, self-hosted, linux, arm64]
+        - name: linux-aarch64-07
+          arch: aarch64
+          platform: linux
+          platform_version: aarch64
+          family: generic
+          runs_on: [package-builder, self-hosted, linux, arm64]
+        - name: linux-aarch64-08
+          arch: aarch64
+          platform: linux
+          platform_version: aarch64
+          family: generic
+          runs_on: [package-builder, self-hosted, linux, arm64]
+        - name: linux-aarch64-09
+          arch: aarch64
+          platform: linux
+          platform_version: aarch64
+          family: generic
+          runs_on: [package-builder, self-hosted, linux, arm64]
+    macos: []

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -10,53 +10,25 @@ jobs:
 
     outputs:
 
-      if_debian_buster_x86_64: ${{ steps.scm.outputs.if_debian_buster_x86_64 }}
+      if_linux_aarch64_00: ${{ steps.scm.outputs.if_linux_aarch64_00 }}
 
-      if_debian_buster_aarch64: ${{ steps.scm.outputs.if_debian_buster_aarch64 }}
+      if_linux_aarch64_01: ${{ steps.scm.outputs.if_linux_aarch64_01 }}
 
-      if_debian_bullseye_x86_64: ${{ steps.scm.outputs.if_debian_bullseye_x86_64 }}
+      if_linux_aarch64_02: ${{ steps.scm.outputs.if_linux_aarch64_02 }}
 
-      if_debian_bullseye_aarch64: ${{ steps.scm.outputs.if_debian_bullseye_aarch64 }}
+      if_linux_aarch64_03: ${{ steps.scm.outputs.if_linux_aarch64_03 }}
 
-      if_debian_bookworm_x86_64: ${{ steps.scm.outputs.if_debian_bookworm_x86_64 }}
+      if_linux_aarch64_04: ${{ steps.scm.outputs.if_linux_aarch64_04 }}
 
-      if_debian_bookworm_aarch64: ${{ steps.scm.outputs.if_debian_bookworm_aarch64 }}
+      if_linux_aarch64_05: ${{ steps.scm.outputs.if_linux_aarch64_05 }}
 
-      if_ubuntu_bionic_x86_64: ${{ steps.scm.outputs.if_ubuntu_bionic_x86_64 }}
+      if_linux_aarch64_06: ${{ steps.scm.outputs.if_linux_aarch64_06 }}
 
-      if_ubuntu_bionic_aarch64: ${{ steps.scm.outputs.if_ubuntu_bionic_aarch64 }}
+      if_linux_aarch64_07: ${{ steps.scm.outputs.if_linux_aarch64_07 }}
 
-      if_ubuntu_focal_x86_64: ${{ steps.scm.outputs.if_ubuntu_focal_x86_64 }}
+      if_linux_aarch64_08: ${{ steps.scm.outputs.if_linux_aarch64_08 }}
 
-      if_ubuntu_focal_aarch64: ${{ steps.scm.outputs.if_ubuntu_focal_aarch64 }}
-
-      if_ubuntu_jammy_x86_64: ${{ steps.scm.outputs.if_ubuntu_jammy_x86_64 }}
-
-      if_ubuntu_jammy_aarch64: ${{ steps.scm.outputs.if_ubuntu_jammy_aarch64 }}
-
-      if_ubuntu_noble_x86_64: ${{ steps.scm.outputs.if_ubuntu_noble_x86_64 }}
-
-      if_ubuntu_noble_aarch64: ${{ steps.scm.outputs.if_ubuntu_noble_aarch64 }}
-
-      if_centos_8_x86_64: ${{ steps.scm.outputs.if_centos_8_x86_64 }}
-
-      if_centos_8_aarch64: ${{ steps.scm.outputs.if_centos_8_aarch64 }}
-
-      if_rockylinux_9_x86_64: ${{ steps.scm.outputs.if_rockylinux_9_x86_64 }}
-
-      if_rockylinux_9_aarch64: ${{ steps.scm.outputs.if_rockylinux_9_aarch64 }}
-
-      if_linux_x86_64: ${{ steps.scm.outputs.if_linux_x86_64 }}
-
-      if_linux_aarch64: ${{ steps.scm.outputs.if_linux_aarch64 }}
-
-      if_linuxmusl_x86_64: ${{ steps.scm.outputs.if_linuxmusl_x86_64 }}
-
-      if_linuxmusl_aarch64: ${{ steps.scm.outputs.if_linuxmusl_aarch64 }}
-
-      if_macos_x86_64: ${{ steps.scm.outputs.if_macos_x86_64 }}
-
-      if_macos_aarch64: ${{ steps.scm.outputs.if_macos_aarch64 }}
+      if_linux_aarch64_09: ${{ steps.scm.outputs.if_linux_aarch64_09 }}
 
 
     steps:
@@ -72,817 +44,112 @@ jobs:
 
         val=true
 
-        idx_file=buster.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-buster-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_buster_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=buster.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-buster-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_buster_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bullseye.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bullseye-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bullseye_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bullseye.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bullseye-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bullseye_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bookworm.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bookworm-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bookworm_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bookworm.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bookworm-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bookworm_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bionic.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-bionic-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_bionic_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bionic.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-bionic-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_bionic_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=focal.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-focal-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_focal_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=focal.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-focal-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_focal_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=jammy.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-jammy-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_jammy_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=jammy.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-jammy-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_jammy_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=noble.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-noble-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_noble_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=noble.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-noble-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_noble_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el8.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing centos-8-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_centos_8_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el8.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing centos-8-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_centos_8_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el9.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing rockylinux-9-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_rockylinux_9_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el9.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing rockylinux-9-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_rockylinux_9_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linux-x86_64'
+          echo 'Skip rebuilding existing linux-aarch64-00'
           val=false
         fi
 
-        echo if_linux_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_00="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linux-aarch64'
+          echo 'Skip rebuilding existing linux-aarch64-01'
           val=false
         fi
 
-        echo if_linux_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_01="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linuxmusl-x86_64'
+          echo 'Skip rebuilding existing linux-aarch64-02'
           val=false
         fi
 
-        echo if_linuxmusl_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_02="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linuxmusl-aarch64'
+          echo 'Skip rebuilding existing linux-aarch64-03'
           val=false
         fi
 
-        echo if_linuxmusl_aarch64="$val" >> $GITHUB_OUTPUT
-
+        echo if_linux_aarch64_03="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-apple-darwin.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing macos-x86_64'
+          echo 'Skip rebuilding existing linux-aarch64-04'
           val=false
         fi
 
-        echo if_macos_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_04="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-apple-darwin.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing macos-aarch64'
+          echo 'Skip rebuilding existing linux-aarch64-05'
           val=false
         fi
 
-        echo if_macos_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_05="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-06'
+          val=false
+        fi
+
+        echo if_linux_aarch64_06="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-07'
+          val=false
+        fi
+
+        echo if_linux_aarch64_07="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-08'
+          val=false
+        fi
+
+        echo if_linux_aarch64_08="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-09'
+          val=false
+        fi
+
+        echo if_linux_aarch64_09="$val" >> $GITHUB_OUTPUT
 
 
 
-  build-debian-buster-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
 
-    if: needs.prep.outputs.if_debian_buster_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-  build-debian-buster-aarch64:
+  build-linux-aarch64-00:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_debian_buster_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-  build-debian-bullseye-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bullseye_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-  build-debian-bullseye-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bullseye_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-  build-debian-bookworm-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bookworm_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-  build-debian-bookworm-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bookworm_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-  build-ubuntu-bionic-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_bionic_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-bionic-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_bionic_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-focal-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_focal_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-focal-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_focal_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-jammy-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_jammy_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-jammy-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_jammy_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-noble-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_noble_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-  build-ubuntu-noble-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_noble_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-  build-centos-8-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_centos_8_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-  build-centos-8-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_centos_8_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-  build-rockylinux-9-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_rockylinux_9_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-  build-rockylinux-9-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_rockylinux_9_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-  build-linux-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_linux_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_GENERIC: true
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-  build-linux-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_linux_aarch64 == 'true'
+    if: needs.prep.outputs.if_linux_aarch64_00 == 'true'
 
 
     steps:
@@ -900,45 +167,19 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
-  build-linuxmusl-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_linuxmusl_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-  build-linuxmusl-aarch64:
+  build-linux-aarch64-01:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_linuxmusl_aarch64 == 'true'
+    if: needs.prep.outputs.if_linux_aarch64_01 == 'true'
 
 
     steps:
     - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
@@ -947,563 +188,221 @@ jobs:
         PKG_PLATFORM_VERSION: "aarch64"
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
-  build-macos-x86_64:
-    runs-on: ['macos-13']
+  build-linux-aarch64-02:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_macos_x86_64 == 'true'
+    if: needs.prep.outputs.if_linux_aarch64_02 == 'true'
 
 
     steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
     - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_ARCH: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-  build-macos-aarch64:
-    runs-on: ['macos-14']
-    needs: prep
-
-    if: needs.prep.outputs.if_macos_aarch64 == 'true'
-
-
-    steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
-    - name: Build
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_ARCH: "aarch64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-  test-debian-buster-x86_64:
-    needs: [build-debian-buster-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-buster-aarch64:
-    needs: [build-debian-buster-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-x86_64:
-    needs: [build-debian-bullseye-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-aarch64:
-    needs: [build-debian-bullseye-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-x86_64:
-    needs: [build-debian-bookworm-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-aarch64:
-    needs: [build-debian-bookworm-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-x86_64:
-    needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-aarch64:
-    needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-x86_64:
-    needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-aarch64:
-    needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-x86_64:
-    needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-aarch64:
-    needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-x86_64:
-    needs: [build-ubuntu-noble-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-aarch64:
-    needs: [build-ubuntu-noble-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-x86_64:
-    needs: [build-centos-8-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-aarch64:
-    needs: [build-centos-8-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-x86_64:
-    needs: [build-rockylinux-9-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-aarch64:
-    needs: [build-rockylinux-9-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linux-x86_64:
-    needs: [build-linux-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linux-x86_64@master
-      env:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
 
-  test-linux-aarch64:
-    needs: [build-linux-aarch64]
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-03:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_03 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-04:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_04 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-05:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_05 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-06:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_06 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-07:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_07 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-08:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_08 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-09:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_09 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+  test-linux-aarch64-00:
+    needs: [build-linux-aarch64-00]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Test
@@ -1517,100 +416,194 @@ jobs:
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-linuxmusl-x86_64:
-    needs: [build-linuxmusl-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: "musl"
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linuxmusl-aarch64:
-    needs: [build-linuxmusl-aarch64]
+  test-linux-aarch64-01:
+    needs: [build-linux-aarch64-01]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_LIBC: "musl"
+        PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-macos-x86_64:
-    needs: [build-macos-x86_64]
-    runs-on: ['macos-13']
+  test-linux-aarch64-02:
+    needs: [build-linux-aarch64-02]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
 
     - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        # Run fewer tests on x86_64, since the test runner is very slow.
-        PKG_TEST_FILES: "test_dump*.py test_backend_*.py test_database.py test_server_*.py test_edgeql_ddl.py test_session.py"
-      run: |
-        # Bump shmmax and shmall to avoid test failures.
-        sudo sysctl -w kern.sysv.shmmax=12582912
-        sudo sysctl -w kern.sysv.shmall=12582912
-        edgedb-pkg/integration/macos/test.sh
-
-  test-macos-aarch64:
-    needs: [build-macos-aarch64]
-    runs-on: ['macos-14']
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-    - name: Test
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
+        PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-      run: |
-        edgedb-pkg/integration/macos/test.sh
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-03:
+    needs: [build-linux-aarch64-03]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-04:
+    needs: [build-linux-aarch64-04]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-05:
+    needs: [build-linux-aarch64-05]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-06:
+    needs: [build-linux-aarch64-06]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-07:
+    needs: [build-linux-aarch64-07]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-08:
+    needs: [build-linux-aarch64-08]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-09:
+    needs: [build-linux-aarch64-09]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
 
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'
@@ -1618,54 +611,26 @@ jobs:
 
     needs:
       - prep
-      - build-debian-buster-x86_64
-      - test-debian-buster-x86_64
-      - build-debian-buster-aarch64
-      - test-debian-buster-aarch64
-      - build-debian-bullseye-x86_64
-      - test-debian-bullseye-x86_64
-      - build-debian-bullseye-aarch64
-      - test-debian-bullseye-aarch64
-      - build-debian-bookworm-x86_64
-      - test-debian-bookworm-x86_64
-      - build-debian-bookworm-aarch64
-      - test-debian-bookworm-aarch64
-      - build-ubuntu-bionic-x86_64
-      - test-ubuntu-bionic-x86_64
-      - build-ubuntu-bionic-aarch64
-      - test-ubuntu-bionic-aarch64
-      - build-ubuntu-focal-x86_64
-      - test-ubuntu-focal-x86_64
-      - build-ubuntu-focal-aarch64
-      - test-ubuntu-focal-aarch64
-      - build-ubuntu-jammy-x86_64
-      - test-ubuntu-jammy-x86_64
-      - build-ubuntu-jammy-aarch64
-      - test-ubuntu-jammy-aarch64
-      - build-ubuntu-noble-x86_64
-      - test-ubuntu-noble-x86_64
-      - build-ubuntu-noble-aarch64
-      - test-ubuntu-noble-aarch64
-      - build-centos-8-x86_64
-      - test-centos-8-x86_64
-      - build-centos-8-aarch64
-      - test-centos-8-aarch64
-      - build-rockylinux-9-x86_64
-      - test-rockylinux-9-x86_64
-      - build-rockylinux-9-aarch64
-      - test-rockylinux-9-aarch64
-      - build-linux-x86_64
-      - test-linux-x86_64
-      - build-linux-aarch64
-      - test-linux-aarch64
-      - build-linuxmusl-x86_64
-      - test-linuxmusl-x86_64
-      - build-linuxmusl-aarch64
-      - test-linuxmusl-aarch64
-      - build-macos-x86_64
-      - test-macos-x86_64
-      - build-macos-aarch64
-      - test-macos-aarch64
+      - build-linux-aarch64-00
+      - test-linux-aarch64-00
+      - build-linux-aarch64-01
+      - test-linux-aarch64-01
+      - build-linux-aarch64-02
+      - test-linux-aarch64-02
+      - build-linux-aarch64-03
+      - test-linux-aarch64-03
+      - build-linux-aarch64-04
+      - test-linux-aarch64-04
+      - build-linux-aarch64-05
+      - test-linux-aarch64-05
+      - build-linux-aarch64-06
+      - test-linux-aarch64-06
+      - build-linux-aarch64-07
+      - test-linux-aarch64-07
+      - build-linux-aarch64-08
+      - test-linux-aarch64-08
+      - build-linux-aarch64-09
+      - test-linux-aarch64-09
     runs-on: ubuntu-latest
     permissions:
       actions: 'read'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,53 +15,25 @@ jobs:
 
     outputs:
 
-      if_debian_buster_x86_64: ${{ steps.scm.outputs.if_debian_buster_x86_64 }}
+      if_linux_aarch64_00: ${{ steps.scm.outputs.if_linux_aarch64_00 }}
 
-      if_debian_buster_aarch64: ${{ steps.scm.outputs.if_debian_buster_aarch64 }}
+      if_linux_aarch64_01: ${{ steps.scm.outputs.if_linux_aarch64_01 }}
 
-      if_debian_bullseye_x86_64: ${{ steps.scm.outputs.if_debian_bullseye_x86_64 }}
+      if_linux_aarch64_02: ${{ steps.scm.outputs.if_linux_aarch64_02 }}
 
-      if_debian_bullseye_aarch64: ${{ steps.scm.outputs.if_debian_bullseye_aarch64 }}
+      if_linux_aarch64_03: ${{ steps.scm.outputs.if_linux_aarch64_03 }}
 
-      if_debian_bookworm_x86_64: ${{ steps.scm.outputs.if_debian_bookworm_x86_64 }}
+      if_linux_aarch64_04: ${{ steps.scm.outputs.if_linux_aarch64_04 }}
 
-      if_debian_bookworm_aarch64: ${{ steps.scm.outputs.if_debian_bookworm_aarch64 }}
+      if_linux_aarch64_05: ${{ steps.scm.outputs.if_linux_aarch64_05 }}
 
-      if_ubuntu_bionic_x86_64: ${{ steps.scm.outputs.if_ubuntu_bionic_x86_64 }}
+      if_linux_aarch64_06: ${{ steps.scm.outputs.if_linux_aarch64_06 }}
 
-      if_ubuntu_bionic_aarch64: ${{ steps.scm.outputs.if_ubuntu_bionic_aarch64 }}
+      if_linux_aarch64_07: ${{ steps.scm.outputs.if_linux_aarch64_07 }}
 
-      if_ubuntu_focal_x86_64: ${{ steps.scm.outputs.if_ubuntu_focal_x86_64 }}
+      if_linux_aarch64_08: ${{ steps.scm.outputs.if_linux_aarch64_08 }}
 
-      if_ubuntu_focal_aarch64: ${{ steps.scm.outputs.if_ubuntu_focal_aarch64 }}
-
-      if_ubuntu_jammy_x86_64: ${{ steps.scm.outputs.if_ubuntu_jammy_x86_64 }}
-
-      if_ubuntu_jammy_aarch64: ${{ steps.scm.outputs.if_ubuntu_jammy_aarch64 }}
-
-      if_ubuntu_noble_x86_64: ${{ steps.scm.outputs.if_ubuntu_noble_x86_64 }}
-
-      if_ubuntu_noble_aarch64: ${{ steps.scm.outputs.if_ubuntu_noble_aarch64 }}
-
-      if_centos_8_x86_64: ${{ steps.scm.outputs.if_centos_8_x86_64 }}
-
-      if_centos_8_aarch64: ${{ steps.scm.outputs.if_centos_8_aarch64 }}
-
-      if_rockylinux_9_x86_64: ${{ steps.scm.outputs.if_rockylinux_9_x86_64 }}
-
-      if_rockylinux_9_aarch64: ${{ steps.scm.outputs.if_rockylinux_9_aarch64 }}
-
-      if_linux_x86_64: ${{ steps.scm.outputs.if_linux_x86_64 }}
-
-      if_linux_aarch64: ${{ steps.scm.outputs.if_linux_aarch64 }}
-
-      if_linuxmusl_x86_64: ${{ steps.scm.outputs.if_linuxmusl_x86_64 }}
-
-      if_linuxmusl_aarch64: ${{ steps.scm.outputs.if_linuxmusl_aarch64 }}
-
-      if_macos_x86_64: ${{ steps.scm.outputs.if_macos_x86_64 }}
-
-      if_macos_aarch64: ${{ steps.scm.outputs.if_macos_aarch64 }}
+      if_linux_aarch64_09: ${{ steps.scm.outputs.if_linux_aarch64_09 }}
 
 
     steps:
@@ -77,817 +49,112 @@ jobs:
 
         val=true
 
-        idx_file=buster.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-buster-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_buster_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=buster.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-buster-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_buster_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bullseye.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bullseye-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bullseye_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bullseye.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bullseye-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bullseye_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bookworm.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bookworm-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bookworm_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bookworm.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing debian-bookworm-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_debian_bookworm_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bionic.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-bionic-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_bionic_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=bionic.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-bionic-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_bionic_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=focal.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-focal-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_focal_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=focal.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-focal-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_focal_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=jammy.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-jammy-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_jammy_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=jammy.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-jammy-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_jammy_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=noble.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-noble-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_noble_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=noble.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing ubuntu-noble-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_ubuntu_noble_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el8.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing centos-8-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_centos_8_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el8.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing centos-8-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_centos_8_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el9.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing rockylinux-9-x86_64'
-            val=false
-          fi
-        fi
-
-        echo if_rockylinux_9_x86_64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        idx_file=el9.nightly.json
-        if [ ! -e "/tmp/$idx_file" ]; then
-          curl --fail -o /tmp/$idx_file -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file || true
-        fi
-        if [ -e "/tmp/$idx_file" ]; then
-          out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-          if [ -n "$out" ]; then
-            echo 'Skip rebuilding existing rockylinux-9-aarch64'
-            val=false
-          fi
-        fi
-
-        echo if_rockylinux_9_aarch64="$val" >> $GITHUB_OUTPUT
-
-        val=true
-
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linux-x86_64'
+          echo 'Skip rebuilding existing linux-aarch64-00'
           val=false
         fi
 
-        echo if_linux_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_00="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linux-aarch64'
+          echo 'Skip rebuilding existing linux-aarch64-01'
           val=false
         fi
 
-        echo if_linux_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_01="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linuxmusl-x86_64'
+          echo 'Skip rebuilding existing linux-aarch64-02'
           val=false
         fi
 
-        echo if_linuxmusl_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_02="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing linuxmusl-aarch64'
+          echo 'Skip rebuilding existing linux-aarch64-03'
           val=false
         fi
 
-        echo if_linuxmusl_aarch64="$val" >> $GITHUB_OUTPUT
-
+        echo if_linux_aarch64_03="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-apple-darwin.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing macos-x86_64'
+          echo 'Skip rebuilding existing linux-aarch64-04'
           val=false
         fi
 
-        echo if_macos_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_04="$val" >> $GITHUB_OUTPUT
 
         val=true
 
-        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-apple-darwin.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing macos-aarch64'
+          echo 'Skip rebuilding existing linux-aarch64-05'
           val=false
         fi
 
-        echo if_macos_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64_05="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-06'
+          val=false
+        fi
+
+        echo if_linux_aarch64_06="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-07'
+          val=false
+        fi
+
+        echo if_linux_aarch64_07="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-08'
+          val=false
+        fi
+
+        echo if_linux_aarch64_08="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl --fail -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-gnu.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter" || true)
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing linux-aarch64-09'
+          val=false
+        fi
+
+        echo if_linux_aarch64_09="$val" >> $GITHUB_OUTPUT
 
 
 
-  build-debian-buster-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
 
-    if: needs.prep.outputs.if_debian_buster_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-  build-debian-buster-aarch64:
+  build-linux-aarch64-00:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_debian_buster_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-  build-debian-bullseye-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bullseye_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-  build-debian-bullseye-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bullseye_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-  build-debian-bookworm-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bookworm_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-  build-debian-bookworm-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_debian_bookworm_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-  build-ubuntu-bionic-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_bionic_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-bionic-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_bionic_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-focal-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_focal_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-focal-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_focal_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-jammy-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_jammy_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-jammy-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_jammy_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-noble-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_noble_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-  build-ubuntu-noble-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_ubuntu_noble_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-  build-centos-8-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_centos_8_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-  build-centos-8-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_centos_8_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-  build-rockylinux-9-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_rockylinux_9_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-  build-rockylinux-9-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_rockylinux_9_aarch64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-  build-linux-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_linux_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_GENERIC: true
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-  build-linux-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-    if: needs.prep.outputs.if_linux_aarch64 == 'true'
+    if: needs.prep.outputs.if_linux_aarch64_00 == 'true'
 
 
     steps:
@@ -905,45 +172,19 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
-  build-linuxmusl-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-    if: needs.prep.outputs.if_linuxmusl_x86_64 == 'true'
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-  build-linuxmusl-aarch64:
+  build-linux-aarch64-01:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_linuxmusl_aarch64 == 'true'
+    if: needs.prep.outputs.if_linux_aarch64_01 == 'true'
 
 
     steps:
     - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
@@ -952,563 +193,221 @@ jobs:
         PKG_PLATFORM_VERSION: "aarch64"
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
-  build-macos-x86_64:
-    runs-on: ['macos-13']
+  build-linux-aarch64-02:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_macos_x86_64 == 'true'
+    if: needs.prep.outputs.if_linux_aarch64_02 == 'true'
 
 
     steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
     - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_ARCH: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-  build-macos-aarch64:
-    runs-on: ['macos-14']
-    needs: prep
-
-    if: needs.prep.outputs.if_macos_aarch64 == 'true'
-
-
-    steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
-    - name: Build
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_ARCH: "aarch64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-  test-debian-buster-x86_64:
-    needs: [build-debian-buster-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-buster-aarch64:
-    needs: [build-debian-buster-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-x86_64:
-    needs: [build-debian-bullseye-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-aarch64:
-    needs: [build-debian-bullseye-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-x86_64:
-    needs: [build-debian-bookworm-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-aarch64:
-    needs: [build-debian-bookworm-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-x86_64:
-    needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-aarch64:
-    needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-x86_64:
-    needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-aarch64:
-    needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-x86_64:
-    needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-aarch64:
-    needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-x86_64:
-    needs: [build-ubuntu-noble-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-aarch64:
-    needs: [build-ubuntu-noble-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-x86_64:
-    needs: [build-centos-8-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-aarch64:
-    needs: [build-centos-8-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-x86_64:
-    needs: [build-rockylinux-9-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-aarch64:
-    needs: [build-rockylinux-9-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linux-x86_64:
-    needs: [build-linux-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linux-x86_64@master
-      env:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
 
-  test-linux-aarch64:
-    needs: [build-linux-aarch64]
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-03:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_03 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-04:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_04 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-05:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_05 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-06:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_06 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-07:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_07 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-08:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_08 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-09:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+    if: needs.prep.outputs.if_linux_aarch64_09 == 'true'
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+  test-linux-aarch64-00:
+    needs: [build-linux-aarch64-00]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Test
@@ -1522,1097 +421,203 @@ jobs:
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-linuxmusl-x86_64:
-    needs: [build-linuxmusl-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: "musl"
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linuxmusl-aarch64:
-    needs: [build-linuxmusl-aarch64]
+  test-linux-aarch64-01:
+    needs: [build-linux-aarch64-01]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_LIBC: "musl"
+        PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-macos-x86_64:
-    needs: [build-macos-x86_64]
-    runs-on: ['macos-13']
+  test-linux-aarch64-02:
+    needs: [build-linux-aarch64-02]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
 
     - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        # Run fewer tests on x86_64, since the test runner is very slow.
-        PKG_TEST_FILES: "test_dump*.py test_backend_*.py test_database.py test_server_*.py test_edgeql_ddl.py test_session.py"
-      run: |
-        # Bump shmmax and shmall to avoid test failures.
-        sudo sysctl -w kern.sysv.shmmax=12582912
-        sudo sysctl -w kern.sysv.shmall=12582912
-        edgedb-pkg/integration/macos/test.sh
-
-  test-macos-aarch64:
-    needs: [build-macos-aarch64]
-    runs-on: ['macos-14']
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-    - name: Test
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
+        PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-      run: |
-        edgedb-pkg/integration/macos/test.sh
-
-  publish-debian-buster-x86_64:
-    needs: [test-debian-buster-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
         PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
 
-  check-published-debian-buster-x86_64:
-    needs: [publish-debian-buster-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-buster
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-buster-aarch64:
-    needs: [test-debian-buster-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-buster-aarch64:
-    needs: [publish-debian-buster-aarch64]
+  test-linux-aarch64-03:
+    needs: [build-linux-aarch64-03]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
 
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-buster
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bullseye-x86_64:
-    needs: [test-debian-bullseye-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bullseye-x86_64:
-    needs: [publish-debian-bullseye-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bullseye
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bullseye@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bullseye-aarch64:
-    needs: [test-debian-bullseye-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bullseye-aarch64:
-    needs: [publish-debian-bullseye-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bullseye
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bullseye@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bookworm-x86_64:
-    needs: [test-debian-bookworm-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bookworm-x86_64:
-    needs: [publish-debian-bookworm-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bookworm
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bookworm@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bookworm-aarch64:
-    needs: [test-debian-bookworm-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bookworm-aarch64:
-    needs: [publish-debian-bookworm-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bookworm
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bookworm@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-bionic-x86_64:
-    needs: [test-ubuntu-bionic-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-bionic-x86_64:
-    needs: [publish-ubuntu-bionic-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-bionic
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-bionic-aarch64:
-    needs: [test-ubuntu-bionic-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-bionic-aarch64:
-    needs: [publish-ubuntu-bionic-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-bionic
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-focal-x86_64:
-    needs: [test-ubuntu-focal-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-focal-x86_64:
-    needs: [publish-ubuntu-focal-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-focal
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-focal-aarch64:
-    needs: [test-ubuntu-focal-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-focal-aarch64:
-    needs: [publish-ubuntu-focal-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-focal
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-jammy-x86_64:
-    needs: [test-ubuntu-jammy-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-jammy-x86_64:
-    needs: [publish-ubuntu-jammy-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-jammy
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-jammy@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-jammy-aarch64:
-    needs: [test-ubuntu-jammy-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-jammy-aarch64:
-    needs: [publish-ubuntu-jammy-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-jammy
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-jammy@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-noble-x86_64:
-    needs: [test-ubuntu-noble-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-noble-x86_64:
-    needs: [publish-ubuntu-noble-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-noble
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-noble@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-noble-aarch64:
-    needs: [test-ubuntu-noble-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-noble-aarch64:
-    needs: [publish-ubuntu-noble-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-noble
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-noble@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-centos-8-x86_64:
-    needs: [test-centos-8-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-8-x86_64:
-    needs: [publish-centos-8-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-8
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-centos-8-aarch64:
-    needs: [test-centos-8-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-8-aarch64:
-    needs: [publish-centos-8-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-8
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-rockylinux-9-x86_64:
-    needs: [test-rockylinux-9-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-rockylinux-9-x86_64:
-    needs: [publish-rockylinux-9-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: rockylinux-9
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/rockylinux-9@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-rockylinux-9-aarch64:
-    needs: [test-rockylinux-9-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-rockylinux-9-aarch64:
-    needs: [publish-rockylinux-9-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: rockylinux-9
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/rockylinux-9@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linux-x86_64:
-    needs: [test-linux-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
         PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_PLATFORM_VERSION: "aarch64"
         PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
 
-  check-published-linux-x86_64:
-    needs: [publish-linux-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
+  test-linux-aarch64-04:
+    needs: [build-linux-aarch64-04]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
 
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: linux-x86_64
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-x86_64@master
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
         PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
         PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
 
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+  test-linux-aarch64-05:
+    needs: [build-linux-aarch64-05]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
-  publish-linux-aarch64:
-    needs: [test-linux-aarch64]
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-06:
+    needs: [build-linux-aarch64-06]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-07:
+    needs: [build-linux-aarch64-07]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-08:
+    needs: [build-linux-aarch64-08]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-09:
+    needs: [build-linux-aarch64-09]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  publish-linux-aarch64-00:
+    needs: [test-linux-aarch64-00]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Publish
@@ -2625,14 +630,14 @@ jobs:
         PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  check-published-linux-aarch64:
-    needs: [publish-linux-aarch64]
+  check-published-linux-aarch64-00:
+    needs: [publish-linux-aarch64-00]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Describe
@@ -2657,67 +662,15 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-linuxmusl-x86_64:
-    needs: [test-linuxmusl-x86_64]
+  publish-linux-aarch64-01:
+    needs: [test-linux-aarch64-01]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: "musl"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-linuxmusl-x86_64:
-    needs: [publish-linuxmusl-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: linuxmusl-x86_64
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linuxmusl-x86_64@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "nightly"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linuxmusl-aarch64:
-    needs: [test-linuxmusl-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
@@ -2726,27 +679,27 @@ jobs:
         PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_LIBC: "musl"
+        PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  check-published-linuxmusl-aarch64:
-    needs: [publish-linuxmusl-aarch64]
+  check-published-linux-aarch64-01:
+    needs: [publish-linux-aarch64-01]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Describe
       id: describe
       uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
       with:
-        target: linuxmusl-aarch64
+        target: linux-aarch64
 
     - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
       env:
         PKG_NAME: "${{ steps.describe.outputs.name }}"
         PKG_SUBDIST: "nightly"
@@ -2761,147 +714,421 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-macos-x86_64:
-    needs: [test-macos-x86_64]
+  publish-linux-aarch64-02:
+    needs: [test-linux-aarch64-02]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: macos-x86_64
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
 
     - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  publish-macos-aarch64:
-    needs: [test-macos-aarch64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: macos-aarch64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  publish-docker:
-    needs:
-      - check-published-debian-bookworm-x86_64
-      - check-published-debian-bookworm-aarch64
+  check-published-linux-aarch64-02:
+    needs: [publish-linux-aarch64-02]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-03:
+    needs: [test-linux-aarch64-03]
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
 
-    - env:
-        VERSION_SLOT: "${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }}"
-        VERSION_CORE: "${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }}"
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
         PKG_SUBDIST: "nightly"
-      id: tags
-      run: |
-        set -e
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-        url='https://registry.hub.docker.com/v2/repositories/edgedb/edgedb/tags?page_size=100'
-        repo_tags=$(
-          while [ -n "$url" ]; do
-            resp=$(curl -L -s "$url")
-            url=$(echo "$resp" | jq -r ".next")
-            if [ "$url" = "null" ] || [ -z "$url" ]; then
-              break
-            fi
-            echo "$resp" | jq -r '."results"[]["name"]'
-          done | grep "^[[:digit:]]\+.*" | grep -v "alpha\|beta\|rc" || :
-        )
+  check-published-linux-aarch64-03:
+    needs: [publish-linux-aarch64-03]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
-        tags=( "$VERSION_CORE" )
-
-        top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
-              | grep "^${VERSION_SLOT}[\.-]" \
-              | sort --version-sort --reverse | head -n 1)
-        if [ "$top" == "$VERSION_CORE" ]; then
-          tags+=( "$VERSION_SLOT" )
-        fi
-
-        if [ -z "$PKG_SUBDIST" ]; then
-          top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
-                | sort --version-sort --reverse | head -n 1)
-          if [ "$top" == "$VERSION_CORE" ]; then
-            tags+=( "latest" )
-          fi
-        fi
-
-        IFS=,
-        echo "tags=${tags[*]}" >> $GITHUB_OUTPUT
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345  # v3
-
-    - name: Publish Docker Image (docker.io)
-      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: edgedb/edgedb
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "nightly,nightly_${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }}_cv${{ needs.check-published-debian-bookworm-x86_64.outputs.catalog-version }}"
-        workdir: dockerfile
-        buildargs: version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }},subdist=nightly
-        platforms: linux/amd64,linux/arm64
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
 
-    - name: Publish Docker Image (ghcr.io)
-      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
       with:
-        registry: ghcr.io
-        name: ${{ github.repository }}
-        username: "edgedb-ci"
-        password: ${{ secrets.GITHUB_CI_BOT_TOKEN }}
-        tags: "nightly,nightly_${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }}_cv${{ needs.check-published-debian-bookworm-x86_64.outputs.catalog-version }}"
-        workdir: dockerfile
-        buildargs: version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }},subdist=nightly
-        platforms: linux/amd64,linux/arm64
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-04:
+    needs: [test-linux-aarch64-04]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-04:
+    needs: [publish-linux-aarch64-04]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-05:
+    needs: [test-linux-aarch64-05]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-05:
+    needs: [publish-linux-aarch64-05]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-06:
+    needs: [test-linux-aarch64-06]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-06:
+    needs: [publish-linux-aarch64-06]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-07:
+    needs: [test-linux-aarch64-07]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-07:
+    needs: [publish-linux-aarch64-07]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-08:
+    needs: [test-linux-aarch64-08]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-08:
+    needs: [publish-linux-aarch64-08]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-09:
+    needs: [test-linux-aarch64-09]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-09:
+    needs: [publish-linux-aarch64-09]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "nightly"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'
@@ -2909,101 +1136,46 @@ jobs:
 
     needs:
       - prep
-      - build-debian-buster-x86_64
-      - test-debian-buster-x86_64
-      - publish-debian-buster-x86_64
-      - check-published-debian-buster-x86_64
-      - build-debian-buster-aarch64
-      - test-debian-buster-aarch64
-      - publish-debian-buster-aarch64
-      - check-published-debian-buster-aarch64
-      - build-debian-bullseye-x86_64
-      - test-debian-bullseye-x86_64
-      - publish-debian-bullseye-x86_64
-      - check-published-debian-bullseye-x86_64
-      - build-debian-bullseye-aarch64
-      - test-debian-bullseye-aarch64
-      - publish-debian-bullseye-aarch64
-      - check-published-debian-bullseye-aarch64
-      - build-debian-bookworm-x86_64
-      - test-debian-bookworm-x86_64
-      - publish-debian-bookworm-x86_64
-      - check-published-debian-bookworm-x86_64
-      - build-debian-bookworm-aarch64
-      - test-debian-bookworm-aarch64
-      - publish-debian-bookworm-aarch64
-      - check-published-debian-bookworm-aarch64
-      - build-ubuntu-bionic-x86_64
-      - test-ubuntu-bionic-x86_64
-      - publish-ubuntu-bionic-x86_64
-      - check-published-ubuntu-bionic-x86_64
-      - build-ubuntu-bionic-aarch64
-      - test-ubuntu-bionic-aarch64
-      - publish-ubuntu-bionic-aarch64
-      - check-published-ubuntu-bionic-aarch64
-      - build-ubuntu-focal-x86_64
-      - test-ubuntu-focal-x86_64
-      - publish-ubuntu-focal-x86_64
-      - check-published-ubuntu-focal-x86_64
-      - build-ubuntu-focal-aarch64
-      - test-ubuntu-focal-aarch64
-      - publish-ubuntu-focal-aarch64
-      - check-published-ubuntu-focal-aarch64
-      - build-ubuntu-jammy-x86_64
-      - test-ubuntu-jammy-x86_64
-      - publish-ubuntu-jammy-x86_64
-      - check-published-ubuntu-jammy-x86_64
-      - build-ubuntu-jammy-aarch64
-      - test-ubuntu-jammy-aarch64
-      - publish-ubuntu-jammy-aarch64
-      - check-published-ubuntu-jammy-aarch64
-      - build-ubuntu-noble-x86_64
-      - test-ubuntu-noble-x86_64
-      - publish-ubuntu-noble-x86_64
-      - check-published-ubuntu-noble-x86_64
-      - build-ubuntu-noble-aarch64
-      - test-ubuntu-noble-aarch64
-      - publish-ubuntu-noble-aarch64
-      - check-published-ubuntu-noble-aarch64
-      - build-centos-8-x86_64
-      - test-centos-8-x86_64
-      - publish-centos-8-x86_64
-      - check-published-centos-8-x86_64
-      - build-centos-8-aarch64
-      - test-centos-8-aarch64
-      - publish-centos-8-aarch64
-      - check-published-centos-8-aarch64
-      - build-rockylinux-9-x86_64
-      - test-rockylinux-9-x86_64
-      - publish-rockylinux-9-x86_64
-      - check-published-rockylinux-9-x86_64
-      - build-rockylinux-9-aarch64
-      - test-rockylinux-9-aarch64
-      - publish-rockylinux-9-aarch64
-      - check-published-rockylinux-9-aarch64
-      - build-linux-x86_64
-      - test-linux-x86_64
-      - publish-linux-x86_64
-      - check-published-linux-x86_64
-      - build-linux-aarch64
-      - test-linux-aarch64
-      - publish-linux-aarch64
-      - check-published-linux-aarch64
-      - build-linuxmusl-x86_64
-      - test-linuxmusl-x86_64
-      - publish-linuxmusl-x86_64
-      - check-published-linuxmusl-x86_64
-      - build-linuxmusl-aarch64
-      - test-linuxmusl-aarch64
-      - publish-linuxmusl-aarch64
-      - check-published-linuxmusl-aarch64
-      - build-macos-x86_64
-      - test-macos-x86_64
-      - publish-macos-x86_64
-      - build-macos-aarch64
-      - test-macos-aarch64
-      - publish-macos-aarch64
-      - publish-docker
+      - build-linux-aarch64-00
+      - test-linux-aarch64-00
+      - publish-linux-aarch64-00
+      - check-published-linux-aarch64-00
+      - build-linux-aarch64-01
+      - test-linux-aarch64-01
+      - publish-linux-aarch64-01
+      - check-published-linux-aarch64-01
+      - build-linux-aarch64-02
+      - test-linux-aarch64-02
+      - publish-linux-aarch64-02
+      - check-published-linux-aarch64-02
+      - build-linux-aarch64-03
+      - test-linux-aarch64-03
+      - publish-linux-aarch64-03
+      - check-published-linux-aarch64-03
+      - build-linux-aarch64-04
+      - test-linux-aarch64-04
+      - publish-linux-aarch64-04
+      - check-published-linux-aarch64-04
+      - build-linux-aarch64-05
+      - test-linux-aarch64-05
+      - publish-linux-aarch64-05
+      - check-published-linux-aarch64-05
+      - build-linux-aarch64-06
+      - test-linux-aarch64-06
+      - publish-linux-aarch64-06
+      - check-published-linux-aarch64-06
+      - build-linux-aarch64-07
+      - test-linux-aarch64-07
+      - publish-linux-aarch64-07
+      - check-published-linux-aarch64-07
+      - build-linux-aarch64-08
+      - test-linux-aarch64-08
+      - publish-linux-aarch64-08
+      - check-published-linux-aarch64-08
+      - build-linux-aarch64-09
+      - test-linux-aarch64-09
+      - publish-linux-aarch64-09
+      - check-published-linux-aarch64-09
     runs-on: ubuntu-latest
     permissions:
       actions: 'read'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,426 +13,7 @@ jobs:
 
 
 
-  build-debian-buster-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-  build-debian-buster-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-  build-debian-bullseye-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-  build-debian-bullseye-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-  build-debian-bookworm-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-  build-debian-bookworm-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-  build-ubuntu-bionic-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-bionic-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-focal-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-focal-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-jammy-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-jammy-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-noble-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-  build-ubuntu-noble-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-  build-centos-8-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-  build-centos-8-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-  build-rockylinux-9-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-  build-rockylinux-9-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-  build-linux-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        BUILD_GENERIC: true
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-  build-linux-aarch64:
+  build-linux-aarch64-00:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
@@ -452,41 +33,17 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
-  build-linuxmusl-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-  build-linuxmusl-aarch64:
+  build-linux-aarch64-01:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
     steps:
     - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
@@ -495,540 +52,205 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
         BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
-  build-macos-x86_64:
-    runs-on: ['macos-13']
+  build-linux-aarch64-02:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
     steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
     - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
-        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_ARCH: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-  build-macos-aarch64:
-    runs-on: ['macos-14']
-    needs: prep
-
-
-    steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
-    - name: Build
-      env:
-        SRC_REF: "${{ github.sha }}"
-        BUILD_IS_RELEASE: "true"
-        PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_ARCH: "aarch64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-  test-debian-buster-x86_64:
-    needs: [build-debian-buster-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-buster-aarch64:
-    needs: [build-debian-buster-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-x86_64:
-    needs: [build-debian-bullseye-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-aarch64:
-    needs: [build-debian-bullseye-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-x86_64:
-    needs: [build-debian-bookworm-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-aarch64:
-    needs: [build-debian-bookworm-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-x86_64:
-    needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-aarch64:
-    needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-x86_64:
-    needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-aarch64:
-    needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-x86_64:
-    needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-aarch64:
-    needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-x86_64:
-    needs: [build-ubuntu-noble-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-aarch64:
-    needs: [build-ubuntu-noble-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-x86_64:
-    needs: [build-centos-8-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-aarch64:
-    needs: [build-centos-8-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-x86_64:
-    needs: [build-rockylinux-9-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-aarch64:
-    needs: [build-rockylinux-9-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linux-x86_64:
-    needs: [build-linux-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linux-x86_64@master
-      env:
         PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
 
-  test-linux-aarch64:
-    needs: [build-linux-aarch64]
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-03:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-04:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-05:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-06:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-07:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-08:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-09:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+  test-linux-aarch64-00:
+    needs: [build-linux-aarch64-00]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Test
@@ -1041,1084 +263,209 @@ jobs:
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-linuxmusl-x86_64:
-    needs: [build-linuxmusl-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-x86_64@master
-      env:
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: "musl"
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linuxmusl-aarch64:
-    needs: [build-linuxmusl-aarch64]
+  test-linux-aarch64-01:
+    needs: [build-linux-aarch64-01]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_LIBC: "musl"
+        PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-macos-x86_64:
-    needs: [build-macos-x86_64]
-    runs-on: ['macos-13']
+  test-linux-aarch64-02:
+    needs: [build-linux-aarch64-02]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
 
     - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        # Run fewer tests on x86_64, since the test runner is very slow.
-        PKG_TEST_FILES: "test_dump*.py test_backend_*.py test_database.py test_server_*.py test_edgeql_ddl.py test_session.py"
-      run: |
-        # Bump shmmax and shmall to avoid test failures.
-        sudo sysctl -w kern.sysv.shmmax=12582912
-        sudo sysctl -w kern.sysv.shmall=12582912
-        edgedb-pkg/integration/macos/test.sh
-
-  test-macos-aarch64:
-    needs: [build-macos-aarch64]
-    runs-on: ['macos-14']
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-    - name: Test
-      env:
-        PKG_PLATFORM: "macos"
+        PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-      run: |
-        edgedb-pkg/integration/macos/test.sh
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-03:
+    needs: [build-linux-aarch64-03]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-04:
+    needs: [build-linux-aarch64-04]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-05:
+    needs: [build-linux-aarch64-05]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-06:
+    needs: [build-linux-aarch64-06]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-07:
+    needs: [build-linux-aarch64-07]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-08:
+    needs: [build-linux-aarch64-08]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-09:
+    needs: [build-linux-aarch64-09]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
   collect:
     needs:
-    - test-debian-buster-x86_64
-    - test-debian-buster-aarch64
-    - test-debian-bullseye-x86_64
-    - test-debian-bullseye-aarch64
-    - test-debian-bookworm-x86_64
-    - test-debian-bookworm-aarch64
-    - test-ubuntu-bionic-x86_64
-    - test-ubuntu-bionic-aarch64
-    - test-ubuntu-focal-x86_64
-    - test-ubuntu-focal-aarch64
-    - test-ubuntu-jammy-x86_64
-    - test-ubuntu-jammy-aarch64
-    - test-ubuntu-noble-x86_64
-    - test-ubuntu-noble-aarch64
-    - test-centos-8-x86_64
-    - test-centos-8-aarch64
-    - test-rockylinux-9-x86_64
-    - test-rockylinux-9-aarch64
-    - test-linux-x86_64
-    - test-linux-aarch64
-    - test-linuxmusl-x86_64
-    - test-linuxmusl-aarch64
-    - test-macos-x86_64
-    - test-macos-aarch64
+    - test-linux-aarch64-00
+    - test-linux-aarch64-01
+    - test-linux-aarch64-02
+    - test-linux-aarch64-03
+    - test-linux-aarch64-04
+    - test-linux-aarch64-05
+    - test-linux-aarch64-06
+    - test-linux-aarch64-07
+    - test-linux-aarch64-08
+    - test-linux-aarch64-09
     runs-on: ubuntu-latest
     steps:
       - run: echo 'All build+tests passed, ready to publish now!'
 
-  publish-debian-buster-x86_64:
+  publish-linux-aarch64-00:
     needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-buster-x86_64:
-    needs: [publish-debian-buster-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-buster
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-buster-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-buster-aarch64:
-    needs: [publish-debian-buster-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-buster
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bullseye-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bullseye-x86_64:
-    needs: [publish-debian-bullseye-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bullseye
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bullseye@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bullseye-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bullseye-aarch64:
-    needs: [publish-debian-bullseye-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bullseye
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bullseye@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bookworm-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bookworm-x86_64:
-    needs: [publish-debian-bookworm-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bookworm
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bookworm@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bookworm-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bookworm-aarch64:
-    needs: [publish-debian-bookworm-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bookworm
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bookworm@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-bionic-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-bionic-x86_64:
-    needs: [publish-ubuntu-bionic-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-bionic
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-bionic-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-bionic-aarch64:
-    needs: [publish-ubuntu-bionic-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-bionic
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-focal-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-focal-x86_64:
-    needs: [publish-ubuntu-focal-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-focal
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-focal-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-focal-aarch64:
-    needs: [publish-ubuntu-focal-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-focal
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-jammy-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-jammy-x86_64:
-    needs: [publish-ubuntu-jammy-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-jammy
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-jammy@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-jammy-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-jammy-aarch64:
-    needs: [publish-ubuntu-jammy-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-jammy
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-jammy@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-noble-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-noble-x86_64:
-    needs: [publish-ubuntu-noble-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-noble
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-noble@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-noble-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-noble-aarch64:
-    needs: [publish-ubuntu-noble-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-noble
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-noble@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-centos-8-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-8-x86_64:
-    needs: [publish-centos-8-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-8
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-centos-8-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-8-aarch64:
-    needs: [publish-centos-8-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-8
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-rockylinux-9-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-rockylinux-9-x86_64:
-    needs: [publish-rockylinux-9-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: rockylinux-9
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/rockylinux-9@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-rockylinux-9-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-rockylinux-9-aarch64:
-    needs: [publish-rockylinux-9-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: rockylinux-9
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/rockylinux-9@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linux-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-linux-x86_64:
-    needs: [publish-linux-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: linux-x86_64
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-x86_64@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linux-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Publish
@@ -2130,14 +477,14 @@ jobs:
         PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  check-published-linux-aarch64:
-    needs: [publish-linux-aarch64]
+  check-published-linux-aarch64-00:
+    needs: [publish-linux-aarch64-00]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Describe
@@ -2161,65 +508,15 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-linuxmusl-x86_64:
+  publish-linux-aarch64-01:
     needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: "musl"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-linuxmusl-x86_64:
-    needs: [publish-linuxmusl-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: linuxmusl-x86_64
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linuxmusl-x86_64@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linuxmusl-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
@@ -2227,27 +524,27 @@ jobs:
         PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_LIBC: "musl"
+        PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  check-published-linuxmusl-aarch64:
-    needs: [publish-linuxmusl-aarch64]
+  check-published-linux-aarch64-01:
+    needs: [publish-linux-aarch64-01]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Describe
       id: describe
       uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
       with:
-        target: linuxmusl-aarch64
+        target: linux-aarch64
 
     - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
       env:
         PKG_NAME: "${{ steps.describe.outputs.name }}"
         PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
@@ -2261,145 +558,405 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-macos-x86_64:
+  publish-linux-aarch64-02:
     needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: macos-x86_64
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
 
     - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
       env:
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  publish-macos-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: macos-aarch64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_PLATFORM: "macos"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  publish-docker:
-    needs:
-      - check-published-debian-bookworm-x86_64
-      - check-published-debian-bookworm-aarch64
+  check-published-linux-aarch64-02:
+    needs: [publish-linux-aarch64-02]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-03:
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
 
-    - env:
-        VERSION_SLOT: "${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }}"
-        VERSION_CORE: "${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }}"
-        PKG_SUBDIST: ""
-      id: tags
-      run: |
-        set -e
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-        url='https://registry.hub.docker.com/v2/repositories/edgedb/edgedb/tags?page_size=100'
-        repo_tags=$(
-          while [ -n "$url" ]; do
-            resp=$(curl -L -s "$url")
-            url=$(echo "$resp" | jq -r ".next")
-            if [ "$url" = "null" ] || [ -z "$url" ]; then
-              break
-            fi
-            echo "$resp" | jq -r '."results"[]["name"]'
-          done | grep "^[[:digit:]]\+.*" | grep -v "alpha\|beta\|rc" || :
-        )
+  check-published-linux-aarch64-03:
+    needs: [publish-linux-aarch64-03]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
-        tags=( "$VERSION_CORE" )
-
-        top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
-              | grep "^${VERSION_SLOT}[\.-]" \
-              | sort --version-sort --reverse | head -n 1)
-        if [ "$top" == "$VERSION_CORE" ]; then
-          tags+=( "$VERSION_SLOT" )
-        fi
-
-        if [ -z "$PKG_SUBDIST" ]; then
-          top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
-                | sort --version-sort --reverse | head -n 1)
-          if [ "$top" == "$VERSION_CORE" ]; then
-            tags+=( "latest" )
-          fi
-        fi
-
-        IFS=,
-        echo "tags=${tags[*]}" >> $GITHUB_OUTPUT
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345  # v3
-
-    - name: Publish Docker Image (docker.io)
-      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: edgedb/edgedb
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "${{ steps.tags.outputs.tags }}"
-        workdir: dockerfile
-        buildargs: version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }}
-        platforms: linux/amd64,linux/arm64
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
 
-    - name: Publish Docker Image (ghcr.io)
-      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
       with:
-        registry: ghcr.io
-        name: ${{ github.repository }}
-        username: "edgedb-ci"
-        password: ${{ secrets.GITHUB_CI_BOT_TOKEN }}
-        tags: "${{ steps.tags.outputs.tags }}"
-        workdir: dockerfile
-        buildargs: version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }}
-        platforms: linux/amd64,linux/arm64
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-04:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-04:
+    needs: [publish-linux-aarch64-04]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-05:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-05:
+    needs: [publish-linux-aarch64-05]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-06:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-06:
+    needs: [publish-linux-aarch64-06]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-07:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-07:
+    needs: [publish-linux-aarch64-07]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-08:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-08:
+    needs: [publish-linux-aarch64-08]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-09:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-09:
+    needs: [publish-linux-aarch64-09]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'
@@ -2408,101 +965,46 @@ jobs:
     needs:
       - prep
       - collect
-      - build-debian-buster-x86_64
-      - test-debian-buster-x86_64
-      - publish-debian-buster-x86_64
-      - check-published-debian-buster-x86_64
-      - build-debian-buster-aarch64
-      - test-debian-buster-aarch64
-      - publish-debian-buster-aarch64
-      - check-published-debian-buster-aarch64
-      - build-debian-bullseye-x86_64
-      - test-debian-bullseye-x86_64
-      - publish-debian-bullseye-x86_64
-      - check-published-debian-bullseye-x86_64
-      - build-debian-bullseye-aarch64
-      - test-debian-bullseye-aarch64
-      - publish-debian-bullseye-aarch64
-      - check-published-debian-bullseye-aarch64
-      - build-debian-bookworm-x86_64
-      - test-debian-bookworm-x86_64
-      - publish-debian-bookworm-x86_64
-      - check-published-debian-bookworm-x86_64
-      - build-debian-bookworm-aarch64
-      - test-debian-bookworm-aarch64
-      - publish-debian-bookworm-aarch64
-      - check-published-debian-bookworm-aarch64
-      - build-ubuntu-bionic-x86_64
-      - test-ubuntu-bionic-x86_64
-      - publish-ubuntu-bionic-x86_64
-      - check-published-ubuntu-bionic-x86_64
-      - build-ubuntu-bionic-aarch64
-      - test-ubuntu-bionic-aarch64
-      - publish-ubuntu-bionic-aarch64
-      - check-published-ubuntu-bionic-aarch64
-      - build-ubuntu-focal-x86_64
-      - test-ubuntu-focal-x86_64
-      - publish-ubuntu-focal-x86_64
-      - check-published-ubuntu-focal-x86_64
-      - build-ubuntu-focal-aarch64
-      - test-ubuntu-focal-aarch64
-      - publish-ubuntu-focal-aarch64
-      - check-published-ubuntu-focal-aarch64
-      - build-ubuntu-jammy-x86_64
-      - test-ubuntu-jammy-x86_64
-      - publish-ubuntu-jammy-x86_64
-      - check-published-ubuntu-jammy-x86_64
-      - build-ubuntu-jammy-aarch64
-      - test-ubuntu-jammy-aarch64
-      - publish-ubuntu-jammy-aarch64
-      - check-published-ubuntu-jammy-aarch64
-      - build-ubuntu-noble-x86_64
-      - test-ubuntu-noble-x86_64
-      - publish-ubuntu-noble-x86_64
-      - check-published-ubuntu-noble-x86_64
-      - build-ubuntu-noble-aarch64
-      - test-ubuntu-noble-aarch64
-      - publish-ubuntu-noble-aarch64
-      - check-published-ubuntu-noble-aarch64
-      - build-centos-8-x86_64
-      - test-centos-8-x86_64
-      - publish-centos-8-x86_64
-      - check-published-centos-8-x86_64
-      - build-centos-8-aarch64
-      - test-centos-8-aarch64
-      - publish-centos-8-aarch64
-      - check-published-centos-8-aarch64
-      - build-rockylinux-9-x86_64
-      - test-rockylinux-9-x86_64
-      - publish-rockylinux-9-x86_64
-      - check-published-rockylinux-9-x86_64
-      - build-rockylinux-9-aarch64
-      - test-rockylinux-9-aarch64
-      - publish-rockylinux-9-aarch64
-      - check-published-rockylinux-9-aarch64
-      - build-linux-x86_64
-      - test-linux-x86_64
-      - publish-linux-x86_64
-      - check-published-linux-x86_64
-      - build-linux-aarch64
-      - test-linux-aarch64
-      - publish-linux-aarch64
-      - check-published-linux-aarch64
-      - build-linuxmusl-x86_64
-      - test-linuxmusl-x86_64
-      - publish-linuxmusl-x86_64
-      - check-published-linuxmusl-x86_64
-      - build-linuxmusl-aarch64
-      - test-linuxmusl-aarch64
-      - publish-linuxmusl-aarch64
-      - check-published-linuxmusl-aarch64
-      - build-macos-x86_64
-      - test-macos-x86_64
-      - publish-macos-x86_64
-      - build-macos-aarch64
-      - test-macos-aarch64
-      - publish-macos-aarch64
-      - publish-docker
+      - build-linux-aarch64-00
+      - test-linux-aarch64-00
+      - publish-linux-aarch64-00
+      - check-published-linux-aarch64-00
+      - build-linux-aarch64-01
+      - test-linux-aarch64-01
+      - publish-linux-aarch64-01
+      - check-published-linux-aarch64-01
+      - build-linux-aarch64-02
+      - test-linux-aarch64-02
+      - publish-linux-aarch64-02
+      - check-published-linux-aarch64-02
+      - build-linux-aarch64-03
+      - test-linux-aarch64-03
+      - publish-linux-aarch64-03
+      - check-published-linux-aarch64-03
+      - build-linux-aarch64-04
+      - test-linux-aarch64-04
+      - publish-linux-aarch64-04
+      - check-published-linux-aarch64-04
+      - build-linux-aarch64-05
+      - test-linux-aarch64-05
+      - publish-linux-aarch64-05
+      - check-published-linux-aarch64-05
+      - build-linux-aarch64-06
+      - test-linux-aarch64-06
+      - publish-linux-aarch64-06
+      - check-published-linux-aarch64-06
+      - build-linux-aarch64-07
+      - test-linux-aarch64-07
+      - publish-linux-aarch64-07
+      - check-published-linux-aarch64-07
+      - build-linux-aarch64-08
+      - test-linux-aarch64-08
+      - publish-linux-aarch64-08
+      - check-published-linux-aarch64-08
+      - build-linux-aarch64-09
+      - test-linux-aarch64-09
+      - publish-linux-aarch64-09
+      - check-published-linux-aarch64-09
     runs-on: ubuntu-latest
     permissions:
       actions: 'read'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,445 +13,7 @@ jobs:
 
 
 
-  build-debian-buster-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-  build-debian-buster-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-  build-debian-bullseye-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-  build-debian-bullseye-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-  build-debian-bookworm-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-  build-debian-bookworm-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/debian-bookworm@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-  build-ubuntu-bionic-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-bionic-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-  build-ubuntu-focal-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-focal-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-  build-ubuntu-jammy-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-jammy-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-jammy@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-  build-ubuntu-noble-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-  build-ubuntu-noble-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-noble@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-  build-centos-8-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-  build-centos-8-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-  build-rockylinux-9-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-  build-rockylinux-9-aarch64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/rockylinux-9@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-  build-linux-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        BUILD_GENERIC: true
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-  build-linux-aarch64:
+  build-linux-aarch64-00:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
@@ -472,42 +34,17 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
-  build-linuxmusl-x86_64:
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-    needs: prep
-
-
-    steps:
-    - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
-      env:
-        SRC_REF: "${{ github.sha }}"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        BUILD_IS_RELEASE: "true"
-        BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
-        METAPKG_GIT_CACHE: disabled
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-  build-linuxmusl-aarch64:
+  build-linux-aarch64-01:
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
     steps:
     - name: Build
-      uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
         PKG_REVISION: "<current-date>"
@@ -517,561 +54,213 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
         BUILD_GENERIC: true
-        PKG_PLATFORM_LIBC: "musl"
         METAPKG_GIT_CACHE: disabled
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
-  build-macos-x86_64:
-    runs-on: ['macos-13']
+  build-linux-aarch64-02:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
     needs: prep
 
 
     steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
     - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
       env:
         SRC_REF: "${{ github.sha }}"
-        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_ARCH: "x86_64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-  build-macos-aarch64:
-    runs-on: ['macos-14']
-    needs: prep
-
-
-    steps:
-    - name: Update Homebrew before installing Rust toolchain
-      run: |
-        # Homebrew renamed `rustup-init` to `rustup`:
-        #   https://github.com/Homebrew/homebrew-core/pull/177840
-        # But the GitHub Action runner is not updated with this change yet.
-        # This caused the later `brew update` in step `Build` to relink Rust
-        # toolchain executables, overwriting the custom toolchain installed by
-        # `dsherret/rust-toolchain-file`. So let's just run `brew update` early.
-        brew update
-
-    - uses: actions/checkout@v4
-      if: true
-      with:
-        sparse-checkout: |
-          rust-toolchain.toml
-        sparse-checkout-cone-mode: false
-
-    - name: Install Rust toolchain
-      uses: dsherret/rust-toolchain-file@v1
-      if: true
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      if: true
-      with:
-        python-version: "3.12"
-
-    - name: Set up NodeJS
-      uses: actions/setup-node@v4
-      if: true
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      if: true
-      run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
-
-    - name: Build
-      env:
-        SRC_REF: "${{ github.sha }}"
-        BUILD_IS_RELEASE: "true"
-        PKG_REVISION: "<current-date>"
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_ARCH: "aarch64"
-        EXTRA_OPTIMIZATIONS: "true"
-        METAPKG_GIT_CACHE: disabled
-        BUILD_GENERIC: true
-      run: |
-        edgedb-pkg/integration/macos/build.sh
-
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-  test-debian-buster-x86_64:
-    needs: [build-debian-buster-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-buster-aarch64:
-    needs: [build-debian-buster-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-x86_64:
-    needs: [build-debian-bullseye-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bullseye-aarch64:
-    needs: [build-debian-bullseye-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bullseye@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-x86_64:
-    needs: [build-debian-bookworm-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-debian-bookworm-aarch64:
-    needs: [build-debian-bookworm-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-bookworm@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-x86_64:
-    needs: [build-ubuntu-bionic-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-bionic-aarch64:
-    needs: [build-ubuntu-bionic-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-x86_64:
-    needs: [build-ubuntu-focal-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-focal-aarch64:
-    needs: [build-ubuntu-focal-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-x86_64:
-    needs: [build-ubuntu-jammy-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-jammy-aarch64:
-    needs: [build-ubuntu-jammy-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-jammy@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-x86_64:
-    needs: [build-ubuntu-noble-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-ubuntu-noble-aarch64:
-    needs: [build-ubuntu-noble-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-noble@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-x86_64:
-    needs: [build-centos-8-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-centos-8-aarch64:
-    needs: [build-centos-8-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-x86_64:
-    needs: [build-rockylinux-9-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-rockylinux-9-aarch64:
-    needs: [build-rockylinux-9-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/rockylinux-9@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linux-x86_64:
-    needs: [build-linux-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linux-x86_64@master
-      env:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: ""
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
 
-  test-linux-aarch64:
-    needs: [build-linux-aarch64]
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-03:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-04:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-05:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-06:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-07:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-08:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+  build-linux-aarch64-09:
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+    needs: prep
+
+
+    steps:
+    - name: Build
+      uses: edgedb/edgedb-pkg/integration/linux/build/linux-aarch64@master
+      env:
+        SRC_REF: "${{ github.sha }}"
+        PKG_REVISION: "<current-date>"
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
+        BUILD_GENERIC: true
+        METAPKG_GIT_CACHE: disabled
+
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+  test-linux-aarch64-00:
+    needs: [build-linux-aarch64-00]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Test
@@ -1085,1126 +274,218 @@ jobs:
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-linuxmusl-x86_64:
-    needs: [build-linuxmusl-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: "musl"
-        # edb test with -j higher than 1 seems to result in workflow
-        # jobs getting killed arbitrarily by Github.
-        PKG_TEST_JOBS: 0
-
-  test-linuxmusl-aarch64:
-    needs: [build-linuxmusl-aarch64]
+  test-linux-aarch64-01:
+    needs: [build-linux-aarch64-01]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_LIBC: "musl"
+        PKG_PLATFORM_LIBC: ""
         # edb test with -j higher than 1 seems to result in workflow
         # jobs getting killed arbitrarily by Github.
         PKG_TEST_JOBS: 0
 
-  test-macos-x86_64:
-    needs: [build-macos-x86_64]
-    runs-on: ['macos-13']
+  test-linux-aarch64-02:
+    needs: [build-linux-aarch64-02]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
 
     - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
       env:
         PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        # Run fewer tests on x86_64, since the test runner is very slow.
-        PKG_TEST_FILES: "test_dump*.py test_backend_*.py test_database.py test_server_*.py test_edgeql_ddl.py test_session.py"
-      run: |
-        # Bump shmmax and shmall to avoid test failures.
-        sudo sysctl -w kern.sysv.shmmax=12582912
-        sudo sysctl -w kern.sysv.shmall=12582912
-        edgedb-pkg/integration/macos/test.sh
-
-  test-macos-aarch64:
-    needs: [build-macos-aarch64]
-    runs-on: ['macos-14']
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-    - name: Test
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "macos"
+        PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-      run: |
-        edgedb-pkg/integration/macos/test.sh
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-03:
+    needs: [build-linux-aarch64-03]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-04:
+    needs: [build-linux-aarch64-04]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-05:
+    needs: [build-linux-aarch64-05]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-06:
+    needs: [build-linux-aarch64-06]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-07:
+    needs: [build-linux-aarch64-07]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-08:
+    needs: [build-linux-aarch64-08]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
+
+  test-linux-aarch64-09:
+    needs: [build-linux-aarch64-09]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-aarch64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        # edb test with -j higher than 1 seems to result in workflow
+        # jobs getting killed arbitrarily by Github.
+        PKG_TEST_JOBS: 0
   collect:
     needs:
-    - test-debian-buster-x86_64
-    - test-debian-buster-aarch64
-    - test-debian-bullseye-x86_64
-    - test-debian-bullseye-aarch64
-    - test-debian-bookworm-x86_64
-    - test-debian-bookworm-aarch64
-    - test-ubuntu-bionic-x86_64
-    - test-ubuntu-bionic-aarch64
-    - test-ubuntu-focal-x86_64
-    - test-ubuntu-focal-aarch64
-    - test-ubuntu-jammy-x86_64
-    - test-ubuntu-jammy-aarch64
-    - test-ubuntu-noble-x86_64
-    - test-ubuntu-noble-aarch64
-    - test-centos-8-x86_64
-    - test-centos-8-aarch64
-    - test-rockylinux-9-x86_64
-    - test-rockylinux-9-aarch64
-    - test-linux-x86_64
-    - test-linux-aarch64
-    - test-linuxmusl-x86_64
-    - test-linuxmusl-aarch64
-    - test-macos-x86_64
-    - test-macos-aarch64
+    - test-linux-aarch64-00
+    - test-linux-aarch64-01
+    - test-linux-aarch64-02
+    - test-linux-aarch64-03
+    - test-linux-aarch64-04
+    - test-linux-aarch64-05
+    - test-linux-aarch64-06
+    - test-linux-aarch64-07
+    - test-linux-aarch64-08
+    - test-linux-aarch64-09
     runs-on: ubuntu-latest
     steps:
       - run: echo 'All build+tests passed, ready to publish now!'
 
-  publish-debian-buster-x86_64:
+  publish-linux-aarch64-00:
     needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-buster-x86_64:
-    needs: [publish-debian-buster-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-x86_64
-        path: artifacts/debian-buster
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-buster
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-buster-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-buster-aarch64:
-    needs: [publish-debian-buster-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-buster-aarch64
-        path: artifacts/debian-buster
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-buster
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bullseye-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bullseye-x86_64:
-    needs: [publish-debian-bullseye-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-x86_64
-        path: artifacts/debian-bullseye
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bullseye
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bullseye@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bullseye-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bullseye-aarch64:
-    needs: [publish-debian-bullseye-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bullseye-aarch64
-        path: artifacts/debian-bullseye
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bullseye
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bullseye@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bullseye"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bookworm-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bookworm-x86_64:
-    needs: [publish-debian-bookworm-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-x86_64
-        path: artifacts/debian-bookworm
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bookworm
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bookworm@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-debian-bookworm-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-debian-bookworm-aarch64:
-    needs: [publish-debian-bookworm-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-debian-bookworm-aarch64
-        path: artifacts/debian-bookworm
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: debian-bookworm
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-bookworm@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "bookworm"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-bionic-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-bionic-x86_64:
-    needs: [publish-ubuntu-bionic-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-x86_64
-        path: artifacts/ubuntu-bionic
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-bionic
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-bionic-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-bionic-aarch64:
-    needs: [publish-ubuntu-bionic-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-bionic-aarch64
-        path: artifacts/ubuntu-bionic
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-bionic
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-focal-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-focal-x86_64:
-    needs: [publish-ubuntu-focal-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-x86_64
-        path: artifacts/ubuntu-focal
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-focal
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-focal-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-focal-aarch64:
-    needs: [publish-ubuntu-focal-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-focal-aarch64
-        path: artifacts/ubuntu-focal
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-focal
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-jammy-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-jammy-x86_64:
-    needs: [publish-ubuntu-jammy-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-x86_64
-        path: artifacts/ubuntu-jammy
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-jammy
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-jammy@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-jammy-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-jammy-aarch64:
-    needs: [publish-ubuntu-jammy-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-jammy-aarch64
-        path: artifacts/ubuntu-jammy
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-jammy
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-jammy@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "jammy"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-noble-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-noble-x86_64:
-    needs: [publish-ubuntu-noble-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-x86_64
-        path: artifacts/ubuntu-noble
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-noble
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-noble@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-ubuntu-noble-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-ubuntu-noble-aarch64:
-    needs: [publish-ubuntu-noble-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-ubuntu-noble-aarch64
-        path: artifacts/ubuntu-noble
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: ubuntu-noble
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-noble@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "noble"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-centos-8-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-8-x86_64:
-    needs: [publish-centos-8-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-x86_64
-        path: artifacts/centos-8
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-8
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-centos-8-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-centos-8-aarch64:
-    needs: [publish-centos-8-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-centos-8-aarch64
-        path: artifacts/centos-8
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: centos-8
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-rockylinux-9-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-rockylinux-9-x86_64:
-    needs: [publish-rockylinux-9-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-x86_64
-        path: artifacts/rockylinux-9
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: rockylinux-9
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/rockylinux-9@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-rockylinux-9-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-rockylinux-9-aarch64:
-    needs: [publish-rockylinux-9-aarch64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-rockylinux-9-aarch64
-        path: artifacts/rockylinux-9
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: rockylinux-9
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/rockylinux-9@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "rockylinux"
-        PKG_PLATFORM_VERSION: "9"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linux-x86_64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: ""
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-linux-x86_64:
-    needs: [publish-linux-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: linux-x86_64
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-x86_64@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linux-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Publish
@@ -2217,14 +498,14 @@ jobs:
         PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  check-published-linux-aarch64:
-    needs: [publish-linux-aarch64]
+  check-published-linux-aarch64-00:
+    needs: [publish-linux-aarch64-00]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linux-aarch64
+        name: builds-linux-aarch64-00
         path: artifacts/linux-aarch64
 
     - name: Describe
@@ -2249,67 +530,15 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-linuxmusl-x86_64:
+  publish-linux-aarch64-01:
     needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_PLATFORM_LIBC: "musl"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  check-published-linuxmusl-x86_64:
-    needs: [publish-linuxmusl-x86_64]
-    runs-on: ['package-builder', 'self-hosted', 'linux', 'x64']
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-x86_64
-        path: artifacts/linuxmusl-x86_64
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: linuxmusl-x86_64
-
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linuxmusl-x86_64@master
-      env:
-        PKG_NAME: "${{ steps.describe.outputs.name }}"
-        PKG_SUBDIST: "testing"
-        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
-    outputs:
-      version-slot: ${{ steps.describe.outputs.version-slot }}
-      version-core: ${{ steps.describe.outputs.version-core }}
-      catalog-version: ${{ steps.describe.outputs.catalog-version }}
-
-  publish-linuxmusl-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
@@ -2318,27 +547,27 @@ jobs:
         PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
-        PKG_PLATFORM_LIBC: "musl"
+        PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  check-published-linuxmusl-aarch64:
-    needs: [publish-linuxmusl-aarch64]
+  check-published-linux-aarch64-01:
+    needs: [publish-linux-aarch64-01]
     runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-linuxmusl-aarch64
-        path: artifacts/linuxmusl-aarch64
+        name: builds-linux-aarch64-01
+        path: artifacts/linux-aarch64
 
     - name: Describe
       id: describe
       uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
       with:
-        target: linuxmusl-aarch64
+        target: linux-aarch64
 
     - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linuxmusl-aarch64@master
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
       env:
         PKG_NAME: "${{ steps.describe.outputs.name }}"
         PKG_SUBDIST: "testing"
@@ -2353,147 +582,421 @@ jobs:
       version-core: ${{ steps.describe.outputs.version-core }}
       catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
-  publish-macos-x86_64:
+  publish-linux-aarch64-02:
     needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: macos-x86_64
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
 
     - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
       env:
         PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-  publish-macos-aarch64:
-    needs: [collect]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      with:
-        name: builds-macos-aarch64
-        path: artifacts/macos-aarch64
-
-    - uses: actions/checkout@v4
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-pkg
-
-    - name: Describe
-      id: describe
-      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
-      with:
-        target: macos-aarch64
-
-    - name: Publish
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "testing"
-        PKG_PLATFORM: "macos"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-  publish-docker:
-    needs:
-      - check-published-debian-bookworm-x86_64
-      - check-published-debian-bookworm-aarch64
+  check-published-linux-aarch64-02:
+    needs: [publish-linux-aarch64-02]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-02
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-03:
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
 
-    - env:
-        VERSION_SLOT: "${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }}"
-        VERSION_CORE: "${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }}"
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
         PKG_SUBDIST: "testing"
-      id: tags
-      run: |
-        set -e
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-        url='https://registry.hub.docker.com/v2/repositories/edgedb/edgedb/tags?page_size=100'
-        repo_tags=$(
-          while [ -n "$url" ]; do
-            resp=$(curl -L -s "$url")
-            url=$(echo "$resp" | jq -r ".next")
-            if [ "$url" = "null" ] || [ -z "$url" ]; then
-              break
-            fi
-            echo "$resp" | jq -r '."results"[]["name"]'
-          done | grep "^[[:digit:]]\+.*" | grep -v "alpha\|beta\|rc" || :
-        )
+  check-published-linux-aarch64-03:
+    needs: [publish-linux-aarch64-03]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
 
-        tags=( "$VERSION_CORE" )
-
-        top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
-              | grep "^${VERSION_SLOT}[\.-]" \
-              | sort --version-sort --reverse | head -n 1)
-        if [ "$top" == "$VERSION_CORE" ]; then
-          tags+=( "$VERSION_SLOT" )
-        fi
-
-        if [ -z "$PKG_SUBDIST" ]; then
-          top=$(printf "%s\n%s\n" "$VERSION_CORE" "$repo_tags" \
-                | sort --version-sort --reverse | head -n 1)
-          if [ "$top" == "$VERSION_CORE" ]; then
-            tags+=( "latest" )
-          fi
-        fi
-
-        IFS=,
-        echo "tags=${tags[*]}" >> $GITHUB_OUTPUT
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345  # v3
-
-    - name: Publish Docker Image (docker.io)
-      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
-        name: edgedb/edgedb
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "${{ steps.tags.outputs.tags }}"
-        workdir: dockerfile
-        buildargs: version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }},subdist=testing
-        platforms: linux/amd64,linux/arm64
+        name: builds-linux-aarch64-03
+        path: artifacts/linux-aarch64
 
-    - name: Publish Docker Image (ghcr.io)
-      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b  # v5
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
       with:
-        registry: ghcr.io
-        name: ${{ github.repository }}
-        username: "edgedb-ci"
-        password: ${{ secrets.GITHUB_CI_BOT_TOKEN }}
-        tags: "${{ steps.tags.outputs.tags }}"
-        workdir: dockerfile
-        buildargs: version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-slot }},exact_version=${{ needs.check-published-debian-bookworm-x86_64.outputs.version-core }},subdist=testing
-        platforms: linux/amd64,linux/arm64
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-04:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-04:
+    needs: [publish-linux-aarch64-04]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-04
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-05:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-05:
+    needs: [publish-linux-aarch64-05]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-05
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-06:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-06:
+    needs: [publish-linux-aarch64-06]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-06
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-07:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-07:
+    needs: [publish-linux-aarch64-07]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-07
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-08:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-08:
+    needs: [publish-linux-aarch64-08]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-08
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
+
+  publish-linux-aarch64-09:
+    needs: [collect]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_PLATFORM_LIBC: ""
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+  check-published-linux-aarch64-09:
+    needs: [publish-linux-aarch64-09]
+    runs-on: ['package-builder', 'self-hosted', 'linux', 'arm64']
+
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: builds-linux-aarch64-09
+        path: artifacts/linux-aarch64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-aarch64
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-aarch64@master
+      env:
+        PKG_NAME: "${{ steps.describe.outputs.name }}"
+        PKG_SUBDIST: "testing"
+        PACKAGE_SERVER: sftp://uploader@package-upload.edgedb.net:22/
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "aarch64"
+        PKG_INSTALL_REF: "${{ steps.describe.outputs.install-ref }}"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    outputs:
+      version-slot: ${{ steps.describe.outputs.version-slot }}
+      version-core: ${{ steps.describe.outputs.version-core }}
+      catalog-version: ${{ steps.describe.outputs.catalog-version }}
 
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'
@@ -2502,101 +1005,46 @@ jobs:
     needs:
       - prep
       - collect
-      - build-debian-buster-x86_64
-      - test-debian-buster-x86_64
-      - publish-debian-buster-x86_64
-      - check-published-debian-buster-x86_64
-      - build-debian-buster-aarch64
-      - test-debian-buster-aarch64
-      - publish-debian-buster-aarch64
-      - check-published-debian-buster-aarch64
-      - build-debian-bullseye-x86_64
-      - test-debian-bullseye-x86_64
-      - publish-debian-bullseye-x86_64
-      - check-published-debian-bullseye-x86_64
-      - build-debian-bullseye-aarch64
-      - test-debian-bullseye-aarch64
-      - publish-debian-bullseye-aarch64
-      - check-published-debian-bullseye-aarch64
-      - build-debian-bookworm-x86_64
-      - test-debian-bookworm-x86_64
-      - publish-debian-bookworm-x86_64
-      - check-published-debian-bookworm-x86_64
-      - build-debian-bookworm-aarch64
-      - test-debian-bookworm-aarch64
-      - publish-debian-bookworm-aarch64
-      - check-published-debian-bookworm-aarch64
-      - build-ubuntu-bionic-x86_64
-      - test-ubuntu-bionic-x86_64
-      - publish-ubuntu-bionic-x86_64
-      - check-published-ubuntu-bionic-x86_64
-      - build-ubuntu-bionic-aarch64
-      - test-ubuntu-bionic-aarch64
-      - publish-ubuntu-bionic-aarch64
-      - check-published-ubuntu-bionic-aarch64
-      - build-ubuntu-focal-x86_64
-      - test-ubuntu-focal-x86_64
-      - publish-ubuntu-focal-x86_64
-      - check-published-ubuntu-focal-x86_64
-      - build-ubuntu-focal-aarch64
-      - test-ubuntu-focal-aarch64
-      - publish-ubuntu-focal-aarch64
-      - check-published-ubuntu-focal-aarch64
-      - build-ubuntu-jammy-x86_64
-      - test-ubuntu-jammy-x86_64
-      - publish-ubuntu-jammy-x86_64
-      - check-published-ubuntu-jammy-x86_64
-      - build-ubuntu-jammy-aarch64
-      - test-ubuntu-jammy-aarch64
-      - publish-ubuntu-jammy-aarch64
-      - check-published-ubuntu-jammy-aarch64
-      - build-ubuntu-noble-x86_64
-      - test-ubuntu-noble-x86_64
-      - publish-ubuntu-noble-x86_64
-      - check-published-ubuntu-noble-x86_64
-      - build-ubuntu-noble-aarch64
-      - test-ubuntu-noble-aarch64
-      - publish-ubuntu-noble-aarch64
-      - check-published-ubuntu-noble-aarch64
-      - build-centos-8-x86_64
-      - test-centos-8-x86_64
-      - publish-centos-8-x86_64
-      - check-published-centos-8-x86_64
-      - build-centos-8-aarch64
-      - test-centos-8-aarch64
-      - publish-centos-8-aarch64
-      - check-published-centos-8-aarch64
-      - build-rockylinux-9-x86_64
-      - test-rockylinux-9-x86_64
-      - publish-rockylinux-9-x86_64
-      - check-published-rockylinux-9-x86_64
-      - build-rockylinux-9-aarch64
-      - test-rockylinux-9-aarch64
-      - publish-rockylinux-9-aarch64
-      - check-published-rockylinux-9-aarch64
-      - build-linux-x86_64
-      - test-linux-x86_64
-      - publish-linux-x86_64
-      - check-published-linux-x86_64
-      - build-linux-aarch64
-      - test-linux-aarch64
-      - publish-linux-aarch64
-      - check-published-linux-aarch64
-      - build-linuxmusl-x86_64
-      - test-linuxmusl-x86_64
-      - publish-linuxmusl-x86_64
-      - check-published-linuxmusl-x86_64
-      - build-linuxmusl-aarch64
-      - test-linuxmusl-aarch64
-      - publish-linuxmusl-aarch64
-      - check-published-linuxmusl-aarch64
-      - build-macos-x86_64
-      - test-macos-x86_64
-      - publish-macos-x86_64
-      - build-macos-aarch64
-      - test-macos-aarch64
-      - publish-macos-aarch64
-      - publish-docker
+      - build-linux-aarch64-00
+      - test-linux-aarch64-00
+      - publish-linux-aarch64-00
+      - check-published-linux-aarch64-00
+      - build-linux-aarch64-01
+      - test-linux-aarch64-01
+      - publish-linux-aarch64-01
+      - check-published-linux-aarch64-01
+      - build-linux-aarch64-02
+      - test-linux-aarch64-02
+      - publish-linux-aarch64-02
+      - check-published-linux-aarch64-02
+      - build-linux-aarch64-03
+      - test-linux-aarch64-03
+      - publish-linux-aarch64-03
+      - check-published-linux-aarch64-03
+      - build-linux-aarch64-04
+      - test-linux-aarch64-04
+      - publish-linux-aarch64-04
+      - check-published-linux-aarch64-04
+      - build-linux-aarch64-05
+      - test-linux-aarch64-05
+      - publish-linux-aarch64-05
+      - check-published-linux-aarch64-05
+      - build-linux-aarch64-06
+      - test-linux-aarch64-06
+      - publish-linux-aarch64-06
+      - check-published-linux-aarch64-06
+      - build-linux-aarch64-07
+      - test-linux-aarch64-07
+      - publish-linux-aarch64-07
+      - check-published-linux-aarch64-07
+      - build-linux-aarch64-08
+      - test-linux-aarch64-08
+      - publish-linux-aarch64-08
+      - check-published-linux-aarch64-08
+      - build-linux-aarch64-09
+      - test-linux-aarch64-09
+      - publish-linux-aarch64-09
+      - check-published-linux-aarch64-09
     runs-on: ubuntu-latest
     permissions:
       actions: 'read'

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -159,15 +159,17 @@ class StreamingTestSuite(unittest.TestSuite):
                 getattr(result, '_moduleSetUpFailed', False)):
             return
 
+        result.annotate_test(test, {
+            'py-hash-secret': py_hash_secret,
+            'py-random-seed': py_random_seed,
+            'runner-pid': os.getpid(),
+        })
+
         start = time.monotonic()
         test.run(result)
         elapsed = time.monotonic() - start
 
         result.record_test_stats(test, {'running-time': elapsed})
-        result.annotate_test(test, {
-            'py-hash-secret': py_hash_secret,
-            'py-random-seed': py_random_seed,
-        })
 
         result._testRunEntered = False
         return result
@@ -768,7 +770,14 @@ class ParallelTextTestResult(unittest.result.TestResult):
         for test, start in self.currently_running.items():
             running_for = now - start
             if running_for > 5.0:
-                still_running[test] = running_for
+                key = str(test)
+                if (
+                    test in self.test_annotations
+                    and (pid := self.test_annotations[test].get('runner-pid'))
+                ):
+                    key = f'{key} (pid={pid})'
+
+                still_running[key] = running_for
         if still_running:
             self.ren.report_still_running(still_running)
 


### PR DESCRIPTION
This is an experiment that I don't expect to work, aimed at fixing
flakes like https://github.com/edgedb/edgedb/actions/runs/12662375681/job/35288956004
where something is hanging in the rust/python async HTTP library.

The (unlikely seeming to me) hypothesis here is that the pipe
write+read is not establishing a "synchronizes-with" relationship
and so is missing the message to the queue.

I don't really think this is possible, though, and even if it were I
kind of expect that it would still probably work.