### PR TITLE
[sql] Fix some bugs with UNION and similar

### DIFF
--- a/edb/pgsql/resolver/relation.py
+++ b/edb/pgsql/resolver/relation.py
@@ -102,11 +102,9 @@ def resolve_SelectStmt(
                 span=stmt.span,
             )
 
-        relation = pgast.SelectStmt(
+        relation = stmt.replace(
             larg=cast(pgast.Query, larg),
             rarg=cast(pgast.Query, rarg),
-            op=stmt.op,
-            all=stmt.all,
             ctes=ctes + extract_ctes_from_ctx(ctx),
         )
         return (relation, ltable)

--- a/tests/test_sql_parse.py
+++ b/tests/test_sql_parse.py
@@ -115,7 +115,7 @@ class TestSQLParse(tb.BaseDocTest):
         """
         SELECT * FROM table_one UNION select * FROM table_two
 % OK %
-        SELECT * FROM table_one UNION (SELECT * FROM table_two)
+        (SELECT * FROM table_one) UNION (SELECT * FROM table_two)
         """
 
     def test_sql_parse_select_08(self):
@@ -252,7 +252,7 @@ class TestSQLParse(tb.BaseDocTest):
         """
         select * FROM table_one UNION select * FROM table_two
 % OK %
-        SELECT * FROM table_one UNION (SELECT * FROM table_two)
+        (SELECT * FROM table_one) UNION (SELECT * FROM table_two)
         """
 
     def test_sql_parse_select_28(self):

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1174,6 +1174,33 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             [12, 4],
         ])
 
+    async def test_sql_query_57(self):
+        res = await self.squery_values(
+            f'''
+            (select 1 limit 1) union (select 2 limit 1);
+            '''
+        )
+        self.assertEqual(
+            res,
+            [
+                [1],
+                [2],
+            ]
+        )
+
+        res = await self.squery_values(
+            f'''
+            (select 1) union (select 2) LIMIT $1;
+            ''',
+            1
+        )
+        self.assertEqual(
+            res,
+            [
+                [1],
+            ]
+        )
+
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname
         res = await self.squery_values(


### PR DESCRIPTION
- Fix parenthesization in top level UNION
  Make sure the LHS of a top-level UNION gets parenthesized. Sometimes
  it works without them, but often it does not.
- Preserve OFFSET/LIMIT clauses on UNION expressions.