### PR TITLE
Don't hardcode number of tests in test_server_ops_multi_tenant

### DIFF
--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1591,8 +1591,10 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                         cf1,
                         cf2
                     )
-                    for i in range(1, 9):
-                        name = f"_test_server_ops_multi_tenant_{i}"
+                    test_prefix = '_test_server_ops_multi_tenant_'
+                    tests = [s for s in dir(self) if s.startswith(test_prefix)]
+                    for name in tests:
+                        i = name.replace(test_prefix, '')
                         with self.subTest(name, i=i):
                             await getattr(self, name)(mtargs)
             finally:


### PR DESCRIPTION
Search based on name for subtests instead of hardcoding the number.
This is generally nicer and means fewer (not none) conflicts to resolve
when backporting.