### PR TITLE
Skip SQL cache in cache recompilation

### DIFF
--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1262,6 +1262,9 @@ cdef class DatabaseConnectionView:
                     # Only recompile queries from the *latest* version,
                     # to avoid quadratic slowdown problems.
                     and req.schema_version == self.schema_version
+                    # SQL queries require _amend_typedesc_in_sql() with a
+                    # backend connection, which is not available here.
+                    and req.input_language != enums.InputLanguage.SQL
                 ):
                     g.create_task(recompile_request(req))
 
@@ -1447,9 +1450,14 @@ cdef class DatabaseConnectionView:
                 )
 
         if use_metrics:
-            metrics.edgeql_query_compilations.inc(
-                1.0, self.tenant.get_instance_name(), 'compiler'
-            )
+            if query_req.input_language is enums.InputLanguage.EDGEQL:
+                metrics.edgeql_query_compilations.inc(
+                    1.0, self.tenant.get_instance_name(), 'compiler'
+                )
+            else:
+                metrics.sql_compilations.inc(
+                    1.0, self.tenant.get_instance_name()
+                )
 
         source = query_req.source
         if query_unit_group.force_non_normalized:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -824,6 +824,12 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
 
                     with self.assertChange(measure_compilations(sd), 1):
                         await con.query(qry)
+                    with self.assertChange(measure_compilations(sd), 0):
+                        await con.query(qry)
+                    with self.assertChange(measure_sql_compilations(sd), 1):
+                        await con.query_sql(sql)
+                    with self.assertChange(measure_sql_compilations(sd), 0):
+                        await con.query_sql(sql)
 
                     await con.execute(
                         "configure current database "
@@ -912,6 +918,9 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                     # It should hit the cache no problem.
                     with self.assertChange(measure_compilations(sd), 0):
                         await con.query(qry)
+                    # TODO(fantix): persistent SQL cache not working?
+                    # with self.assertChange(measure_sql_compilation(sd), 0):
+                    #     await con.query_sql(sql)
 
                 finally:
                     await con.aclose()


### PR DESCRIPTION
A complete SQL compilation requires a backend connection to amend the in/out tids. We recompiled wrong SQL cache with out_type_tid=000...000, so this commit temporarily discards SQL cache after DDL to avoid such issue.

An alternative is to acquire a backend connection during recompilation, but I'm not confident enough to do so with all the asyncio timeouts in place, and it's before release time, so let's be safe and sacrifice the SQL cache which was anyway wrong.

(It would be nice if we can only recompile the cached queries affected by the issued DDL, but that's another optimization story)

Also fixed so that compiling SQL over binary protocol bumps the `sql_compilations_total` metrics instead of `edgeql_query_compilations_total`.

The added test is verified to reproduce the issue - it fails as expected without the fix:

```
==============================================================================================================================================================================================================================================
FAIL: test_server_ops_cache_recompile_01 (test_server_ops.TestServerOps.test_server_ops_cache_recompile_01)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Py_HashSecret: 4664988fb465adcf76f10d7640e2a996a700fe98c30faf48
random.seed(): c162e11efcc05861
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "gel/protocol/protocol.pyx", line 411, in gel.protocol.protocol.SansIOProtocol._execute
  File "gel/protocol/protocol.pyx", line 1141, in gel.protocol.protocol.SansIOProtocol.parse_data_messages
  File "gel/protocol/./codecs/./base.pyx", line 49, in gel.protocol.protocol.BaseCodec.decode
NotImplementedError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "edb/testbase/server.py", line 413, in assertChange
    yield
  File "tests/test_server_ops.py", line 793, in test_server_ops_cache_recompile_01
    await con.query_sql(sql)
  File "/site-packages/gel/abstract.py", line 418, in query_sql
    return await self._query(QueryContext(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "edb/testbase/connection.py", line 406, in _query
    return await self.raw_query(query_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "edb/testbase/connection.py", line 447, in raw_query
    return await self._retry_operation(_inner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "edb/testbase/connection.py", line 413, in _retry_operation
    return await func()
           ^^^^^^^^^^^^
  File "edb/testbase/connection.py", line 442, in _inner
    res = await self._protocol.query(ctx)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "gel/protocol/protocol.pyx", line 505, in query
  File "gel/protocol/protocol.pyx", line 502, in execute
  File "gel/protocol/protocol.pyx", line 464, in _execute
gel.errors.ClientError: unable to decode data to Python objects

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  edb/testbase/server.py:212, in wrapper
    self.loop.run_until_complete(
  /asyncio/base_events.py:686, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  tests/test_server_ops.py:792, in test_server_ops_cache_recompile_01
    with self.assertChange(measure_sql_compilations(sd), 1):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /contextlib.py:158, in __exit__
    self.gen.throw(value)
  edb/testbase/server.py:417, in assertChange
    self.assertEqual(expected_change, change)
AssertionError: 1 != 0.0
```

Refs b4bdbc235