### PR TITLE
Support required link properties

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -519,7 +519,7 @@ def _infer_shape(
                 ptrref=ptrref,
                 source_ctx=shape_set.span,
                 irexpr=rptr.expr,
-                is_mut_assignment=is_mutation,
+                is_mut_assignment=rptr.is_mutation,
                 specified_card=specified_card,
                 specified_required=specified_required,
                 shape_op=shape_op,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -610,7 +610,8 @@ def _process_view(
 
         if ptr_set:
             src_path_id = path_id
-            if ptrcls.is_link_property(ctx.env.schema):
+            is_linkprop = ptrcls.is_link_property(ctx.env.schema)
+            if is_linkprop:
                 src_path_id = src_path_id.ptr_path()
 
             ptr_set.path_id = pathctx.extend_path_id(
@@ -626,6 +627,15 @@ def _process_view(
                 direction=s_pointers.PointerDirection.Outbound,
                 ptrref=not_none(ptr_set.path_id.rptr()),
                 is_definition=True,
+
+                is_mutation=(
+                    is_mutation
+                    or (
+                        is_linkprop
+                        and s_ctx.view_rptr is not None
+                        and s_ctx.view_rptr.exprtype.is_mutation()
+                    )
+                ),
             )
             # XXX: We would maybe like to *not* do this when it
             # already has a context, since for explain output that

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -476,6 +476,8 @@ class Pointer(Expr):
     anchor: typing.Optional[str] = None
     show_as_anchor: typing.Optional[str] = None
 
+    is_mutation: bool = False
+
     @property
     def is_inbound(self) -> bool:
         return self.direction == s_pointers.PointerDirection.Inbound

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -240,12 +240,7 @@ class PropertyCommand(
             scls.is_link_property(schema)
             and not scls.is_pure_computable(schema)
         ):
-            # link properties cannot be required or multi
-            if self.get_attribute_value('required'):
-                raise errors.InvalidPropertyDefinitionError(
-                    'link properties cannot be required',
-                    span=self.span,
-                )
+            # link properties cannot be multi
             if (self.get_attribute_value('cardinality')
                     is qltypes.SchemaCardinality.Many):
                 raise errors.InvalidPropertyDefinitionError(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3595,16 +3595,90 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result("select X { foo }", [{"foo": "test"}])
 
     async def test_edgeql_ddl_link_property_01(self):
-        with self.assertRaisesRegex(
-                edgedb.InvalidPropertyDefinitionError,
-                r"link properties cannot be required"):
-            await self.con.execute("""
-                CREATE TYPE TestLinkPropType_01 {
-                    CREATE LINK test_linkprop_link_01 -> std::Object {
-                        CREATE REQUIRED PROPERTY test_link_prop_01
-                            -> std::int64;
-                    };
+        await self.con.execute("""
+            CREATE TYPE Tgt;
+            INSERT Tgt;
+            CREATE TYPE TestLinkPropType_01 {
+                CREATE LINK test_linkprop_link_01 -> std::Object {
+                    CREATE REQUIRED PROPERTY test_link_prop_01
+                        -> std::int64;
                 };
+            };
+        """)
+        await self.con.execute("""
+            insert TestLinkPropType_01 {
+                test_linkprop_link_01 := (select Tgt limit 1) {
+                    @test_link_prop_01 := 12
+                }
+            }
+        """)
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            r"required property 'test_link_prop_01'",
+        ):
+            await self.con.execute("""
+                insert TestLinkPropType_01 {
+                    test_linkprop_link_01 := (select Tgt limit 1) {
+                        @test_link_prop_01 := (select 12 filter false)
+                    }
+                }
+            """)
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            r"required property 'test_link_prop_01'",
+        ):
+            # TODO?: It would be better if we rejected this statically...
+            await self.con.execute("""
+                insert TestLinkPropType_01 {
+                    test_linkprop_link_01 := (select Tgt limit 1)
+                }
+            """)
+
+        await self.con.execute("""
+            alter type TestLinkPropType_01
+            alter link test_linkprop_link_01
+            alter property test_link_prop_01
+            set optional
+        """)
+
+        await self.con.execute("""
+            insert TestLinkPropType_01 {
+                test_linkprop_link_01 := (select Tgt limit 1)
+            }
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            r"required property 'test_link_prop_01'",
+        ):
+            await self.con.execute("""
+                alter type TestLinkPropType_01
+                alter link test_linkprop_link_01
+                alter property test_link_prop_01
+                set required
+            """)
+
+        await self.con.execute("""
+            delete TestLinkPropType_01
+        """)
+
+        await self.con.execute("""
+            alter type TestLinkPropType_01
+            alter link test_linkprop_link_01
+            alter property test_link_prop_01
+            set required
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            r"required property 'test_link_prop_01'",
+        ):
+            await self.con.execute("""
+                insert TestLinkPropType_01 {
+                    test_linkprop_link_01 := (select Tgt limit 1) {
+                        @test_link_prop_01 := (select 12 filter false)
+                    }
+                }
             """)
 
     async def test_edgeql_ddl_link_property_02(self):
@@ -3622,23 +3696,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_link_property_03(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidPropertyDefinitionError,
-                r"link properties cannot be required"):
-            await self.con.execute("""
-                CREATE TYPE TestLinkPropType_03 {
-                    CREATE LINK test_linkprop_link_03 -> std::Object;
-                };
-
-                ALTER TYPE TestLinkPropType_03 {
-                    ALTER LINK test_linkprop_link_03 {
-                        CREATE REQUIRED PROPERTY test_link_prop_03
-                            -> std::int64;
-                    };
-                };
-            """)
-
-    async def test_edgeql_ddl_link_property_04(self):
-        with self.assertRaisesRegex(
-                edgedb.InvalidPropertyDefinitionError,
                 r"multi properties aren't supported for links"):
             await self.con.execute("""
                 CREATE TYPE TestLinkPropType_04 {
@@ -3652,27 +3709,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    async def test_edgeql_ddl_link_property_05(self):
-        with self.assertRaisesRegex(
-                edgedb.InvalidPropertyDefinitionError,
-                r"link properties cannot be required"):
-            await self.con.execute("""
-                CREATE TYPE TestLinkPropType_05 {
-                    CREATE LINK test_linkprop_link_05 -> std::Object {
-                        CREATE PROPERTY test_link_prop_05 -> std::int64;
-                    };
-                };
-
-                ALTER TYPE TestLinkPropType_05 {
-                    ALTER LINK test_linkprop_link_05 {
-                        ALTER PROPERTY test_link_prop_05 {
-                            SET REQUIRED;
-                        };
-                    };
-                };
-            """)
-
-    async def test_edgeql_ddl_link_property_06(self):
+    async def test_edgeql_ddl_link_property_04(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidPropertyDefinitionError,
                 r"multi properties aren't supported for links"):


### PR DESCRIPTION
Some plumbing was needed to mirror the behavior for non link
properties of allowing potentially empty sets (to be caught at
runtime).

We don't yet support emitting error statically when a link prop isn't
included at all. I might do that in a follow-up.

Fixes #5571