### PR TITLE
Add a FULL_SCHEMA field to tests that doesn't use a module

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1544,6 +1544,11 @@ class DatabaseTestCase(ConnectedTestCase):
 
                     schema.append(f'\nmodule {module_name} {{ {module} }}')
 
+        full_schema_fn = getattr(cls, 'FULL_SCHEMA', None)
+        if full_schema_fn:
+            with open(full_schema_fn, 'r') as sf:
+                schema.append(sf.read())
+
         if schema:
             has_nontrivial_script = True
 


### PR DESCRIPTION
I'm doing this so I can hook up a thing to inittestdb some gel-python
tests. Wild we haven't had this before tbh.