### PR TITLE
Don't ISE during recompilation of queries that produce warnings

### DIFF
--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -89,8 +89,13 @@ class Span(markup.MarkupExceptionContext):
         return dic
 
     def _calc_points(self):
+        # HACK: If we don't have an actual buffer (probably because we
+        # are recompiling after a schema change), just fake something
+        # long enough. Line numbers will be wrong but positions will
+        # still be right...
+        buffer = self.buffer.encode('utf-8') if self.buffer else b' ' * self.end
         self._points = ql_parser.SourcePoint.from_offsets(
-            self.buffer.encode('utf-8'),
+            buffer,
             [self.start, self.end]
         )
 

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -128,7 +128,7 @@ cdef class SQLParamsSource:
         return self._cached_key
 
     def text(self):
-        return '<unknown>'
+        return ''
 
     def serialize(self):
         if self._serialized is not None:

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -513,7 +513,7 @@ cdef class Database:
             try:
                 query_req = rpc.CompilationRequest.deserialize(
                     in_data,
-                    "<unknown>",
+                    "",
                     self.server.compilation_config_serializer,
                 )
 


### PR DESCRIPTION
The queries get recompiled without their full source buffer, which
some of the span machinery gets mad at.

Hack around it. (There are certainly better approaches.)