### PR TITLE
Better logging on test timeout

### DIFF
--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -502,7 +502,9 @@ class MockHttpServer:
     def stop(self):
         self._http_server.shutdown()
         if self._http_runner is not None:
-            self._http_runner.join()
+            self._http_runner.join(timeout=60)
+            if self._http_runner.is_alive():
+                raise RuntimeError("Mock HTTP server failed to stop")
             self._http_runner = None
 
     def __exit__(self, *exc):

--- a/edb/tools/test/decorators.py
+++ b/edb/tools/test/decorators.py
@@ -22,8 +22,10 @@ from __future__ import annotations
 import asyncio
 import functools
 import unittest
+import logging
 
 
+logger = logging.getLogger("edb.server")
 skip = unittest.skip
 
 
@@ -66,9 +68,15 @@ def async_timeout(timeout: int):
             try:
                 await asyncio.wait_for(test_func(*args, **kwargs), timeout)
             except asyncio.TimeoutError:
+                logger.error(
+                    f"Test {test_func} failed due to timeout after {timeout}"
+                    "seconds")
                 raise AssertionError(
                     f"Test failed due to timeout after {timeout} seconds")
             except asyncio.CancelledError as e:
+                logger.error(
+                    f"Test {test_func} failed due to timeout after {timeout}"
+                    "seconds", e)
                 raise AssertionError(
                     f"Test failed due to timeout after {timeout} seconds", e)
         return wrapper

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -29,6 +29,7 @@ from edb.testbase import http as http_tb
 async def async_timeout(coroutine, timeout=5):
     return await asyncio.wait_for(coroutine, timeout=timeout)
 
+
 def run_async(coroutine, timeout=5):
     with asyncio.Runner(debug=True) as runner:
         runner.run(async_timeout(coroutine, timeout))


### PR DESCRIPTION
I have a theory that the default async test runner is causing weird issues with the HTTP code. I don't know what's going on, but writing a custom unit test runner here appears to make it all work.