### PR TITLE
Fix an interaction between aliases and optional globals with a default

### DIFF
--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -547,6 +547,12 @@ def fini_toplevel(
                     name=pg_types.pg_type_from_ir_typeref(param.ir_type)
                 )
             )))
+            if isinstance(param, irast.Global) and param.has_present_arg:
+                targets.append(pgast.ResTarget(val=pgast.TypeCast(
+                    arg=pgast.ParamRef(number=pgparam.index + 1),
+                    type_name=pgast.TypeName(name=('bool',)),
+                )))
+
         if targets:
             stmt.append_cte(
                 pgast.CommonTableExpr(

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -54,6 +54,11 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             create global CurUser := (
                 select User filter .name = global cur_user);
 
+            create alias DumbAlias := {
+                cur_user := global cur_user,
+                cur_card := global cur_card,
+            };
+
             create function get_current_user() -> OPTIONAL User using (
                 select User filter .name = global cur_user
             );
@@ -914,3 +919,12 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             ''',
             []
         )
+
+    async def test_edgeql_globals_unused_01(self):
+        # Make sure it works when selecting something
+        # that has "unused" optional globals with a default.
+        # (There previously was a bug where we'd choke because
+        # of confusion about the "present" argument.)
+        await self.con.query('''
+            select DumbAlias { cur_user }
+        ''')


### PR DESCRIPTION
Optional globals with a default get turned into *two* parameters, one
for the value and one for whether they were set. This is to
distinguish between the cases of setting to `{}` and not setting
anything.

The "unused parameter" handling wasn't accounting for this so we would
pass more arguments than the query expected in cases where a global
got seen during compilation but didn't end up in the final query.