### PR TITLE
Add an `override-cors-allowed-origins` option

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -292,6 +292,8 @@ class ServerConfig(NamedTuple):
 
     admin_ui: bool
 
+    override_cors_allowed_origins: Optional[str]
+
 
 class PathPath(click.Path):
     name = 'path'
@@ -1081,6 +1083,16 @@ server_options = typeutils.chain_decorators([
         ),
         default='default',
         help='Enable admin UI.'),
+    click.option(
+        '--override-cors-allowed-origins',
+        envvar="GEL_SERVER_OVERRIDE_CORS_ALLOWED_ORIGINS",
+        cls=EnvvarResolver,
+        hidden=True,
+        help='A comma separated list of origins to always allow CORS requests '
+             'from regardless of the `cors_allow_orgin` config. The `*` '
+             'character can be used as a wildcard. Intended for use by cloud '
+             'to always allow the cloud UI to make requests to the instance.'
+    ),
     click.option(
         '--disable-dynamic-system-config', is_flag=True,
         envvar="GEL_SERVER_DISABLE_DYNAMIC_SYSTEM_CONFIG",

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -246,6 +246,7 @@ async def _run_server(
             pidfile_dir=args.pidfile_dir,
             new_instance=new_instance,
             admin_ui=args.admin_ui,
+            override_cors_origins=args.override_cors_allowed_origins,
             disable_dynamic_system_config=args.disable_dynamic_system_config,
             compiler_state=compiler.state,
             tenant=tenant,

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -468,6 +468,7 @@ async def run_server(
             default_auth_method=args.default_auth_method,
             testmode=args.testmode,
             admin_ui=args.admin_ui,
+            override_cors_origins=args.override_cors_allowed_origins,
             disable_dynamic_system_config=args.disable_dynamic_system_config,
             compiler_pool_size=args.compiler_pool_size,
             compiler_pool_mode=srvargs.CompilerPoolMode.MultiTenant,

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -20,6 +20,7 @@
 
 
 from __future__ import annotations
+import re
 from typing import (
     Any,
     Callable,
@@ -160,6 +161,7 @@ class BaseServer:
         default_auth_method: srvargs.ServerAuthMethods = (
             srvargs.DEFAULT_AUTH_METHODS),
         admin_ui: bool = False,
+        override_cors_origins: Optional[str] = None,
         disable_dynamic_system_config: bool = False,
         compiler_state: edbcompiler.CompilerState,
         use_monitor_fs: bool = False,
@@ -252,6 +254,15 @@ class BaseServer:
 
         self._admin_ui = admin_ui
 
+        self._override_cors_origins = [
+            re.compile(
+                '^' + origin
+                    .replace('.', '\\.')
+                    .replace('*', '.*') + '$'
+            ) if '*' in origin else origin
+            for origin in override_cors_origins.split(',')
+        ] if override_cors_origins else []
+
         self._file_watch_handles = []
         self._tls_certs_reload_retry_handle: Any | asyncio.TimerHandle = None
 
@@ -307,6 +318,9 @@ class BaseServer:
 
     def is_admin_ui_enabled(self):
         return self._admin_ui
+
+    def get_override_cors_origins(self):
+        return self._override_cors_origins
 
     def on_binary_client_created(self) -> str:
         self._binary_proto_id_counter += 1


### PR DESCRIPTION
For cloud instances we currently default to setting the `cors_allow_origins` config to `*` to let the cloud ui make queries to the instance. But the user can change that config, which breaks the UI, and also for security it's probably better to leave the default `cors_allow_origins` config empty.

Since we want to allow the cloud UI to always be able to query the instance, regardless of how the user configures `cors_allow_origins`, this server option will allow us to set the cloud ui as an always allowed cors origin. Supporting multiple origins and wildcards is to handle the gel rename (allow both our new and old cloud ui urls to work) and for staging ui builds.