### PR TITLE
Reenable test_sql_query_computed_11 

### DIFF
--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2099,7 +2099,6 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         )
         self.assertEqual(res, [["user_robin"]])
 
-    @test.skip("This is flaking in CI")
     async def test_sql_query_computed_11(self):
         # globals
 


### PR DESCRIPTION
Refs #8125, reenable `test_sql_query_computed_11` and see how it goes.

Revert "Disable a test that has been flaking in CI (#8058)"

This reverts commit 2d2079843fc4106572ef17b66c6801838d5595c0.