### PR TITLE
Try to make the otc code trigger serialization errors less

### DIFF
--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -160,6 +160,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             create annotation std::description :=
                 "The date and time when the code expires.";
         };
+        create index on (.expires_at);
 
         create required link factor: ext::auth::Factor {
             on target delete delete source;

--- a/edb/pgsql/patches_6x.py
+++ b/edb/pgsql/patches_6x.py
@@ -332,6 +332,7 @@ std::__pg_generate_series(
             create annotation std::description :=
                 "The date and time when the code expires.";
         };
+        create index on (.expires_at);
 
         create required link factor: ext::auth::Factor {
             on target delete delete source;


### PR DESCRIPTION
Move deletion of expired OneTimeCodes to a separate query where we
suppress serialization errors. That was requiring a table scan every
time. Also add an index to expires_at so it doesn't require a full
table lock.