### PR TITLE
Warn on START MIGRATION if no scoping future is present

### DIFF
--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -45,6 +45,7 @@ from edb.schema import database as s_db
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as s_delta
 from edb.schema import expraliases as s_expraliases
+from edb.schema import futures as s_futures
 from edb.schema import functions as s_func
 from edb.schema import globals as s_globals
 from edb.schema import indexes as s_indexes
@@ -533,6 +534,20 @@ def _start_migration(
             base_schema=base_schema,
             testmode=ctx.is_testmode(),
         )
+
+        if not (
+            s_futures.future_enabled(target_schema, 'simple_scoping')
+            or s_futures.future_enabled(target_schema, 'warn_old_scoping')
+        ):
+            warnings += (
+                errors.DeprecatedScopingError(
+                    f"\nSchema does not have 'using future simple_scoping'.\n"
+                    f"Non-simple_scoping will be removed in Gel 8.0.\n"
+                    f"See https://docs.geldata.com/reference/edgeql/"
+                    f"path_resolution\n"
+                ),
+            )
+
         query = dataclasses.replace(query, warnings=tuple(warnings))
 
     current_tx.update_migration_state(

--- a/edb/testbase/connection.py
+++ b/edb/testbase/connection.py
@@ -28,6 +28,7 @@ import typing
 
 import abc
 import asyncio
+import contextlib
 import enum
 import functools
 import random
@@ -404,6 +405,16 @@ class Connection(options._OptionsMixin, _Executor):
 
     def _get_annotations(self) -> dict[str, str]:
         return self._options.annotations
+
+    @contextlib.contextmanager
+    def capture_warnings(self) -> typing.Iterator[list[errors.EdgeDBError]]:
+        old = self._capture_warnings
+        warnings: list[errors.EdgeDBError] = []
+        self._capture_warnings = warnings
+        try:
+            yield warnings
+        finally:
+            self._capture_warnings = old
 
     def _warning_handler(self, warnings, res):
         if self._capture_warnings is not None:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -999,18 +999,16 @@ class ConnectedTestCase(ClusterTestCase):
 
     @contextlib.contextmanager
     def ignore_warnings(self, warning_message=None):
-        old = self.con._capture_warnings
-        warnings = []
-        self.con._capture_warnings = warnings
-        try:
+        with self.con.capture_warnings() as warnings:
             yield
-        finally:
-            self.con._capture_warnings = old
 
         if warning_message is not None:
             for warning in warnings:
-                with self.assertRaisesRegex(Exception, warning_message):
-                    raise warning
+                # If it doesn't match the re, send it back to the con.
+                # It might get raised or it might get captured by an
+                # enclosing call to capture_warnings/ignore_warnings.
+                if not re.search(warning_message, str(warning)):
+                    self.con._get_warning_handler()([warning], None)
 
     @classmethod
     async def setup_and_connect(cls):
@@ -1434,7 +1432,8 @@ class DatabaseTestCase(ConnectedTestCase):
         if class_set_up != 'skip':
             script = cls.get_setup_script()
             if script:
-                await cls.con.execute(script)
+                with cls.con.ignore_warnings():
+                    await cls.con.execute(script)
 
     @staticmethod
     def get_set_up():
@@ -1595,13 +1594,15 @@ class DatabaseTestCase(ConnectedTestCase):
                     {migration}
                 }}
             """
-        await self.con.execute(f"""
-            START MIGRATION TO {{
-                {migration}
-            }};
-            POPULATE MIGRATION;
-            COMMIT MIGRATION;
-        """)
+
+        with self.ignore_warnings('Non-simple_scoping will be removed'):
+            await self.con.execute(f"""
+                START MIGRATION TO {{
+                    {migration}
+                }};
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
 
 
 class Error:
@@ -1941,7 +1942,10 @@ class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
             # compare the new branch schema to the original. We expect there
             # to be no difference and therefore a new migration to the
             # original schema should have the "complete" status right away.
-            await self.con.execute(f'start migration to {{ {orig_schema} }}')
+            with self.ignore_warnings():
+                await self.con.execute(
+                    f'start migration to {{ {orig_schema} }}'
+                )
             mig_status = json.loads(
                 await self.con.query_single_json(
                     'describe current migration as json'
@@ -2300,7 +2304,8 @@ async def _setup_database(
         if setup_script:
             async for tx in dbconn.retrying_transaction():
                 async with tx:
-                    await dbconn.execute(setup_script)
+                    with dbconn.capture_warnings():
+                        await dbconn.execute(setup_script)
     except Exception as ex:
         raise RuntimeError(
             f'exception during initialization of {dbname!r} test DB: '

--- a/tests/test_edgeql_fts_schema.py
+++ b/tests/test_edgeql_fts_schema.py
@@ -85,23 +85,17 @@ class TestEdgeQLFTSSchema(tb.DDLTestCase):
 
     async def test_edgeql_fts_schema_language_03(self):
         # Test adding an index to existing schema
-        await self.con.execute(
+        await self.migrate(
             r"""
-            start migration to {
-                module default {
-                    type Text {
-                        required text0: str;
-                        required text1: str;
-                        required text2: str;
-                        required text3: str;
-                        required text4: str;
-                        required text5: str;
-                        required text6: str;
-                    }
+                type Text {
+                    required text0: str;
+                    required text1: str;
+                    required text2: str;
+                    required text3: str;
+                    required text4: str;
+                    required text5: str;
+                    required text6: str;
                 }
-            };
-            populate migration;
-            commit migration;
             """
         )
 
@@ -218,6 +212,7 @@ class TestEdgeQLFTSSchema(tb.DDLTestCase):
 
             # move the property to a Base type
             start migration to {
+                using future simple_scoping;
                 module default {
                     abstract type Base {
                         required property x -> str;

--- a/tests/test_edgeql_tutorial.py
+++ b/tests/test_edgeql_tutorial.py
@@ -33,6 +33,7 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
     async def test_edgeql_tutorial(self):
         await self.con.execute(r'''
             START MIGRATION TO {
+                using future simple_scoping;
                 module default {
                     type Movie {
                         required property title -> str;
@@ -207,6 +208,7 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
 
         await self.con.execute(r'''
             START MIGRATION TO {
+                using future simple_scoping;
                 module default {
                     type Movie {
                         required property title -> str;

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -424,59 +424,60 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             select distinct sys::ExtensionPackage.name
         ''')
 
-        # This tests that toggling scoping futures works with
-        # extensions, and that the extensions work if it is enabled
-        # first.
-        await self.con.execute(f"""
-            START MIGRATION TO {{
-                using future warn_old_scoping;
-                module default {{ }}
-            }};
-            POPULATE MIGRATION;
-            COMMIT MIGRATION;
-        """)
+        with self.ignore_warnings('Non-simple_scoping will be removed'):
+            # This tests that toggling scoping futures works with
+            # extensions, and that the extensions work if it is enabled
+            # first.
+            await self.con.execute(f"""
+                START MIGRATION TO {{
+                    using future warn_old_scoping;
+                    module default {{ }}
+                }};
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
 
-        ext_commands = ''.join(f'using extension {ext};\n' for ext in exts)
-        await self.con.execute(f"""
-            START MIGRATION TO {{
-                using future warn_old_scoping;
-                {ext_commands}
-                module default {{ }}
-            }};
-            POPULATE MIGRATION;
-            COMMIT MIGRATION;
-        """)
+            ext_commands = ''.join(f'using extension {ext};\n' for ext in exts)
+            await self.con.execute(f"""
+                START MIGRATION TO {{
+                    using future warn_old_scoping;
+                    {ext_commands}
+                    module default {{ }}
+                }};
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
 
-        await self.con.query("""
-            describe current database config as ddl
-        """)
-        await self.con.query("""
-            describe instance config as ddl
-        """)
+            await self.con.query("""
+                describe current database config as ddl
+            """)
+            await self.con.query("""
+                describe instance config as ddl
+            """)
 
-        await self.con.execute(f"""
-            START MIGRATION TO {{
-                {ext_commands}
-                module default {{ }}
-            }};
-            POPULATE MIGRATION;
-            COMMIT MIGRATION;
-        """)
+            await self.con.execute(f"""
+                START MIGRATION TO {{
+                    {ext_commands}
+                    module default {{ }}
+                }};
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
 
-        await self.con.execute(f"""
-            START MIGRATION TO {{
-                using future warn_old_scoping;
-                {ext_commands}
-                module default {{ }}
-            }};
-            POPULATE MIGRATION;
-            COMMIT MIGRATION;
-        """)
+            await self.con.execute(f"""
+                START MIGRATION TO {{
+                    using future warn_old_scoping;
+                    {ext_commands}
+                    module default {{ }}
+                }};
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)
 
-        await self.con.execute(f"""
-            START MIGRATION TO {{
-                module default {{ }}
-            }};
-            POPULATE MIGRATION;
-            COMMIT MIGRATION;
-        """)
+            await self.con.execute(f"""
+                START MIGRATION TO {{
+                    module default {{ }}
+                }};
+                POPULATE MIGRATION;
+                COMMIT MIGRATION;
+            """)

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2464,6 +2464,7 @@ class TestServerProtoMigration(tb.QueryTestCase):
 
         await self.con.execute(f'''
             START MIGRATION TO {{
+                using future simple_scoping;
                 module default {{
                     type {typename} {{
                         required property foo -> str;
@@ -3399,14 +3400,8 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
     async def test_server_proto_backend_tid_propagation_03(self):
         try:
-            await self.con.execute('''
-                START MIGRATION TO {
-                    module default {
-                        scalar type tid_prop_03 extending str;
-                    }
-                };
-                POPULATE MIGRATION;
-                COMMIT MIGRATION;
+            await self.migrate('''
+                scalar type tid_prop_03 extending str;
             ''')
 
             result = await self.con.query_single('''
@@ -3946,14 +3941,14 @@ class TestServerCapabilities(tb.QueryTestCase):
             edgedb.DisabledCapabilityError, "disabled by the client"
         ):
             await self.con._fetchall(
-                'START MIGRATION TO {}',
+                'START MIGRATION TO { using future simple_scoping;}',
                 __allow_capabilities__=caps,
             )
 
     async def test_server_capabilities_07(self):
         caps = enums.Capability.ALL & ~enums.Capability.TRANSACTION
         await self.con._fetchall(
-            'START MIGRATION TO {};'
+            'START MIGRATION TO { using future simple_scoping; };'
             'POPULATE MIGRATION;'
             'ABORT MIGRATION;',
             __allow_capabilities__=caps,


### PR DESCRIPTION
Most of the work here is suppressing the warning in the test suite.
The main way is to make `migrate` suppress it, and make more call
sites use `migrate` instead of explicit `start migration`.

This is to start nudging users to do the migration.
Fixes #8888.