### PR TITLE
Report the number of times a feature is used as a metric

### DIFF
--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1247,7 +1247,7 @@ def produce_feature_used_metrics(
     features: dict[str, float] = {}
 
     def _track(key: str) -> None:
-        features[key] = 1
+        features[key] = features.get(key, 0) + 1
 
     # TODO(perf): Should we optimize peeking into the innards directly
     # so we can skip creating the proxies?
@@ -1408,7 +1408,7 @@ def administer_repair_schema(
         user_schema=current_tx.get_user_schema_if_updated(),
         global_schema=current_tx.get_global_schema_if_updated(),
         config_ops=config_ops,
-        feature_used_metrics={},
+        feature_used_metrics=None,
     )
 
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -359,9 +359,17 @@ cdef class Database:
         tname = self.tenant.get_instance_name()
         keys = self._feature_used_metrics.keys() | feature_used_metrics.keys()
         for key in keys:
+            # Update the count of how many times the feature is used
             metrics.feature_used.inc(
                 feature_used_metrics.get(key, 0.0)
                 - self._feature_used_metrics.get(key, 0.0),
+                tname,
+                key,
+            )
+            # Update the count of branches using the feature at all
+            metrics.feature_used_branches.inc(
+                (feature_used_metrics.get(key, 0.0) > 0)
+                - (self._feature_used_metrics.get(key, 0.0) > 0),
                 tname,
                 key,
             )
@@ -1873,9 +1881,16 @@ cdef class DatabaseIndex:
     cdef inline set_current_branches(self):
         metrics.current_branches.set(
             sum(
-                1
+                dbname != defines.EDGEDB_SYSTEM_DB
                 for dbname in self._dbs
-                if dbname != defines.EDGEDB_SYSTEM_DB
+            ),
+            self._tenant.get_instance_name(),
+        )
+        metrics.current_introspected_branches.set(
+            sum(
+                dbname != defines.EDGEDB_SYSTEM_DB
+                and db.user_schema_pickle is not None
+                for dbname, db in self._dbs.items()
             ),
             self._tenant.get_instance_name(),
         )

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -224,7 +224,7 @@ feature_used_branches = registry.new_labeled_gauge(
 )
 feature_used = registry.new_labeled_gauge(
     'feature_used_num_count_current',
-    'How many branches a schema feature is used by.',
+    'How many times a schema feature is used.',
     labels=('tenant', 'feature'),
 )
 

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -47,6 +47,12 @@ current_branches = registry.new_labeled_gauge(
     labels=('tenant',),
 )
 
+current_introspected_branches = registry.new_labeled_gauge(
+    'branches_introspected_current',
+    'Current number of branches whose schemas are introspected.',
+    labels=('tenant',),
+)
+
 total_backend_connections = registry.new_labeled_counter(
     'backend_connections_total',
     'Total number of backend connections established.',
@@ -211,8 +217,13 @@ extension_used = registry.new_labeled_gauge(
     labels=('tenant', 'extension'),
 )
 
-feature_used = registry.new_labeled_gauge(
+feature_used_branches = registry.new_labeled_gauge(
     'feature_used_branch_count_current',
+    'How many branches a schema feature is used by.',
+    labels=('tenant', 'feature'),
+)
+feature_used = registry.new_labeled_gauge(
+    'feature_used_num_count_current',
     'How many branches a schema feature is used by.',
     labels=('tenant', 'feature'),
 )


### PR DESCRIPTION
Currently we only report how many branches it is used in total.

Also report how many branches have their schemas introspected
currently.  This is helpful here because we only get feature count
info from introspected branches.