### PR TITLE
Fix policy object duplication in degenerate multiple inheritance cases

### DIFF
--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -417,7 +417,7 @@ def try_type_rewrite(
         all_child_descs = [
             x
             for child in stype.children(schema)
-            for x in child.descendants(schema)
+            for x in [child, *child.descendants(schema)]
         ]
         child_descs = set(all_child_descs)
         if len(child_descs) != len(all_child_descs):

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -1710,10 +1710,29 @@ class TestEdgeQLPolicies(tb.DDLTestCase):
             drop type T
         ''')
 
-    async def test_edgeql_policies_set_global_01(self):
+    async def test_edgeql_policies_diamond_02(self):
         # Verify that selecting a type with overlapping children and
         # access policies in at least one child works
 
+        await self.con.execute('''
+            create type A;
+            create type B extending A;
+            create type C extending B, A { create access policy ok allow all; };
+            insert C;
+        ''')
+
+        await self.assert_query_result(
+            r'''
+            select A
+            ''',
+            [{}]
+        )
+
+        await self.con.execute('''
+            drop type C
+        ''')
+
+    async def test_edgeql_policies_set_global_01(self):
         await self.con.execute('''
             create global cur: uuid;
             create type T {


### PR DESCRIPTION
If we have `B extending A` and `C extending B, A`, the logic in
policies.py for determining if `A` has overlapping children fails to
realize that it clearly does, and so generates broken code that
selects from `C` twice.

Should fix one of the test failures in #8865.