### PR TITLE
Drop dump_traceback_later call

### DIFF
--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -96,8 +96,6 @@ def init_worker(
     global py_random_seed
 
     faulthandler.enable(file=sys.stderr, all_threads=True)
-    # If we're still running after 30 minutes, dump the traceback.
-    faulthandler.dump_traceback_later(30 * 60, file=sys.stderr)
 
     if additional_init:
         additional_init()


### PR DESCRIPTION
30 minutes can get hit easily, and I think this might have been causing
crashes in our nightly tests.
See https://github.com/edgedb/edgedb/actions/runs/12779694201/job/35626124790

I don't fully understand why it would crash though.