### PR TITLE
Fix typo with `gel.toml` server-version

### DIFF
--- a/docs/intro/quickstart/setup/fastapi.rst
+++ b/docs/intro/quickstart/setup/fastapi.rst
@@ -69,7 +69,7 @@ Setting up your environment
       :caption: gel.toml
 
       [instance]
-      server-version = 6.1
+      server-version = "6.11"
 
       [hooks]
       schema.update.after = "uvx gel-py"

--- a/docs/intro/quickstart/setup/nextjs.rst
+++ b/docs/intro/quickstart/setup/nextjs.rst
@@ -69,7 +69,7 @@ Setting up your environment
       :caption: gel.toml
 
       [instance]
-      server-version = 6.1
+      server-version = "6.11"
 
       [hooks]
       schema.update.after = "npx @gel/generate edgeql-js"


### PR DESCRIPTION
It is a version string, not a number.