### PR TITLE
Add `pg_show_all_settings` to allowed pg functions

### DIFF
--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -226,6 +226,7 @@ ALLOWED_ADMIN_FUNCTIONS = frozenset(
         'pg_last_wal_replay_lsn',
         'pg_current_wal_flush_lsn',
         'pg_relation_is_publishable',
+        'pg_show_all_settings',
     }
 )
 

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1968,7 +1968,8 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         await self.scon.execute("SET DateStyle=ISO;")
         await self.scon.execute("SET client_min_messages=notice;")
         await self.scon.execute(
-            "SELECT set_config('bytea_output','hex',false) FROM pg_settings"
+            "SELECT set_config('bytea_output','hex',false)"
+            "  FROM pg_catalog.pg_show_all_settings()"
             " WHERE name = 'bytea_output'; "
         )
         await self.scon.execute("SET client_encoding='WIN874';")


### PR DESCRIPTION
This is used by pgAdmin4 as of 8.12 and replaces their usage of the table `pg_catalog.pg_settings` with `pg_catalog.pg_show_all_settings()`.

Closes #8297

See https://github.com/pgadmin-org/pgadmin4/pull/7870