### PR TITLE
Introduce a lru_method_cache decorator for caching methods

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -51,6 +51,7 @@ import immutables as immu
 from edb import errors
 from edb.common import adapter
 from edb.common import english
+from edb.common import lru
 
 from . import casts as s_casts
 from . import functions as s_func
@@ -1218,7 +1219,7 @@ class FlatSchema(Schema):
                 type=s_oper.Operator,
             )
 
-    @functools.lru_cache()
+    @lru.lru_method_cache()
     def _get_casts(
         self,
         stype: s_types.Type,
@@ -1274,7 +1275,7 @@ class FlatSchema(Schema):
         return self._get_referrers(
             scls, scls_type=scls_type, field_name=field_name)
 
-    @functools.lru_cache()
+    @lru.lru_method_cache()
     def _get_referrers(
         self,
         scls: so.Object,
@@ -1312,8 +1313,8 @@ class FlatSchema(Schema):
 
             return frozenset(referrers)  # type: ignore
 
-    @functools.lru_cache()
-    def get_referrers_ex(  # type: ignore
+    @lru.lru_method_cache()
+    def get_referrers_ex(
         self,
         scls: so.Object,
         *,

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -45,8 +45,9 @@ import immutables
 
 from edb import errors
 from edb.common import binwrapper
-from edb.common import value_dispatch
+from edb.common import lru
 from edb.common import uuidgen
+from edb.common import value_dispatch
 
 from edb.protocol import enums as p_enums
 from edb.server import config
@@ -1900,7 +1901,7 @@ class StateSerializer(InputShapeSerializer):
 
 
 class CompilationConfigSerializer(InputShapeSerializer):
-    @functools.lru_cache(64)
+    @lru.lru_method_cache(64)
     def encode_configs(
         self, *configs: immutables.Map[str, config.SettingValue] | None
     ) -> bytes:

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -37,6 +37,7 @@ import time
 import immutables
 
 from edb.common import debug
+from edb.common import lru
 
 from edb.pgsql import params as pgparams
 
@@ -189,7 +190,7 @@ class AbstractPool:
         assert self._dbindex is not None
         return self._make_init_args(*self._dbindex.get_cached_compiler_args())
 
-    @functools.lru_cache(1)
+    @lru.lru_method_cache(1)
     def _make_init_args(self, dbs, global_schema_pickle, system_config):
         init_args = (
             dbs,
@@ -1103,7 +1104,7 @@ class RemotePool(AbstractPool):
             if worker.done():
                 (await worker).close()
 
-    @functools.lru_cache(1)
+    @lru.lru_method_cache(1)
     def _make_init_args(self, dbs, global_schema_pickle, system_config):
         init_args = (
             dbs,
@@ -1337,7 +1338,7 @@ class MultiTenantPool(FixedPool):
         for worker in self._workers.values():
             worker.invalidate(client_id)
 
-    @functools.cache
+    @lru.method_cache
     def _get_init_args(self):
         init_args = (
             self._backend_runtime_params,

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -36,6 +36,7 @@ import httptools
 import immutables
 
 from edb.common import debug
+from edb.common import lru
 from edb.common import markup
 
 from .. import metrics
@@ -204,7 +205,7 @@ class MultiSchemaPool(pool_mod.FixedPool):
         # this is deferred to _init_server()
         pass
 
-    @functools.cache
+    @lru.method_cache
     def _get_init_args(self):
         init_args = (
             self._backend_runtime_params,

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -36,7 +36,6 @@ from typing import (
 
 import asyncio
 import copy
-import functools
 import hashlib
 import json
 import logging
@@ -53,6 +52,7 @@ import urllib.parse
 
 from edb import buildmeta
 from edb import errors
+from edb.common import lru
 from edb.common import supervisor
 from edb.common import uuidgen
 
@@ -925,7 +925,7 @@ class RemoteCluster(BaseCluster):
         if self._ha_backend is not None:
             self._ha_backend.stop_watching()
 
-    @functools.cache
+    @lru.method_cache
     def get_client_id(self) -> int:
         tenant_id = self._instance_params.tenant_id
         if self._ha_backend is not None:

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -35,7 +35,6 @@ from typing import (
 import asyncio
 import contextlib
 import dataclasses
-import functools
 import json
 import logging
 import os
@@ -54,6 +53,7 @@ import immutables
 from edb import buildmeta
 from edb import errors
 from edb.common import asyncutil
+from edb.common import lru
 from edb.common import retryloop
 from edb.common import verutils
 from edb.common.log import current_tenant
@@ -355,7 +355,7 @@ class Tenant(ha_base.ClusterProtocol):
     def get_pgaddr(self) -> pgconnparams.ConnectionParams:
         return self._cluster.get_pgaddr()
 
-    @functools.lru_cache
+    @lru.method_cache
     def get_backend_runtime_params(self) -> pgparams.BackendRuntimeParams:
         return self._cluster.get_runtime_params()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,10 +259,6 @@ ignore = [
 
     # TODO: enable this
     "B905", # zip() without an explicit strict= parameter
-
-    # TODO: enable this (this was tried before - it is non-trivial)
-    "B019", # Use of functools.lru_cache or functools.cache on methods can lead
-    # to memory leaks
 ]
 flake8-bugbear.extend-immutable-calls = ["immutables.Map"]
 


### PR DESCRIPTION
The decorator arranges for a cache to be stored inside the object on
first call.

Inspired by #8261 but without per-object toil.
Fixes #5377.