### PR TITLE
Try to leave more backend connections free in test suite

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -414,11 +414,11 @@ def compute_default_max_backend_connections() -> int:
 
 def adjust_testmode_max_connections(max_conns):
     # Some test cases will start a second EdgeDB server (default
-    # max_backend_connections=10), so we should reserve some backend
+    # max_backend_connections=5), so we should reserve some backend
     # connections for that. This is ideally calculated upon the edb test -j
     # option, but that also depends on the total available memory. We are
     # hard-coding 15 reserved connections here for simplicity.
-    return max(1, max_conns // 2, max_conns - 15)
+    return max(1, max_conns // 2, max_conns - 30)
 
 
 def _validate_compiler_pool_size(ctx, param, value):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2726,7 +2726,7 @@ def start_edgedb_server(
     bind_addrs: tuple[str, ...] = ('localhost',),
     auto_shutdown_after: Optional[int]=None,
     bootstrap_command: Optional[str]=None,
-    max_allowed_connections: Optional[int]=10,
+    max_allowed_connections: Optional[int]=5,
     compiler_pool_size: int=2,
     compiler_pool_mode: Optional[edgedb_args.CompilerPoolMode] = None,
     adjacent_to: Optional[tconn.Connection]=None,


### PR DESCRIPTION
In our "Tests on PostgreSQL Versions", we regularly have failures due
to being out of backend connections in start_edgedb_server tests that
share the backend. Leave some more reserved for those tests and try to
use few connections in them also.