### PR TITLE
Bump the compatible extension version for pgvector.

### DIFF
--- a/edb/lib/ext/pgvector.edgeql
+++ b/edb/lib/ext/pgvector.edgeql
@@ -19,7 +19,7 @@
 
 create extension package pgvector version '0.7.4' {
     set ext_module := "ext::pgvector";
-    set sql_extensions := ["vector >=0.7.4,<0.8.0"];
+    set sql_extensions := ["vector >=0.7.4,<0.9.0"];
 
     set sql_setup_script := $script$
         -- Rename the vector_norm to be consistent with l2_norm


### PR DESCRIPTION
The `ext::pgvector` is now compatible with vector < 0.9.0. It has been tested with 0.8.0 specifically.