### PR TITLE
Implement caching for JWKSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
  "futures",
  "genetic_algorithm",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "pretty_assertions",
  "pyo3",
  "pyo3_util",
@@ -633,6 +633,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1106,6 +1115,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gel-http"
+version = "0.1.0"
+dependencies = [
+ "eventsource-stream",
+ "futures",
+ "http",
+ "http-body-util",
+ "http-cache-semantics",
+ "lru 0.13.0",
+ "pyo3",
+ "pyo3_util",
+ "reqwest",
+ "rstest 0.23.0",
+ "scopeguard",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "gel-jwt"
 version = "0.1.0"
 dependencies = [
@@ -1140,7 +1168,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
  "tracing",
  "uuid",
  "zeroize",
@@ -1259,7 +1287,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1372,21 +1400,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.0"
-dependencies = [
- "eventsource-stream",
- "futures",
- "pyo3",
- "pyo3_util",
- "reqwest",
- "rstest 0.23.0",
- "scopeguard",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1403,7 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -1414,9 +1427,31 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-cache-semantics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
+dependencies = [
+ "http",
+ "http-serde",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]
@@ -1435,7 +1470,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "httparse",
  "itoa",
@@ -1452,7 +1487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1472,7 +1507,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -1800,6 +1835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2087,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2336,6 +2386,12 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2668,7 +2724,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2834,8 +2890,8 @@ version = "0.1.0"
 dependencies = [
  "conn_pool",
  "gel-auth",
+ "gel-http",
  "gel-jwt",
- "http 0.1.0",
  "pgrust",
  "pyo3",
  "pyo3_util",
@@ -3467,6 +3523,37 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
     "rust/gel-auth",
     "rust/gel-jwt",
     "rust/gel-stream",
+    "rust/gel-http",
     "rust/pgrust",
-    "rust/http",
     "rust/pyo3_util",
 ]
 resolver = "2"
@@ -30,7 +30,7 @@ db_proto = { path = "rust/db_proto" }
 captive_postgres = { path = "rust/captive_postgres" }
 conn_pool = { path = "rust/conn_pool" }
 pgrust = { path = "rust/pgrust" }
-http = { path = "rust/http" }
+gel-http = { path = "rust/gel-http" }
 pyo3_util = { path = "rust/pyo3_util" }
 
 [profile.release]

--- a/edb/server/_rust_native/Cargo.toml
+++ b/edb/server/_rust_native/Cargo.toml
@@ -16,7 +16,7 @@ pyo3 = { workspace = true }
 pyo3_util.workspace = true
 conn_pool = { workspace = true, features = [ "python_extension" ] }
 pgrust = { workspace = true, features = [ "python_extension" ] }
-http = { workspace = true, features = [ "python_extension" ] }
+gel-http = { workspace = true, features = [ "python_extension" ] }
 gel-auth = { workspace = true, features = [ "python_extension" ] }
 gel-jwt = { workspace = true, features = [ "python_extension" ] }
 

--- a/edb/server/_rust_native/src/lib.rs
+++ b/edb/server/_rust_native/src/lib.rs
@@ -33,7 +33,7 @@ fn _rust_native(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
 
     add_child_module(py, m, "_conn_pool", conn_pool::python::_conn_pool)?;
     add_child_module(py, m, "_pg_rust", pgrust::python::_pg_rust)?;
-    add_child_module(py, m, "_http", http::python::_http)?;
+    add_child_module(py, m, "_http", gel_http::python::_gel_http)?;
     add_child_module(py, m, "_jwt", gel_jwt::python::_jwt)?;
 
     Ok(())

--- a/edb/server/protocol/auth_ext/base.py
+++ b/edb/server/protocol/auth_ext/base.py
@@ -151,7 +151,7 @@ class OpenIDConnectProvider(BaseProvider):
         async with self.http_factory(
             base_url=f"{jwks_uri.scheme}://{jwks_uri.netloc}"
         ) as client:
-            r = await client.get(jwks_uri.path)
+            r = await client.get(jwks_uri.path, cache=True)
 
         # Load the token as a JWT object and verify it directly
         try:
@@ -178,6 +178,9 @@ class OpenIDConnectProvider(BaseProvider):
 
     async def _get_oidc_config(self) -> data.OpenIDConfig:
         client = self.http_factory(base_url=self.issuer_url)
-        response = await client.get('/.well-known/openid-configuration')
+        response = await client.get(
+            '/.well-known/openid-configuration',
+            cache=True
+        )
         config = response.json()
         return data.OpenIDConfig(**config)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -300,7 +300,7 @@ class Tenant(ha_base.ClusterProtocol):
                 user_agent=f"EdgeDB {buildmeta.get_version_string(short=True)}",
                 stat_callback=lambda stat: logger.debug(
                     f"HTTP stat: {originator} {stat}"
-                ),
+                )
             )
         return self._http_client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     'psutil~=5.8',
     'setproctitle~=1.2',
 
-    'hishel==0.0.24',
     'webauthn~=2.0.0',
     'argon2-cffi~=23.1.0',
     'aiosmtplib~=3.0',

--- a/rust/gel-http/Cargo.toml
+++ b/rust/gel-http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http"
+name = "gel-http"
 version = "0.1.0"
 license = "MIT/Apache-2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
@@ -19,6 +19,10 @@ tracing.workspace = true
 
 scopeguard = "1"
 eventsource-stream = "0.2.3"
+http-cache-semantics = { version = "2", features = [] }
+http = "1"
+http-body-util = "0.1.2"
+lru = "0.13"
 
 # We want to use rustls to avoid setenv issues w/ OpenSSL and the system certs. As long
 # as we don't call `openssl_probe::*init*env*()` functions (functions that call setenv

--- a/rust/gel-http/src/cache.rs
+++ b/rust/gel-http/src/cache.rs
@@ -1,0 +1,340 @@
+use http::{HeaderMap, Method, Request, Response, Uri};
+use http_cache_semantics::{AfterResponse, BeforeRequest, CacheOptions, CachePolicy};
+use lru::LruCache;
+use std::{
+    num::NonZero,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime},
+};
+
+#[derive(Debug, Clone)]
+pub enum CacheBefore {
+    Request(http::Request<Vec<u8>>),
+    Response(http::Response<Vec<u8>>),
+}
+
+struct CacheItems<T> {
+    items: LruCache<Uri, (T, Vec<u8>)>,
+    byte_size: usize,
+    max_byte_size: usize,
+}
+
+impl<T> CacheItems<T> {
+    fn new(capacity: NonZero<usize>, max_byte_size: usize) -> Self {
+        Self {
+            items: LruCache::new(capacity),
+            byte_size: 0,
+            max_byte_size,
+        }
+    }
+
+    fn insert(&mut self, uri: Uri, policy: T, body: Vec<u8>) {
+        let body_len = body.len();
+        if let Some((_, old_body)) = self.items.push(uri, (policy, body)) {
+            self.byte_size = self.byte_size.saturating_sub(old_body.1.len());
+        }
+        self.byte_size = self.byte_size.saturating_add(body_len);
+        while self.byte_size > self.max_byte_size {
+            if let Some((_, old_body)) = self.items.pop_lru() {
+                self.byte_size = self.byte_size.saturating_sub(old_body.1.len());
+            } else {
+                return;
+            }
+        }
+    }
+
+    fn get_mut(&mut self, uri: &Uri) -> Option<&mut (T, Vec<u8>)> {
+        self.items.get_mut(uri)
+    }
+}
+
+#[derive(Clone)]
+pub struct Cache {
+    cache_options: CacheOptions,
+    cache: Arc<Mutex<CacheItems<CachePolicy>>>,
+}
+
+impl Cache {
+    pub fn new() -> Self {
+        Self {
+            cache_options: CacheOptions {
+                shared: false,
+                // Immutable objects should be cached for 24 hours
+                immutable_min_time_to_live: Duration::from_secs(86_400),
+                ..Default::default()
+            },
+            cache: Arc::new(Mutex::new(CacheItems::new(
+                NonZero::new(100).unwrap(),
+                1024 * 1024,
+            ))),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_cache_body(&self, url: &Uri) -> Option<(bool, Vec<u8>)> {
+        let mut cache = self.cache.lock().unwrap();
+        let entry = cache.get_mut(url);
+        if let Some((policy, body)) = entry {
+            let state = policy.is_stale(SystemTime::now());
+            return Some((state, body.clone()));
+        }
+        None
+    }
+
+    pub fn before_request(
+        &self,
+        allow_cache: bool,
+        method: &Method,
+        url: &Uri,
+        headers: &HeaderMap,
+        body: Vec<u8>,
+    ) -> CacheBefore {
+        let mut req = Request::new(body);
+        *req.method_mut() = method.clone();
+        *req.uri_mut() = url.clone();
+        *req.headers_mut() = headers.clone();
+
+        // Only cache GET requests
+        if !allow_cache || method != Method::GET {
+            return CacheBefore::Request(req);
+        }
+
+        let now = SystemTime::now();
+        let mut cache = self.cache.lock().unwrap();
+        if let Some((policy, body)) = cache.get_mut(url) {
+            match policy.before_request(&req, now) {
+                BeforeRequest::Fresh(parts) => {
+                    // Fresh response from cache
+                    CacheBefore::Response(Response::from_parts(parts, body.clone()))
+                }
+                BeforeRequest::Stale { request, .. } => {
+                    *req.uri_mut() = request.uri;
+                    *req.headers_mut() = request.headers;
+                    *req.method_mut() = request.method;
+                    CacheBefore::Request(req)
+                }
+            }
+        } else {
+            CacheBefore::Request(req)
+        }
+    }
+
+    pub fn after_request(
+        &self,
+        allow_cache: bool,
+        method: Method,
+        uri: Uri,
+        headers: HeaderMap,
+        res: &mut http::Response<Vec<u8>>,
+    ) {
+        // Only cache GET requests
+        if !allow_cache || method != Method::GET {
+            return;
+        }
+
+        let now = SystemTime::now();
+        let mut cache = self.cache.lock().unwrap();
+        let entry = cache.get_mut(&uri);
+
+        let mut req = Request::new(());
+        *req.method_mut() = method;
+        *req.uri_mut() = uri.clone();
+        *req.headers_mut() = headers;
+
+        let mut resp = Response::new(vec![]);
+        *resp.status_mut() = res.status();
+        *resp.headers_mut() = res.headers().clone();
+
+        if let Some((policy, body)) = entry {
+            let parts = match policy.after_response(&req, &resp, now) {
+                AfterResponse::NotModified(new_policy, parts) => {
+                    // Not modified, return the cached response
+                    *policy = new_policy;
+                    *resp.body_mut() = body.clone();
+                    parts
+                }
+                AfterResponse::Modified(new_policy, parts) => {
+                    // Modified, update the cache
+                    *policy = new_policy;
+                    *body = res.body().clone();
+                    parts
+                }
+            };
+            *resp.headers_mut() = parts.headers;
+            *resp.status_mut() = parts.status;
+            *resp.version_mut() = parts.version;
+        } else {
+            let policy = CachePolicy::new_options(&req, &resp, now, self.cache_options);
+            if policy.is_storable() {
+                cache.insert(uri, policy, res.body().clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::*;
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn get_google() -> (Method, Uri, HeaderMap, Vec<u8>) {
+        let method = Method::GET;
+        let uri = Uri::from_str("https://www.google.com").unwrap();
+        let headers = HeaderMap::new();
+        let body = vec![];
+        (method, uri, headers, body)
+    }
+
+    fn cache_control(resp: &mut Response<Vec<u8>>, value: &str) {
+        resp.headers_mut().insert(
+            HeaderName::from_static("cache-control"),
+            HeaderValue::from_str(value).unwrap(),
+        );
+    }
+
+    fn etag(resp: &mut Response<Vec<u8>>, value: &str) {
+        resp.headers_mut().insert(
+            HeaderName::from_static("etag"),
+            HeaderValue::from_str(value).unwrap(),
+        );
+    }
+
+    fn response(status: StatusCode, body: &str) -> Response<Vec<u8>> {
+        let mut resp = Response::new(body.as_bytes().to_vec());
+        *resp.status_mut() = status;
+        resp
+    }
+
+    #[test]
+    fn test_cache_byte_size_eviction() {
+        let mut cache_items = CacheItems::<()>::new(NonZero::new(100).unwrap(), 1024 * 1024);
+        cache_items.insert(
+            Uri::from_str("https://www.google.com").unwrap(),
+            (),
+            vec![0; 1024 * 1024],
+        );
+        assert_eq!(cache_items.byte_size, 1024 * 1024);
+        assert_eq!(cache_items.items.len(), 1);
+        cache_items.insert(
+            Uri::from_str("https://www.example.com").unwrap(),
+            (),
+            vec![0; 1],
+        );
+        assert_eq!(cache_items.byte_size, 1);
+        assert_eq!(cache_items.items.len(), 1);
+        cache_items.insert(
+            Uri::from_str("https://www.google.com").unwrap(),
+            (),
+            vec![0; 1024 * 1024],
+        );
+        assert_eq!(cache_items.byte_size, 1024 * 1024);
+        assert_eq!(cache_items.items.len(), 1);
+    }
+
+    #[test]
+    fn test_cache_capacity_eviction() {
+        let mut cache_items = CacheItems::<()>::new(NonZero::new(100).unwrap(), 1024 * 1024);
+        for i in 0..120 {
+            cache_items.insert(
+                Uri::from_str(&format!("https://www.example.com/{}", i)).unwrap(),
+                (),
+                vec![0; 10],
+            );
+        }
+        assert_eq!(cache_items.byte_size, 1000);
+        assert_eq!(cache_items.items.len(), 100);
+    }
+
+    #[test]
+    fn test_cache() {
+        let cache = Cache::new();
+        let (method, uri, headers, body) = get_google();
+        let before = cache.before_request(true, &method, &uri, &headers, body);
+        assert!(matches!(before, CacheBefore::Request(_)));
+
+        let mut resp = response(StatusCode::OK, "");
+        cache_control(&mut resp, "max-age=3600");
+        etag(&mut resp, "\"1234567890\"");
+        cache.after_request(
+            true,
+            method.clone(),
+            uri.clone(),
+            headers.clone(),
+            &mut resp,
+        );
+
+        let (method, uri, headers, body) = get_google();
+        let after = cache.before_request(true, &method, &uri, &headers, body);
+
+        let CacheBefore::Response(resp) = after else {
+            panic!("Expected a response {after:?}");
+        };
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("etag"),
+            Some(&HeaderValue::from_str("\"1234567890\"").unwrap())
+        );
+        assert_eq!(
+            resp.headers().get("cache-control"),
+            Some(&HeaderValue::from_str("max-age=3600").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_cache_not_modified() {
+        let cache = Cache::new();
+        let (method, uri, headers, body) = get_google();
+        let before = cache.before_request(true, &method, &uri, &headers, body);
+        assert!(matches!(before, CacheBefore::Request(_)));
+
+        let mut resp = response(StatusCode::OK, "contents!");
+        cache_control(
+            &mut resp,
+            "max-age=0, must-revalidate, stale-while-revalidate=86400",
+        );
+        etag(&mut resp, "\"1234567890\"");
+        cache.after_request(
+            true,
+            method.clone(),
+            uri.clone(),
+            headers.clone(),
+            &mut resp,
+        );
+
+        let (state, body) = cache.get_cache_body(&uri).unwrap();
+        assert_eq!(state, true);
+        assert_eq!(body, "contents!".as_bytes());
+
+        let (method, uri, headers, body) = get_google();
+        let after = cache.before_request(true, &method, &uri, &headers, body);
+        let CacheBefore::Request(req) = after else {
+            panic!("Expected a request {after:?}");
+        };
+        assert_eq!(req.method(), &Method::GET);
+        assert_eq!(req.uri(), &uri);
+        assert_eq!(
+            req.headers().get("if-none-match"),
+            Some(&HeaderValue::from_str("\"1234567890\"").unwrap())
+        );
+
+        let mut resp = response(StatusCode::NOT_MODIFIED, "");
+        cache_control(
+            &mut resp,
+            "max-age=0, must-revalidate, stale-while-revalidate=86400",
+        );
+        etag(&mut resp, "\"1234567890\"");
+        cache.after_request(
+            true,
+            method.clone(),
+            uri.clone(),
+            headers.clone(),
+            &mut resp,
+        );
+
+        let (state, body) = cache.get_cache_body(&uri).unwrap();
+        assert_eq!(state, true);
+        assert_eq!(body, "contents!".as_bytes());
+    }
+}

--- a/rust/gel-http/src/lib.rs
+++ b/rust/gel-http/src/lib.rs
@@ -1,2 +1,3 @@
+mod cache;
 #[cfg(feature = "python_extension")]
 pub mod python;

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -1315,7 +1315,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_discovery = self.mock_oauth_server.requests[
                 discovery_request
             ]
-            self.assertEqual(len(requests_for_discovery), 2)
+            self.assertEqual(len(requests_for_discovery), 1)
 
             requests_for_token = self.mock_oauth_server.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)
@@ -2121,7 +2121,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_discovery = self.mock_oauth_server.requests[
                 discovery_request
             ]
-            self.assertEqual(len(requests_for_discovery), 2)
+            self.assertEqual(len(requests_for_discovery), 1)
 
             requests_for_token = self.mock_oauth_server.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)
@@ -2253,7 +2253,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             )
 
             redirect_to = f"{self.http_addr}/some/path"
-            _, headers, status = self.http_con_request(
+            body, headers, status = self.http_con_request(
                 http_con,
                 {
                     "provider": provider_name,
@@ -2263,7 +2263,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 path="authorize",
             )
 
-            self.assertEqual(status, 302)
+            self.assertEqual(status, 302, body)
 
             location = headers.get("location")
             assert location is not None
@@ -2428,7 +2428,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
             requests_for_discovery = self.mock_oauth_server.requests[
                 discovery_request
             ]
-            self.assertEqual(len(requests_for_discovery), 2)
+            self.assertEqual(len(requests_for_discovery), 1)
 
             requests_for_token = self.mock_oauth_server.requests[token_request]
             self.assertEqual(len(requests_for_token), 1)


### PR DESCRIPTION
In the previous HTTP rewrite, we accidentally removed caching for JWK keys and OIDC configurations. This restores it using an in-memory cache.

This adds a cache parameter to the Python-side `get(...)`.

The cache is enabled only for OIDC and JWK discovery requests -- the assumption is that we'd prefer fresh user information when fetching during login over speed.