### PR TITLE
Fix DATE_TRUNC with GROUP BY parameter binding

### DIFF
--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -632,6 +632,8 @@ funcs_with_text_args: set[str] = {
     'jsonb_object_agg_unique',
     'json_object_agg_unique_strict',
     'jsonb_object_agg_unique_strict',
+    'date_trunc',
+    'date_part',
 }
 
 

--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -632,8 +632,8 @@ funcs_with_text_args: set[str] = {
     'jsonb_object_agg_unique',
     'json_object_agg_unique_strict',
     'jsonb_object_agg_unique_strict',
-    'date_trunc',
     'date_part',
+    'date_trunc',
 }
 
 


### PR DESCRIPTION
Made sure the test was real this time and actually fails and succeeds as expected.

Two issues fixed:

1. Added 'date_trunc' and 'date_part' to funcs_with_text_args so their text precision argument ('month', 'year', etc.) is correctly typed.

2. Fixed remap_arguments in pg_ext.pyx to use extra_blobs() instead of variables(). The variables() method returns a deduplicated dict, but when the same literal appears multiple times (e.g., DATE_TRUNC in both SELECT and GROUP BY), we need all occurrences. This matches the pattern used in args_ser.pyx.

Closes #9118