### PR TITLE
Compile policy expressions with apply_user_access_policies=False in compile_expr

### DIFF
--- a/edb/schema/policies.py
+++ b/edb/schema/policies.py
@@ -223,6 +223,7 @@ class AccessPolicyCommand(
                     path_prefix_anchor='__subject__',
                     singletons=frozenset({source}),
                     apply_query_rewrites=not context.stdmode,
+                    apply_user_access_policies=False,
                     track_schema_ref_exprs=track_schema_ref_exprs,
                     in_ddl_context_name=in_ddl_context_name,
                     detached=True,


### PR DESCRIPTION
User policies aren't evaluated recursively, so there is no reason
to compile other user access policies while checking one policy.

Doing so creates spurious dependencies and was leading to some weird
user-reported errors as a knock on effect, where one of these spurious
policy dependencies didn't exist yet (I think that probably was
requiring another bug to make manifest, and I'm still tracking that
down.)