### PR TITLE
[sql] Fix native SQL protocol on old postgres versions

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -972,6 +972,11 @@ class WindowDef(ImmutableBase):
 class RangeSubselect(PathRangeVar):
     """Subquery appearing in FROM clauses."""
 
+    # Before postgres 16, an alias is always required on selects from
+    # a subquery. Try to catch that with the typechecker by getting
+    # rid of the default value.
+    alias: Alias
+
     lateral: bool = False
     subquery: Query
 

--- a/edb/pgsql/resolver/__init__.py
+++ b/edb/pgsql/resolver/__init__.py
@@ -149,7 +149,10 @@ def resolve(
                         val=expr.construct_row_expr(columns, ctx=ctx)
                     )
                 ],
-                from_clause=[pgast.RangeSubselect(subquery=e)],
+                from_clause=[pgast.RangeSubselect(
+                    subquery=e,
+                    alias=pgast.Alias(aliasname='r'),
+                )],
                 ctes=e.ctes,
             )
             e.ctes = []


### PR DESCRIPTION
I broke it in #8256 by adding a RangeSubselect without an alias.