### PR TITLE
Do not fail if SMTP provider is not configured

### DIFF
--- a/edb/server/protocol/auth_ext/email.py
+++ b/edb/server/protocol/auth_ext/email.py
@@ -3,6 +3,7 @@ import urllib.parse
 import random
 import logging
 
+from email.message import EmailMessage
 from typing import Any, Coroutine
 from edb.server import tenant, smtp
 from edb import errors
@@ -107,7 +108,7 @@ async def send_fake_email(tenant: tenant.Tenant) -> None:
 
 
 async def _maybe_send_message(
-    msg: str,
+    msg: EmailMessage,
     tenant: tenant.Tenant,
     db: Any,
     test_mode: bool,

--- a/edb/server/protocol/auth_ext/email.py
+++ b/edb/server/protocol/auth_ext/email.py
@@ -1,11 +1,16 @@
 import asyncio
 import urllib.parse
 import random
+import logging
 
 from typing import Any, Coroutine
 from edb.server import tenant, smtp
+from edb import errors
 
 from . import util, ui
+
+
+logger = logging.getLogger("edb.server.ext.auth")
 
 
 async def send_password_reset_email(
@@ -30,12 +35,7 @@ async def send_password_reset_email(
         reset_url=reset_url,
         **email_args,
     )
-    smtp_provider = smtp.SMTP(db)
-    coro = smtp_provider.send(
-        msg,
-        test_mode=test_mode,
-    )
-    await _protected_send(coro, tenant)
+    await _maybe_send_message(msg, tenant, db, test_mode)
 
 
 async def send_verification_email(
@@ -70,12 +70,7 @@ async def send_verification_email(
         verify_url=verify_url,
         **email_args,
     )
-    smtp_provider = smtp.SMTP(db)
-    coro = smtp_provider.send(
-        msg,
-        test_mode=test_mode,
-    )
-    await _protected_send(coro, tenant)
+    await _maybe_send_message(msg, tenant, db, test_mode)
 
 
 async def send_magic_link_email(
@@ -100,12 +95,7 @@ async def send_magic_link_email(
         link=link,
         **email_args,
     )
-    smtp_provider = smtp.SMTP(db)
-    coro = smtp_provider.send(
-        msg,
-        test_mode=test_mode,
-    )
-    await _protected_send(coro, tenant)
+    await _maybe_send_message(msg, tenant, db, test_mode)
 
 
 async def send_fake_email(tenant: tenant.Tenant) -> None:
@@ -113,6 +103,30 @@ async def send_fake_email(tenant: tenant.Tenant) -> None:
         pass
 
     coro = noop_coroutine()
+    await _protected_send(coro, tenant)
+
+
+async def _maybe_send_message(
+    msg: str,
+    tenant: tenant.Tenant,
+    db: Any,
+    test_mode: bool,
+) -> None:
+    try:
+        smtp_provider = smtp.SMTP(db)
+    except errors.ConfigurationError as e:
+        logger.debug(
+            "ConfigurationError while instantiating SMTP provider, "
+            f"sending fake email instead: {e}"
+        )
+        smtp_provider = None
+    if smtp_provider is None:
+        coro = send_fake_email(tenant)
+    else:
+        coro = smtp_provider.send(
+            msg,
+            test_mode=test_mode,
+        )
     await _protected_send(coro, tenant)
 
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -2824,7 +2824,9 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             current_email_provider_name;
             """,
         )
-        await self._wait_for_db_config("cfg::current_email_provider_name")
+        await self._wait_for_db_config(
+            "cfg::current_email_provider_name", is_reset=True
+        )
         try:
             with self.http_con() as http_con:
                 email = f"{uuid.uuid4()}@example.com"


### PR DESCRIPTION
Now that we have webhooks, it is valid to not have an SMTP provider configured. In this case, we log an error and send a fake email instead.

Closes #8224 