### PR TITLE
Fix broken error messages for type mismatches in a number of schema objects

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1940,13 +1940,16 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
 
             if check_default_type:
                 default_type = ir_default.stype
-                if not default_type.assignment_castable_to(p_type, schema):
+                if not default_type.assignment_castable_to(
+                    p_type, ir_default.schema
+                ):
                     raise errors.InvalidFunctionDefinitionError(
                         f'cannot create the `{signature}` function: '
                         f'invalid declaration of parameter '
                         f'{p.get_displayname(schema)!r}: '
                         f'unexpected type of the default expression: '
-                        f'{default_type.get_displayname(schema)}, expected '
+                        f'{default_type.get_displayname(ir_default.schema)}, '
+                        f'expected '
                         f'{p_type.get_displayname(schema)}',
                         span=self.span)
 

--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -188,7 +188,7 @@ class AccessPolicyCommand(
                 span = self.get_attribute_span(field)
                 raise errors.SchemaDefinitionError(
                     f'{vname} expression for {pol_name} is of invalid type: '
-                    f'{expr_type.get_displayname(schema)}, '
+                    f'{expr_type.get_displayname(expression.irast.schema)}, '
                     f'expected {target.get_displayname(schema)}',
                     span=self.span,
                 )

--- a/edb/schema/triggers.py
+++ b/edb/schema/triggers.py
@@ -153,8 +153,8 @@ class TriggerCommand(
                     raise errors.SchemaDefinitionError(
                         f'{vname} expression for {trig_name} is of invalid '
                         f'type: '
-                        f'{expr_type.get_displayname(schema)}, '
-                        f'expected {target.get_displayname(schema)}',
+                        f'{expr_type.get_displayname(expression.irast.schema)}'
+                        f', expected {target.get_displayname(schema)}',
                         span=span,
                     )
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4294,12 +4294,21 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             """)
 
     async def test_edgeql_ddl_function_08(self):
-        with self.assertRaisesRegex(
+        async with self.assertRaisesRegexTx(
                 edgedb.InvalidFunctionDefinitionError,
                 r'invalid declaration.*unexpected type of the default'):
 
             await self.con.execute("""
                 CREATE FUNCTION ddlf_08(s: std::str = 1) -> std::str
+                    USING EdgeQL $$ SELECT "1" $$;
+            """)
+
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidFunctionDefinitionError,
+                r'invalid declaration.*unexpected type of the default'):
+
+            await self.con.execute("""
+                CREATE FUNCTION ddlf_08(s: std::str = ()) -> std::str
                     USING EdgeQL $$ SELECT "1" $$;
             """)
 
@@ -6862,6 +6871,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 create type X {
                     create access policy test
                         allow all using (1);
+                };
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            r"using expression.* is of invalid type",
+        ):
+            await self.con.execute("""
+                create type X {
+                    create access policy test
+                        allow all using (());
                 };
             """)
 

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -1372,7 +1372,7 @@ class TestTriggers(tb.QueryTestCase):
             ['c'],
         )
 
-    async def test_edgeql_triggers_when_bad(self):
+    async def test_edgeql_triggers_when_bad_01(self):
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaDefinitionError,
                 r"data-modifying statements are not allowed"):
@@ -1380,6 +1380,20 @@ class TestTriggers(tb.QueryTestCase):
                 alter type InsertTest {
                   create trigger log_new after insert, update for each
                   when (exists (insert Note { name := "!" }))
+                  do (
+                    insert Note { name := "new", note := __new__.name }
+                  );
+                };
+            ''')
+
+    async def test_edgeql_triggers_when_bad_02(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.SchemaDefinitionError,
+                r"when expression.*is of invalid type"):
+            await self.con.query('''
+                alter type InsertTest {
+                  create trigger log_new after insert, update for each
+                  when (())
                   do (
                     insert Note { name := "new", note := __new__.name }
                   );


### PR DESCRIPTION
Currently, for triggers, access policies, and function argument
defaults, if the inferred type is something that doesn't appear in the
schema (like a tuple), we a "cannot get item data" error.

Fix that by using the schemas generated while compiling the expressions.

Fixes #8291.