### PR TITLE
Fix `ADMINISTER schema_repair()`

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -618,6 +618,7 @@ def apply_ddl_script_ex(
     stdmode: bool = False,
     internal_schema_mode: bool = False,
     testmode: bool = False,
+    store_migration_sdl: bool=False,
     schema_object_ids: Optional[
         Mapping[Tuple[sn.Name, Optional[str]], uuid.UUID]
     ]=None,
@@ -639,6 +640,7 @@ def apply_ddl_script_ex(
             stdmode=stdmode,
             internal_schema_mode=internal_schema_mode,
             testmode=testmode,
+            store_migration_sdl=store_migration_sdl,
             schema_object_ids=schema_object_ids,
             compat_ver=compat_ver,
         )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -17415,6 +17415,16 @@ DDLStatement);
             [{}],
         )
 
+    async def test_edgeql_ddl_schema_repair(self):
+        await self.con.execute('''
+            create type Tgt {
+                create property lol := count(Object)
+            }
+        ''')
+        await self.con.execute('''
+            administer schema_repair()
+        ''')
+
     async def test_edgeql_ddl_alias_and_create_set_required(self):
         await self.con.execute(r"""
             create type T;


### PR DESCRIPTION
It got fully broken by an extra argument being added to some (but not
all) s_ddl functions.  Since arguments were being passed in a big
untyped kwargs and there wasn't a test, it got missed.

Add a test, too.