### PR TITLE
Mark the assert_* functions as being Immutable

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2024_01_28_00_00
+EDGEDB_CATALOG_VERSION = 2024_02_03_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -31,7 +31,7 @@ std::assert_single(
     CREATE ANNOTATION std::description :=
         "Check that the input set contains at most one element, raise
          CardinalityViolationError otherwise.";
-    SET volatility := 'Stable';
+    SET volatility := 'Immutable';
     SET preserves_optionality := true;
     USING SQL EXPRESSION;
 };
@@ -49,7 +49,7 @@ std::assert_exists(
     CREATE ANNOTATION std::description :=
         "Check that the input set contains at least one element, raise
          CardinalityViolationError otherwise.";
-    SET volatility := 'Stable';
+    SET volatility := 'Immutable';
     SET preserves_upper_cardinality := true;
     USING SQL EXPRESSION;
 };
@@ -67,7 +67,7 @@ std::assert_distinct(
     CREATE ANNOTATION std::description :=
         "Check that the input set is a proper set, i.e. all elements
          are unique";
-    SET volatility := 'Stable';
+    SET volatility := 'Immutable';
     SET preserves_optionality := true;
     SET preserves_upper_cardinality := true;
     USING SQL EXPRESSION;

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -83,7 +83,7 @@ std::assert(
 {
     CREATE ANNOTATION std::description :=
         "Assert that a boolean value is true.";
-    SET volatility := 'Immutable';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         edgedb_VER.raise_on_null(

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -83,7 +83,7 @@ std::assert(
 {
     CREATE ANNOTATION std::description :=
         "Assert that a boolean value is true.";
-    SET volatility := 'Stable';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT (
         edgedb_VER.raise_on_null(


### PR DESCRIPTION
This seems basically semantically correct to me.

The motivation is that we use `assert_exists(<typname>{})` as a dummy
expression when making schema changes that affect schema expressions,
and currently it is possible to get errors due to that expression
being `Stable`.