### PR TITLE
Fix dump and MIGRATION REWRITE when there are many (>1000) migrations

### DIFF
--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -287,3 +287,27 @@ class AlterMigration(MigrationCommand, sd.AlterObject[Migration]):
 class DeleteMigration(MigrationCommand, sd.DeleteObject[Migration]):
 
     astnode = qlast.DropMigration
+
+
+def get_ordered_migrations(
+    schema: s_schema.Schema,
+) -> list[Migration]:
+    '''Get all the migrations, in order.
+
+    It would be nice if our toposort could do this for us, but
+    toposort is implemented recursively, and it would be a pain to
+    change that.
+
+    '''
+    output = []
+    mig = schema.get_last_migration()
+    while mig:
+        output.append(mig)
+
+        parents = mig.get_parents(schema).objects(schema)
+        assert len(parents) <= 1, "only one parent supported currently"
+        mig = parents[0] if parents else None
+
+    output.reverse()
+
+    return output

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -23,6 +23,7 @@ import json
 import os.path
 import re
 import textwrap
+import unittest
 import uuid
 
 import edgedb
@@ -13254,4 +13255,16 @@ class TestEdgeQLMigrationRewriteNonisolated(TestEdgeQLMigrationRewrite):
                 };
                 POPULATE MIGRATION;
                 COMMIT MIGRATION;
+            """)
+
+    @unittest.skipIf(
+        True,
+        """
+        This test is still pretty slow
+        """
+    )
+    async def test_edgeql_migration_rewrite_raw_02(self):
+        for _ in range(1200):
+            await self.con.execute(r"""
+                create applied migration { }
             """)


### PR DESCRIPTION
Currently those paths rely on topological sorting of the migration
history.  Our topo sort has various bells and whistles that would make
it irritating to rewrite it non-recursively (not impossible, of
course; there is a theorem to that effect); instead, order the
migrations in a more obvious way.

It takes about a minute to set up that many migrations, so I haven't
added a test. If we think it is worth it I can, though.