### PR TITLE
Implement \(expr)-style string interpolation

### DIFF
--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -222,7 +222,7 @@ fn is_operator(token: &Token) -> bool {
         DecimalConst | FloatConst | IntConst | BigIntConst | BinStr | Parameter
         | ParameterAndType | Str | BacktickName | Keyword(_) | Ident | Substitution | EOI
         | Epsilon | StartBlock | StartExtension | StartFragment | StartMigration
-        | StartSDLDocument => false,
+        | StartSDLDocument | StrInterpStart | StrInterpCont | StrInterpEnd => false,
     }
 }
 

--- a/edb/edgeql-parser/src/helpers/strings.rs
+++ b/edb/edgeql-parser/src/helpers/strings.rs
@@ -73,10 +73,9 @@ pub fn unquote_string(value: &str) -> Result<Cow<str>, UnquoteError> {
             .map_err(UnquoteError)?;
         Ok(value[msize..value.len() - msize].into())
     } else {
-        let start = if value.starts_with("\\)") { 2 } else { 1 };
         let end_trim = if value.ends_with("\\(") { 2 } else { 1 };
 
-        Ok(_unquote_string(&value[start..value.len() - end_trim])
+        Ok(_unquote_string(&value[1..value.len() - end_trim])
             .map_err(UnquoteError)?
             .into())
     }

--- a/edb/edgeql-parser/src/helpers/strings.rs
+++ b/edb/edgeql-parser/src/helpers/strings.rs
@@ -73,7 +73,10 @@ pub fn unquote_string(value: &str) -> Result<Cow<str>, UnquoteError> {
             .map_err(UnquoteError)?;
         Ok(value[msize..value.len() - msize].into())
     } else {
-        Ok(_unquote_string(&value[1..value.len() - 1])
+        let start = if value.starts_with("\\)") { 2 } else { 1 };
+        let end_trim = if value.ends_with("\\(") { 2 } else { 1 };
+
+        Ok(_unquote_string(&value[start..value.len() - end_trim])
             .map_err(UnquoteError)?
             .into())
     }

--- a/edb/edgeql-parser/src/parser.rs
+++ b/edb/edgeql-parser/src/parser.rs
@@ -750,6 +750,10 @@ fn get_token_kind(token_name: &str) -> Kind {
         "PARAMETERANDTYPE" => ParameterAndType,
         "SUBSTITUTION" => Substitution,
 
+        "STRINTERPSTART" => StrInterpStart,
+        "STRINTERPCONT" => StrInterpCont,
+        "STRINTERPEND" => StrInterpEnd,
+
         _ => {
             let mut token_name = token_name.to_lowercase();
 

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -426,11 +426,8 @@ impl<'a> Tokenizer<'a> {
             '=' => Ok((Eq, 1)),
             ',' => Ok((Comma, 1)),
             '(' => Ok((OpenParen, 1)),
-            ')' if self.open_parens == 0 && !self.str_interp_stack.is_empty() => {
-                self.parse_string_interp_cont(
-                    &self.str_interp_stack[self.str_interp_stack.len() - 1],
-                )
-            }
+            ')' if self.open_parens == 0 && !self.str_interp_stack.is_empty() => self
+                .parse_string_interp_cont(&self.str_interp_stack[self.str_interp_stack.len() - 1]),
             ')' => Ok((CloseParen, 1)),
             '[' => Ok((OpenBracket, 1)),
             ']' => Ok((CloseBracket, 1)),

--- a/edb/edgeql-parser/src/validation.rs
+++ b/edb/edgeql-parser/src/validation.rs
@@ -206,7 +206,9 @@ pub fn parse_value(token: &Token) -> Result<Option<Value>, String> {
             return unquote_bytes(text).map(Value::Bytes).map(Some);
         }
 
-        Str => unquote_string(text).map_err(|s| s.to_string())?.to_string(),
+        Str | StrInterpStart | StrInterpEnd | StrInterpCont => {
+            unquote_string(text).map_err(|s| s.to_string())?.to_string()
+        }
         BacktickName => text[1..text.len() - 1].replace("``", "`"),
         Ident | Keyword(_) => text.to_string(),
         Substitution => text[2..text.len() - 1].to_string(),

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -251,7 +251,7 @@ class FunctionCall(Expr):
     window: typing.Optional[WindowSpec] = None
 
 
-class StrInterpFragment(Expr):
+class StrInterpFragment(Base):
     expr: Expr
     suffix: str
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -251,6 +251,16 @@ class FunctionCall(Expr):
     window: typing.Optional[WindowSpec] = None
 
 
+class StrInterpFragment(Expr):
+    expr: Expr
+    suffix: str
+
+
+class StrInterp(Expr):
+    prefix: str
+    interpolations: list[StrInterpFragment]
+
+
 class BaseConstant(Expr):
     """Constant (a literal value)."""
     __abstract_node__ = True

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -455,6 +455,16 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._write_keywords('GLOBAL ')
         self.visit(node.name)
 
+    def visit_StrInterp(self, node: qlast.StrInterp) -> None:
+        self.write("'")
+        self.write(edgeql_quote.escape_string(node.prefix))
+        for fragment in node.interpolations:
+            self.write("\\(")
+            self.visit(fragment.expr)
+            self.write("\\)")
+            self.write(edgeql_quote.escape_string(fragment.suffix))
+        self.write("'")
+
     def visit_UnaryOp(self, node: qlast.UnaryOp) -> None:
         op = str(node.op).upper()
         self.write(op)

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -461,7 +461,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         for fragment in node.interpolations:
             self.write("\\(")
             self.visit(fragment.expr)
-            self.write("\\)")
+            self.write(")")
             self.write(edgeql_quote.escape_string(fragment.suffix))
         self.write("'")
 

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -67,6 +67,18 @@ class T_STARTSDLDOCUMENT(GrammarToken):
     pass
 
 
+class T_STRINTERPSTART(GrammarToken):
+    pass
+
+
+class T_STRINTERPCONT(GrammarToken):
+    pass
+
+
+class T_STRINTERPEND(GrammarToken):
+    pass
+
+
 class T_DOT(Token, lextoken='.'):
     pass
 

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -35,25 +35,25 @@ _re_ident_or_num = re.compile(r'''(?x)
 ''')
 
 
+def escape_string(s: str) -> str:
+    # characters escaped according to
+    # https://www.edgedb.com/docs/reference/edgeql/lexical#strings
+    result = s
+
+    # escape backslash first
+    result = result.replace('\\', '\\\\')
+
+    result = result.replace('\'', '\\\'')
+    result = result.replace('\b', '\\b')
+    result = result.replace('\f', '\\f')
+    result = result.replace('\n', '\\n')
+    result = result.replace('\r', '\\r')
+    result = result.replace('\t', '\\t')
+
+    return result
+
+
 def quote_literal(string: str) -> str:
-
-    def escape_string(s: str) -> str:
-        # characters escaped according to
-        # https://www.edgedb.com/docs/reference/edgeql/lexical#strings
-        result = s
-
-        # escape backslash first
-        result = result.replace('\\', '\\\\')
-
-        result = result.replace('\'', '\\\'')
-        result = result.replace('\b', '\\b')
-        result = result.replace('\f', '\\f')
-        result = result.replace('\n', '\\n')
-        result = result.replace('\r', '\\r')
-        result = result.replace('\t', '\\t')
-
-        return result
-
     return "'" + escape_string(string) + "'"
 
 

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -629,6 +629,19 @@ def trace_Array(node: qlast.Array, *, ctx: TracerContext) -> None:
 
 
 @trace.register
+def trace_StrInterpFragment(
+    node: qlast.StrInterpFragment, *, ctx: TracerContext
+) -> None:
+    trace(node.expr, ctx=ctx)
+
+
+@trace.register
+def trace_StrInterp(node: qlast.StrInterp, *, ctx: TracerContext) -> None:
+    for el in node.interpolations:
+        trace(el, ctx=ctx)
+
+
+@trace.register
 def trace_Set(node: qlast.Set, *, ctx: TracerContext) -> None:
     for el in node.elements:
         trace(el, ctx=ctx)

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -10616,7 +10616,7 @@ aa \
     async def test_edgeql_expr_str_interpolation_01(self):
         await self.assert_query_result(
             r'''
-                select "1 + 1 = \(1 + 1\)"
+                select "1 + 1 = \(1 + 1)"
             ''',
             ['1 + 1 = 2'],
         )
@@ -10624,8 +10624,8 @@ aa \
         # Have some more fun. Nest it a bit.
         await self.assert_query_result(
             r'''select "asdf \(str_reverse("1234") ++
-"[\(sum({1,2,3})\)]"\)! count(User)=\
+"[\(sum({1,2,3}))]")! count(User)=\
 \(
-count(User)\)" ++ "!";''',
+count(User))" ++ "!";''',
             ['asdf 4321[6]! count(User)=0!'],
         )

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -10621,6 +10621,13 @@ aa \
             ['1 + 1 = 2'],
         )
 
+        await self.assert_query_result(
+            r'''
+                select ("1 + 1 = \(1 + 1)")
+            ''',
+            ['1 + 1 = 2'],
+        )
+
         # Have some more fun. Nest it a bit.
         await self.assert_query_result(
             r'''select "asdf \(str_reverse("1234") ++

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -10612,3 +10612,20 @@ aa \
                     "Foo' does not exist",
                 ):
                     await self.con.execute(query)
+
+    async def test_edgeql_expr_str_interpolation_01(self):
+        await self.assert_query_result(
+            r'''
+                select "1 + 1 = \(1 + 1\)"
+            ''',
+            ['1 + 1 = 2'],
+        )
+
+        # Have some more fun. Nest it a bit.
+        await self.assert_query_result(
+            r'''select "asdf \(str_reverse("1234") ++
+"[\(sum({1,2,3})\)]"\)! count(User)=\
+\(
+count(User)\)" ++ "!";''',
+            ['asdf 4321[6]! count(User)=0!'],
+        )

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -476,7 +476,7 @@ aa';
 
     def test_edgeql_syntax_constants_41(self):
         r"""
-        SELECT 'aaa \(aaa\) bbb';
+        SELECT 'aaa \(aaa) bbb';
         """
 
     def test_edgeql_syntax_constants_42(self):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -474,12 +474,9 @@ aa';
         SELECT "\x1F\x01\x8F\x6e";
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"invalid string literal: invalid escape sequence '\\\('",
-                  line=2, col=16)
     def test_edgeql_syntax_constants_41(self):
         r"""
-        SELECT 'aaa \(aaa) bbb';
+        SELECT 'aaa \(aaa\) bbb';
         """
 
     def test_edgeql_syntax_constants_42(self):


### PR DESCRIPTION
`\(` is currently rejected inside string literals, so there is no
compatability issue.

Expressions in the `\( )` blocks get automatically cast to str.

The implement is based on the lexer producing `STRINTERPSTART`,
`STRINTERPCONT`, and `STRINTERPEND` tokens that are parsed by the
parser.  The lexer needs to be a little stateful, unfortunately, to
track what kind of opening quote opened the string.

Fixes #272.