### PR TITLE
Rename `gel` script entrypoint to `gel-dev`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ edgedb = "edb.cli:rustcli"
 gel-server = "edb.server.main:main"
 gel-load-ext = "edb.load_ext.main:main"
 gel-ls = "edb.language_server.main:main"
-gel = "edb.cli:rustcli"
+gel-dev = "edb.cli:rustcli"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
`gel-python` now installs `gel` as the entrypoint, so to preserve the
current behavior of using the locally-built CLI, install it as `gel-dev`
(the gel-python entrypoint recognizes it and will run it if it's in
PATH).
