### PR TITLE
multitenant: patch stdlib with testmode schema if requested

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1552,8 +1552,6 @@ def parse_args(**kwargs: Any):
         if kwargs['compiler_pool_mode'] is not CompilerPoolMode.MultiTenant:
             abort("must use --compiler-pool-mode=fixed_multi_tenant "
                   "in multi-tenant mode")
-        if kwargs['testmode']:
-            abort("cannot use --testmode in multi-tenant mode")
 
     bootstrap_script_text: Optional[str]
     if kwargs['bootstrap_command_file']:

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -687,6 +687,14 @@ server_options = typeutils.chain_decorators([
         envvar="GEL_SERVER_MULTITENANT_CONFIG_FILE",
         cls=EnvvarResolver,
         hidden=True,
+        help='Start the server in multi-tenant mode, with reloadable tenants '
+             'configured in the given file. Each tenant must have a unique '
+             'SNI name as the key to route the traffic correctly, as well as '
+             'a dedicated backend DSN to host the tenant data. See edb/server/'
+             'multitenant.py for config file format. All tenants share the '
+             'same compiler pool, thus the same stdlib. So if any of the '
+             'backends contains test-mode schema, the server should be '
+             'started with --testmode to handle them properly.',
     ),
     click.option(
         '-l', '--log-level',

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -543,6 +543,12 @@ async def run_server(
                     "without pre-compiled standard library"
                 )
             if args.testmode:
+                # In multitenant mode, the server/compiler is started without a
+                # backend and will be connected to many backends. That means we
+                # cannot load the stdlib from a certain backend; instead, the
+                # pre-compiled stdlib is always in use. This means that we need
+                # to explicitly enable --testmode starting a multitenant server
+                # in order to handle backends with test-mode schema properly.
                 try:
                     stdlib = _patch_stdlib_testmode(stdlib)
                 except errors.SchemaError:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -53,6 +53,7 @@ import setproctitle
 import uvloop
 
 from edb import buildmeta
+from edb import errors
 from edb.ir import statypes
 from edb.common import exceptions
 from edb.common import devmode
@@ -71,6 +72,7 @@ from . import service_manager
 
 if TYPE_CHECKING:
     from . import server
+    from edb.server import bootstrap
 else:
     # Import server lazily to make sure that most of imports happen
     # under coverage (if we're testing with it).  Otherwise
@@ -411,6 +413,49 @@ async def _get_remote_pgcluster(
     return cluster, args
 
 
+def _patch_stdlib_testmode(
+    stdlib: bootstrap.StdlibBits
+) -> bootstrap.StdlibBits:
+    from edb import edgeql
+    from edb.pgsql import delta as delta_cmds
+    from edb.pgsql import params as pg_params
+    from edb.edgeql import ast as qlast
+    from edb.schema import ddl as s_ddl
+    from edb.schema import delta as sd
+    from edb.schema import schema as s_schema
+    from edb.schema import std as s_std
+
+    schema = s_schema.ChainedSchema(
+        s_schema.EMPTY_SCHEMA,
+        stdlib.stdschema,
+        stdlib.global_schema,
+    )
+    reflschema = stdlib.reflschema
+    ctx = sd.CommandContext(
+        stdmode=True,
+        backend_runtime_params=pg_params.get_default_runtime_params(),
+    )
+
+    for modname in s_schema.TESTMODE_SOURCES:
+        ddl_text = s_std.get_std_module_text(modname)
+        for ddl_cmd in edgeql.parse_block(ddl_text):
+            assert isinstance(ddl_cmd, qlast.DDLCommand)
+            delta = s_ddl.delta_from_ddl(
+                ddl_cmd, modaliases={}, schema=schema, stdmode=True
+            )
+            if not delta.canonical:
+                sd.apply(delta, schema=schema)
+            delta = delta_cmds.CommandMeta.adapt(delta)
+            schema = sd.apply(delta, schema=schema, context=ctx)
+            reflschema = delta.apply(reflschema, ctx)
+
+    return stdlib._replace(
+        stdschema=schema.get_top_schema(),
+        global_schema=schema.get_global_schema(),
+        reflschema=reflschema,
+    )
+
+
 async def run_server(
     args: srvargs.ServerConfig,
     *,
@@ -496,6 +541,13 @@ async def run_server(
                     "Cannot run multi-tenant server "
                     "without pre-compiled standard library"
                 )
+            if args.testmode:
+                try:
+                    stdlib = _patch_stdlib_testmode(stdlib)
+                except errors.SchemaError:
+                    # The pre-compiled standard library already has test-mode
+                    # schema; ignore the patching error.
+                    pass
 
             compiler = edbcompiler.new_compiler(
                 stdlib.stdschema,

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -425,7 +425,7 @@ def _patch_stdlib_testmode(
     from edb.schema import schema as s_schema
     from edb.schema import std as s_std
 
-    schema = s_schema.ChainedSchema(
+    schema: s_schema.Schema = s_schema.ChainedSchema(
         s_schema.EMPTY_SCHEMA,
         stdlib.stdschema,
         stdlib.global_schema,
@@ -449,6 +449,7 @@ def _patch_stdlib_testmode(
             schema = sd.apply(delta, schema=schema, context=ctx)
             reflschema = delta.apply(reflschema, ctx)
 
+    assert isinstance(schema, s_schema.ChainedSchema)
     return stdlib._replace(
         stdschema=schema.get_top_schema(),
         global_schema=schema.get_global_schema(),

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2394,7 +2394,6 @@ class _EdgeDBServer:
         extra_args: Optional[List[str]] = None,
         net_worker_mode: Optional[str] = None,
         password: Optional[str] = None,
-        testmode: bool = True,
     ) -> None:
         self.bind_addrs = bind_addrs
         self.auto_shutdown_after = auto_shutdown_after
@@ -2432,7 +2431,6 @@ class _EdgeDBServer:
         self.extra_args = extra_args
         self.net_worker_mode = net_worker_mode
         self.password = password
-        self.testmode = testmode
 
     async def wait_for_server_readiness(self, stream: asyncio.StreamReader):
         while True:
@@ -2482,14 +2480,12 @@ class _EdgeDBServer:
         cmd = [
             sys.executable, '-m', 'edb.server.main',
             '--port', 'auto',
+            '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',
             '--compiler-pool-size', str(self.compiler_pool_size),
             '--tls-cert-mode', str(self.tls_cert_mode),
             '--jose-key-mode', 'generate',
         ]
-
-        if self.testmode:
-            cmd.extend(['--testmode'])
 
         if self.compiler_pool_mode is not None:
             cmd.extend(('--compiler-pool-mode', self.compiler_pool_mode.value))
@@ -2767,7 +2763,6 @@ def start_edgedb_server(
     default_branch: Optional[str] = None,
     net_worker_mode: Optional[str] = None,
     force_new: bool = False,  # True for ignoring multitenant config env
-    testmode: bool = True,
 ):
     if (not devmode.is_in_dev_mode() or adjacent_to) and not runstate_dir:
         if backend_dsn or adjacent_to:
@@ -2849,7 +2844,6 @@ def start_edgedb_server(
         default_branch=default_branch,
         net_worker_mode=net_worker_mode,
         password=password,
-        testmode=testmode,
     )
 
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1798,13 +1798,6 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         )
 
     async def _test_server_ops_multi_tenant_7(self, mtargs: MultiTenantArgs):
-        # FIXME(fantix?) - We can't test this outside devmode, because we
-        # can't currently use testmode in multi-tenant mode.
-        # This means that we can't access the server-info debug endpoint
-        # to get the info we need outside of devmode.
-        if not devmode.is_in_dev_mode():
-            return
-
         self.assertEqual(
             (await mtargs.current_email_provider(1))["sender"],
             "sender@host1.com",

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1520,7 +1520,6 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                 runstate_dir=runstate_dir,
                 backend_dsn=f'postgres:///?user=postgres&host={path}',
                 reset_auth=True,
-                testmode=False,
                 auto_shutdown_after=1,
             ) as sd:
                 connect_args = {
@@ -1577,7 +1576,6 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                     runstate_dir=runstate_dir,
                     multitenant_config=conf_file.name,
                     max_allowed_connections=None,
-                    testmode=False,
                     http_endpoint_security=args.ServerEndpointSecurityMode.Optional,
                 )
                 async with srv as sd:


### PR DESCRIPTION
- [x] patch stdlib starting multitenant server with --testmode
- [x] fix tests
- [ ] reject tenant backends with incompatible std schema
- [x] [Build CI sample run](https://github.com/edgedb/edgedb/actions/runs/12817630831)
- [x] [Standalone backend CI sample run](https://github.com/edgedb/edgedb/actions/runs/12821283901)