### PR TITLE
Don't emit instance configs matching their defaults in DESCRIBE INSTANCE CONFIG

### DIFF
--- a/edb/edgeql/compiler/config_desc.py
+++ b/edb/edgeql/compiler/config_desc.py
@@ -188,6 +188,16 @@ def _describe_config_inner(
         condition = f'EXISTS json_get(conf, {ql(fpn)})'
         if is_internal:
             condition = f'({condition}) AND testmode'
+        # For INSTANCE, filter out configs that are set to the default.
+        # This is because we currently implement the defaults by
+        # setting them with CONFIGURE INSTANCE, so we can't detect
+        # defaults by seeing what is unset.
+        if (
+            scope == qltypes.ConfigScope.INSTANCE
+            and (default := p.get_default(schema))
+        ):
+            condition = f'({condition}) AND {psource} ?!= ({default.text})'
+
         items.append(f"(\n{item}\n    IF {condition} ELSE ''\n  )")
 
     return items

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1706,6 +1706,11 @@ class TestSeparateCluster(tb.TestCaseWithHttpClient):
             http_endpoint_security=args.ServerEndpointSecurityMode.Optional,
         ) as sd:
             con1 = await sd.connect()
+
+            # Shouldn't be anything in INSTANCE CONFIG, to start.
+            res = await con1.query_single('DESCRIBE INSTANCE CONFIG;')
+            self.assertEqual(res, '')
+
             con2 = await sd.connect()
 
             await con1.execute('''


### PR DESCRIPTION
Doing this can cause some problems with dumps---they will appear in dumps,
even though they may not be configurable on cloud.

Addresses part of #7332.