### PR TITLE
Fix schema_repair() more fully

### DIFF
--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1405,9 +1405,10 @@ def administer_repair_schema(
 
     return dbstate.DDLQuery(
         sql=sql,
-        user_schema=current_tx.get_user_schema_if_updated(),  # type: ignore
+        user_schema=current_tx.get_user_schema_if_updated(),
         global_schema=current_tx.get_global_schema_if_updated(),
         config_ops=config_ops,
+        feature_used_metrics={},
     )
 
 


### PR DESCRIPTION
It didn't work if it actually had any schema to repair.  Testing this
is annoying because it only comes up in the presence of bugs or patches,
basically.

It will get exercised by #8303.