### PR TITLE
[sql] Fix (SELECT * FROM ...) in subqueries

### DIFF
--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -315,6 +315,11 @@ def _lookup_column(
             return [
                 (t, c)
                 for t in ctx.scope.tables
+                # Only look at the highest precedence level for
+                # *. That is, we take everything in our local FROM
+                # clauses but not stuff in enclosing queries, if we
+                # are a subquery.
+                if t.precedence == 0
                 for c in t.columns
                 if not c.hidden
             ]

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2286,6 +2286,19 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         res = await self.squery_values('SELECT * FROM ONLY "Content"')
         self.assertEqual(len(res), 0)
 
+    async def test_sql_query_subquery_splat_01(self):
+        res = await self.squery_values(
+            '''
+            with "average_pages" as (select avg("pages") as "value" from "Book")
+            select pages from "Book"
+            where "Book".pages < (select * from "average_pages")
+            '''
+        )
+        self.assertEqual(
+            res,
+            [[206]],
+        )
+
     async def test_sql_query_unsupported_01(self):
         # test error messages of unsupported queries
 


### PR DESCRIPTION
Currently it will select all columns in *all* tables in scope. We only
want to select from the things in the FROM clause.