### PR TITLE
Fix language server nightly build on macOS

### DIFF
--- a/.github/workflows.src/ls-build.inc.yml
+++ b/.github/workflows.src/ls-build.inc.yml
@@ -128,6 +128,12 @@
     steps:
     - uses: actions/checkout@v4
       with:
+        sparse-checkout: rust-toolchain.toml
+        sparse-checkout-cone-mode: false
+        fetch-depth: 0
+
+    - uses: actions/checkout@v4
+      with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg

--- a/.github/workflows/ls-nightly.yml
+++ b/.github/workflows/ls-nightly.yml
@@ -226,6 +226,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        sparse-checkout: rust-toolchain.toml
+        sparse-checkout-cone-mode: false
+        fetch-depth: 0
+
+    - uses: actions/checkout@v4
+      with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
@@ -279,6 +285,12 @@ jobs:
 
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: rust-toolchain.toml
+        sparse-checkout-cone-mode: false
+        fetch-depth: 0
+
     - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg


### PR DESCRIPTION
With #7660, we also need the `rust-toolchain.toml` file checked out.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/13272781689)