### PR TITLE
Make \(name)-style string interpolation work for errmessage

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -175,7 +175,12 @@ class Constraint(
     )
 
     errmessage = so.SchemaField(
-        str, default=None, compcoef=0.971, allow_ddl_set=True)
+        str,
+        default=None,
+        compcoef=0.971,
+        allow_ddl_set=True,
+        allow_interpolation=True,
+    )
 
     is_aggregate = so.SchemaField(
         bool, default=False, compcoef=0.971, allow_ddl_set=False)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -4214,6 +4214,11 @@ class AlterObjectProperty(Command):
                     schema=schema,
                 )
 
+            elif (
+                isinstance(astnode.value, qlast.StrInterp)
+                and field.allow_interpolation
+            ):
+                new_value = utils.str_interpolation_to_old_style(astnode.value)
             else:
                 new_value = qlcompiler.evaluate_ast_to_python_val(
                     astnode.value, schema=schema) if astnode.value else None

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -498,8 +498,8 @@ class Field(struct.ProtoField, Generic[T]):
 
 class SchemaField(Field[Type_T]):
 
-    __slots__ = ('default', 'hashable', 'allow_ddl_set', 'index',
-                 'get_default_specialized')
+    __slots__ = ('default', 'hashable', 'allow_ddl_set', 'allow_interpolation',
+                 'index', 'get_default_specialized')
 
     #: The default value to use for the field.
     default: Any
@@ -507,6 +507,10 @@ class SchemaField(Field[Type_T]):
     hashable: bool
     #: Whether it's possible to set the field in DDL.
     allow_ddl_set: bool
+    #: Whether, when setting the field in DDL, we allow \(expr)
+    #: string interpolation (and transform it into {field}
+    #: style interpolation).
+    allow_interpolation: bool
     #: Field index within the object data tuple
     index: int
     #: Specialized get_default function
@@ -519,12 +523,14 @@ class SchemaField(Field[Type_T]):
         default: Any = NoDefault,
         hashable: bool = True,
         allow_ddl_set: bool = False,
+        allow_interpolation: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(type, **kwargs)
         self.default = default
         self.hashable = hashable
         self.allow_ddl_set = allow_ddl_set
+        self.allow_interpolation = allow_interpolation
         self.index = -1
         # Use this instead of get_default if you can; get_default has to
         # be a method because it comes from the parent

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -18,6 +18,7 @@
 
 
 import os.path
+import re
 
 import edgedb
 
@@ -962,7 +963,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     ON (len(__subject__))
             {
                 SET errmessage :=
-                    '{__subject__} must be no longer than {max} characters.';
+                    '\(__subject__) must be no longer than \(max) characters.';
                 USING (__subject__ <= max);
             };
 
@@ -970,7 +971,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     ON (len(__subject__)) EXTENDING std::max_value
             {
                 SET errmessage :=
-                    '{__subject__} must be no longer than {max} characters.';
+                    '\(__subject__) must be no longer than \(max) characters.';
             };
 
             CREATE TYPE ConstraintOnTest1 {
@@ -1239,6 +1240,25 @@ class TestConstraintsDDL(tb.DDLTestCase):
             await self.con.execute(
                 """
                 INSERT ConstraintOnTest4_2 { email := '' };
+                """
+            )
+
+        await self.con.execute(r"""
+            CREATE type ConstraintOnTest4_3 {
+                CREATE required property email -> str {
+                    CREATE constraint min_len_value(4) {
+                        SET errmessage := '\\(min) \\(min)';
+                    };
+                };
+            };
+        """)
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            re.escape(r'\(min) \(min)'),
+        ):
+            await self.con.execute(
+                """
+                INSERT ConstraintOnTest4_3 { email := '' };
                 """
             )
 


### PR DESCRIPTION
This is (somewhat unfortunately) implemented by translating it to
the old {name} style used previously for errmessage.

It would be somewhat nicer to store the string using \(name)
style, but doing that loses the ability to prevent interpolation
by doing \\(name). (Since the lexed version is stored in that
case, we wouldn't be able to distinguish between the cases.)