### PR TITLE
Make sure config spec-dependent functions are regened when grafting testmode

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1781,8 +1781,10 @@ async def _init_stdlib(
             await conn.sql_execute(testmode_sql.encode("utf-8"))
             trampolines.extend(new_trampolines)
         # _testmode includes extra config settings, so make sure
-        # those are picked up.
+        # those are picked up...
         config_spec = config.load_spec_from_schema(stdlib.stdschema)
+        # ...and that config functions dependent on it are regenerated
+        await metaschema.regenerate_config_support_functions(conn, config_spec)
 
     logger.info('Finalizing database setup...')
 


### PR DESCRIPTION
When adding remapping machinery in #8275 I forgot that `_testmode`
config gets grafted onto bootstrap cache shipped in production builds.
Rectify that.
