### PR TITLE
Drop access policy on schema::Permission

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_07_28_00_00
+EDGEDB_CATALOG_VERSION = 2025_07_29_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -474,11 +474,6 @@ CREATE REQUIRED GLOBAL sys::current_role -> str {
 # These modules are populated before sys permissions so we need to
 # add these restrictions here.
 
-ALTER TYPE schema::Permission {
-    CREATE ACCESS POLICY ap_read allow select using (
-        global sys::perm::superuser
-    );
-};
 ALTER TYPE schema::Migration {
     CREATE ACCESS POLICY ap_read allow select using (
         global sys::perm::ddl


### PR DESCRIPTION
I don't think there is any reason to restrict this.
You can already basically figure out all used permissions
by looking at the expressions in access policies/etc.

Work on #8177.