### PR TITLE
Revert "Fix half-dunder pointer names (#9100)"

### DIFF
--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -475,7 +475,10 @@ def _source_table_info(
         catenate=False, versioned=versioned,
     )
     ptr_name = pointer.get_shortname(schema).name
-    col_name = _column_name_of_pointer(pointer.id, ptr_name)
+    if ptr_name.startswith('__') or ptr_name == 'id':
+        col_name = ptr_name
+    else:
+        col_name = str(pointer.id)
     table_type = 'ObjectType'
 
     return table, table_type, col_name
@@ -724,7 +727,11 @@ def _get_ptrref_storage_info(
                 versioned=versioned,
 
             )
-            col_name = _column_name_of_pointer(ptrref.id, ptrref.shortname.name)
+            ptrname = ptrref.shortname.name
+            if ptrname.startswith('__') or ptrname == 'id':
+                col_name = ptrname
+            else:
+                col_name = str(ptrref.id)
             table_type = 'ObjectType'
 
         elif _ptrref_storable_in_pointer(ptrref):
@@ -774,16 +781,6 @@ def _ptrref_storable_in_pointer(ptrref: irast.BasePointerRef) -> bool:
             ptrref.out_cardinality.is_multi()
             or ptrref.has_properties
         )
-
-
-def _column_name_of_pointer(ptr_id: uuid.UUID, ptr_name: str) -> str:
-    if (
-        (ptr_name.startswith('__') and ptr_name.endswith('__'))
-        or ptr_name == 'id'
-    ):
-        return ptr_name
-    else:
-        return str(ptr_id)
 
 
 def has_table(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -20129,16 +20129,6 @@ DDLStatement);
             };
         """)
 
-    async def test_edgeql_ddl_half_dunder_00(self):
-        await self.con.execute(r"""
-            create type Example { create property s: str; };
-            alter type Example { alter property s { rename to __s; }; };
-        """)
-        await self.assert_query_result(
-            'select Example { __s }',
-            [],
-        )
-
 
 class TestDDLNonIsolated(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
This reverts commit 9c9594f85beffa677c936d3da060d742c46bbad7.

Fixing half-dunder names has the problem that it leaves any database
still using them (via an inplace-upgrade or minor version upgrade) in
a pretty broken state, where some of the postgres columns may have
half-dunder names, but now there is now way to recover the situation:
it won't be possible to rename or delete the pointers.

In order to fix this, we'll probably need migration code that can run
during an inplace upgrade.