### PR TITLE
Fix missing return_data in no email found case

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1489,6 +1489,15 @@ class Router:
                     f"email={email}"
                 )
                 await auth_emails.send_fake_email(self.tenant)
+                if magic_link_client.provider.verification_method == "Code":
+                    return_data = {
+                        "code": "true",
+                        "email": email,
+                    }
+                else:
+                    return_data = {
+                        "email_sent": email,
+                    }
             else:
                 identity_id = email_factor.identity.id
                 if magic_link_client.provider.verification_method == "Code":


### PR DESCRIPTION
We pretend to send an email when you sign in with an email that does not yet exist to prevent account enumeration. We failed to actually set a valid response payload.