### PR TITLE
test: bootstrap without testmode for multitenant test

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1552,6 +1552,8 @@ def parse_args(**kwargs: Any):
         if kwargs['compiler_pool_mode'] is not CompilerPoolMode.MultiTenant:
             abort("must use --compiler-pool-mode=fixed_multi_tenant "
                   "in multi-tenant mode")
+        if kwargs['testmode']:
+            abort("cannot use --testmode in multi-tenant mode")
 
     bootstrap_script_text: Optional[str]
     if kwargs['bootstrap_command_file']:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2394,6 +2394,7 @@ class _EdgeDBServer:
         extra_args: Optional[List[str]] = None,
         net_worker_mode: Optional[str] = None,
         password: Optional[str] = None,
+        testmode: bool = True,
     ) -> None:
         self.bind_addrs = bind_addrs
         self.auto_shutdown_after = auto_shutdown_after
@@ -2431,6 +2432,7 @@ class _EdgeDBServer:
         self.extra_args = extra_args
         self.net_worker_mode = net_worker_mode
         self.password = password
+        self.testmode = testmode
 
     async def wait_for_server_readiness(self, stream: asyncio.StreamReader):
         while True:
@@ -2480,12 +2482,14 @@ class _EdgeDBServer:
         cmd = [
             sys.executable, '-m', 'edb.server.main',
             '--port', 'auto',
-            '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',
             '--compiler-pool-size', str(self.compiler_pool_size),
             '--tls-cert-mode', str(self.tls_cert_mode),
             '--jose-key-mode', 'generate',
         ]
+
+        if self.testmode:
+            cmd.extend(['--testmode'])
 
         if self.compiler_pool_mode is not None:
             cmd.extend(('--compiler-pool-mode', self.compiler_pool_mode.value))
@@ -2763,6 +2767,7 @@ def start_edgedb_server(
     default_branch: Optional[str] = None,
     net_worker_mode: Optional[str] = None,
     force_new: bool = False,  # True for ignoring multitenant config env
+    testmode: bool = True,
 ):
     if (not devmode.is_in_dev_mode() or adjacent_to) and not runstate_dir:
         if backend_dsn or adjacent_to:
@@ -2844,6 +2849,7 @@ def start_edgedb_server(
         default_branch=default_branch,
         net_worker_mode=net_worker_mode,
         password=password,
+        testmode=testmode,
     )
 
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1577,6 +1577,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                     runstate_dir=runstate_dir,
                     multitenant_config=conf_file.name,
                     max_allowed_connections=None,
+                    testmode=False,
                     http_endpoint_security=args.ServerEndpointSecurityMode.Optional,
                 )
                 async with srv as sd:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1520,6 +1520,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                 runstate_dir=runstate_dir,
                 backend_dsn=f'postgres:///?user=postgres&host={path}',
                 reset_auth=True,
+                testmode=False,
                 auto_shutdown_after=1,
             ) as sd:
                 connect_args = {


### PR DESCRIPTION
The compiler in multitenant server always use the stdlib cache pickle regardless of the actual stdlib in each tenant's backend. So we must bootstrap the backends without testmode schemas, because the stdlib cache pickle does not always have testmode schemas, e.g. in release CIs.

[Sample nightly run](https://github.com/edgedb/edgedb/actions/runs/12772132339)