### PR TITLE
[5.x] Fix dump and MIGRATION REWRITE when there are many (>1000) migrations (#8240)

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -80,7 +80,6 @@ def delta_schemas(
     include_module_diff: bool=True,
     include_std_diff: bool=False,
     include_derived_types: bool=True,
-    include_migrations: bool=False,
     include_extensions: bool=False,
     linearize_delta: bool=True,
     descriptive_mode: bool=False,
@@ -133,9 +132,6 @@ def delta_schemas(
 
         include_derived_types:
             Whether to include derived types, like unions, in the diff.
-
-        include_migrations:
-            Whether to include migrations in the diff.
 
         linearize_delta:
             Whether the resulting diff should be properly ordered
@@ -305,6 +301,7 @@ def delta_schemas(
         s_mod.Module,
         s_func.Parameter,
         s_pseudo.PseudoType,
+        s_migr.Migration,
     )
 
     schemaclasses = [
@@ -313,10 +310,6 @@ def delta_schemas(
         if (
             not issubclass(schemacls, excluded_classes)
             and not schemacls.is_abstract()
-            and (
-                include_migrations
-                or not issubclass(schemacls, s_migr.Migration)
-            )
         )
     ]
 
@@ -994,8 +987,12 @@ def ddl_text_from_schema(
         include_module_diff=include_module_ddl,
         include_std_diff=include_std_ddl,
         include_derived_types=False,
-        include_migrations=include_migrations,
     )
+    if include_migrations:
+        context = so.ComparisonContext()
+        for mig in s_migr.get_ordered_migrations(schema):
+            diff.add(mig.as_create_delta(schema, context))
+
     return ddl_text_from_delta(None, schema, diff,
                                include_ext_version=not include_migrations)
 

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -260,3 +260,27 @@ class AlterMigration(MigrationCommand, sd.AlterObject[Migration]):
 class DeleteMigration(MigrationCommand, sd.DeleteObject[Migration]):
 
     astnode = qlast.DropMigration
+
+
+def get_ordered_migrations(
+    schema: s_schema.Schema,
+) -> list[Migration]:
+    '''Get all the migrations, in order.
+
+    It would be nice if our toposort could do this for us, but
+    toposort is implemented recursively, and it would be a pain to
+    change that.
+
+    '''
+    output = []
+    mig = schema.get_last_migration()
+    while mig:
+        output.append(mig)
+
+        parents = mig.get_parents(schema).objects(schema)
+        assert len(parents) <= 1, "only one parent supported currently"
+        mig = parents[0] if parents else None
+
+    output.reverse()
+
+    return output

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1010,11 +1010,8 @@ def _commit_migration_rewrite(
 
     cmds: List[qlast.DDLCommand] = []
     # Now we find all the migrations...
-    migrations = s_delta.sort_by_cross_refs(
-        schema,
-        schema.get_objects(type=s_migrations.Migration),
-    )
-    for mig in migrations:
+    migrations = s_migrations.get_ordered_migrations(schema)
+    for mig in reversed(migrations):
         cmds.append(
             qlast.DropMigration(  # type: ignore
                 name=qlast.ObjectRef(name=mig.get_name(schema).name)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -23,6 +23,7 @@ import json
 import os.path
 import re
 import textwrap
+import unittest
 import uuid
 
 import edgedb
@@ -13104,4 +13105,16 @@ class TestEdgeQLMigrationRewriteNonisolated(TestEdgeQLMigrationRewrite):
                 };
                 POPULATE MIGRATION;
                 COMMIT MIGRATION;
+            """)
+
+    @unittest.skipIf(
+        True,
+        """
+        This test is still pretty slow
+        """
+    )
+    async def test_edgeql_migration_rewrite_raw_02(self):
+        for _ in range(1200):
+            await self.con.execute(r"""
+                create applied migration { }
             """)


### PR DESCRIPTION
Currently those paths rely on topological sorting of the migration
history.  Our topo sort has various bells and whistles that would make
it irritating to rewrite it non-recursively (not impossible, of
course; there is a theorem to that effect); instead, order the
migrations in a more obvious way.

It takes about a minute to set up that many migrations, so I haven't
added a test. If we think it is worth it I can, though.