### PR TITLE
Fix inline functions substituting parameters from hidden nodes.

### DIFF
--- a/edb/common/ast/transformer.py
+++ b/edb/common/ast/transformer.py
@@ -64,6 +64,12 @@ class NodeTransformer(visitor.NodeVisitor):
             changes = {}
 
             for field, old_value in base.iter_fields(node, include_meta=False):
+                field_spec = node._fields[field]
+                if self.skip_hidden and field_spec.hidden:
+                    continue
+                if field in self.extra_skips:
+                    continue
+
                 old_value = getattr(node, field, None)
 
                 if typeutils.is_container(old_value):
@@ -79,6 +85,12 @@ class NodeTransformer(visitor.NodeVisitor):
 
         else:
             for field, old_value in base.iter_fields(node, include_meta=False):
+                field_spec = node._fields[field]
+                if self.skip_hidden and field_spec.hidden:
+                    continue
+                if field in self.extra_skips:
+                    continue
+
                 old_value = getattr(node, field, None)
 
                 if typeutils.is_container(old_value):

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -479,6 +479,10 @@ def compile_FunctionCall(
 
 class ArgumentInliner(ast.NodeTransformer):
 
+    # Don't look through hidden nodes, they may contain references to nodes
+    # which should not be modified. For example, irast.Stmt.parent_stmt.
+    skip_hidden = True
+
     mapped_args: dict[irast.PathId, irast.PathId]
     inlined_arg_keys: list[int | str]
 


### PR DESCRIPTION
close #8285

A function body may be a statement which contains references to a parent statement. Ensure that this parent's parameters are not substituted while inlining the function parameters.
