### PR TITLE
Drop tx isolation of interal queries in ext::ai to RepeatableRead

### DIFF
--- a/edb/server/pgcon/pgcon.pyi
+++ b/edb/server/pgcon/pgcon.pyi
@@ -26,6 +26,7 @@ from typing import (
 
 import asyncio
 
+from edb.server import defines as edbdef
 from edb.server import pgconnparams
 
 class BackendError(Exception):
@@ -49,7 +50,12 @@ class PGConnection(asyncio.Protocol):
 
     def __init__(self, dbname): ...
     async def close(self): ...
-    async def sql_execute(self, sql: bytes | tuple[bytes, ...]) -> None: ...
+    async def sql_execute(
+        self,
+        sql: bytes | tuple[bytes, ...],
+        *,
+        tx_isolation: edbdef.TxIsolationLevel | None = None,
+    ) -> None: ...
     async def sql_fetch(
         self,
         sql: bytes,
@@ -57,6 +63,7 @@ class PGConnection(asyncio.Protocol):
         args: tuple[bytes, ...] | list[bytes] = (),
         use_prep_stmt: bool = False,
         state: Optional[bytes] = None,
+        tx_isolation: edbdef.TxIsolationLevel | None = None,
     ) -> list[tuple[bytes, ...]]: ...
     async def sql_fetch_val(
         self,
@@ -65,6 +72,7 @@ class PGConnection(asyncio.Protocol):
         args: tuple[bytes, ...] | list[bytes] = (),
         use_prep_stmt: bool = False,
         state: Optional[bytes] = None,
+        tx_isolation: edbdef.TxIsolationLevel | None = None,
     ) -> bytes: ...
     async def sql_fetch_col(
         self,
@@ -73,6 +81,7 @@ class PGConnection(asyncio.Protocol):
         args: tuple[bytes, ...] | list[bytes] = (),
         use_prep_stmt: bool = False,
         state: Optional[bytes] = None,
+        tx_isolation: edbdef.TxIsolationLevel | None = None,
     ) -> list[bytes]: ...
     async def sql_describe(
         self,

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1389,6 +1389,7 @@ cdef class PGConnection:
         args: tuple[bytes, ...] | list[bytes] = (),
         use_prep_stmt: bool = False,
         state: Optional[bytes] = None,
+        tx_isolation: defines.TxIsolationLevel | None = None,
     ) -> list[tuple[bytes, ...]]:
         if use_prep_stmt:
             sql_digest = hashlib.sha1()
@@ -1408,6 +1409,7 @@ cdef class PGConnection:
             bind_data=args_ser.combine_raw_args(args),
             use_prep_stmt=use_prep_stmt,
             state=state,
+            tx_isolation=tx_isolation,
         )
 
     async def sql_fetch_val(
@@ -1417,12 +1419,14 @@ cdef class PGConnection:
         args: tuple[bytes, ...] | list[bytes] = (),
         use_prep_stmt: bool = False,
         state: Optional[bytes] = None,
+        tx_isolation: defines.TxIsolationLevel | None = None,
     ) -> bytes:
         data = await self.sql_fetch(
             sql,
             args=args,
             use_prep_stmt=use_prep_stmt,
             state=state,
+            tx_isolation=tx_isolation,
         )
         if data is None or len(data) == 0:
             return None
@@ -1442,12 +1446,14 @@ cdef class PGConnection:
         args: tuple[bytes, ...] | list[bytes] = (),
         use_prep_stmt: bool = False,
         state: Optional[bytes] = None,
+        tx_isolation: defines.TxIsolationLevel | None = None,
     ) -> list[bytes]:
         data = await self.sql_fetch(
             sql,
             args=args,
             use_prep_stmt=use_prep_stmt,
             state=state,
+            tx_isolation=tx_isolation,
         )
         if not data:
             return []

--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -50,6 +50,7 @@ from edb.common import markup
 from edb.common import uuidgen
 
 from edb.server import compiler, http
+from edb.server import defines as edbdef
 from edb.server.compiler import sertypes
 from edb.server.protocol import execute
 from edb.server.protocol import request_scheduler as rs
@@ -892,7 +893,8 @@ async def _get_pending_embeddings(
         {where_clause}
         ORDER BY
             q."target_dims_shortening"
-        """.encode()
+        """.encode(),
+        tx_isolation=edbdef.TxIsolationLevel.RepeatableRead,
     )
 
     if not entries:
@@ -1028,6 +1030,7 @@ async def _update_embeddings_in_db(
             f'{{"{id_array}"}}'.encode(),
             str(offset).encode(),
         ),
+        tx_isolation=edbdef.TxIsolationLevel.RepeatableRead,
     )
 
     return int(entries.decode())


### PR DESCRIPTION
Avoid unnecessary isolation load.  We already do this in other
internal loops.
