### PR TITLE
Fix accessing single link properties through FOR bindings

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -507,6 +507,11 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                             span=step.span,
                         )
 
+                    # Mark the underlying pointer as needing a link table,
+                    # so that we access the mapped table to begin with.
+                    assert isinstance(fake_tip.expr, irast.Pointer)
+                    fake_tip.expr.force_link_table = True
+
                 else:
                     raise errors.EdgeQLSyntaxError(
                         f"unexpected reference to link property {ptr_name!r} "

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -465,6 +465,12 @@ class Pointer(Expr):
     source: Set
     ptrref: BasePointerRef
     direction: s_pointers.PointerDirection
+    # Whether to *always* use a link table when this pointer is
+    # accessed.  This is needed (for example) when a (possibly single)
+    # link property is being referenced in a FOR iterator, and we
+    # aren't going to have access to the Pointer when we access
+    # the iterator variable.
+    force_link_table: bool = False
 
     # If the pointer is a computed pointer (or a computed pointer
     # definition), the expression.

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -645,6 +645,8 @@ def new_pointer_rvar(
     ir_ptr = ir_set.expr
     ptrref = ir_ptr.ptrref
 
+    link_bias = link_bias or ir_ptr.force_link_table
+
     ptr_info = pg_types.get_ptrref_storage_info(
         ptrref, resolve_type=False, link_bias=link_bias, allow_missing=True,
         versioned=ctx.env.versioned_stdlib,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -863,7 +863,8 @@ def process_set_as_link_property_ref(
 
         if link_rvar is None:
             src_rvar = get_set_rvar(ir_source, ctx=newctx)
-            assert irutils.is_set_instance(link_prefix, irast.Pointer)
+            assert irutils.is_set_instance(link_prefix, irast.Pointer), (
+                f'projecting lprop on {link_prefix.expr}')
             link_rvar = relctx.new_pointer_rvar(
                 link_prefix, src_rvar=src_rvar,
                 link_bias=True, ctx=newctx)
@@ -1108,7 +1109,11 @@ def process_set_as_path(
     rvars = []
 
     ptr_info = pg_types.get_ptrref_storage_info(
-        ptrref, resolve_type=False, link_bias=False, allow_missing=True)
+        ptrref,
+        resolve_type=False,
+        link_bias=rptr.force_link_table,
+        allow_missing=True,
+    )
 
     # Path is a link property.
     is_linkprop = ptrref.source_ptr is not None

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -1350,3 +1350,11 @@ class TestEdgeQLFor(tb.QueryTestCase):
             await self.con.query('''
                 FOR d IN User.deck SELECT (d.name, d@count);
             ''')
+
+    async def test_edgeql_for_lprop_04(self):
+        await self.assert_query_result(
+            '''
+            for u in User for m in u.avatar select m@text;
+            ''',
+            {'Best', 'Wow'},
+        )

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -8544,7 +8544,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ptrs = list(val.__dataclass_fields__.keys())
         self.assertEqual(ptrs[0], '__tid__')
 
-    @test.xerror("a linkprop related ISE!")
+    @test.xerror("""
+        a linkprop related ISE!
+
+        This one is kind of screwy. *An* issue is that the FOR loop over
+        a single link is hiding the linkprop (despite our `needs_link_table`
+        based efforts).
+
+        But:
+         1. This code obviously ought to work, though you could argue
+            about whether the link property should be in the shape.
+         2. If the link prop was specified explicitly in the shape, that
+            ought to work (per our paper semantics, at least!).
+         3. It only passes the frontend for bad reasons, though!
+            If we name the field `owner2` we get a "has no property" error!!
+    """)
     async def test_edgeql_select_tid_position_06(self):
         res = await self.con._fetchall("""
             FOR issue IN Issue SELECT issue {


### PR DESCRIPTION
This is a follow-up of #7805, and partially fixes #8903.