### PR TITLE
WIP: Extracting the config concerns from tenant/dbview

### DIFF
--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Mapping, TypedDict
+from typing import Any, Mapping, TypedDict, TYPE_CHECKING
 
 import enum
 
@@ -26,6 +26,8 @@ import immutables
 
 from edb import errors
 from edb.edgeql.qltypes import ConfigScope
+if TYPE_CHECKING:
+    from edb.server import server
 
 from .ops import OpCode, Operation, SettingValue
 from .ops import (

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -59,7 +59,6 @@ cdef class DatabaseIndex:
         object _comp_sys_config
         object _std_schema
         object _global_schema_pickle
-        object _default_sysconfig
         object _sys_config_spec
         object _cached_compiler_args
 
@@ -242,9 +241,8 @@ cdef class DatabaseConnectionView:
     cpdef get_database_config(self)
     cdef set_database_config(self, new_conf)
 
-    cdef get_system_config(self)
     cpdef get_compilation_system_config(self)
-    cdef config_lookup(self, name)
+    cdef lookup_config(self, name)
 
     cdef set_modaliases(self, new_aliases)
     cpdef get_modaliases(self)

--- a/edb/server/dbview/dbview.pyi
+++ b/edb/server/dbview/dbview.pyi
@@ -48,7 +48,7 @@ class CompiledQuery:
 class Database:
     name: str
     dbver: int
-    db_config: Config
+    db_config: server.ServerSysConfig
     extensions: set[str]
     user_config_spec: config.Spec
     dml_queries_executed: int
@@ -145,22 +145,17 @@ class DatabaseIndex:
         *,
         std_schema: s_schema.Schema,
         global_schema_pickle: bytes,
-        sys_config: Config,
-        default_sysconfig: Config,
-        sys_config_spec: config.Spec,
+        sys_config: server.ServerSysConfig,
     ) -> None:
         ...
 
     def count_connections(self, dbname: str) -> int:
         ...
 
-    def get_sys_config(self) -> Config:
-        ...
-
     def get_compilation_system_config(self) -> Config:
         ...
 
-    def update_sys_config(self, sys_config: Config) -> None:
+    def update_sys_config(self) -> None:
         ...
 
     def has_db(self, dbname: str) -> bool:

--- a/edb/server/dbview/dbview.pyi
+++ b/edb/server/dbview/dbview.pyi
@@ -48,7 +48,7 @@ class CompiledQuery:
 class Database:
     name: str
     dbver: int
-    db_config: server.ServerSysConfig
+    db_config: Config
     extensions: set[str]
     user_config_spec: config.Spec
     dml_queries_executed: int

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -596,11 +596,10 @@ cdef class Database:
         spec = self._index._sys_config_spec
         if self.user_config_spec is not None:
             spec = config.ChainedSpec(spec, self.user_config_spec)
-        return config.lookup(
+        return self._index._sys_config.lookup(
             name,
             self.db_config or DEFAULT_CONFIG,
-            self._index._sys_config,
-            spec=spec,
+            spec=spec
         )
 
 
@@ -805,9 +804,6 @@ cdef class DatabaseConnectionView:
             # multiple connections do db configs.)
             pass
 
-
-    cdef get_system_config(self):
-        return self._db._index.get_sys_config()
 
     cpdef get_compilation_system_config(self):
         return self._db._index.get_compilation_system_config()
@@ -1291,12 +1287,12 @@ cdef class DatabaseConnectionView:
         self._reset_tx_state()
         return side_effects
 
-    cdef config_lookup(self, name):
-        return self.server.config_lookup(
+    cdef lookup_config(self, name):
+        return self.server.config.lookup(
             name,
             self.get_session_config(),
             self.get_database_config(),
-            self.get_system_config(),
+            self._db._index._sys_config._sys_config
         )
 
     async def recompile_cached_queries(
@@ -1310,7 +1306,7 @@ cdef class DatabaseConnectionView:
         concurrency_control = asyncio.Semaphore(compile_concurrency)
         rv = []
 
-        recompile_timeout = self.config_lookup(
+        recompile_timeout = self.lookup_config(
             "auto_rebuild_query_cache_timeout",
         )
 
@@ -1567,7 +1563,7 @@ cdef class DatabaseConnectionView:
                 if unit.user_schema:
                     user_schema = unit.user_schema
                     user_schema_version = unit.user_schema_version
-            if user_schema and not self.config_lookup(
+            if user_schema and not self.lookup_config(
                 "auto_rebuild_query_cache",
             ):
                 user_schema = None
@@ -1893,7 +1889,7 @@ cdef class DatabaseConnectionView:
             if self.in_tx():
                 isolation = self._in_tx_isolation_level
             else:
-                isolation = self.config_lookup(
+                isolation = self.lookup_config(
                     "default_transaction_isolation"
                 )
                 if isolation and isolation.to_str() == "RepeatableRead":
@@ -1915,7 +1911,7 @@ cdef class DatabaseConnectionView:
                 )
 
         if not self.in_tx() and has_write:
-            access_mode = self.config_lookup("default_transaction_access_mode")
+            access_mode = self.lookup_config("default_transaction_access_mode")
             if access_mode and access_mode.to_str() == "ReadOnly":
                 raise query_capabilities.make_error(
                     ~enums.Capability.WRITE,
@@ -1947,17 +1943,15 @@ cdef class DatabaseIndex:
         std_schema,
         global_schema_pickle,
         sys_config,
-        default_sysconfig,  # system config without system override
-        sys_config_spec,
     ):
         self._dbs = {}
         self._server = tenant.server
         self._tenant = tenant
         self._std_schema = std_schema
         self._global_schema_pickle = global_schema_pickle
-        self._default_sysconfig = default_sysconfig
-        self._sys_config_spec = sys_config_spec
-        self.update_sys_config(sys_config)
+        self._sys_config = sys_config
+        self._sys_config_spec = sys_config.settings
+        self.update_sys_config()
         self._cached_compiler_args = None
 
     def count_connections(self, dbname: str):
@@ -1968,23 +1962,15 @@ cdef class DatabaseIndex:
 
         return sum(1 for dbv in (<Database>db)._views if not dbv.is_transient)
 
-    def get_sys_config(self):
-        return self._sys_config
-
     def get_compilation_system_config(self):
         return self._comp_sys_config
 
-    def update_sys_config(self, sys_config):
+    def update_sys_config(self):
         cdef Database db
         for db in self._dbs.values():
             db.dbver = next_dbver()
 
-        with self._default_sysconfig.mutate() as mm:
-            mm.update(sys_config)
-            sys_config = mm.finish()
-        self._sys_config = sys_config
-        self._comp_sys_config = config.get_compilation_config(
-            sys_config, spec=self._sys_config_spec)
+        self._comp_sys_config = self._sys_config.get_compilation_config()
         self.invalidate_caches()
 
     def has_db(self, dbname):
@@ -2116,9 +2102,8 @@ cdef class DatabaseIndex:
         # _save_system_overrides *must* happen before
         # the callbacks below, because certain config changes
         # may cause the backend connection to drop.
-        self.update_sys_config(
-            op.apply(spec, self._sys_config)
-        )
+        self._sys_config.apply(op)
+        self.update_sys_config()
 
         await self._save_system_overrides(conn, spec)
 
@@ -2175,8 +2160,4 @@ cdef class DatabaseIndex:
         return self._cached_compiler_args
 
     def lookup_config(self, name: str):
-        return config.lookup(
-            name,
-            self._sys_config,
-            spec=self._sys_config_spec,
-        )
+        return self._sys_config.lookup(name)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -599,6 +599,7 @@ cdef class Database:
         return self._index._sys_config.lookup(
             name,
             self.db_config or DEFAULT_CONFIG,
+            self._index._sys_config._sys_config,
             spec=spec
         )
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -2065,10 +2065,8 @@ cdef class DatabaseIndex:
     def iter_dbs(self):
         return iter(self._dbs.values())
 
-    async def _save_system_overrides(self, conn, spec):
-        data = config.to_json(
-            spec,
-            self._sys_config._sys_config,
+    async def _save_system_overrides(self, conn):
+        data = self._sys_config.to_json(
             setting_filter=lambda v: v.source == 'system override',
             include_source=False,
         )
@@ -2105,7 +2103,7 @@ cdef class DatabaseIndex:
         self._sys_config.apply(op)
         self.update_sys_config()
 
-        await self._save_system_overrides(conn, spec)
+        await self._save_system_overrides(conn)
 
         if op.opcode is config.OpCode.CONFIG_ADD:
             await self._server._on_system_config_add(op.setting_name, op_value)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -2068,7 +2068,7 @@ cdef class DatabaseIndex:
     async def _save_system_overrides(self, conn, spec):
         data = config.to_json(
             spec,
-            self._sys_config,
+            self._sys_config._sys_config,
             setting_filter=lambda v: v.source == 'system override',
             include_source=False,
         )

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -598,8 +598,7 @@ cdef class Database:
             spec = config.ChainedSpec(spec, self.user_config_spec)
         return self._index._sys_config.lookup(
             name,
-            self.db_config or DEFAULT_CONFIG,
-            self._index._sys_config._sys_config,
+            configs=(self.db_config or DEFAULT_CONFIG,),
             spec=spec
         )
 
@@ -1291,9 +1290,10 @@ cdef class DatabaseConnectionView:
     cdef lookup_config(self, name):
         return self.server.config.lookup(
             name,
-            self.get_session_config(),
-            self.get_database_config(),
-            self._db._index._sys_config._sys_config
+            configs=(
+                self.get_session_config(),
+                self.get_database_config(),
+            ),
         )
 
     async def recompile_cached_queries(

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -606,7 +606,7 @@ async def run_server(
                     compiler=compiler,
                 )
             )
-            sys_config = server.ServerSysConfig(config_spec=compiler_state.config_spec, sys_config=sys_config, default_sysconfig=immutables.Map())
+            sys_config = server.ServerSysConfig(config_settings=compiler_state.config_spec, sys_config=sys_config, default_sysconfig=immutables.Map())
             del compiler
             if backend_settings:
                 abort(

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -66,7 +66,6 @@ from . import logsetup
 from . import pgcluster
 from . import service_manager
 
-
 if TYPE_CHECKING:
     from . import server
     from edb.server import bootstrap
@@ -207,6 +206,9 @@ async def _run_server(
 
     with signalctl.SignalController(signal.SIGINT, signal.SIGTERM) as sc:
         from . import tenant as edbtenant
+        from . import server
+
+        sys_config = server.ServerSysConfig(config_settings=compiler.state.config_spec)
 
         # max_backend_connections should've been calculated already by now
         assert args.max_backend_connections is not None
@@ -216,6 +218,7 @@ async def _run_server(
             max_backend_connections=args.max_backend_connections,
             backend_adaptive_ha=args.backend_adaptive_ha,
             extensions_dir=args.extensions_dir,
+            sys_config=sys_config,
         )
         tenant.set_init_con_data(init_con_data)
         tenant.set_reloadable_files(
@@ -531,6 +534,7 @@ async def run_server(
         from edb.schema import reflection as s_refl
         from . import bootstrap
         from . import multitenant
+        from . import server
 
         try:
             stdlib: bootstrap.StdlibBits | None
@@ -602,6 +606,7 @@ async def run_server(
                     compiler=compiler,
                 )
             )
+            sys_config = server.ServerSysConfig(config_spec=compiler_state.config_spec, sys_config=sys_config, default_sysconfig=immutables.Map())
             del compiler
             if backend_settings:
                 abort(

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -208,7 +208,9 @@ async def _run_server(
         from . import tenant as edbtenant
         from . import server
 
-        sys_config = server.ServerSysConfig(config_settings=compiler.state.config_spec)
+        sys_config = server.ServerSysConfig(
+            config_settings=compiler.state.config_spec
+        )
 
         # max_backend_connections should've been calculated already by now
         assert args.max_backend_connections is not None
@@ -599,14 +601,17 @@ async def run_server(
                 compiler_state.config_spec,
             )
 
-            sys_config, backend_settings, init_con_data = (
+            config_map, backend_settings, init_con_data = (
                 initialize_static_cfg(
                     args,
                     is_remote_cluster=True,
                     compiler=compiler,
                 )
             )
-            sys_config = server.ServerSysConfig(config_settings=compiler_state.config_spec, sys_config=sys_config, default_sysconfig=immutables.Map())
+            sys_config = server.ServerSysConfig(
+                config_settings=compiler_state.config_spec,
+                sys_config=config_map,
+            )
             del compiler
             if backend_settings:
                 abort(

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -238,11 +238,14 @@ class MultiTenantServer(server.BaseServer):
                 "No secret key"
             )
 
+        sys_config = server.ServerSysConfig(config_settings=self._sys_config.config_settings)
+
         tenant = edbtenant.Tenant(
             cluster,
             instance_name=conf["instance-name"],
             max_backend_connections=max_conns,
             backend_adaptive_ha=conf.get("backend-adaptive-ha", False),
+            sys_config=sys_config,
         )
         tenant.set_init_con_data(self._init_con_data)
         config_file = conf.get("config-file")

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -237,7 +237,7 @@ class MultiTenantServer(server.BaseServer):
             )
 
         sys_config = server.ServerSysConfig(
-            config_settings=self._sys_config.config_settings
+            config_settings=self._sys_config.settings
         )
 
         tenant = edbtenant.Tenant(

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -69,7 +69,6 @@ TenantConfig = TypedDict(
 
 class MultiTenantServer(server.BaseServer):
     _config_file: pathlib.Path
-    _sys_config: Mapping[str, config.SettingValue]
     _init_con_data: list[config.ConState]
 
     _tenants_by_sslobj: MutableMapping
@@ -88,7 +87,7 @@ class MultiTenantServer(server.BaseServer):
         config_file: pathlib.Path,
         *,
         compiler_pool_tenant_cache_size: int,
-        sys_config: Mapping[str, config.SettingValue],
+        sys_config: server.ServerSysConfig,
         init_con_data: list[config.ConState],
         sys_queries: Mapping[str, bytes],
         report_config_typedesc: dict[defines.ProtocolVersion, bytes],
@@ -112,9 +111,6 @@ class MultiTenantServer(server.BaseServer):
         self._task_serial = 0
         self._sys_queries = sys_queries
         self._report_config_typedesc = report_config_typedesc
-
-    def _get_sys_config(self) -> Mapping[str, config.SettingValue]:
-        return self._sys_config
 
     def _sni_callback(self, sslobj, server_name, _sslctx):
         if server_name is None:
@@ -440,7 +436,7 @@ class MultiTenantServer(server.BaseServer):
 async def run_server(
     args: srvargs.ServerConfig,
     *,
-    sys_config: Mapping[str, config.SettingValue],
+    sys_config: server.ServerSysConfig,
     init_con_data: list[config.ConState],
     sys_queries: Mapping[str, bytes],
     report_config_typedesc: dict[defines.ProtocolVersion, bytes],

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -87,7 +87,6 @@ class MultiTenantServer(server.BaseServer):
         config_file: pathlib.Path,
         *,
         compiler_pool_tenant_cache_size: int,
-        sys_config: server.ServerSysConfig,
         init_con_data: list[config.ConState],
         sys_queries: Mapping[str, bytes],
         report_config_typedesc: dict[defines.ProtocolVersion, bytes],
@@ -95,7 +94,6 @@ class MultiTenantServer(server.BaseServer):
     ):
         super().__init__(**kwargs)
         self._config_file = config_file
-        self._sys_config = sys_config
         self._init_con_data = init_con_data
         self._compiler_pool_tenant_cache_size = compiler_pool_tenant_cache_size
 

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -236,7 +236,9 @@ class MultiTenantServer(server.BaseServer):
                 "No secret key"
             )
 
-        sys_config = server.ServerSysConfig(config_settings=self._sys_config.config_settings)
+        sys_config = server.ServerSysConfig(
+            config_settings=self._sys_config.config_settings
+        )
 
         tenant = edbtenant.Tenant(
             cluster,

--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -55,8 +55,8 @@ class TenantState:
 
 
 async def _http_task(tenant: edbtenant.Tenant, state: TenantState) -> None:
-    http_max_connections = tenant._server.config_lookup(
-        'http_max_connections', tenant.get_sys_config()
+    http_max_connections = tenant.config.lookup(
+        'http_max_connections'
     )
     http_client = state.http_client
     http_client._update_limit(http_max_connections)

--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -601,7 +601,7 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         # (such as the ability to write to a protected socket).
         if self._external_auth:
             authmethods = [
-                self.server.config_settings.get_type_by_name('cfg::Trust')()
+                self.server.config.settings.get_type_by_name('cfg::Trust')()
             ]
         else:
             authmethods = await self.tenant.get_auth_methods(

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -842,7 +842,7 @@ cdef class HttpProtocol:
 
             config = db.db_config.get('cors_allow_origins')
         if config is None:
-            config = self.tenant.get_sys_config().get('cors_allow_origins')
+            config = self.tenant.config.lookup('cors_allow_origins')
 
         allowed_origins = config.value if config else None
         overrides = self.server.get_cors_always_allowed_origins()

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -141,6 +141,7 @@ class ServerSysConfig:
     def apply(self, op: config.Operation):
         assert self._sys_config is not None, "ServerConfig is not initialized"
         op.apply(self._config_settings, self._sys_config)
+        self.update(self._sys_config)
 
     def get_compilation_config(self) -> immutables.Map[str, config.SettingValue]:
         assert self._sys_config is not None, "ServerConfig is not initialized"
@@ -157,6 +158,17 @@ class ServerSysConfig:
         spec = spec or self._config_settings
         return config.lookup(name, *db_config, spec=spec)
 
+    def to_json(
+        self,
+        setting_filter: Optional[Callable[[config.SettingValue], bool]] = None,
+        include_source: bool = True,
+    ) -> str:
+        return config.to_json(
+            self._config_settings,
+            self._sys_config,
+            setting_filter=setting_filter,
+            include_source=include_source,
+        )
 
 class BaseServer:
     _sys_queries: Mapping[str, bytes]

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -103,10 +103,15 @@ class StartupError(Exception):
 
 class ServerSysConfig:
     _sys_config: Mapping[str, config.SettingValue] | None
-    _default_sysconfig: Mapping[str, config.SettingValue] | None
+    _default_sysconfig: Mapping[str, config.SettingValue]
     _config_settings: config.Spec
 
-    def __init__(self, config_settings: config.Spec, sys_config: Mapping[str, config.SettingValue] = None, default_sysconfig: Mapping[str, config.SettingValue] = None):
+    def __init__(
+            self,
+            config_settings: config.Spec,
+            sys_config: Mapping[str, config.SettingValue] = None,
+            default_sysconfig: Mapping[str, config.SettingValue] = immutables.Map(),
+    ):
         self._sys_config = sys_config
         self._default_sysconfig = default_sysconfig
         self._config_settings = config_settings
@@ -126,12 +131,10 @@ class ServerSysConfig:
         default_sysconfig: Mapping[str, config.SettingValue] = None,
     ):
         assert self._sys_config is None, "ServerConfig is already initialized"
-        assert self._default_sysconfig is None, "default_sysconfig is already initialized"
         self._sys_config = sys_config
         self._default_sysconfig = default_sysconfig
 
     def update(self, sys_config: Mapping[str, config.SettingValue]):
-        assert self._default_sysconfig is not None, "ServerConfig is not initialized"
         with self._default_sysconfig.mutate() as mm:
             mm.update(sys_config)
             sys_config = mm.finish()

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -107,13 +107,18 @@ class ServerSysConfig:
     _config_settings: config.Spec
 
     def __init__(self, config_settings: config.Spec, sys_config: Mapping[str, config.SettingValue] = None, default_sysconfig: Mapping[str, config.SettingValue] = None):
-        self._sys_config = None
+        self._sys_config = sys_config
         self._default_sysconfig = default_sysconfig
         self._config_settings = config_settings
 
     @property
     def settings(self) -> config.Spec:
         return self._config_settings
+
+    @property
+    def sys_config(self) -> Mapping[str, config.SettingValue]:
+        assert self._sys_config is not None, "ServerConfig is not initialized"
+        return self._sys_config
 
     @property
     def default_sysconfig(self) -> Mapping[str, config.SettingValue]:
@@ -1258,7 +1263,7 @@ class BaseServer:
                 listen_port=self._listen_port,
             ),
             instance_config=config.debug_serialize_config(
-                self._sys_config),
+                self._sys_config.sys_config),
             compiler_pool=(
                 self._compiler_pool.get_debug_info()
                 if self._compiler_pool

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -141,7 +141,6 @@ class ServerSysConfig:
     def apply(self, op: config.Operation):
         assert self._sys_config is not None, "ServerConfig is not initialized"
         op.apply(self._config_settings, self._sys_config)
-        self.update(self._sys_config)
 
     def get_compilation_config(self) -> immutables.Map[str, config.SettingValue]:
         assert self._sys_config is not None, "ServerConfig is not initialized"

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -101,8 +101,61 @@ class StartupError(Exception):
     pass
 
 
+class ServerSysConfig:
+    _sys_config: Mapping[str, config.SettingValue] | None
+    _default_sysconfig: Mapping[str, config.SettingValue] | None
+    _config_settings: config.Spec
+
+    def __init__(self, config_settings: config.Spec, sys_config: Mapping[str, config.SettingValue] = None, default_sysconfig: Mapping[str, config.SettingValue] = None):
+        self._sys_config = None
+        self._default_sysconfig = default_sysconfig
+        self._config_settings = config_settings
+
+    @property
+    def settings(self) -> config.Spec:
+        return self._config_settings
+
+    @property
+    def default_sysconfig(self) -> Mapping[str, config.SettingValue]:
+        assert self._default_sysconfig is not None, "default_sysconfig is not initialized"
+        return self._default_sysconfig
+
+    def init(self, sys_config: Mapping[str, config.SettingValue], default_sysconfig: Mapping[str, config.SettingValue]):
+        assert self._sys_config is None, "ServerConfig is already initialized"
+        assert self._default_sysconfig is None, "default_sysconfig is already initialized"
+        self._sys_config = sys_config
+        self._default_sysconfig = default_sysconfig
+
+    def update(self, sys_config: Mapping[str, config.SettingValue]):
+        assert self._default_sysconfig is not None, "ServerConfig is not initialized"
+        with self._default_sysconfig.mutate() as mm:
+            mm.update(sys_config)
+            sys_config = mm.finish()
+        self._sys_config = sys_config
+
+    def apply(self, op: config.Operation):
+        assert self._sys_config is not None, "ServerConfig is not initialized"
+        op.apply(self._config_settings, self._sys_config)
+
+    def get_compilation_config(self) -> immutables.Map[str, config.SettingValue]:
+        assert self._sys_config is not None, "ServerConfig is not initialized"
+        return config.get_compilation_config(self._sys_config, spec=self._config_settings)
+
+    def lookup(
+        self,
+        name: str,
+        *db_config: Mapping[str, config.SettingValue],
+        spec: config.Spec = None,
+    ) -> Any:
+        assert self._sys_config is not None, "ServerConfig is not initialized"
+        db_config = db_config or (self._sys_config,)
+        spec = spec or self._config_settings
+        return config.lookup(name, *db_config, spec=spec)
+
+
 class BaseServer:
     _sys_queries: Mapping[str, bytes]
+    _sys_config: ServerSysConfig
     _local_intro_query: bytes
     _global_intro_query: bytes
     _report_config_typedesc: dict[defines.ProtocolVersion, bytes]
@@ -140,6 +193,7 @@ class BaseServer:
     def __init__(
         self,
         *,
+        sys_config: ServerSysConfig,
         runstate_dir,
         internal_runstate_dir,
         compiler_pool_size,
@@ -172,8 +226,8 @@ class BaseServer:
         self.__loop = asyncio.get_running_loop()
         self._use_monitor_fs = use_monitor_fs
 
+        self._sys_config = sys_config
         self._schema_class_layout = compiler_state.schema_class_layout
-        self._config_settings = compiler_state.config_spec
         self._refl_schema = compiler_state.refl_schema
         self._std_schema = compiler_state.std_schema
         assert compiler_state.global_intro_query is not None
@@ -282,7 +336,7 @@ class BaseServer:
         for transport, methods in auth_methods_spec.items():
             result = []
             for method in methods:
-                auth_type = self.config_settings.get_type_by_name(
+                auth_type = self.config.settings.get_type_by_name(
                     f'cfg::{method.value}'
                 )
                 result.append(auth_type())
@@ -473,39 +527,28 @@ class BaseServer:
 
         return finalizer
 
-    def _get_sys_config(self) -> Mapping[str, config.SettingValue]:
-        raise NotImplementedError
-
-    def config_lookup(
-        self,
-        name: str,
-        *configs: Mapping[str, config.SettingValue],
-    ) -> Any:
-        return config.lookup(name, *configs, spec=self._config_settings)
-
     @property
-    def config_settings(self) -> config.Spec:
-        return self._config_settings
+    def config(self) -> ServerSysConfig:
+        return self._sys_config
 
     async def init(self):
         if self.is_admin_ui_enabled():
             ui_ext.cache_assets()
 
-        sys_config = self._get_sys_config()
         if not self._listen_hosts:
             self._listen_hosts = (
-                self.config_lookup('listen_addresses', sys_config)
+                self.config.lookup('listen_addresses')
                 or ('localhost',)
             )
 
         if self._listen_port is None:
             self._listen_port = (
-                self.config_lookup('listen_port', sys_config)
+                self.config.lookup('listen_port')
                 or defines.EDGEDB_PORT
             )
 
-        self._stmt_cache_size = self.config_lookup(
-            '_pg_prepared_statement_cache_size', sys_config
+        self._stmt_cache_size = self.config.lookup(
+            '_pg_prepared_statement_cache_size'
         )
 
         self.reinit_idle_gc_collector()
@@ -518,8 +561,8 @@ class BaseServer:
             self._idle_gc_handler.cancel()
             self._idle_gc_handler = None
 
-        session_idle_timeout = self.config_lookup(
-            'session_idle_timeout', self._get_sys_config())
+        session_idle_timeout = self.config.lookup(
+            'session_idle_timeout')
 
         timeout = session_idle_timeout.to_microseconds()
         timeout /= 1_000_000.0  # convert to seconds
@@ -687,7 +730,7 @@ class BaseServer:
         self, db_config_json: bytes, user_schema: s_schema.Schema
     ) -> Mapping[str, config.SettingValue]:
         spec = config.ChainedSpec(
-            self._config_settings,
+            self.config.settings,
             config.load_ext_spec_from_schema(
                 user_schema,
                 self.get_std_schema(),
@@ -1215,7 +1258,7 @@ class BaseServer:
                 listen_port=self._listen_port,
             ),
             instance_config=config.debug_serialize_config(
-                self._get_sys_config()),
+                self._sys_config),
             compiler_pool=(
                 self._compiler_pool.get_debug_info()
                 if self._compiler_pool
@@ -1300,15 +1343,12 @@ class Server(BaseServer):
         new_instance: bool,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(sys_config=tenant.config, **kwargs)
         self._tenant = tenant
         self._startup_script = startup_script
         self._new_instance = new_instance
 
         tenant.set_server(self)
-
-    def _get_sys_config(self) -> Mapping[str, config.SettingValue]:
-        return self._tenant.get_sys_config()
 
     async def init(self) -> None:
         logger.debug("starting server init")
@@ -1560,8 +1600,8 @@ class Server(BaseServer):
             )
 
     def _reload_stmt_cache_size(self):
-        size = self.config_lookup(
-            '_pg_prepared_statement_cache_size', self._get_sys_config()
+        size = self.config.lookup(
+            '_pg_prepared_statement_cache_size'
         )
         self._stmt_cache_size = size
         self._tenant.set_stmt_cache_size(size)
@@ -1690,18 +1730,16 @@ class Server(BaseServer):
     async def _on_system_config_reset(self, setting_name):
         try:
             if setting_name == 'listen_addresses':
-                cfg = self._get_sys_config()
                 await self._restart_servers_new_addr(
-                    self.config_lookup('listen_addresses', cfg)
+                    self.config.lookup('listen_addresses')
                     or ('localhost',),
                     self._listen_port,
                 )
 
             elif setting_name == 'listen_port':
-                cfg = self._get_sys_config()
                 await self._restart_servers_new_addr(
                     self._listen_hosts,
-                    self.config_lookup('listen_port', cfg)
+                    self.config.lookup('listen_port')
                     or defines.EDGEDB_PORT,
                 )
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -120,12 +120,11 @@ class ServerSysConfig:
         assert self._sys_config is not None, "ServerConfig is not initialized"
         return self._sys_config
 
-    @property
-    def default_sysconfig(self) -> Mapping[str, config.SettingValue]:
-        assert self._default_sysconfig is not None, "default_sysconfig is not initialized"
-        return self._default_sysconfig
-
-    def init(self, sys_config: Mapping[str, config.SettingValue], default_sysconfig: Mapping[str, config.SettingValue]):
+    def init(
+        self,
+        sys_config: Mapping[str, config.SettingValue],
+        default_sysconfig: Mapping[str, config.SettingValue] = None,
+    ):
         assert self._sys_config is None, "ServerConfig is already initialized"
         assert self._default_sysconfig is None, "default_sysconfig is already initialized"
         self._sys_config = sys_config
@@ -149,11 +148,11 @@ class ServerSysConfig:
     def lookup(
         self,
         name: str,
-        *db_config: Mapping[str, config.SettingValue],
+        configs: Optional[tuple[Mapping[str, config.SettingValue], ...]] = None,
         spec: config.Spec = None,
     ) -> Any:
         assert self._sys_config is not None, "ServerConfig is not initialized"
-        db_config = db_config or (self._sys_config,)
+        db_config = configs or () + (self._sys_config,)
         spec = spec or self._config_settings
         return config.lookup(name, *db_config, spec=spec)
 

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -1633,7 +1633,7 @@ class Tenant(ha_base.ClusterProtocol):
         return self._dbindex.remove_view(dbview_)
 
     def schedule_reported_config_if_needed(self, setting_name: str) -> None:
-        setting = self._server.config_settings.get(setting_name)
+        setting = self._server.config.settings.get(setting_name)
         if setting and setting.report and self._accept_new_tasks:
             self.create_task(self._load_reported_config(), interruptable=True)
 
@@ -1778,7 +1778,7 @@ class Tenant(ha_base.ClusterProtocol):
                 result = await result
 
             def setting_filter(value: config.SettingValue) -> bool:
-                if self._server.config_settings[value.name].backend_setting:
+                if self._server.config.settings[value.name].backend_setting:
                     raise errors.ConfigurationError(
                         f"backend config {value.name!r} cannot be set "
                         f"via config file"
@@ -1786,7 +1786,7 @@ class Tenant(ha_base.ClusterProtocol):
                 return True
 
             json_obj = config.to_json_obj(
-                self._server.config_settings,
+                self._server.config.settings,
                 result["cfg::Config"],
                 include_source=False,
                 setting_filter=setting_filter,
@@ -2216,7 +2216,7 @@ class Tenant(ha_base.ClusterProtocol):
                 tenant_id=self._tenant_id,
             ),
             instance_config=config.debug_serialize_config(
-                self.config),
+                self.config.sys_config),
             user_roles=self._roles,
             pg_addr=dict(
                 server_settings=vars(self._cluster.get_connection_params()),

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -105,6 +105,7 @@ class RoleDescriptor(TypedDict):
 
 class Tenant(ha_base.ClusterProtocol):
     _server: edbserver.BaseServer
+    _sys_config: server.ServerSysConfig
     _cluster: pgcluster.BaseCluster
     _tenant_id: str
     _instance_name: str
@@ -166,8 +167,10 @@ class Tenant(ha_base.ClusterProtocol):
         max_backend_connections: int,
         backend_adaptive_ha: bool = False,
         extensions_dir: tuple[pathlib.Path, ...] = (),
+        sys_config: server.ServerSysConfig,
     ):
         self._cluster = cluster
+        self._sys_config = sys_config
         self._tenant_id = self.get_backend_runtime_params().tenant_id
         self._instance_name = instance_name
         self._instance_data = immutables.Map()
@@ -303,8 +306,8 @@ class Tenant(ha_base.ClusterProtocol):
 
     def get_http_client(self, *, originator: str) -> HttpClient:
         if self._http_client is None:
-            http_max_connections = self._server.config_lookup(
-                'http_max_connections', self.get_sys_config()
+            http_max_connections = self.config.lookup(
+                'http_max_connections'
             )
             self._http_client = HttpClient(
                 http_max_connections,
@@ -394,9 +397,9 @@ class Tenant(ha_base.ClusterProtocol):
     def get_readiness_reason(self) -> str:
         return self._readiness_reason
 
-    def get_sys_config(self) -> Mapping[str, config.SettingValue]:
-        assert self._dbindex is not None
-        return self._dbindex.get_sys_config()
+    @property
+    def config(self) -> server.ServerSysConfig:
+        return self._sys_config
 
     def get_report_config_data(
         self,
@@ -559,23 +562,19 @@ class Tenant(ha_base.ClusterProtocol):
             )
 
         logger.info("loading system config")
-        sys_config = await self._load_sys_config()
-        default_sysconfig = await self._load_sys_config("sysconfig_default")
+        self.config.init(await self._load_sys_config(), await self._load_sys_config("sysconfig_default"))
         await self._load_reported_config()
 
         # To make in-place upgrade failures more testable, check
         # 'force_database_error' with a 'startup' scope.
-        force_error = self._server.config_lookup(
-            'force_database_error', sys_config)
+        force_error = self.config.lookup('force_database_error')
         edbcompiler.maybe_force_database_error(force_error, scope='startup')
 
         self._dbindex = dbview.DatabaseIndex(
             self,
             std_schema=self._server.get_std_schema(),
             global_schema_pickle=global_schema_pickle,
-            sys_config=sys_config,
-            default_sysconfig=default_sysconfig,
-            sys_config_spec=self._server.config_settings,
+            sys_config=self._server.config,
         )
 
         await self._introspect_dbs()
@@ -1540,7 +1539,7 @@ class Tenant(ha_base.ClusterProtocol):
         else:
             sys_config_json = await syscon.sql_fetch_val(query)
 
-        return config.from_json(self._server.config_settings, sys_config_json)
+        return config.from_json(self.config.settings, sys_config_json)
 
     async def _reintrospect_global_schema(self) -> None:
         if not self._initing and not self._running:
@@ -1558,9 +1557,7 @@ class Tenant(ha_base.ClusterProtocol):
         self._dbindex.update_global_schema(global_schema_pickle)
 
     def populate_sys_auth(self) -> None:
-        assert self._dbindex is not None
-        cfg = self._dbindex.get_sys_config()
-        auth = self._server.config_lookup("auth", cfg) or ()
+        auth = self.config.lookup("auth") or ()
         self._sys_auth = tuple(sorted(auth, key=lambda a: a.priority))
 
     def resolve_branch_name(
@@ -1827,10 +1824,11 @@ class Tenant(ha_base.ClusterProtocol):
                     pgcon.RESET_STATIC_CFG_SCRIPT + (self._init_con_sql or b'')
                 )
                 syscon.last_init_con_data = self._init_con_data
-            sys_config = await self._load_sys_config(syscon=syscon)
+            cfg = await self._load_sys_config(syscon=syscon)
             # GOTCHA: no need to notify other EdgeDBs on the same backend about
             # such change to sysconfig, because static config is instance-local
-        self._dbindex.update_sys_config(sys_config)
+        self.config.update(cfg)
+        self._dbindex.update_sys_config()
 
     def reload(self):
         # In multi-tenant mode, the file paths for the following states may be
@@ -2088,7 +2086,8 @@ class Tenant(ha_base.ClusterProtocol):
         async def task():
             try:
                 cfg = await self._load_sys_config()
-                self._dbindex.update_sys_config(cfg)
+                self.config.update(cfg)
+                self._dbindex.update_sys_config()
                 self._server.reinit_idle_gc_collector()
             except Exception:
                 metrics.background_errors.inc(
@@ -2217,7 +2216,7 @@ class Tenant(ha_base.ClusterProtocol):
                 tenant_id=self._tenant_id,
             ),
             instance_config=config.debug_serialize_config(
-                self.get_sys_config()),
+                self.config),
             user_roles=self._roles,
             pg_addr=dict(
                 server_settings=vars(self._cluster.get_connection_params()),

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -105,7 +105,7 @@ class RoleDescriptor(TypedDict):
 
 class Tenant(ha_base.ClusterProtocol):
     _server: edbserver.BaseServer
-    _sys_config: server.ServerSysConfig
+    _sys_config: edbserver.ServerSysConfig
     _cluster: pgcluster.BaseCluster
     _tenant_id: str
     _instance_name: str
@@ -167,7 +167,7 @@ class Tenant(ha_base.ClusterProtocol):
         max_backend_connections: int,
         backend_adaptive_ha: bool = False,
         extensions_dir: tuple[pathlib.Path, ...] = (),
-        sys_config: server.ServerSysConfig,
+        sys_config: edbserver.ServerSysConfig,
     ):
         self._cluster = cluster
         self._sys_config = sys_config
@@ -398,7 +398,7 @@ class Tenant(ha_base.ClusterProtocol):
         return self._readiness_reason
 
     @property
-    def config(self) -> server.ServerSysConfig:
+    def config(self) -> edbserver.ServerSysConfig:
         return self._sys_config
 
     def get_report_config_data(

--- a/edb/testbase/cluster.py
+++ b/edb/testbase/cluster.py
@@ -284,6 +284,7 @@ class BaseCluster:
         ) -> dict[str, Any]:
             while True:
                 line = await stream.readline()
+                print(line)
                 if not line:
                     raise ClusterError("Gel server terminated")
                 if line.startswith(b'READY='):
@@ -299,6 +300,7 @@ class BaseCluster:
                 )
 
         async def test() -> None:
+            print(status_sock)
             stat_reader, stat_writer = await asyncio.open_connection(
                 sock=status_sock,
             )
@@ -307,6 +309,7 @@ class BaseCluster:
                     _read_server_status(stat_reader),
                     timeout=timeout
                 )
+                print(data)
             except asyncio.TimeoutError:
                 raise ClusterError(
                     f'Gel server did not initialize '
@@ -359,6 +362,8 @@ class BaseCluster:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
+        print(args)
+        print(res)
         return res.returncode
 
     async def set_test_config(self) -> None:

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -542,8 +542,9 @@ class TestCompilerPool(tbs.TestCase):
         cls._schema_class_layout = _schema_class_layout
 
     async def _test_pool_disconnect_queue(self, pool_class):
+        config_settings = config.load_spec_from_schema(self._std_schema)
         with tempfile.TemporaryDirectory() as td:
-            config = server.ServerSysConfig(config_settings=config.load_spec_from_schema(self._std_schema), default_sysconfig=immutables.Map())
+            sys_config = server.ServerSysConfig(config_settings)
             pool_ = await pool.create_compiler_pool(
                 runstate_dir=td,
                 pool_size=2,
@@ -557,7 +558,7 @@ class TestCompilerPool(tbs.TestCase):
                     unittest.mock.MagicMock(),
                     std_schema=self._std_schema,
                     global_schema_pickle=pickle.dumps(None, -1),
-                    sys_config=config,
+                    sys_config=sys_config,
                 ),
             )
             try:

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -42,6 +42,7 @@ from edb.server import args as edbargs
 from edb.server import compiler as edbcompiler
 from edb.server.compiler import rpc
 from edb.server import config
+from edb.server import server
 from edb.server.compiler_pool import amsg
 from edb.server.compiler_pool import pool
 from edb.server.dbview import dbview
@@ -542,6 +543,7 @@ class TestCompilerPool(tbs.TestCase):
 
     async def _test_pool_disconnect_queue(self, pool_class):
         with tempfile.TemporaryDirectory() as td:
+            config = server.ServerSysConfig(config_settings=config.load_spec_from_schema(self._std_schema), default_sysconfig=immutables.Map())
             pool_ = await pool.create_compiler_pool(
                 runstate_dir=td,
                 pool_size=2,
@@ -555,10 +557,7 @@ class TestCompilerPool(tbs.TestCase):
                     unittest.mock.MagicMock(),
                     std_schema=self._std_schema,
                     global_schema_pickle=pickle.dumps(None, -1),
-                    sys_config={},
-                    default_sysconfig=immutables.Map(),
-                    sys_config_spec=config.load_spec_from_schema(
-                        self._std_schema),
+                    sys_config=config,
                 ),
             )
             try:


### PR DESCRIPTION
The config system is currently spread across many files, re-implemented a number of times in slightly different ways. This is a first step at refactoring where we get code out of untyped cython and move it to typed python so it can then be refactored again.

In addition, we try to avoid the zig-zagged config init between servers and tenants and pre-init: a sys_config is initialized once and passed to both tenant and server.

In a follow-up PR, we'll start to extract the config file and magic config handling as well.