### PR TITLE
Allow tuples in GIN, GIST and BRIN indexes

### DIFF
--- a/tests/schemas/pg_trgm.esdl
+++ b/tests/schemas/pg_trgm.esdl
@@ -26,6 +26,16 @@ type Gin extending Base {
     index ext::pg_trgm::gin on (.p_str);
 }
 
+type Gin2 extending Base {
+    p_str_2: str;
+    index ext::pg_trgm::gist on ((.p_str, .p_str_2));
+}
+
 type Gist extending Base {
     index ext::pg_trgm::gist on (.p_str);
+}
+
+type Gist2 extending Base {
+    p_str_2: str;
+    index ext::pg_trgm::gist on ((.p_str, .p_str_2));
 }

--- a/tests/schemas/pg_trgm_setup.edgeql
+++ b/tests/schemas/pg_trgm_setup.edgeql
@@ -18,7 +18,14 @@
 
 for x in range_unpack(range(1, 1001)) union (
     insert Gist {
-        p_str := "qwertyu" ++ str_pad_start(<str>x, 4, "0")
+        p_str := "qwertyu" ++ str_pad_start(<str>x, 4, "0"),
+    }
+);
+
+for x in range_unpack(range(1, 1001)) union (
+    insert Gist2 {
+        p_str := "qwertyu" ++ str_pad_start(<str>x, 4, "0"),
+        p_str_2 := "iopasdf" ++ str_pad_start(<str>x, 4, "0"),
     }
 );
 
@@ -531,7 +538,12 @@ for x in {
     "Samarra School",
     "Jangal-e Marakeh Sar",
 } union (
-    insert Gist {
+    (insert Gist {
         p_str := x
-    }
+    })
+    union
+    (insert Gist2 {
+        p_str := x,
+        p_str_2 := x,
+    })
 );


### PR DESCRIPTION
This is an oversight, as all those Postgres indexes support indexing
multiple columns.
