### PR TITLE
Try to fix test_server_ops_multi_tenant in release builds

### DIFF
--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1800,6 +1800,13 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         )
 
     async def _test_server_ops_multi_tenant_7(self, mtargs: MultiTenantArgs):
+        # FIXME(fantix?) - We can't test this outside devmode, because we
+        # can't currently use testmode in multi-tenant mode.
+        # This means that we can't access the server-info debug endpoint
+        # to get the info we need outside of devmode.
+        if not devmode.is_in_dev_mode():
+            return
+
         self.assertEqual(
             (await mtargs.current_email_provider(1))["sender"],
             "sender@host1.com",


### PR DESCRIPTION
One of the tests needs to access the /server-info endpoint in order to
test magic_smtp_config. But since testmode doesn't work with
multitenant (see #8216), this does not work when being run outside
devmode.

Skip that part of the test when not in devmode, then.

I don't find this particularly satisfying.