### PR TITLE
[sql] Fix using `distinct`+`order by` and similar in native protocol

### DIFF
--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2896,6 +2896,19 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             implicit_limit=3,
         )
 
+    async def test_sql_native_query_26(self):
+        await self.assert_sql_query_result(
+            """
+                select distinct title, pages from "Book"
+                order by title, pages;
+            """,
+            [
+                {'title': 'Chronicles of Narnia', 'pages': 206},
+                {'title': 'Hunger Games', 'pages': 374},
+            ],
+            apply_access_policies=False,
+        )
+
 
 class TestSQLQueryNonTransactional(tb.SQLQueryTestCase):
 


### PR DESCRIPTION
It doesn't work in general to stick everything in the target list into
a call to ROW, because certain things in SQL only work when an
expression appears in the target list.

Preserve the shape of the original query and turn it into ROWs in an
outer query.