### PR TITLE
test: longer timeout for test_server_ops_multi_tenant

### DIFF
--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1735,7 +1735,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         mtargs.reload_server()
 
         async for tr in self.try_until_fails(
-            wait_for=edgedb.AvailabilityError
+            wait_for=edgedb.AvailabilityError, timeout=30
         ):
             async with tr:
                 await self._test_server_ops_multi_tenant_1(mtargs)
@@ -1762,7 +1762,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         mtargs.reload_server()
 
         async for tr in self.try_until_succeeds(
-            ignore=edgedb.AvailabilityError
+            ignore=edgedb.AvailabilityError, timeout=30
         ):
             async with tr:
                 await self._test_server_ops_multi_tenant_1(mtargs)
@@ -1915,7 +1915,9 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         assert mtargs.srv.proc is not None
         mtargs.srv.proc.send_signal(signal.SIGHUP)
 
-        async for tr in self.try_until_succeeds(ignore=AssertionError):
+        async for tr in self.try_until_succeeds(
+            ignore=AssertionError, timeout=30
+        ):
             async with tr:
                 self.assertEqual(
                     (await mtargs.current_email_provider(1))["sender"],


### PR DESCRIPTION
Some aarch64 CI jobs are hitting failures in this test, probably due to slow reloading longer than 5 seconds (before PR).