### PR TITLE
pg-ext: fix bug in query reparse

### DIFF
--- a/edb/server/compiler/sql.py
+++ b/edb/server/compiler/sql.py
@@ -237,7 +237,7 @@ def _compile_sql(
         extract_data = _build_constant_extraction_map(orig_stmt, stmt)
 
         unit = dbstate.SQLQueryUnit(
-            orig_query=orig_text,
+            orig_query=pg_codegen.generate_source(orig_stmt),
             fe_settings=fe_settings,
             # by default, the query is sent to PostgreSQL unchanged
             query=orig_text,

--- a/edb/server/pgcon/pgcon_sql.pyx
+++ b/edb/server/pgcon/pgcon_sql.pyx
@@ -139,7 +139,7 @@ cdef class PGSQLConnection:
 
             be_parse = True
             if action.action == PGAction.PARSE:
-                sql_text, data = action.args
+                sql_text, data = action.args[:2]
                 if action.stmt_name in prepared:
                     action.frontend_only = True
                 else:

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -1484,7 +1484,7 @@ cdef class PgConnection(frontend.FrontendConnection):
         outer_stmt, new_stmts = await self._parse_statement(
             stmt_name,
             qu.orig_query,
-            parse_action.args[1],
+            parse_action.args[2],
             dbv,
             force_recompilation=True,
             injected_action=True,
@@ -1716,12 +1716,12 @@ cdef class PgConnection(frontend.FrontendConnection):
             nested_ps_name = unit.deallocate.stmt_name
             unit = self._validate_deallocate_stmt(unit)
 
-        parse_data = remap_parameters(parse_data, unit.params)
+        remapped_parse_data = remap_parameters(parse_data, unit.params)
 
         action = PGMessage(
             PGAction.PARSE,
             stmt_name=unit.stmt_name,
-            args=(unit.query.encode("utf-8"), parse_data),
+            args=(unit.query.encode("utf-8"), remapped_parse_data, parse_data),
             query_unit=unit,
             fe_settings=fe_settings,
             injected=injected_action,

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2974,6 +2974,21 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             '''
         )
 
+    async def test_sql_query_reparse_01(self):
+        query = '''SELECT ('literal str'::text, 42::int)'''
+
+        res1 = await self.squery_values(query)
+
+        # force a reparse
+        await self.scon.execute('SET LOCAL apply_access_policies_pg TO false')
+
+        # re-run the same query, asyncpg should just issue a BIND message
+        # of the cached prepared statement, and Gel should reparse/recompile
+        # the original query.
+        res2 = await self.squery_values(query)
+
+        self.assertEqual(res1, res2)
+
     async def test_sql_native_query_00(self):
         await self.assert_sql_query_result(
             """


### PR DESCRIPTION
The error looks like this:

```
    edb/server/protocol/pg_ext.pyx, line 70, in edb.server.protocol.pg_ext.managed_error
        > yield
    edb/server/protocol/pg_ext.pyx, line 1201, in edb.server.protocol.pg_ext.PgConnection.extended_query
        > stmt = await self._ensure_ps_locality(
    edb/server/protocol/pg_ext.pyx, line 1443, in _ensure_ps_locality
        > parse_actions, new_stmts = await self._reparse(
    edb/server/protocol/pg_ext.pyx, line 1484, in _reparse
        > outer_stmt, new_stmts = await self._parse_statement(
    edb/server/protocol/pg_ext.pyx, line 1680, in _parse_statement
        > return await self._parse_unit(
    edb/server/protocol/pg_ext.pyx, line 1719, in _parse_unit
        > parse_data = remap_parameters(parse_data, unit.params)
    edb/server/protocol/pg_ext.pyx, line 1992, in edb.server.protocol.pg_ext.remap_parameters
        > assert len(bytes(buf)) == 2 + 4 * len(params)

AssertionError:
```

It happens when binding the same query a second time with different settings, please refer to the added test in this PR for details.

The reason it happened is because we used the normalized query string in the reparse, as well as the remapped `parse_data`, then it failed in the following `remap_parameters()`.

The fix is to just use the original query, as well as the original `parse_data`.