### PR TITLE
Add a server_notice callback during handshake

### DIFF
--- a/rust/pgrust/src/python.rs
+++ b/rust/pgrust/src/python.rs
@@ -24,6 +24,7 @@ use pyo3::{
 };
 use std::collections::HashMap;
 use std::{borrow::Cow, path::Path};
+use tracing::warn;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[pyclass(eq, eq_int)]
@@ -474,6 +475,10 @@ impl ConnectionStateUpdate for PyConnectionStateUpdate {
                 e.print(py);
             }
         });
+    }
+
+    fn server_notice(&mut self, notice: &PgServerError) {
+        warn!("Unexpected server notice during handshake: {:?}", notice);
     }
 
     fn server_error(&mut self, error: &PgServerError) {


### PR DESCRIPTION
@elprans reported an unexpected notice message in the connected state. It's not clear why this is showing up, so let's add proper handling for it and log it.

```
WARNING 1 - 2025-01-10T19:11:09.185 edb.server: [pgrust::handshake::client_state_machine] Unexpected message 78 (length 243) received in Connected state 
```

Notice messages should not show up during the early handshake, but we may as well route them the same way we route errors "just in case".