### PR TITLE
Fix casting from JSON in indexes/constraints

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_08_04_00_00
+EDGEDB_CATALOG_VERSION = 2025_08_05_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/pgsql/dbops/functions.py
+++ b/edb/pgsql/dbops/functions.py
@@ -51,6 +51,9 @@ class Function(base.DBObject):
         strict: bool = False,
         parallel_safe: bool = False,
         set_returning: bool = False,
+
+        # Unused for Function, used in VersionedFunction.
+        wrapper_volatility: Optional[str] = None,
     ):
         if volatility.lower() == 'modifying':
             volatility = 'volatile'

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1923,6 +1923,7 @@ class CastCommand(MetaCommand):
             args=args,
             returns=returns,
             strict=False,
+            wrapper_volatility=cast.get_volatility(schema),
             text=not_none(cast.get_code(schema)),
         )
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -15990,6 +15990,15 @@ type default::Foo {
                 };
             """)
 
+    async def test_edgeql_ddl_index_10(self):
+        await self.con.execute(r"""
+            create type T {
+                create property foo -> json;
+                create index on (<str>.foo);
+                create index on (<int64>.foo);
+            };
+        """)
+
     async def test_edgeql_ddl_index_fts_01(self):
         await self.con.execute('''
             CREATE ABSTRACT TYPE default::Named {


### PR DESCRIPTION
This was a regression introduced in 6.8 by #8804, which changed the
volatility of a handful of metaschema functions, including
jsonb_extract_scalar. jsonb_extract_scalar is used by basically every
cast *from* json.

The issue is that the cast functions now are Stable, which breaks
things. I introduced a mechanism in the original patch whereby the
trampoline functions would stay marked Immutable, but this only
mattered when the generated queries were calling metaschema functions
directly, whereas casts have wrapper functions.

Our casts, unlike functions and operators, don't set the volatility of the
function. (And indeed, this is why changing the underlying volatility
of jsonb_extract_scalar made things faster--it let us eliminate a volatility
mismatch.)

The fix is to make sure the trampoline function for casts that are
called in indexes has volatility set.

We'll need to do a patch for 6.10 to update the trampoline
volatilities, but in-place upgrades shouldn't need any intervention,
since trampolines get recreated there automatically.