### PR TITLE
[6.x] Remove insertion of extra repairs in patch queue

### DIFF
--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -43,24 +43,6 @@ def get_version_key(num_patches: int):
         return f'_v{num_major}'
 
 
-def _setup_patches(patches: list[tuple[str, str]]) -> list[tuple[str, str]]:
-    """Do postprocessing on the patches list
-
-    For technical reasons, we can't run a user schema repair if there
-    is a pending standard schema change, so when applying repairs we
-    always defer them to the *last* repair patch, and we ensure that
-    edgeql+schema is followed by a repair if necessary.
-    """
-    seen_repair = False
-    npatches = []
-    for kind, patch in patches:
-        npatches.append((kind, patch))
-        if kind.startswith('edgeql+schema') and seen_repair:
-            npatches.append(('repair', ''))
-        seen_repair |= kind == 'repair'
-    return npatches
-
-
 """
 The actual list of patches. The patches are (kind, script) pairs.
 
@@ -76,7 +58,7 @@ The current kinds are:
  * repair - fix up inconsistencies in *user* schemas
  * sql-introspection - refresh all sql introspection views
 """
-PATCHES: list[tuple[str, str]] = _setup_patches([
+PATCHES: list[tuple[str, str]] = [
     # 6.0b2
     # One of the sql-introspection's adds a param with a default to
     # uuid_to_oid, so we need to drop the original to avoid ambiguity.
@@ -85,4 +67,4 @@ drop function if exists edgedbsql_v6_2f20b3fed0.uuid_to_oid(uuid) cascade
 '''),
     ('sql-introspection', ''),
     ('metaschema-sql', 'SysConfigFullFunction'),
-])
+]

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -686,8 +686,7 @@ def prepare_repair_patch(
     globalschema: s_schema.Schema,
     schema_class_layout: s_refl.SchemaClassLayout,
     backend_params: params.BackendRuntimeParams,
-    config: Any,
-) -> bytes:
+) -> str:
     compiler = edbcompiler.new_compiler(
         std_schema=stdschema,
         reflection_schema=reflschema,
@@ -701,13 +700,13 @@ def prepare_repair_patch(
     )
     res = edbcompiler.repair_schema(compilerctx)
     if not res:
-        return b""
+        return ""
     sql, _, _ = res
 
-    return sql
+    return sql.decode('utf-8')
 
 
-PatchEntry = tuple[tuple[str, ...], tuple[str, ...], dict[str, Any], bool]
+PatchEntry = tuple[tuple[str, ...], tuple[str, ...], dict[str, Any]]
 
 
 async def gather_patch_info(
@@ -786,6 +785,8 @@ def prepare_patch(
     patch_info: Optional[dict[str, list[str]]],
     user_schema: Optional[s_schema.Schema]=None,
     global_schema: Optional[s_schema.Schema]=None,
+    *,
+    dbname: Optional[str]=None,
 ) -> PatchEntry:
     val = f'{pg_common.quote_literal(json.dumps(num + 1))}::jsonb'
     # TODO: This is an INSERT because 2.0 shipped without num_patches.
@@ -801,7 +802,7 @@ def prepare_patch(
 
     # Pure SQL patches are simple
     if kind == 'sql':
-        return (patch, update), (), {}, False
+        return (patch, update), (), {}
 
     # metaschema-sql: just recreate a function from metaschema
     if kind == 'metaschema-sql':
@@ -809,11 +810,37 @@ def prepare_patch(
         create = dbops.CreateFunction(func(), or_replace=True)
         block = dbops.PLTopBlock()
         create.generate(block)
-        return (block.to_string(), update), (), {}, False
+        return (block.to_string(), update), (), {}
 
     if kind == 'repair':
         assert not patch
-        return (update,), (), {}, True
+        if not user_schema:
+            return (update,), (), dict(is_user_update=True)
+        assert global_schema
+
+        # TODO: Implement the last-repair-only optimization?
+        try:
+            logger.info("repairing database '%s'", dbname)
+            sql = prepare_repair_patch(
+                schema,
+                reflschema,
+                user_schema,
+                global_schema,
+                schema_class_layout,
+                backend_params
+            )
+        except errors.EdgeDBError as e:
+            if isinstance(e, errors.InternalServerError):
+                raise
+            raise errors.SchemaError(
+                f'Could not repair schema inconsistencies in '
+                f'database branch "{dbname}". Probably the schema is '
+                f'no longer valid due to a bug fix.\n'
+                f'Downgrade to the last working version, fix '
+                f'the schema issue, and try again.'
+            ) from e
+
+        return (update, sql), (), {}
 
     # EdgeQL and reflection schema patches need to be compiled.
     current_block = dbops.PLTopBlock()
@@ -874,7 +901,7 @@ def prepare_patch(
         # There isn't anything to do on the system database for
         # userext updates.
         if user_schema is None:
-            return (update,), (), dict(is_user_ext_update=True), False
+            return (update,), (), dict(is_user_update=True)
 
         # Only run a userext update if the extension we are trying to
         # update is installed.
@@ -883,7 +910,7 @@ def prepare_patch(
             s_exts.Extension, extension_name, default=None)
 
         if not extension:
-            return (update,), (), {}, False
+            return (update,), (), {}
 
         assert global_schema
         cschema = s_schema.ChainedSchema(
@@ -1097,13 +1124,13 @@ def prepare_patch(
         sys_updates = (patch,) + sys_updates
     else:
         regular_updates = spatches + (update,)
-        # FIXME: This is a hack to make the is_user_ext_update cases
+        # FIXME: This is a hack to make the is_user_update cases
         # work (by ensuring we can always read their current state),
         # but this is actually a pretty dumb approach and we can do
         # better.
         regular_updates += sys_updates
 
-    return regular_updates, sys_updates, updates, False
+    return regular_updates, sys_updates, updates
 
 
 async def create_branch(


### PR DESCRIPTION
Currently, if there is *any* repair in a patch queue, we insert a
repair after *every* patch that modifies the std schema.

This was in combination with deferring all repairs until the last one
in the queue, which allowed us to avoid needing to load the current
standard schema in order to do a repair. But we implemented support
for doing that as part of patching user extensions, so merge all of
the schema repair code into that.

I tested this on 5.x's substantial collection of complex patches (see https://github.com/edgedb/edgedb/pull/8277), and
then forward ported to master, and then backported this to 6.x.