### PR TITLE
Tweak parser recovery

### DIFF
--- a/edb/tools/parser_demo.py
+++ b/edb/tools/parser_demo.py
@@ -391,6 +391,6 @@ QUERIES = [
     '''sdl# comment
     ''',
     '''
-       CREATE BRANCH hello;
+       FOR x in foo.bar + bar UNION x;
     '''
 ]

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2830,6 +2830,13 @@ aa';
         default::Movie.name;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Missing keyword 'SELECT'", line=1, col=1)
+    def test_edgeql_syntax_select_14(self):
+        """
+        std::assert_single((select 1));
+        """
+
     def test_edgeql_syntax_group_01(self):
         """
         GROUP User
@@ -3410,7 +3417,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r'Unexpected.+bad', hint=None, line=4, col=25)
+                  r"Missing '\.'", hint=None, line=4, col=24)
     def test_edgeql_syntax_update_08(self):
         """
         WITH x := (
@@ -3827,7 +3834,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Missing '\('",
+                  r"Missing ','",
                   line=2, col=29)
     def test_edgeql_syntax_function_20(self):
         """


### PR DESCRIPTION
Closes #8609

This PR increases cost of `if` and `group` keywords to prevent them from
being suggested, since they are usually not what is missing.

Also, I've adjusted how parsers are recovered and added a special path
for parsers with custom errors: when we detect a custom error, we will
not try to fix any other error and just skip tokens until EOI. This will
have the effect of never producing an AST if there is a custom file, but
reporting just the custom error and no other errors.

It does add a guarantee that the custom error will never be discarded in
lieu of other recovery paths.
