### PR TITLE
Check for explicit id write presence in a slightly more resilient way

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -654,7 +654,13 @@ def compile_insert_unless_conflict_on(
 def _has_explicit_id_write(stmt: irast.MutatingStmt) -> bool:
     for elem, _ in stmt.subject.shape:
         if elem.expr.ptrref.shortname.name == 'id':
-            return elem.span is not None
+            # We want to make sure it isn't an implicit id (which
+            # won't have an expr) or a default value (which won't have
+            # a span).
+            #
+            # ... it is at least a little dodgy to check for default
+            # value by span presence.
+            return elem.span is not None and elem.expr.expr is not None
     return False
 
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -8185,3 +8185,14 @@ class TestRepeatableReadInsert(tb.QueryTestCase):
                     name := "test"
                 };
             """)
+
+    async def test_edgeql_rr_update_04(self):
+        # should be fine
+        await self.con.query(
+            r"""
+                update (
+                    select Person
+                    filter .name = 'adsf'
+                ).note set {};
+            """,
+        )


### PR DESCRIPTION
Currently we distinguish an explicit id write from an implicitly
injected id or a default value by whether a span is present.

This is kind of fragile, especially in the implicit case,
so also check whether an expression is present.

This will fix #9089 if back-ported to 6.x. That bug was already
accidentally fixed by #8531.