### PR TITLE
Fix just-introduced bug for `reindex(Obj.ptr)` with `future simple_scoping`

### DIFF
--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1533,6 +1533,7 @@ def administer_reindex(
 ) -> dbstate.BaseQuery:
     from edb.ir import ast as irast
     from edb.ir import typeutils as irtypeutils
+    from edb.ir import utils as irutils
 
     from edb.schema import objtypes as s_objtypes
     from edb.schema import constraints as s_constraints
@@ -1573,18 +1574,17 @@ def administer_reindex(
             modaliases=modaliases
         ),
     )
-    expr = ir.expr
+    expr = irutils.unwrap_set(ir.expr)
     if ptr:
         if (
             not expr.expr
-            or not isinstance(expr.expr, irast.SelectStmt)
-            or not isinstance(expr.expr.result.expr, irast.Pointer)
+            or not isinstance(expr.expr, irast.Pointer)
         ):
             raise errors.QueryError(
                 'invalid pointer argument to reindex()',
                 span=arg.span,
             )
-        rptr = expr.expr.result.expr
+        rptr = expr.expr
         source = rptr.source
     else:
         rptr = None

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -20054,7 +20054,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                 insert Mig03 { n := <int64>{} };
             ''')
 
-    async def test_edgeql_ddl_reindex(self):
+    async def _test_edgeql_ddl_reindex(self):
         await self.con.execute('''
             create type Tgt;
             create type Foo {
@@ -20102,6 +20102,20 @@ class TestDDLNonIsolated(tb.DDLTestCase):
                 drop type Foo;
                 drop type Tgt;
                 drop module test;
+            ''')
+
+    async def test_edgeql_ddl_reindex_old_scoping(self):
+        await self._test_edgeql_ddl_reindex()
+
+    async def test_edgeql_ddl_reindex_simple_scoping(self):
+        await self.con.execute('''
+            create future simple_scoping;
+        ''')
+        try:
+            await self._test_edgeql_ddl_reindex()
+        finally:
+            await self.con.execute('''
+                drop future simple_scoping;
             ''')
 
     async def _deadlock_tester(self, setup, teardown, modification, query):


### PR DESCRIPTION
I *just* introduced this in #8985, fortunately.

With the new optimization, in simple_scoping mode the IR was actually
coming back with fewer select wrappers in simple_scoping mode than
with old scoping...