### PR TITLE
Make indexes get hit more when ordering by something with exclusive constraint

### DIFF
--- a/tests/schemas/explain.esdl
+++ b/tests/schemas/explain.esdl
@@ -45,6 +45,9 @@ type User extending Dictionary {
         }
     }
     multi link owned_issues := .<owner[is Issue];
+    rank: int64 {
+        default := 0;
+    }
 }
 
 abstract type Owned {


### PR DESCRIPTION
Our ORDER BY defaults to `empty first`, while UNIQUE constraints
default to an `NULLS LAST`.

It ought to be possible to migrate things to use `CREATE UNIQUE INDEX`
instead, which would let us specify `NULLS FIRST`, but the migration
would be painful.

For now, when ordering on a required pointer with an exclusive
constraint, inject appropriate ordering instructions.  Since this is
only done on required pointers, it shouldn't have any impact.

Should fix #8035.