### PR TITLE
Fix default_transaction_isolation on system/database level

### DIFF
--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -146,7 +146,24 @@ def compile_ConfigReset(
             span=expr.span,
         )
 
-    elif isinstance(info.param_type, s_objtypes.ObjectType):
+    if (
+        expr.scope == qltypes.ConfigScope.INSTANCE and
+        info.backend_setting == 'default_transaction_isolation'
+    ):
+        # Special case for default_transaction_isolation:
+        # Gel default is `serializable`, while PG default is `read committed`.
+        default = info.ptr.get_default(ctx.env.schema)
+        if default is not None:
+            return compile_ConfigSet(
+                qlast.ConfigSet(
+                    name=expr.name,
+                    scope=expr.scope,
+                    expr=default.parse(),
+                ),
+                ctx=ctx,
+            )
+
+    if isinstance(info.param_type, s_objtypes.ObjectType):
         param_type_name = info.param_type.get_name(ctx.env.schema)
         param_type_ref = qlast.ObjectRef(
             name=param_type_name.name,


### PR DESCRIPTION
`client` GucSource (backend connection parameter) has higher priority than `database` or `configuration file` (system). Now that `default_transaction_isolation` is exposed, it has to be removed from the backend connection parameters. Instead, it now becomes a permanent system config that always has a value.

This breaks remote backends without config file access unless they are preconfigured with `default_transaction_isolation = serializable` system-wide.

Refs #8276 

- [ ] Add test