### PR TITLE
Avoid memory leak by moving `lru_cache` to `__init__`

### DIFF
--- a/edb/common/enum.py
+++ b/edb/common/enum.py
@@ -32,7 +32,7 @@ class StrEnum(str, enum.Enum):
 @functools.total_ordering
 class OrderedEnumMixin():
 
-    def __init__(self) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         self._index_of = functools.lru_cache(maxsize=None)(self.__index_of)
 
     @classmethod

--- a/edb/common/enum.py
+++ b/edb/common/enum.py
@@ -31,9 +31,12 @@ class StrEnum(str, enum.Enum):
 
 @functools.total_ordering
 class OrderedEnumMixin():
+
+    def __init__(self) -> None:
+        self._index_of = functools.lru_cache(maxsize=None)(self.__index_of)
+
     @classmethod
-    @functools.lru_cache(None)
-    def _index_of(cls, value):
+    def __index_of(cls, value):
         return list(cls).index(value)
 
     def __lt__(self, other):

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -550,6 +550,9 @@ class FlatSchema(Schema):
         self._globalname_to_id = immu.Map()
         self._refs_to = immu.Map()
         self._generation = 0
+        self.get_referrers_ex = functools.lru_cache()(self._get_referrers_ex)
+        self._get_referrers = functools.lru_cache()(self._get_referrers_uncached)
+        self._get_casts = functools.lru_cache()(self._get_casts_uncached)
 
     def _get_object_ids(self) -> Iterable[uuid.UUID]:
         return self._id_to_type.keys()
@@ -1218,8 +1221,7 @@ class FlatSchema(Schema):
                 type=s_oper.Operator,
             )
 
-    @functools.lru_cache()
-    def _get_casts(
+    def _get_casts_uncached(
         self,
         stype: s_types.Type,
         *,
@@ -1274,8 +1276,7 @@ class FlatSchema(Schema):
         return self._get_referrers(
             scls, scls_type=scls_type, field_name=field_name)
 
-    @functools.lru_cache()
-    def _get_referrers(
+    def _get_referrers_uncached(
         self,
         scls: so.Object,
         *,
@@ -1312,8 +1313,7 @@ class FlatSchema(Schema):
 
             return frozenset(referrers)  # type: ignore
 
-    @functools.lru_cache()
-    def get_referrers_ex(  # type: ignore
+    def _get_referrers_ex(  # type: ignore
         self,
         scls: so.Object,
         *,

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -550,7 +550,7 @@ class FlatSchema(Schema):
         self._globalname_to_id = immu.Map()
         self._refs_to = immu.Map()
         self._generation = 0
-        self.get_referrers_ex = functools.lru_cache()(self._get_referrers_ex)
+        self._get_referrers_ex = functools.lru_cache()(self._get_referrers_ex_uncached)
         self._get_referrers = functools.lru_cache()(self._get_referrers_uncached)
         self._get_casts = functools.lru_cache()(self._get_casts_uncached)
 
@@ -1313,7 +1313,19 @@ class FlatSchema(Schema):
 
             return frozenset(referrers)  # type: ignore
 
-    def _get_referrers_ex(  # type: ignore
+    def get_referrers_ex(
+        self,
+        scls: so.Object,
+        *,
+        scls_type: Optional[Type[so.Object_T]] = None,
+        field_name: Optional[str] = None,
+    ) -> Dict[
+        Tuple[Type[so.Object_T], str],
+        FrozenSet[so.Object_T],
+    ]:
+        return self._get_referrers_ex(scls=scls, scls_type=scls_type, field_name=field_name)
+
+    def _get_referrers_ex_uncached(  # type: ignore
         self,
         scls: so.Object,
         *,

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -1900,8 +1900,12 @@ class StateSerializer(InputShapeSerializer):
 
 
 class CompilationConfigSerializer(InputShapeSerializer):
-    @functools.lru_cache(64)
-    def encode_configs(
+
+    def __init__(self, type_id: uuid.UUID, type_data: bytes, protocol_version: tuple[int, int]) -> None:
+        super().__init__(type_id, type_data, protocol_version)
+        self.encode_configs = functools.lru_cache(64)(self._encode_configs)
+
+    def _encode_configs(
         self, *configs: immutables.Map[str, config.SettingValue] | None
     ) -> bytes:
         state: dict[str, Any] = {}

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -199,13 +199,13 @@ class MultiSchemaPool(pool_mod.FixedPool):
         self._cache_size = cache_size
         self._clients = {}
         self._secret = secret
+        self._get_init_args = functools.lru_cache()(self._get_init_args_uncached)
 
     def _init(self, kwargs: dict[str, typing.Any]) -> None:
         # this is deferred to _init_server()
         pass
 
-    @functools.cache
-    def _get_init_args(self):
+    def _get_init_args_uncached(self):
         init_args = (
             self._backend_runtime_params,
             self._std_schema,

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -866,6 +866,7 @@ class RemoteCluster(BaseCluster):
         )
         self._connection_addr = connection_addr
         self._ha_backend = ha_backend
+        self.get_client_id = functools.lru_cache()(self._get_client_id)
 
     def _get_connection_addr(self) -> Optional[Tuple[str, int]]:
         if self._ha_backend is not None:
@@ -925,8 +926,7 @@ class RemoteCluster(BaseCluster):
         if self._ha_backend is not None:
             self._ha_backend.stop_watching()
 
-    @functools.cache
-    def get_client_id(self) -> int:
+    def _get_client_id(self) -> int:
         tenant_id = self._instance_params.tenant_id
         if self._ha_backend is not None:
             backend_dsn = self._ha_backend.dsn

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -226,6 +226,7 @@ class Tenant(ha_base.ClusterProtocol):
 
         # If it isn't stored in instdata, it is the old default.
         self.default_database = defines.EDGEDB_OLD_DEFAULT_DB
+        self.get_backend_runtime_params = functools.lru_cache()(self._get_backend_runtime_params)
 
     def set_reloadable_files(
         self,
@@ -355,8 +356,7 @@ class Tenant(ha_base.ClusterProtocol):
     def get_pgaddr(self) -> pgconnparams.ConnectionParams:
         return self._cluster.get_pgaddr()
 
-    @functools.lru_cache
-    def get_backend_runtime_params(self) -> pgparams.BackendRuntimeParams:
+    def _get_backend_runtime_params(self) -> pgparams.BackendRuntimeParams:
         return self._cluster.get_runtime_params()
 
     def get_instance_name(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,10 +259,6 @@ ignore = [
 
     # TODO: enable this
     "B905", # zip() without an explicit strict= parameter
-
-    # TODO: enable this (this was tried before - it is non-trivial)
-    "B019", # Use of functools.lru_cache or functools.cache on methods can lead
-    # to memory leaks
 ]
 flake8-bugbear.extend-immutable-calls = ["immutables.Map"]
 


### PR DESCRIPTION
Related to Issue #5377
Closes #5377

### What was wrong?
The codebase currently use the `lru_cache` decorator in the classes over methods. The ruff linter reported a warning, indicating potential memory leaks in class methods, because the `lru_cache` decorator retain instance references, impeding garbage collection and potentially leading to memory-related issues.

### How was it fixed?
I stopped using decorators directly over methods and instead applied the decorator functions during class instance initialization.