### PR TITLE
Add note about `overloaded` to inheritance docs

### DIFF
--- a/docs/reference/datamodel/inheritance.rst
+++ b/docs/reference/datamodel/inheritance.rst
@@ -157,6 +157,10 @@ When extending a base object type, you can modify its properties, for example, b
     }
   }
 
+.. note::
+
+  ``overloaded`` can only be used to modify properties of the object type, not computed properties.
+
 .. _ref_datamodel_inheritance_links:
 
 Links

--- a/docs/reference/datamodel/properties.rst
+++ b/docs/reference/datamodel/properties.rst
@@ -265,6 +265,10 @@ overloading due to a name clash:
         overloaded required name: str;
     }
 
+.. note::
+
+  ``overloaded`` can only be used to modify properties of the object type, not computed properties.
+
 
 .. _ref_eql_sdl_props:
 .. _ref_eql_sdl_props_syntax:


### PR DESCRIPTION
This concept only applies to inheritance, so it's a bit strange that it didn't get mentioned here, but only in the properties documentation.

Question: is there anything else to note about `overloaded` that isn't already covered in the docs? I was wondering if we have any constraints on how you can overload like not being able to change the type, or no `required` -> `optional` or something like that?