### PR TITLE
Fix docs build

### DIFF
--- a/edb/protocol/__init__.py
+++ b/edb/protocol/__init__.py
@@ -24,7 +24,6 @@ import typing
 
 from . import messages
 from . import render_utils
-from .protocol import Connection  # NoQA
 
 from .messages import *  # NoQA
 

--- a/edb/testbase/protocol/test.py
+++ b/edb/testbase/protocol/test.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from edb.testbase import server
 
 from edb.protocol import protocol  # type: ignore
+from edb.protocol.protocol import Connection
 
 
 class ProtocolTestCase(server.DatabaseTestCase):
@@ -29,7 +30,7 @@ class ProtocolTestCase(server.DatabaseTestCase):
     PARALLELISM_GRANULARITY = 'database'
     BASE_TEST_CLASS = True
 
-    con: protocol.Connection
+    con: Connection
 
     def setUp(self):
         self.con = self.loop.run_until_complete(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -26,6 +26,7 @@ import edgedb
 from edb.server import args as srv_args
 from edb.server import compiler
 from edb import protocol
+from edb.protocol.protocol import Connection
 from edb.testbase import server as tb
 from edb.testbase import connection as tconn
 from edb.testbase.protocol.test import ProtocolTestCase
@@ -44,7 +45,7 @@ class TestProtocol(ProtocolTestCase):
         data: bool = False,
         sql: bool = False,
         cc: protocol.CommandComplete | None = None,
-        con: protocol.Connection | None = None,
+        con: Connection | None = None,
         input_language: protocol.InputLanguage = protocol.InputLanguage.EDGEQL,
     ) -> None:
         exec_args = dict(


### PR DESCRIPTION
It seems the docs build doesn't like the `from .protocol import Connection` import in `edb/protocol/__init__.py`, so remove that and import `Connection` directly where needed.