### PR TITLE
multitenant: retry adding tenants more eagerly

### DIFF
--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -316,7 +316,7 @@ class MultiTenantServer(server.BaseServer):
             rloop = retryloop.RetryLoop(
                 backoff=retryloop.exp_backoff(),
                 timeout=300,
-                ignore=(pgerrors.BackendError, IOError),
+                ignore=Exception,
                 retry_cb=_warn,
             )
             async for iteration in rloop:

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -46,7 +46,6 @@ from . import pgcluster
 from . import server
 from . import tenant as edbtenant
 from .compiler_pool import pool as compiler_pool
-from .pgcon import errors as pgerrors
 
 logger = logging.getLogger("edb.server")
 


### PR DESCRIPTION
When adding a new tenant, the server should keep retrying regardless of the error type, e.g. StartupError as demonstrated in the unit test.