### PR TITLE
Update coalesce operation example to avoid path factoring

### DIFF
--- a/docs/reference/stdlib/set.rst
+++ b/docs/reference/stdlib/set.rst
@@ -339,7 +339,8 @@ Sets
 
         # Get a set of tuples (<issue name>, <priority>)
         # for all issues.
-        select (Issue.name, Issue.priority.name ?? 'n/a');
+        for issue in Issue
+        select (issue.name, issue.priority.name ?? 'n/a');
 
     Without the coalescing operator, the above query will skip any
     ``Issue`` without priority.


### PR DESCRIPTION
The example code given does not work with the future-supported simple factoring; added a for loop so that this example is compatible with future versions of Gel.