### PR TITLE
Revert "Also retry on transaction serialization errors (#8317)"

### DIFF
--- a/edb/testbase/connection.py
+++ b/edb/testbase/connection.py
@@ -416,10 +416,7 @@ class Connection(options._OptionsMixin, abstract.AsyncIOExecutor):
             # since that *ought* to be done at the transaction level.
             # Though in reality in the test suite it is usually done at the
             # test runner level.
-            except (
-                errors.TransactionConflictError,
-                errors.TransactionSerializationError,
-            ):
+            except errors.TransactionConflictError:
                 if i >= 10 or self.is_in_transaction():
                     raise
                 await asyncio.sleep(


### PR DESCRIPTION
TransactionSerializationError is a subtype of TransactionConflictError.
This PR was a no-op.

This reverts commit e6a79943874a694789ce258b7d7098577e574d3c.