### PR TITLE
Add simple clustering to captive_postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ name = "captive_postgres"
 version = "0.1.0"
 dependencies = [
  "gel_auth",
+ "nix",
  "openssl",
  "socket2",
  "tempfile",

--- a/rust/captive_postgres/Cargo.toml
+++ b/rust/captive_postgres/Cargo.toml
@@ -14,4 +14,5 @@ gel_auth.workspace = true
 
 openssl = "0.10.55"
 tempfile = "3"
-socket2 = "0.5.8"
+socket2 = { version = "0.5", features = ["all"] }
+nix = { version = "0.29", features = ["signal"] }

--- a/rust/captive_postgres/src/ephemeral_port.rs
+++ b/rust/captive_postgres/src/ephemeral_port.rs
@@ -1,0 +1,52 @@
+use std::net::{Ipv4Addr, TcpListener};
+use std::time::Instant;
+
+use crate::{HOT_LOOP_INTERVAL, LINGER_DURATION, PORT_RELEASE_TIMEOUT};
+
+/// Represents an ephemeral port that can be allocated and released for immediate re-use by another process.
+pub struct EphemeralPort {
+    port: u16,
+    listener: Option<TcpListener>,
+}
+
+impl EphemeralPort {
+    /// Allocates a new ephemeral port.
+    ///
+    /// Returns a Result containing the EphemeralPort if successful,
+    /// or an IO error if the allocation fails.
+    pub fn allocate() -> std::io::Result<Self> {
+        let socket = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)?;
+        socket.set_reuse_address(true)?;
+        socket.set_reuse_port(true)?;
+        socket.set_linger(Some(LINGER_DURATION))?;
+        socket.bind(&std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, 0)).into())?;
+        socket.listen(1)?;
+        let listener = TcpListener::from(socket);
+        let port = listener.local_addr()?.port();
+        Ok(EphemeralPort {
+            port,
+            listener: Some(listener),
+        })
+    }
+
+    /// Consumes the EphemeralPort and returns the allocated port number.
+    pub fn take(self) -> u16 {
+        // Drop the listener to free up the port
+        drop(self.listener);
+
+        // Loop until the port is free
+        let start = Instant::now();
+
+        // If we can successfully connect to the port, it's not fully closed
+        while start.elapsed() < PORT_RELEASE_TIMEOUT {
+            let res = std::net::TcpStream::connect((Ipv4Addr::LOCALHOST, self.port));
+            if res.is_err() {
+                // If connection fails, the port is released
+                break;
+            }
+            std::thread::sleep(HOT_LOOP_INTERVAL);
+        }
+
+        self.port
+    }
+}

--- a/rust/captive_postgres/src/stdio_reader.rs
+++ b/rust/captive_postgres/src/stdio_reader.rs
@@ -1,0 +1,48 @@
+use std::io::BufRead;
+use std::sync::{Arc, RwLock};
+use std::thread;
+
+pub struct StdioReader {
+    output: Arc<RwLock<String>>,
+}
+
+impl StdioReader {
+    pub fn spawn<R: BufRead + Send + 'static>(reader: R, prefix: impl Into<String>) -> Self {
+        let prefix = prefix.into();
+        let output = Arc::new(RwLock::new(String::new()));
+        let output_clone = Arc::clone(&output);
+
+        thread::spawn(move || {
+            let mut buf_reader = std::io::BufReader::new(reader);
+            loop {
+                let mut line = String::new();
+                match buf_reader.read_line(&mut line) {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if let Ok(mut output) = output_clone.write() {
+                            output.push_str(&line);
+                        }
+                        eprint!("[{}]: {}", prefix, line);
+                    }
+                    Err(e) => {
+                        let error_line = format!("Error reading {}: {}\n", prefix, e);
+                        if let Ok(mut output) = output_clone.write() {
+                            output.push_str(&error_line);
+                        }
+                        eprintln!("{}", error_line);
+                    }
+                }
+            }
+        });
+
+        StdioReader { output }
+    }
+
+    pub fn contains(&self, s: &str) -> bool {
+        if let Ok(output) = self.output.read() {
+            output.contains(s)
+        } else {
+            false
+        }
+    }
+}


### PR DESCRIPTION
In anticipation of work on postgres clustering support, adds an option to create a captive postgres cluster from scratch. This bootstraps a primary and N secondaries, each one streaming the WAL from the primary.

The secondary is bootstrapped from `pg_basebackup` over the localhost connection, with a `standby.signal` file.

This is what the test output from test_create_cluster looks like:

```
---- tests::test_create_cluster stdout ----
initdb command:
  "/devel/github/edgedb/build/postgres/install/bin/initdb" "-D" "/tmp/.tmphZYXZg/data" "-A" "trust" "--pwfile" "/tmp/.tmpNXDTJ3" "-U" "username" "--no-instructions"
initdb: exit status: 0
=== begin initdb stdout:===
The files belonging to this database system will be owned by user "matt".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.UTF-8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

creating directory /tmp/.tmphZYXZg/data ... ok
creating subdirectories ... ok
selecting dynamic shared memory implementation ... posix
selecting default "max_connections" ... 100
selecting default "shared_buffers" ... 128MB
selecting default time zone ... America/Edmonton
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

=== end initdb stdout ===
postgres command:
  "/devel/github/edgedb/build/postgres/install/bin/postgres" "-D" "/tmp/.tmphZYXZg/data" "-h" "127.0.0.1" "-F" "-p" "34733" "-c" "wal_level=replica"
[pg_stderr 151842]: 2025-01-20 10:53:14.237 MST [151842] LOG:  starting PostgreSQL 17.2 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, 64-bit
[pg_stderr 151842]: 2025-01-20 10:53:14.237 MST [151842] LOG:  listening on IPv4 address "127.0.0.1", port 34733
[pg_stderr 151842]: 2025-01-20 10:53:14.237 MST [151842] LOG:  listening on Unix socket "/tmp/.s.PGSQL.34733"
[pg_stderr 151842]: 2025-01-20 10:53:14.238 MST [151847] LOG:  database system was shut down at 2025-01-20 10:53:14 MST
[pg_stderr 151842]: 2025-01-20 10:53:14.240 MST [151842] LOG:  database system is ready to accept connections
Database is ready
TCP socket at 127.0.0.1:34733 bound successfully (local address was 127.0.0.1:58350)
pg_basebackup command:
  "/devel/github/edgedb/build/postgres/install/bin/pg_basebackup" "-D" "/tmp/.tmp9SXDzR/data" "-h" "localhost" "-p" "34733" "-U" "username" "-X" "stream"
[pg_stderr 151842]: 2025-01-20 10:53:14.334 MST [151845] LOG:  checkpoint starting: force wait
[pg_stderr 151842]: 2025-01-20 10:53:14.340 MST [151845] LOG:  checkpoint complete: wrote 3 buffers (0.0%); 0 WAL file(s) added, 0 removed, 1 recycled; write=0.001 s, sync=0.001 s, total=0.006 s; sync files=0, longest=0.000 s, average=0.000 s; distance=11331 kB, estimate=11331 kB; lsn=0/2000080, redo lsn=0/2000028
pg_basebackup: exit status: 0
pg_basebackup: No output

postgres command:
  "/devel/github/edgedb/build/postgres/install/bin/postgres" "-D" "/tmp/.tmp9SXDzR/data" "-h" "127.0.0.1" "-F" "-p" "42179" "-c" "primary_conninfo=host=localhost port=34733 user=username password=password" "-c" "hot_standby=on"
[pg_stderr 151856]: 2025-01-20 10:53:14.387 MST [151856] LOG:  starting PostgreSQL 17.2 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, 64-bit
[pg_stderr 151856]: 2025-01-20 10:53:14.387 MST [151856] LOG:  listening on IPv4 address "127.0.0.1", port 42179
[pg_stderr 151856]: 2025-01-20 10:53:14.387 MST [151856] LOG:  listening on Unix socket "/tmp/.s.PGSQL.42179"
[pg_stderr 151856]: 2025-01-20 10:53:14.388 MST [151861] LOG:  database system was interrupted; last known up at 2025-01-20 10:53:14 MST
[pg_stderr 151856]: 2025-01-20 10:53:14.388 MST [151861] LOG:  starting backup recovery with redo LSN 0/2000028, checkpoint LSN 0/2000080, on timeline ID 1
[pg_stderr 151856]: 2025-01-20 10:53:14.388 MST [151861] LOG:  entering standby mode
[pg_stderr 151856]: 2025-01-20 10:53:14.388 MST [151861] LOG:  redo starts at 0/2000028
[pg_stderr 151856]: 2025-01-20 10:53:14.388 MST [151861] LOG:  completed backup recovery with redo LSN 0/2000028 and end LSN 0/2000120
[pg_stderr 151856]: 2025-01-20 10:53:14.388 MST [151861] LOG:  consistent recovery state reached at 0/2000120
[pg_stderr 151856]: 2025-01-20 10:53:14.388 MST [151856] LOG:  database system is ready to accept read-only connections
[pg_stderr 151856]: 2025-01-20 10:53:14.390 MST [151862] LOG:  started streaming WAL from primary at 0/3000000 on timeline 1
Database is ready
TCP socket at 127.0.0.1:42179 bound successfully (local address was 127.0.0.1:37644)
[pg_stderr 151856]: 2025-01-20 10:53:14.477 MST [151856] LOG:  received smart shutdown request
[pg_stderr 151856]: 2025-01-20 10:53:14.477 MST [151862] FATAL:  terminating walreceiver process due to administrator command
[pg_stderr 151856]: 2025-01-20 10:53:14.478 MST [151859] LOG:  shutting down
[pg_stderr 151856]: 2025-01-20 10:53:14.481 MST [151856] LOG:  database system is shut down
Process 151856 died gracefully. (ExitStatus(unix_wait_status(0)))
[pg_stderr 151842]: 2025-01-20 10:53:14.585 MST [151842] LOG:  received smart shutdown request
[pg_stderr 151842]: 2025-01-20 10:53:14.586 MST [151842] LOG:  background worker "logical replication launcher" (PID 151850) exited with exit code 1
[pg_stderr 151842]: 2025-01-20 10:53:14.586 MST [151845] LOG:  shutting down
[pg_stderr 151842]: 2025-01-20 10:53:14.586 MST [151845] LOG:  checkpoint starting: shutdown immediate
[pg_stderr 151842]: 2025-01-20 10:53:14.586 MST [151845] LOG:  checkpoint complete: wrote 0 buffers (0.0%); 0 WAL file(s) added, 0 removed, 1 recycled; write=0.001 s, sync=0.001 s, total=0.001 s; sync files=0, longest=0.000 s, average=0.000 s; distance=16384 kB, estimate=16384 kB; lsn=0/3000028, redo lsn=0/3000028
[pg_stderr 151842]: 2025-01-20 10:53:14.590 MST [151842] LOG:  database system is shut down
Process 151842 died gracefully. (ExitStatus(unix_wait_status(0)))
```

