### PR TITLE
Expose `administer statistics_update()`

### DIFF
--- a/docs/reference/admin/index.rst
+++ b/docs/reference/admin/index.rst
@@ -43,4 +43,5 @@ Administrative commands for managing EdgeDB:
     configure
     databases
     roles
+    statistics_update
     vacuum

--- a/docs/reference/admin/index.rst
+++ b/docs/reference/admin/index.rst
@@ -26,9 +26,13 @@ Administrative commands for managing EdgeDB:
 
       Create, remove, or alter a branch.
 
-    * :ref:`administer vacuum <ref_admin_vacuum>`
+    * :ref:`administer statistics_update() <ref_admin_statistics_update>`
 
-      Reclaim storage space
+      Update internal statistics about data.
+
+    * :ref:`administer vacuum() <ref_admin_vacuum>`
+
+      Reclaim storage space.
 
 
 .. toctree::

--- a/docs/reference/admin/statistics_update.rst
+++ b/docs/reference/admin/statistics_update.rst
@@ -1,0 +1,52 @@
+.. versionadded:: 6.0
+
+.. _ref_admin_statistics_update:
+
+==============================
+administer statistics_update()
+==============================
+
+:eql-statement:
+
+Update internal statistics about data.
+
+.. eql:synopsis::
+
+    administer statistics_update "("
+      [<type_link_or_property> [, ...]]
+    ")"
+
+
+Description
+-----------
+
+Collects statistics about the contents of data in the current branch.
+Subsequently, the query planner uses these statistics to help determine the
+most efficient execution plans for queries.
+
+:eql:synopsis:`<type_link_or_property>`
+    If a type name or a path to a link or property are specified, that data
+    will be targeted for statistics update. If omitted, all user-accessible
+    data will be analyzed.
+
+
+Examples
+--------
+
+Update the statistics on type ``SomeType``:
+
+.. code-block:: edgeql
+
+    administer statistics_update(SomeType);
+
+Update statistics of type ``SomeType`` and the link ``OtherType.ptr``.
+
+.. code-block:: edgeql
+
+    administer statistics_update(SomeType, OtherType.ptr);
+
+Update statistics on everything that is user-accessible in the database:
+
+.. code-block:: edgeql
+
+    administer statistics_update();

--- a/docs/reference/admin/statistics_update.rst
+++ b/docs/reference/admin/statistics_update.rst
@@ -20,7 +20,7 @@ Update internal statistics about data.
 Description
 -----------
 
-Collects statistics about the contents of data in the current branch.
+Updates statistics about the contents of data in the current branch.
 Subsequently, the query planner uses these statistics to help determine the
 most efficient execution plans for queries.
 

--- a/docs/reference/admin/vacuum.rst
+++ b/docs/reference/admin/vacuum.rst
@@ -15,6 +15,7 @@ Reclaim storage space.
     administer vacuum "("
       [<type_link_or_property> [, ...]]
       [, full := {true | false}]
+      [, statistics_update := {true | false}]
     ")"
 
 
@@ -35,6 +36,10 @@ Cleans and reclaims storage by removing obsolete data.
     and reclaimed space is kept available for reuse in the database, reducing
     the rate of growth of the database.
 
+:eql:synopsis:`statistics_update := {true | false}`
+    If set to ``true``, updates statistics used by the planner to determine
+    the most efficient way to execute queries on specified data.  See also
+    :ref:`administer statistics_update() <ref_admin_statistics_update>`.
 
 Examples
 --------

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1746,18 +1746,7 @@ def _compile_ql_administer(
     script_info: Optional[irast.ScriptInfo] = None,
 ) -> dbstate.BaseQuery:
     if ql.expr.func == 'statistics_update':
-        if not ctx.is_testmode():
-            raise errors.QueryError(
-                'statistics_update() can only be executed in test mode',
-                span=ql.span)
-
-        if ql.expr.args or ql.expr.kwargs:
-            raise errors.QueryError(
-                'statistics_update() does not take arguments',
-                span=ql.expr.span,
-            )
-
-        return dbstate.MaintenanceQuery(sql=b'ANALYZE')
+        return ddl.administer_statistics_update(ctx, ql)
     elif ql.expr.func == 'schema_repair':
         return ddl.administer_repair_schema(ctx, ql)
     elif ql.expr.func == 'reindex':

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1734,7 +1734,7 @@ def administer_statistics_update(
 
     return dbstate.MaintenanceQuery(
         sql=command.encode('utf-8'),
-        is_transactional=False,
+        is_transactional=True,
     )
 
 


### PR DESCRIPTION
There's no reason to keep this private given that `vacuum()` is public.
Oh, and teach `vacuum()` to run `statistics_update` (i.e `VACUUM
ANALYZE`).
