### PR TITLE
Use better histogram buckets

### DIFF
--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -24,6 +24,13 @@ from edb.common import prometheus as prom
 
 registry = prom.Registry(prefix='edgedb_server')
 
+COUNT_BUCKETS = prom.per_order_buckets(
+    1, 10000, entries_per_order=5,
+)
+BYTES_BUCKETS = prom.per_order_buckets(
+    8, 2**20, entries_per_order=4, base=2,
+)
+
 compiler_process_spawns = registry.new_counter(
     'compiler_process_spawns_total',
     'Total number of compiler processes spawned.'
@@ -144,6 +151,7 @@ sql_compilations = registry.new_labeled_counter(
 queries_per_connection = registry.new_labeled_histogram(
     'queries_per_connection',
     'Number of queries per connection.',
+    buckets=COUNT_BUCKETS,
     labels=('tenant', 'interface'),
 )
 
@@ -151,6 +159,7 @@ query_size = registry.new_labeled_histogram(
     'query_size',
     'The size of a query.',
     unit=prom.Unit.BYTES,
+    buckets=BYTES_BUCKETS,
     labels=('tenant', 'interface'),
 )
 

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -25,10 +25,10 @@ from edb.common import prometheus as prom
 registry = prom.Registry(prefix='edgedb_server')
 
 COUNT_BUCKETS = prom.per_order_buckets(
-    1, 10000, entries_per_order=5,
+    1, 10000, entries_per_order=2,
 )
 BYTES_BUCKETS = prom.per_order_buckets(
-    8, 2**20, entries_per_order=4, base=2,
+    32, 2**20, entries_per_order=1, base=2,
 )
 
 compiler_process_spawns = registry.new_counter(


### PR DESCRIPTION
Use a method of generating buckets based on specifying how many
buckets to use per order of magnitude.

For bytes, I did 4 buckets per binary order of magnitude, because
binary felt sensible to me. Is that stupid, and I should just use
decimal orders of magnitude?

For our bytes field, we use:
(8, 12.0, 16, 24.0, 32, 48.0, 64, 96.0, 128, 192.0, 256, 384.0, 512, 768.0, 1024, 1536.0, 2048, 3072.0, 4096, 6144.0, 8192, 12288.0, 16384, 24576.0, 32768, 49152.0, 65536, 98304.0, 131072, 196608.0, 262144, 393216.0, 524288, 786432.0, 1048576)

And for querys per connection, we use:
(1, 2.0, 4.0, 6.0, 8.0, 10.0, 20.0, 40.0, 60.0, 80.0, 100.0, 200.0, 400.0, 600.0, 800.0, 1000.0, 2000.0, 4000.0, 6000.0, 8000.0, 10000.0)

Fixes #8245.