### PR TITLE
Fix FILTER clause MANY warning when FILTER body is a literal set of bools

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -229,7 +229,7 @@ def compile_Set(expr: qlast.Set, *, ctx: context.ContextLevel) -> irast.Set:
             )
             res = dispatch.compile(bigunion, ctx=ctx)
             if cres := try_constant_set(res):
-                res = setgen.ensure_set(cres, ctx=ctx)
+                res = setgen.ensure_set(cres, span=res.span, ctx=ctx)
             return res
     else:
         return setgen.new_empty_set(


### PR DESCRIPTION
This is super marginal, but `select 1 filter {true, false}` did not
produce a warning because we only emit the warning when the node has a
span, and we weren't putting a span on `ConstantSet`s.