### PR TITLE
Also retry on transaction serialization errors

### DIFF
--- a/edb/testbase/connection.py
+++ b/edb/testbase/connection.py
@@ -416,7 +416,10 @@ class Connection(options._OptionsMixin, abstract.AsyncIOExecutor):
             # since that *ought* to be done at the transaction level.
             # Though in reality in the test suite it is usually done at the
             # test runner level.
-            except errors.TransactionConflictError:
+            except (
+                errors.TransactionConflictError,
+                errors.TransactionSerializationError,
+            ):
                 if i >= 5 or self.is_in_transaction():
                     raise
                 await asyncio.sleep(


### PR DESCRIPTION
A lot of them popped up in the tests in the last two days, and we
should have been retrying them.

This is kind of weird, though because until quite recently we *never*
retried queries in `TRANSACTION_ISOLATION = False` tests and they
didn't fail *this* often.

The failures are all on things that interact with worker tasks
operating on the tables, though, so there is a lot of scope for timing
trouble.