### PR TITLE
Delete old .s.EDGEDB.admin.XXX sockets

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -749,7 +749,17 @@ class BaseServer:
             self._runstate_dir, f'.s.GEL.admin.{port}')
         symlink = os.path.join(
             self._runstate_dir, f'.s.EDGEDB.admin.{port}')
-        if not os.path.exists(symlink):
+
+        exists = False
+        try:
+            mode = os.lstat(symlink).st_mode
+            if stat.S_ISSOCK(mode):
+                os.unlink(symlink)
+            else:
+                exists = True
+        except FileNotFoundError:
+            pass
+        if not exists:
             os.symlink(admin_unix_sock_path, symlink)
 
         assert len(admin_unix_sock_path) <= (


### PR DESCRIPTION
This will make sure we can create the fallback symlink
even if an old socket wasn't deleted, which should fix
edgedb/edgedb-cli#1418.

(Though maybe we want a CLI-side fix *also*, so 6.0b2 works better?)